### PR TITLE
Agent conversation: tool results, user-message echo, webview styles

### DIFF
--- a/apps/webview/package.json
+++ b/apps/webview/package.json
@@ -14,6 +14,7 @@
     "@hookform/resolvers": "^5.4.0",
     "@linkcode/i18n": "workspace:*",
     "@linkcode/transport": "workspace:*",
+    "@linkcode/ui": "workspace:*",
     "@linkcode/workbench": "workspace:*",
     "coss-ui": "workspace:*",
     "foxact": "^0.3.6",

--- a/packages/agent-adapter/src/__tests__/normalize.test.ts
+++ b/packages/agent-adapter/src/__tests__/normalize.test.ts
@@ -5,7 +5,7 @@ import { env } from 'node:process';
 import type { SessionUpdate } from '@agentclientprotocol/sdk';
 import { describe, expect, it } from 'vitest';
 import { acpUpdateToEvent, mapAcpStop } from '../acp/acp-adapter';
-import { mapClaudeStop } from '../native/claude-code';
+import { claudeToolResultEvents, editToolDiffs, mapClaudeStop } from '../native/claude-code';
 import { CodexAdapter, mapCodexStatus, mapCodexUsage } from '../native/codex';
 import { contentToText, toolKindFromName } from '../util';
 
@@ -180,3 +180,88 @@ describe('acpUpdateToEvent', () => {
 function sessionUpdateFixture(value: object): SessionUpdate {
   return value as SessionUpdate;
 }
+
+type ClaudeUserMessage = Parameters<typeof claudeToolResultEvents>[0];
+function claudeUserFixture(content: unknown, toolUseResult?: unknown): ClaudeUserMessage {
+  return { type: 'user', message: { role: 'user', content }, tool_use_result: toolUseResult } as ClaudeUserMessage;
+}
+
+describe('claudeToolResultEvents', () => {
+  it('maps a successful tool_result to a completed tool-call-update', () => {
+    expect(
+      claudeToolResultEvents(
+        claudeUserFixture([{ type: 'tool_result', tool_use_id: 't1', content: 'done' }]),
+      ),
+    ).toEqual([
+      {
+        type: 'tool-call-update',
+        update: {
+          toolCallId: 't1',
+          status: 'completed',
+          content: [{ type: 'content', content: { type: 'text', text: 'done' } }],
+          rawOutput: 'done',
+        },
+      },
+    ]);
+  });
+
+  it('marks is_error results as failed and flattens block-array content', () => {
+    const [event] = claudeToolResultEvents(
+      claudeUserFixture([
+        {
+          type: 'tool_result',
+          tool_use_id: 't2',
+          is_error: true,
+          content: [
+            { type: 'text', text: 'boom' },
+            { type: 'image', source: { type: 'base64', data: 'x', media_type: 'image/png' } },
+          ],
+        },
+      ]),
+    );
+    expect(event).toMatchObject({
+      type: 'tool-call-update',
+      update: {
+        toolCallId: 't2',
+        status: 'failed',
+        content: [{ type: 'content', content: { type: 'text', text: 'boom' } }],
+      },
+    });
+  });
+
+  it('ignores non-tool_result blocks and string content', () => {
+    expect(claudeToolResultEvents(claudeUserFixture('just text'))).toEqual([]);
+    expect(claudeToolResultEvents(claudeUserFixture([{ type: 'text', text: 'hi' }]))).toEqual([]);
+  });
+});
+
+describe('editToolDiffs', () => {
+  it('builds an old→new diff for an Edit input', () => {
+    expect(editToolDiffs({ file_path: '/a.ts', old_string: 'foo', new_string: 'bar' })).toEqual([
+      { type: 'diff', path: '/a.ts', oldText: 'foo', newText: 'bar' },
+    ]);
+  });
+  it('builds a new-only diff for a Write input', () => {
+    expect(editToolDiffs({ file_path: '/a.ts', content: 'hello' })).toEqual([
+      { type: 'diff', path: '/a.ts', newText: 'hello' },
+    ]);
+  });
+  it('expands MultiEdit edits into one diff each', () => {
+    expect(
+      editToolDiffs({
+        file_path: '/a.ts',
+        edits: [
+          { old_string: 'a', new_string: 'b' },
+          { old_string: 'c', new_string: 'd' },
+        ],
+      }),
+    ).toEqual([
+      { type: 'diff', path: '/a.ts', oldText: 'a', newText: 'b' },
+      { type: 'diff', path: '/a.ts', oldText: 'c', newText: 'd' },
+    ]);
+  });
+  it('returns nothing for non-edit tool inputs', () => {
+    expect(editToolDiffs({ command: 'ls' })).toEqual([]);
+    expect(editToolDiffs('nope')).toEqual([]);
+  });
+});

--- a/packages/agent-adapter/src/acp/acp-adapter.ts
+++ b/packages/agent-adapter/src/acp/acp-adapter.ts
@@ -156,8 +156,8 @@ export function acpUpdateToEvent(update: SessionUpdate): AgentEvent | null {
       return contentChunk('agent-message-chunk', u.content);
     case 'agent_thought_chunk':
       return contentChunk('agent-thought-chunk', u.content);
-    case 'user_message_chunk':
-      return contentChunk('user-message-chunk', u.content);
+    // Note: user_message_chunk is intentionally not mapped — the Engine is the single source of truth
+    // for user messages (it echoes the prompt into the stream), so adapters never emit them.
     case 'tool_call':
       return { type: 'tool-call', toolCall: toToolCall(u) };
     case 'tool_call_update':

--- a/packages/agent-adapter/src/native/claude-code.ts
+++ b/packages/agent-adapter/src/native/claude-code.ts
@@ -7,6 +7,7 @@ import type {
   SessionMessage,
 } from '@anthropic-ai/claude-agent-sdk';
 import type {
+  AgentEvent,
   AgentHistoryCapabilities,
   AgentHistoryEvent,
   AgentHistoryId,
@@ -21,6 +22,7 @@ import type {
   PermissionOption,
   StartOptions,
   StopReason,
+  ToolCallContent,
 } from '@linkcode/schema';
 import { nextMessageId } from '../adapter';
 import { BaseAgentAdapter } from '../base';
@@ -41,6 +43,11 @@ import { contentToText, toolKindFromName } from '../util';
 type StreamEvent = Extract<SDKMessage, { type: 'stream_event' }>['event'];
 type AssistantMessage = Extract<SDKMessage, { type: 'assistant' }>['message'];
 type ResultMessage = Extract<SDKMessage, { type: 'result' }>;
+type UserMessage = Extract<SDKMessage, { type: 'user' }>;
+type ToolResultBlock = Extract<
+  Exclude<UserMessage['message']['content'], string>[number],
+  { type: 'tool_result' }
+>;
 
 const PERMISSION_OPTIONS: PermissionOption[] = [
   { optionId: 'allow', name: 'Allow', kind: 'allow_once' },
@@ -209,6 +216,10 @@ export class ClaudeCodeAdapter extends BaseAgentAdapter {
       case 'assistant':
         this.handleAssistant(msg.message);
         break;
+      case 'user':
+        // Tool results arrive on a `user` message (one tool_result block per finished tool call).
+        for (const event of claudeToolResultEvents(msg)) this.emit(event);
+        break;
       case 'result':
         this.handleResult(msg);
         break;
@@ -234,7 +245,8 @@ export class ClaudeCodeAdapter extends BaseAgentAdapter {
             title: block.name,
             kind: toolKindFromName(block.name),
             status: 'in_progress',
-            content: [],
+            // Edit/Write/MultiEdit carry the change in their input — surface it as a diff up front.
+            content: editToolDiffs(block.input),
             rawInput: block.input,
           },
         });
@@ -257,6 +269,71 @@ export class ClaudeCodeAdapter extends BaseAgentAdapter {
       this.emitError('Claude returned an error', undefined, true);
     }
   }
+}
+
+/**
+ * Map Claude's `tool_result` blocks (carried on a `user` message) to normalized `tool-call-update`
+ * events. Each finished tool call produces one update: terminal status (completed / failed) plus its
+ * output as content. Pure so it can be unit-tested without a live query.
+ */
+export function claudeToolResultEvents(message: UserMessage): AgentEvent[] {
+  const content = message.message.content;
+  if (typeof content === 'string') return [];
+  const events: AgentEvent[] = [];
+  for (const block of content) {
+    if (block.type !== 'tool_result') continue;
+    events.push({
+      type: 'tool-call-update',
+      update: {
+        toolCallId: block.tool_use_id,
+        status: block.is_error === true ? 'failed' : 'completed',
+        content: toolResultContent(block.content),
+        rawOutput: message.tool_use_result ?? block.content,
+      },
+    });
+  }
+  return events;
+}
+
+/** Flatten a tool_result's content (string or block array) into normalized tool-call content. */
+function toolResultContent(content: ToolResultBlock['content']): ToolCallContent[] {
+  if (content === undefined) return [];
+  if (typeof content === 'string') {
+    return content.length > 0 ? [{ type: 'content', content: { type: 'text', text: content } }] : [];
+  }
+  const out: ToolCallContent[] = [];
+  for (const block of content) {
+    if (block.type === 'text' && block.text.length > 0) {
+      out.push({ type: 'content', content: { type: 'text', text: block.text } });
+    }
+  }
+  return out;
+}
+
+/** Build diff content from an Edit/Write/MultiEdit tool input (detected by shape, not tool name). */
+export function editToolDiffs(input: unknown): ToolCallContent[] {
+  if (!isRecord(input)) return [];
+  const path = typeof input.file_path === 'string' ? input.file_path : undefined;
+  if (path === undefined) return [];
+  // Write: full new contents, no prior text.
+  if (typeof input.content === 'string') {
+    return [{ type: 'diff', path, newText: input.content }];
+  }
+  // Edit: a single old → new replacement.
+  if (typeof input.old_string === 'string' && typeof input.new_string === 'string') {
+    return [{ type: 'diff', path, oldText: input.old_string, newText: input.new_string }];
+  }
+  // MultiEdit: an ordered list of replacements against the same file.
+  if (Array.isArray(input.edits)) {
+    return input.edits.flatMap((edit): ToolCallContent[] =>
+      isRecord(edit) &&
+      typeof edit.old_string === 'string' &&
+      typeof edit.new_string === 'string'
+        ? [{ type: 'diff', path, oldText: edit.old_string, newText: edit.new_string }]
+        : [],
+    );
+  }
+  return [];
 }
 
 function mapClaudeHistorySession(session: SDKSessionInfo): AgentHistorySession {

--- a/packages/engine/src/__tests__/engine.test.ts
+++ b/packages/engine/src/__tests__/engine.test.ts
@@ -1,0 +1,85 @@
+import { BaseAgentAdapter } from '@linkcode/agent-adapter';
+import type { AdapterFactory } from '@linkcode/agent-adapter';
+import type { ContentBlock, SessionId, WireMessage } from '@linkcode/schema';
+import { createLocalTransportPair, createWireMessage } from '@linkcode/transport';
+import { describe, expect, it } from 'vitest';
+import { Engine } from '../engine';
+
+/** Minimal adapter that records the prompts it receives and emits nothing of its own. */
+class RecordingAdapter extends BaseAgentAdapter {
+  readonly kind = 'claude-code' as const;
+  readonly prompts: ContentBlock[][] = [];
+  protected onStart(): Promise<void> {
+    return Promise.resolve();
+  }
+  protected onPrompt(content: ContentBlock[]): Promise<void> {
+    this.prompts.push(content);
+    return Promise.resolve();
+  }
+}
+
+describe('Engine user-message echo', () => {
+  it('broadcasts a user-message-chunk for a prompt and forwards it to the adapter', async () => {
+    const adapter = new RecordingAdapter();
+    const factory: AdapterFactory = () => adapter;
+    const [clientSide, engineSide] = createLocalTransportPair();
+    const engine = new Engine(engineSide, factory);
+    await engine.start();
+    await clientSide.connect();
+
+    const received: WireMessage[] = [];
+    clientSide.onMessage((m) => received.push(m));
+    const waitFor = (pred: (m: WireMessage) => boolean): Promise<WireMessage> =>
+      new Promise((resolve) => {
+        const existing = received.find(pred);
+        if (existing) {
+          resolve(existing);
+          return;
+        }
+        const off = clientSide.onMessage((m) => {
+          if (pred(m)) {
+            off();
+            resolve(m);
+          }
+        });
+      });
+
+    clientSide.send(
+      createWireMessage({
+        kind: 'session.start',
+        clientReqId: 'r1',
+        opts: { kind: 'claude-code', cwd: '/repo' },
+      }),
+    );
+    const started = await waitFor(
+      (m) => m.payload.kind === 'session.started' && m.payload.replyTo === 'r1',
+    );
+    const sessionId = (started.payload as { sessionId: SessionId }).sessionId;
+
+    clientSide.send(
+      createWireMessage({
+        kind: 'agent.input',
+        clientReqId: 'r2',
+        sessionId,
+        input: { type: 'prompt', content: [{ type: 'text', text: 'hello' }] },
+      }),
+    );
+    await waitFor((m) => m.payload.kind === 'request.succeeded' && m.payload.replyTo === 'r2');
+
+    const userEvents = received.filter(
+      (m) => m.payload.kind === 'agent.event' && m.payload.event.type === 'user-message-chunk',
+    );
+    expect(userEvents).toHaveLength(1);
+    expect(userEvents[0]?.payload).toMatchObject({
+      kind: 'agent.event',
+      sessionId,
+      event: { type: 'user-message-chunk', content: { type: 'text', text: 'hello' } },
+    });
+
+    // The prompt is still forwarded to the adapter.
+    expect(adapter.prompts).toEqual([[{ type: 'text', text: 'hello' }]]);
+
+    await engine.stop();
+    clientSide.close();
+  });
+});

--- a/packages/engine/src/engine.ts
+++ b/packages/engine/src/engine.ts
@@ -1,8 +1,10 @@
-import { createAdapter } from '@linkcode/agent-adapter';
+import { createAdapter, nextMessageId } from '@linkcode/agent-adapter';
 import type { AdapterFactory, AgentAdapter } from '@linkcode/agent-adapter';
 import { noop } from 'foxact/noop';
 import type {
+  AgentEvent,
   AgentKind,
+  ContentBlock,
   SessionId,
   SessionInfo,
   StartOptions,
@@ -64,6 +66,9 @@ export class Engine {
         await this.tryReply(p.clientReqId, async () => {
           const session = this.sessions.get(p.sessionId);
           if (!session) throw new Error(`Unknown session: ${p.sessionId}`);
+          // The user's prompt is a session-level event, not adapter output: echo it into the broadcast
+          // stream (single source of truth) so every attached client renders it before the agent replies.
+          if (p.input.type === 'prompt') this.emitUserMessage(p.sessionId, p.input.content);
           await session.adapter.send(p.input);
           this.sendSuccess(p.clientReqId);
         });
@@ -163,7 +168,7 @@ export class Engine {
     };
     const unsub = adapter.onEvent((event) => {
       if (event.type === 'status') info.status = event.status;
-      this.transport.send(createWireMessage({ kind: 'agent.event', sessionId, event }));
+      this.emitSessionEvent(sessionId, event);
     });
     this.sessions.set(sessionId, { adapter, unsub, info });
     try {
@@ -175,6 +180,19 @@ export class Engine {
       throw err;
     }
     this.transport.send(createWireMessage({ kind: 'session.started', replyTo, sessionId }));
+  }
+
+  /** Broadcast a normalized agent event for a session to every attached client. */
+  private emitSessionEvent(sessionId: SessionId, event: AgentEvent): void {
+    this.transport.send(createWireMessage({ kind: 'agent.event', sessionId, event }));
+  }
+
+  /** Echo a user prompt into the session event stream as user-message chunks (one per block, shared id). */
+  private emitUserMessage(sessionId: SessionId, content: ContentBlock[]): void {
+    const messageId = nextMessageId();
+    for (const block of content) {
+      this.emitSessionEvent(sessionId, { type: 'user-message-chunk', messageId, content: block });
+    }
   }
 
   private async tryReply(replyTo: string, fn: () => Promise<void>): Promise<void> {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -300,6 +300,9 @@ importers:
       '@linkcode/transport':
         specifier: workspace:*
         version: link:../../packages/transport
+      '@linkcode/ui':
+        specifier: workspace:*
+        version: link:../../packages/ui
       '@linkcode/workbench':
         specifier: workspace:*
         version: link:../../packages/workbench


### PR DESCRIPTION
## What

Three fixes that make live agent sessions actually usable in the UI.

### `fix(webview): declare @linkcode/ui dep so styles.css resolves`
`index.css` imported `@linkcode/ui/styles.css` but the package was never a declared webview dependency (it's used transitively via `@linkcode/workbench`'s `AppShell`), so Tailwind/Vite couldn't resolve it. Declared it.

### `feat(agent-adapter): surface claude-code tool results and edit diffs` — LC-2
`ClaudeCodeAdapter` never handled the SDK `user` message carrying `tool_result` blocks, and only emitted the initial `tool-call` (in_progress) — so tool calls stayed stuck at "in progress" in the UI. Now it emits a `tool-call-update` (completed/failed + output) on each tool result, and synthesizes `diff` content for Edit/Write/MultiEdit inputs. Covered by pure-function unit tests.

### `feat(engine): echo user prompts into the session event stream` — LC-6
Live prompts never reached the conversation timeline: nothing emitted a `user-message-chunk` for them (only history reads and the ACP echo did), so the UI showed agent output only. The Engine is now the single source of truth — it broadcasts a `user-message-chunk` per prompt block before forwarding to the adapter, covering all adapters uniformly. Dropped the ACP adapter's `user_message_chunk` mapping to avoid a double-emit.

## Test
- `typecheck` clean (engine + agent-adapter)
- `vitest` — 21 passing (added claude tool-result/diff cases + an Engine user-echo integration test)
- `eslint` clean on changed files

## Linear
Refs LC-2, LC-6 (both under the initial-phase epic LC-1).
