### PR TITLE
chore(license): adopt BUSL-1.1 with brand and third-party licensing

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,129 @@
+License text copyright (c) 2017 MariaDB Corporation Ab, All Rights Reserved.
+"Business Source License" is a trademark of MariaDB Corporation Ab.
+
+Parameters
+
+Licensor:             ArcBox, Inc., d/b/a ArcBox Labs
+Licensed Work:        LinkCode. The Licensed Work is (c) 2026 ArcBox, Inc.
+                      The Licensed Work does not include, and this License does
+                      not apply to: (1) third-party components, which remain
+                      governed by their own license or notice files included in
+                      their respective directories; and (2) the LinkCode Brand
+                      Assets -- logos, application icons, splash screens, and
+                      other brand imagery identified in assets/LICENSE -- which
+                      are licensed separately under that file.
+Additional Use Grant: You may make production use of the Licensed Work, provided
+                      your use does not include offering the Licensed Work to
+                      third parties on a hosted or embedded basis in order to
+                      compete with ArcBox, Inc.'s paid version(s) of the Licensed
+                      Work, including the LinkCode cloud service. For purposes of
+                      this license:
+
+                      "Product" means software that is offered to end users to
+                      manage in their own environments or offered as a service on
+                      a hosted basis.
+
+                      A "Competitive Offering" is a Product that is offered to
+                      third parties on a paid basis, including through paid
+                      support arrangements, that significantly overlaps with the
+                      capabilities of ArcBox, Inc.'s paid version(s) of the
+                      Licensed Work. If your Product is not a Competitive Offering
+                      when you first make it generally available, it will not
+                      become a Competitive Offering later due to ArcBox, Inc.
+                      releasing a new version of the Licensed Work with additional
+                      capabilities. In addition, Products that are not provided on
+                      a paid basis are not Competitive Offerings.
+
+                      "Embedded" means including the source code or executable
+                      code from the Licensed Work in a Competitive Offering.
+                      "Embedded" also means packaging the Competitive Offering in
+                      such a way that the Licensed Work must be accessed or
+                      downloaded for the Competitive Offering to operate.
+
+                      Hosting or using the Licensed Work for internal purposes
+                      within an organization is not considered a Competitive
+                      Offering. ArcBox, Inc. considers your organization to
+                      include all of your affiliates under common control.
+Change Date:          Four years from the first publicly available distribution
+                      of the applicable version of the Licensed Work.
+Change License:       Apache License, Version 2.0
+
+For information about alternative licensing arrangements for the Licensed Work,
+please contact business@arcbox.dev.
+
+Notice
+
+The Business Source License (this document, or the "License") is not an Open
+Source license. However, the Licensed Work will eventually be made available
+under an Open Source License, as stated in this License.
+
+-----------------------------------------------------------------------------
+
+Business Source License 1.1
+
+Terms
+
+The Licensor hereby grants you the right to copy, modify, create derivative
+works, redistribute, and make non-production use of the Licensed Work. The
+Licensor may make an Additional Use Grant, above, permitting limited
+production use.
+
+Effective on the Change Date, or the fourth anniversary of the first publicly
+available distribution of a specific version of the Licensed Work under this
+License, whichever comes first, the Licensor hereby grants you rights under
+the terms of the Change License, and the rights granted in the paragraph
+above terminate.
+
+If your use of the Licensed Work does not comply with the requirements
+currently in effect as described in this License, you must purchase a
+commercial license from the Licensor, its affiliated entities, or authorized
+resellers, or you must refrain from using the Licensed Work.
+
+All copies of the original and modified Licensed Work, and derivative works
+of the Licensed Work, are subject to this License. This License applies
+separately for each version of the Licensed Work and the Change Date may vary
+for each version of the Licensed Work released by Licensor.
+
+You must conspicuously display this License on each original or modified copy
+of the Licensed Work. If you receive the Licensed Work in original or
+modified form from a third party, the terms and conditions set forth in this
+License apply to your use of that work.
+
+Any use of the Licensed Work in violation of this License will automatically
+terminate your rights under this License for the current and all other
+versions of the Licensed Work.
+
+This License does not grant you any right in any trademark or logo of
+Licensor or its affiliates (provided that you may use a trademark or logo of
+Licensor as expressly required by this License).
+
+TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS PROVIDED ON
+AN "AS IS" BASIS. LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS,
+EXPRESS OR IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND
+TITLE.
+
+MariaDB hereby grants you permission to use this License's text to license
+your works, and to refer to it using the trademark "Business Source License",
+as long as you comply with the Covenants of Licensor below.
+
+Covenants of Licensor
+
+In consideration of the right to use this License's text and the "Business
+Source License" name and trademark, Licensor covenants to MariaDB, and to all
+other recipients of the licensed work to be provided by Licensor:
+
+1. To specify as the Change License the GPL Version 2.0 or any later version,
+   or a license that is compatible with GPL Version 2.0 or a later version,
+   where "compatible" means that software provided under the Change License can
+   be included in a program with software provided under GPL Version 2.0 or a
+   later version. Licensor may specify additional Change Licenses without
+   limitation.
+
+2. To either: (a) specify an additional grant of rights to use that does not
+   impose any additional restriction on the right granted in this License, as
+   the Additional Use Grant; or (b) insert the text "None".
+
+3. To specify a Change Date.
+
+4. Not to modify this License in any other way.

--- a/assets/BRAND.md
+++ b/assets/BRAND.md
@@ -1,0 +1,65 @@
+# LinkCode Brand Usage Terms
+
+These Brand Usage Terms describe when and how you may use the LinkCode and
+ArcBox names, logos, icons, and related brand elements (the **"Marks"**). They
+are maintained by ArcBox, Inc. (d/b/a ArcBox Labs) and may be updated from time
+to time.
+
+LinkCode is governed by three separate layers — it helps to keep them apart:
+
+| Layer             | Covers                                  | Document           |
+| ----------------- | --------------------------------------- | ------------------ |
+| Source code       | The LinkCode source                     | `LICENSE` (BUSL-1.1) |
+| Brand asset files | Copyright in the logo/icon image files  | `assets/LICENSE`   |
+| Brand usage       | Trademark & brand usage (this document) | `assets/BRAND.md`  |
+
+The source-code license (BUSL-1.1) does **not** grant any right to use the
+Marks. Even where the code permits a use, the Marks remain subject to these
+terms.
+
+## Marks covered
+
+- The names "LinkCode" and "ArcBox".
+- The LinkCode and ArcBox logos, wordmarks, and application icons.
+- The distinctive visual design of the LinkCode application (its trade dress).
+
+## Uses that do not need permission
+
+You may, without asking us, make honest, factual ("nominative") references to
+LinkCode — for example:
+
+- Stating that your project, plugin, or service works with, integrates with, is
+  compatible with, or is built on LinkCode.
+- Linking to the LinkCode repository, website, or releases.
+- Using the name "LinkCode" in blog posts, talks, documentation, or tutorials
+  that discuss or review LinkCode.
+
+When you do, please: use the Marks only as adjectives, not as your own product
+name; do not alter them; and do not imply that ArcBox, Inc. sponsors, endorses,
+or is affiliated with you when it is not.
+
+## Uses that need our written permission
+
+- Using "LinkCode" or "ArcBox" (or a confusingly similar name) as, or as part
+  of, the name of your product, service, company, app, domain, or social
+  account.
+- Using the logos or icons as your own brand, or modifying / recoloring them.
+- Putting the Marks on merchandise, or using them in advertising or fundraising.
+- Any use that suggests official status, endorsement, or affiliation.
+
+## Forks and redistributions
+
+You are free to fork and redistribute the source code under the terms of the
+[`LICENSE`](../LICENSE). However, a fork or redistribution:
+
+- Must not use the LinkCode or ArcBox names, logos, or icons as its own identity;
+- Must replace the Brand Assets (see [`assets/LICENSE`](../assets/LICENSE)) with
+  its own branding; and
+- May state, factually, that it is "a fork of LinkCode" or "based on LinkCode".
+
+## Contact
+
+To request permission or ask about a specific use, contact legal@arcbox.dev.
+
+These terms are not legal advice and do not transfer ownership of any Mark. All
+rights in the Marks are reserved by ArcBox, Inc.

--- a/assets/LICENSE
+++ b/assets/LICENSE
@@ -1,0 +1,61 @@
+LinkCode Brand Assets License
+=============================
+
+Copyright (c) 2026 ArcBox, Inc., d/b/a ArcBox Labs. All rights reserved.
+
+This file governs the "Brand Assets" of LinkCode. The Brand Assets are NOT part
+of the "Licensed Work" and are NOT licensed under the Business Source License
+1.1 (see the repository-root LICENSE). They are licensed only as set out below.
+
+
+1. Brand Assets
+
+   "Brand Assets" means the LinkCode and ArcBox logos, wordmarks, application
+   icons, splash screens, and other brand imagery owned by ArcBox, Inc.,
+   including the following files in this repository:
+
+   - assets/ (this directory), including assets/icon.png and the Icon Composer
+     source bundle assets/linkcode.icon/
+   - apps/mobile/assets/ (favicon.png, android-icon-foreground.png,
+     android-icon-monochrome.png, splash-icon.png)
+   - apps/desktop/build-resources/icon-dock.png
+
+   This list is illustrative, not exhaustive: any other logo, icon, or brand
+   image owned by ArcBox, Inc. in this repository is a Brand Asset whether or
+   not it is listed here. Functional files that merely sit alongside Brand
+   Assets -- for example, apps/desktop/build-resources/entitlements.mac.plist --
+   are part of the Licensed Work and are not Brand Assets.
+
+
+2. What you may do without asking
+
+   You may reproduce and display the Brand Assets, unmodified and in their
+   original proportions, solely to refer or link to LinkCode and ArcBox, Inc.
+   (for example, to state that your project works with LinkCode, or to link
+   back to this repository), provided you do not imply sponsorship, endorsement,
+   or affiliation that does not exist.
+
+
+3. What requires written permission
+
+   Any other use requires the prior written permission of ArcBox, Inc.,
+   including (without limitation): modifying or recoloring the Brand Assets;
+   using them as, or as part of, the name, logo, or icon of your own product,
+   service, company, app, fork, or distribution; using them on merchandise; or
+   using them in any way likely to cause confusion about the origin of a
+   product or service.
+
+   Forking the source code grants no right to the LinkCode or ArcBox names,
+   logos, or icons. A fork or redistribution must replace the Brand Assets with
+   its own branding.
+
+
+4. Trademarks
+
+   "LinkCode" and "ArcBox", and the associated logos, are trademarks of
+   ArcBox, Inc. This file licenses copyright in the Brand Asset files only; it
+   grants no trademark rights. For the full brand and trademark policy, see
+   BRAND.md.
+
+
+To request permission, contact legal@arcbox.dev.

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "linkcode",
   "version": "0.0.0",
   "private": true,
+  "license": "BUSL-1.1",
   "type": "module",
   "scripts": {
     "build": "turbo run build",

--- a/packages/coss-ui/LICENSE
+++ b/packages/coss-ui/LICENSE
@@ -1,0 +1,35 @@
+These UI components are vendored from coss.com/ui (the Cal.com Design System):
+https://github.com/cosscom/coss
+
+That repository's default license is AGPL-3.0-or-later, but its UI directories
+(apps/ui/ and apps/origin/) are licensed under the MIT License per the upstream
+LICENSING.md. The vendored components originate from those MIT-licensed
+directories and are redistributed here under the MIT License, reproduced below.
+
+When syncing additional components from upstream, take them only from the
+MIT-licensed directories (apps/ui/, apps/origin/) -- not from AGPL-licensed parts
+of that repository (e.g. packages/ui, "@coss/ui").
+
+---
+
+MIT License
+
+Copyright (c) Cal.com, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/coss-ui/package.json
+++ b/packages/coss-ui/package.json
@@ -2,6 +2,7 @@
   "name": "coss-ui",
   "private": true,
   "version": "0.0.0",
+  "license": "MIT",
   "type": "module",
   "exports": {
     "./icons": "./src/icons.tsx",


### PR DESCRIPTION
Extracts the license-related work into its own PR (branched from `origin/master`, so it carries none of the other in-progress working-tree changes).

## Source code — BUSL-1.1
- `LICENSE` — Business Source License 1.1, source-available (not open source). Each version converts to **Apache-2.0** four years after its first public release. The Additional Use Grant allows all production use **except** offering LinkCode as a competing hosted/embedded commercial service. Licensor: ArcBox, Inc., d/b/a ArcBox Labs.
- `package.json` — `"license": "BUSL-1.1"`.

## Brand (separate from the code license)
- `assets/LICENSE` — copyright license for brand assets (logos, app icons, splash screens), © ArcBox, Inc.
- `assets/BRAND.md` — Brand Usage Terms (trademark / brand usage policy).

## Third-party
- `packages/coss-ui/LICENSE` + `"license": "MIT"` — the vendored coss.com/ui components are MIT (© Cal.com, Inc.). The upstream repo defaults to AGPL-3.0, but its UI directories are MIT-carved-out; the file documents this so future syncs only pull from those MIT dirs.

Contacts: commercial licensing → business@arcbox.dev · brand/legal → legal@arcbox.dev.

> ⚠️ The Additional Use Grant's substantive boundaries ("hosted or embedded", "Competitive Offering") should get a legal review before being relied on in production.