### PR TITLE
feat(workbench): frontend mock data host for dev

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -7,6 +7,7 @@
   "main": "out/main/index.js",
   "scripts": {
     "dev": "electron-vite dev",
+    "dev:mock": "electron-vite dev --mode mock",
     "build": "electron-vite build",
     "package": "pnpm run build && electron-builder --dir -c.mac.identity=null",
     "dist": "pnpm run build && electron-builder",

--- a/apps/desktop/src/renderer/src/app.tsx
+++ b/apps/desktop/src/renderer/src/app.tsx
@@ -1,5 +1,9 @@
-import { SocketIoTransport } from '@linkcode/transport';
-import { Workbench, WorkbenchAppProviders, WorkbenchProviders } from '@linkcode/workbench';
+import {
+  createDaemonTransport,
+  Workbench,
+  WorkbenchAppProviders,
+  WorkbenchProviders,
+} from '@linkcode/workbench';
 import { useSingleton } from 'foxact/use-singleton';
 import { SettingsView } from './settings/settings-view';
 import { useDesktopSettingsStore } from './settings/store';
@@ -31,7 +35,7 @@ function DaemonConnection({
   daemonUrl,
   children,
 }: React.PropsWithChildren<{ daemonUrl: string }>): React.ReactNode {
-  const { current: transport } = useSingleton(() => new SocketIoTransport({ url: daemonUrl }));
+  const { current: transport } = useSingleton(() => createDaemonTransport(daemonUrl));
   return (
     <WorkbenchProviders transport={transport} daemonUrl={daemonUrl}>
       {children}

--- a/apps/webview/package.json
+++ b/apps/webview/package.json
@@ -10,6 +10,7 @@
   },
   "scripts": {
     "dev": "vite",
+    "dev:mock": "vite --mode mock",
     "build": "vite build",
     "preview": "vite preview",
     "typecheck": "tsc --noEmit",

--- a/apps/webview/src/routes/root-layout.tsx
+++ b/apps/webview/src/routes/root-layout.tsx
@@ -1,5 +1,8 @@
-import { SocketIoTransport } from '@linkcode/transport';
-import { WorkbenchAppProviders, WorkbenchProviders } from '@linkcode/workbench';
+import {
+  createDaemonTransport,
+  WorkbenchAppProviders,
+  WorkbenchProviders,
+} from '@linkcode/workbench';
 import { useSettingsStore } from '@webview/settings/store';
 import { useSingleton } from 'foxact/use-singleton';
 import { Outlet } from 'react-router';
@@ -26,7 +29,7 @@ function DaemonConnection({
   daemonUrl,
   children,
 }: React.PropsWithChildren<{ daemonUrl: string }>): React.ReactNode {
-  const { current: transport } = useSingleton(() => new SocketIoTransport({ url: daemonUrl }));
+  const { current: transport } = useSingleton(() => createDaemonTransport(daemonUrl));
   return (
     <WorkbenchProviders transport={transport} daemonUrl={daemonUrl}>
       {children}

--- a/apps/webview/vite.config.ts
+++ b/apps/webview/vite.config.ts
@@ -19,7 +19,12 @@ export default defineConfig({
       customCollections: ExternalPackageIconLoader('@proj-airi/lobe-icons'),
     }),
   ],
-  resolve: { alias: { '@webview': resolve(import.meta.dirname, 'src') } },
+  resolve: {
+    alias: { '@webview': resolve(import.meta.dirname, 'src') },
+    // apps/mobile pins Expo's react (19.2.3), so the hoisted install nests a second react under
+    // shared deps like use-intl; force every react import onto the renderer's own copy.
+    dedupe: ['react', 'react-dom'],
+  },
   server: { port: 5173 },
   // Workspace packages are exported as TS source and transpiled on the fly by Vite/esbuild, so no prebundling is needed.
   optimizeDeps: {

--- a/packages/workbench/src/index.ts
+++ b/packages/workbench/src/index.ts
@@ -4,6 +4,7 @@ export * from './app/workbench-app';
 export * from './app/workbench-providers';
 export * from './git/hooks';
 export * from './git/panel';
+export * from './runtime/daemon-transport';
 export * from './runtime/debug';
 export * from './runtime/provider';
 export * from './runtime/tayori';

--- a/packages/workbench/src/mock/__tests__/dev-mock-transport.test.ts
+++ b/packages/workbench/src/mock/__tests__/dev-mock-transport.test.ts
@@ -20,6 +20,19 @@ function toolCalls(events: readonly AgentEvent[]): ToolCall[] {
   return events.flatMap((event) => (event.type === 'tool-call' ? [event.toolCall] : []));
 }
 
+async function eventually<T>(
+  read: () => T | false | null | undefined,
+  timeoutMs = 5000,
+): Promise<T> {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < timeoutMs) {
+    const value = read();
+    if (value) return value;
+    await wait(50);
+  }
+  throw new Error('timed out waiting for mock event');
+}
+
 describe('dev mock transport', () => {
   it('drives the current workbench data plane without a daemon', async () => {
     const client = await connectedClient();
@@ -79,23 +92,22 @@ describe('dev mock transport', () => {
     if (!showcase) throw new Error('showcase session not found');
 
     const events = collectEvents(client, showcase.sessionId);
-    const initialTools = toolCalls(events);
-    const terminalTool = initialTools.find((tool) =>
-      tool.content.some((content) => content.type === 'terminal'),
-    );
-    const terminalId = terminalTool?.content.find(
-      (content) => content.type === 'terminal',
-    )?.terminalId;
-    expect(terminalId).toBeTruthy();
+    const terminalId = await eventually(() => {
+      const terminalTool = toolCalls(events).find((tool) =>
+        tool.content.some((content) => content.type === 'terminal'),
+      );
+      return terminalTool?.content.find((content) => content.type === 'terminal')?.terminalId;
+    });
 
     let terminalOutput = '';
-    if (terminalId) {
-      client.subscribeTerminalOutput(terminalId, (data) => {
-        terminalOutput += data;
-      });
-    }
+    client.subscribeTerminalOutput(terminalId, (data) => {
+      terminalOutput += data;
+    });
 
-    await wait(1500);
+    await eventually(
+      () => events.some((event) => event.type === 'stop' && event.stopReason === 'end_turn'),
+      15000,
+    );
 
     expect(events.some((event) => event.type === 'user-message')).toBe(true);
     expect(events.some((event) => event.type === 'agent-thought-chunk')).toBe(true);
@@ -140,7 +152,31 @@ describe('dev mock transport', () => {
     ).toBe(true);
 
     client.dispose();
-  });
+  }, 20000);
+
+  it('does not resume the showcase stream inside a later user turn after cancel', async () => {
+    const client = await connectedClient();
+    const sessions = await client.listSessions();
+    const showcase = sessions.find((session) => session.title === 'Mocked streaming showcase');
+    if (!showcase) throw new Error('showcase session not found');
+
+    const events = collectEvents(client, showcase.sessionId);
+    await eventually(() => events.some((event) => event.type === 'user-message'));
+
+    await client.cancel(showcase.sessionId);
+    const prompt = 'word '.repeat(120).trim();
+    const pendingPrompt = client.promptText(showcase.sessionId, prompt);
+    await wait(1600);
+
+    const strayShowcaseChunks = events.filter(
+      (event) =>
+        event.type === 'agent-message-chunk' && event.messageId.startsWith('mock-showcase-stream'),
+    );
+    expect(strayShowcaseChunks).toHaveLength(0);
+
+    await expect(pendingPrompt).resolves.toEqual({ ok: true });
+    client.dispose();
+  }, 10000);
 
   it('cancels an in-flight prompt turn', async () => {
     const client = await connectedClient();

--- a/packages/workbench/src/mock/__tests__/dev-mock-transport.test.ts
+++ b/packages/workbench/src/mock/__tests__/dev-mock-transport.test.ts
@@ -1,0 +1,197 @@
+import { LinkCodeClient } from '@linkcode/client-core';
+import type { AgentEvent, ProvidersConfig, SessionId, ToolCall } from '@linkcode/schema';
+import { wait } from 'foxts/wait';
+import { describe, expect, it } from 'vitest';
+import { createDevMockTransport } from '../dev-mock-transport';
+
+async function connectedClient(): Promise<LinkCodeClient> {
+  const client = new LinkCodeClient(createDevMockTransport());
+  await client.connect();
+  return client;
+}
+
+function collectEvents(client: LinkCodeClient, sessionId: SessionId): AgentEvent[] {
+  const events: AgentEvent[] = [];
+  client.subscribe(sessionId, (event) => events.push(event));
+  return events;
+}
+
+function toolCalls(events: readonly AgentEvent[]): ToolCall[] {
+  return events.flatMap((event) => (event.type === 'tool-call' ? [event.toolCall] : []));
+}
+
+describe('dev mock transport', () => {
+  it('drives the current workbench data plane without a daemon', async () => {
+    const client = await connectedClient();
+
+    const seeded = await client.listSessions();
+    expect(seeded.length).toBeGreaterThan(0);
+    expect(seeded.some((session) => session.status === 'stopped')).toBe(true);
+
+    const sessionId = await client.startSession({
+      kind: 'codex',
+      cwd: '/mock/repo',
+      model: 'mock-model-large',
+    });
+    const sessions = await client.listSessions();
+    expect(sessions).toHaveLength(seeded.length + 1);
+    expect(sessions.find((session) => session.sessionId === sessionId)).toMatchObject({
+      kind: 'codex',
+      cwd: '/mock/repo',
+      status: 'idle',
+    });
+
+    const events = collectEvents(client, sessionId);
+    await client.promptText(sessionId, 'Hello mocked daemon');
+
+    expect(events.some((event) => event.type === 'user-message')).toBe(true);
+    expect(events.some((event) => event.type === 'agent-thought-chunk')).toBe(true);
+    expect(events.some((event) => event.type === 'token-usage')).toBe(true);
+    expect(events.some((event) => event.type === 'stop' && event.stopReason === 'end_turn')).toBe(
+      true,
+    );
+
+    // The reply streams as many chunks (one bubble via a shared messageId) and echoes the model.
+    const chunks = events.filter((event) => event.type === 'agent-message-chunk');
+    expect(chunks.length).toBeGreaterThan(1);
+    expect(new Set(chunks.map((chunk) => chunk.messageId)).size).toBe(1);
+    const replyText = chunks
+      .map((chunk) => ('text' in chunk.content ? chunk.content.text : ''))
+      .join('');
+    expect(replyText).toContain('mock-model-large');
+    expect(replyText).toContain('Hello mocked daemon');
+
+    const providers = {
+      codex: { enabled: true, defaultModel: 'mock-model' },
+    } satisfies ProvidersConfig;
+    await client.setProviderConfig(providers);
+    expect(await client.getProviderConfig()).toEqual(providers);
+
+    client.dispose();
+  });
+
+  it('seeds a rich streaming showcase conversation', async () => {
+    const client = await connectedClient();
+
+    const sessions = await client.listSessions();
+    const showcase = sessions.find((session) => session.title === 'Mocked streaming showcase');
+    expect(showcase).toMatchObject({ status: 'running' });
+    if (!showcase) throw new Error('showcase session not found');
+
+    const events = collectEvents(client, showcase.sessionId);
+    const initialTools = toolCalls(events);
+    const terminalTool = initialTools.find((tool) =>
+      tool.content.some((content) => content.type === 'terminal'),
+    );
+    const terminalId = terminalTool?.content.find(
+      (content) => content.type === 'terminal',
+    )?.terminalId;
+    expect(terminalId).toBeTruthy();
+
+    let terminalOutput = '';
+    if (terminalId) {
+      client.subscribeTerminalOutput(terminalId, (data) => {
+        terminalOutput += data;
+      });
+    }
+
+    await wait(1500);
+
+    expect(events.some((event) => event.type === 'user-message')).toBe(true);
+    expect(events.some((event) => event.type === 'agent-thought-chunk')).toBe(true);
+    expect(events.some((event) => event.type === 'plan')).toBe(true);
+    expect(events.some((event) => event.type === 'permission-request')).toBe(true);
+    expect(events.some((event) => event.type === 'error')).toBe(true);
+    expect(events.some((event) => event.type === 'token-usage')).toBe(true);
+    expect(events.some((event) => event.type === 'stop' && event.stopReason === 'end_turn')).toBe(
+      true,
+    );
+
+    const tools = toolCalls(events);
+    expect(tools.some((tool) => tool.content.some((content) => content.type === 'diff'))).toBe(
+      true,
+    );
+    expect(tools.some((tool) => tool.content.some((content) => content.type === 'terminal'))).toBe(
+      true,
+    );
+    expect(tools.some((tool) => tool.status === 'failed')).toBe(true);
+    expect(terminalOutput).toContain('pnpm vitest run packages/workbench/src/mock');
+    expect(terminalOutput).toContain('mock terminal stream finished');
+
+    const streamChunks = events.filter(
+      (event): event is Extract<AgentEvent, { type: 'agent-message-chunk' }> =>
+        event.type === 'agent-message-chunk' && event.messageId.startsWith('mock-showcase-stream'),
+    );
+    expect(streamChunks.length).toBeGreaterThan(1);
+    expect(new Set(streamChunks.map((chunk) => chunk.messageId)).size).toBe(1);
+
+    const permission = events.find((event) => event.type === 'permission-request');
+    if (permission?.type !== 'permission-request') throw new Error('permission request not found');
+    await expect(
+      client.respondPermission(showcase.sessionId, permission.requestId, {
+        outcome: 'selected',
+        optionId: 'allow_once',
+      }),
+    ).resolves.toEqual({ ok: true });
+    expect(
+      toolCalls(events).some(
+        (tool) => tool.toolCallId === permission.toolCall.toolCallId && tool.status === 'completed',
+      ),
+    ).toBe(true);
+
+    client.dispose();
+  });
+
+  it('cancels an in-flight prompt turn', async () => {
+    const client = await connectedClient();
+    const sessionId = await client.startSession({ kind: 'codex', cwd: '/mock/repo' });
+    const events = collectEvents(client, sessionId);
+
+    const pending = client.promptText(sessionId, 'stream me a long reply');
+    await wait(300); // past the thought, into the chunk stream
+    await client.cancel(sessionId);
+    await expect(pending).resolves.toEqual({ ok: true });
+
+    // No further chunks after cancel, and no end_turn stop — the turn really stopped.
+    await wait(200);
+    const chunksAfterCancel = events.filter((event) => event.type === 'agent-message-chunk');
+    await wait(200);
+    expect(events.filter((event) => event.type === 'agent-message-chunk')).toHaveLength(
+      chunksAfterCancel.length,
+    );
+    expect(events.some((event) => event.type === 'stop' && event.stopReason === 'cancelled')).toBe(
+      true,
+    );
+    expect(events.some((event) => event.type === 'stop' && event.stopReason === 'end_turn')).toBe(
+      false,
+    );
+
+    client.dispose();
+  });
+
+  it('forces the error path with the fail prompt', async () => {
+    const client = await connectedClient();
+    const sessionId = await client.startSession({ kind: 'codex', cwd: '/mock/repo' });
+    const events = collectEvents(client, sessionId);
+
+    await expect(client.promptText(sessionId, 'fail')).rejects.toThrow('Mock failure');
+    expect(events.some((event) => event.type === 'error')).toBe(true);
+
+    client.dispose();
+  });
+
+  it('rejects input to stopped sessions and enforces resume parity', async () => {
+    const client = await connectedClient();
+    const sessionId = await client.startSession({ kind: 'codex', cwd: '/mock/repo' });
+
+    await expect(client.resumeSession(sessionId)).rejects.toThrow('already running');
+
+    await client.stopSession(sessionId);
+    await expect(client.promptText(sessionId, 'hi')).rejects.toThrow('stopped');
+
+    expect(await client.resumeSession(sessionId)).toBe(sessionId);
+    await expect(client.promptText(sessionId, 'hi again')).resolves.toEqual({ ok: true });
+
+    client.dispose();
+  });
+});

--- a/packages/workbench/src/mock/__tests__/dev-mock-transport.test.ts
+++ b/packages/workbench/src/mock/__tests__/dev-mock-transport.test.ts
@@ -104,17 +104,98 @@ describe('dev mock transport', () => {
       (await client.listWorkspaces()).some((item) => item.workspaceId === workspace.workspaceId),
     ).toBe(false);
 
+    // Starting a session registers its directory as a workspace, like the engine's touch().
+    await client.startSession({ kind: 'codex', cwd: '/mock/fresh' });
+    expect((await client.listWorkspaces()).map((item) => item.cwd)).toContain('/mock/fresh');
+
+    // Git fixtures vary by cwd: dirty repo with a troubled PR, clean repo without one, non-repo.
     await expect(client.getGitStatus('/mock/linkcode')).resolves.toMatchObject({
       isRepo: true,
       branch: 'mock-host',
+      dirtyFileCount: 3,
     });
     await expect(client.getGitPullRequestStatus('/mock/linkcode')).resolves.toMatchObject({
       status: 'ok',
+      pullRequest: { checks: 'failing', reviewDecision: 'changes_requested' },
     });
     await expect(client.getGitDiff('/mock/linkcode', 'uncommitted')).resolves.toMatchObject({
       truncated: false,
       stat: { files: 1, additions: 1, deletions: 1 },
     });
+    await expect(client.getGitStatus('/mock/platform')).resolves.toMatchObject({
+      isRepo: true,
+      dirtyFileCount: 0,
+    });
+    await expect(client.getGitPullRequestStatus('/mock/platform')).resolves.toEqual({
+      status: 'ok',
+      pullRequest: null,
+    });
+    await expect(client.getGitStatus('/mock/scratch')).resolves.toEqual({ isRepo: false });
+    await expect(client.getGitPullRequestStatus('/mock/scratch')).resolves.toEqual({
+      status: 'unavailable',
+      reason: 'not_git_repo',
+    });
+
+    client.dispose();
+  }, 15000);
+
+  it('lists canned provider history and imports it as a cold session', async () => {
+    const client = await connectedClient();
+
+    const linkcode = await client.listHistory('claude-code', { cwd: '/mock/linkcode' });
+    expect(linkcode.sessions.length).toBeGreaterThan(0);
+    expect(
+      linkcode.sessions.every(
+        (entry) => entry.kind === 'claude-code' && entry.cwd === '/mock/linkcode',
+      ),
+    ).toBe(true);
+
+    const platform = await client.listHistory('claude-code', { cwd: '/mock/platform' });
+    expect(platform.sessions.every((entry) => entry.cwd === '/mock/platform')).toBe(true);
+
+    const entry = linkcode.sessions[0];
+    const record = await client.importSession('claude-code', entry.historyId);
+    expect(record).toMatchObject({
+      kind: 'claude-code',
+      cwd: '/mock/linkcode',
+      origin: { type: 'imported', historyId: entry.historyId },
+      runs: [],
+    });
+
+    // Imported sessions are cold: listed as stopped, resumable, then promptable.
+    const imported = (await client.listSessions()).find(
+      (session) => session.sessionId === record.sessionId,
+    );
+    expect(imported).toMatchObject({ status: 'stopped', title: entry.title });
+    await expect(client.resumeSession(record.sessionId)).resolves.toBe(record.sessionId);
+
+    await expect(client.importSession('codex', entry.historyId)).rejects.toThrow(
+      'Unknown history session',
+    );
+
+    client.dispose();
+  });
+
+  it('opens an echo terminal', async () => {
+    const client = await connectedClient();
+
+    const terminalId = await client.openTerminal({ cols: 80, rows: 24, cwd: '/mock/linkcode' });
+    let output = '';
+    client.subscribeTerminalOutput(terminalId, (data) => {
+      output += data;
+    });
+    let exitCode: number | null | undefined;
+    client.subscribeTerminalExit(terminalId, (code) => {
+      exitCode = code;
+    });
+
+    client.terminalInput(terminalId, 'ls\r');
+    await eventually(() => output.includes('ls'));
+    expect(output).toContain('mock echo terminal');
+
+    client.closeTerminal(terminalId);
+    await eventually(() => exitCode !== undefined);
+    expect(exitCode).toBe(0);
 
     client.dispose();
   });

--- a/packages/workbench/src/mock/__tests__/dev-mock-transport.test.ts
+++ b/packages/workbench/src/mock/__tests__/dev-mock-transport.test.ts
@@ -83,6 +83,42 @@ describe('dev mock transport', () => {
     client.dispose();
   });
 
+  it('answers workspace and git calls mounted by the workbench shell', async () => {
+    const client = await connectedClient();
+
+    const workspaces = await client.listWorkspaces();
+    expect(workspaces.map((workspace) => workspace.cwd)).toEqual(
+      expect.arrayContaining(['/mock/linkcode', '/mock/platform']),
+    );
+
+    const workspace = await client.registerWorkspace('/mock/new', 'New Mock');
+    expect(workspace).toMatchObject({ cwd: '/mock/new', name: 'New Mock' });
+    await expect(client.updateWorkspace(workspace.workspaceId, 'Renamed Mock')).resolves.toEqual({
+      ok: true,
+    });
+    expect(
+      (await client.listWorkspaces()).find((item) => item.workspaceId === workspace.workspaceId),
+    ).toMatchObject({ name: 'Renamed Mock' });
+    await expect(client.archiveWorkspace(workspace.workspaceId)).resolves.toEqual({ ok: true });
+    expect(
+      (await client.listWorkspaces()).some((item) => item.workspaceId === workspace.workspaceId),
+    ).toBe(false);
+
+    await expect(client.getGitStatus('/mock/linkcode')).resolves.toMatchObject({
+      isRepo: true,
+      branch: 'mock-host',
+    });
+    await expect(client.getGitPullRequestStatus('/mock/linkcode')).resolves.toMatchObject({
+      status: 'ok',
+    });
+    await expect(client.getGitDiff('/mock/linkcode', 'uncommitted')).resolves.toMatchObject({
+      truncated: false,
+      stat: { files: 1, additions: 1, deletions: 1 },
+    });
+
+    client.dispose();
+  });
+
   it('seeds a rich streaming showcase conversation', async () => {
     const client = await connectedClient();
 

--- a/packages/workbench/src/mock/data/git.ts
+++ b/packages/workbench/src/mock/data/git.ts
@@ -1,0 +1,104 @@
+import type { GitDiff, GitPullRequestStatus, GitStatus } from '@linkcode/schema';
+import { normalizeCwdKey } from '@linkcode/schema';
+
+export interface GitFixture {
+  status: GitStatus;
+  prStatus: GitPullRequestStatus;
+  diff: GitDiff;
+}
+
+const EMPTY_DIFF: GitDiff = {
+  patch: '',
+  truncated: false,
+  stat: { files: 0, additions: 0, deletions: 0 },
+};
+
+const RICH_DIFF: GitDiff = {
+  patch:
+    "diff --git a/mock.ts b/mock.ts\nindex 0000000..1111111 100644\n--- a/mock.ts\n+++ b/mock.ts\n@@ -1 +1 @@\n-const mode = 'daemon';\n+const mode = 'mock';\n",
+  truncated: false,
+  stat: { files: 1, additions: 1, deletions: 1 },
+};
+
+const MOCK_REMOTE = {
+  url: 'https://github.com/linkcode/mock.git',
+  identity: {
+    provider: 'github',
+    host: 'github.com',
+    owner: 'linkcode',
+    repo: 'mock',
+  },
+} as const;
+
+/**
+ * Per-cwd fixtures so each seeded workspace exercises a different UI branch: a dirty repo with a
+ * troubled PR, a clean repo with no PR, and a directory that isn't a repo at all.
+ */
+const FIXTURES = new Map<string, GitFixture>(
+  Object.entries({
+    '/mock/linkcode': {
+      status: {
+        isRepo: true,
+        repoRoot: '/mock/linkcode',
+        branch: 'mock-host',
+        dirtyFileCount: 3,
+        ahead: 1,
+        behind: 2,
+        remote: MOCK_REMOTE,
+      },
+      prStatus: {
+        status: 'ok',
+        pullRequest: {
+          provider: 'github',
+          number: 42,
+          title: 'Mock host data-plane coverage',
+          url: 'https://github.com/linkcode/mock/pull/42',
+          state: 'open',
+          isDraft: false,
+          baseBranch: 'main',
+          headBranch: 'mock-host',
+          checks: 'failing',
+          reviewDecision: 'changes_requested',
+        },
+      },
+      diff: RICH_DIFF,
+    },
+    '/mock/platform': {
+      status: {
+        isRepo: true,
+        repoRoot: '/mock/platform',
+        branch: 'main',
+        dirtyFileCount: 0,
+        ahead: 0,
+        behind: 0,
+        remote: MOCK_REMOTE,
+      },
+      prStatus: { status: 'ok', pullRequest: null },
+      diff: EMPTY_DIFF,
+    },
+    '/mock/scratch': {
+      status: { isRepo: false },
+      prStatus: { status: 'unavailable', reason: 'not_git_repo' },
+      diff: EMPTY_DIFF,
+    },
+  } satisfies Record<string, GitFixture>).map(([cwd, fixture]) => [normalizeCwdKey(cwd), fixture]),
+);
+
+/** Unknown directories (fresh sessions) answer as a plain dirty repo with no PR. */
+export function gitFixtureFor(cwd: string): GitFixture {
+  return (
+    FIXTURES.get(normalizeCwdKey(cwd)) ?? {
+      status: {
+        isRepo: true,
+        repoRoot: cwd,
+        branch: 'mock-host',
+        dirtyFileCount: 1,
+        ahead: 1,
+        behind: 0,
+        remote: MOCK_REMOTE,
+      },
+      prStatus: { status: 'ok', pullRequest: null },
+      diff: RICH_DIFF,
+    }
+  );
+}

--- a/packages/workbench/src/mock/data/history.ts
+++ b/packages/workbench/src/mock/data/history.ts
@@ -1,0 +1,35 @@
+import type { AgentHistoryId, AgentHistorySession } from '@linkcode/schema';
+
+const DAY_MS = 24 * 3_600_000;
+
+export interface SeedHistoryEntry extends Omit<AgentHistorySession, 'createdAt' | 'updatedAt'> {
+  ageMs: number;
+}
+
+/** Provider-local history the sidebar's per-workspace import drilldown lists and imports from. */
+export const SEED_HISTORY: SeedHistoryEntry[] = [
+  {
+    historyId: 'mock-hist-claude-1' as AgentHistoryId,
+    kind: 'claude-code',
+    title: 'Design the wire protocol envelope',
+    cwd: '/mock/linkcode',
+    messageCount: 24,
+    ageMs: 3 * DAY_MS,
+  },
+  {
+    historyId: 'mock-hist-codex-1' as AgentHistoryId,
+    kind: 'codex',
+    title: 'Spike reconnect backoff strategies',
+    cwd: '/mock/linkcode',
+    messageCount: 9,
+    ageMs: 5 * DAY_MS,
+  },
+  {
+    historyId: 'mock-hist-claude-2' as AgentHistoryId,
+    kind: 'claude-code',
+    title: 'Audit fleet table queries',
+    cwd: '/mock/platform',
+    messageCount: 41,
+    ageMs: 9 * DAY_MS,
+  },
+];

--- a/packages/workbench/src/mock/data/prompt.ts
+++ b/packages/workbench/src/mock/data/prompt.ts
@@ -1,0 +1,12 @@
+export const MOCK_REPLY =
+  'Dev mock host is online. The real daemon is bypassed, but the UI is still using the transport contract.';
+
+/** Prompting exactly this text forces the error path (the platform mocks' `?outcome=` analog). */
+export const FAIL_PROMPT = 'fail';
+
+/** Simulated round-trip on control ops so list/start loading states stay visible in dev. */
+export const CONTROL_LATENCY_MS = 300;
+/** Pacing between streamed reply chunks. */
+export const CHUNK_LATENCY_MS = 24;
+
+export const WORD_CHUNK_PATTERN = /\S+\s*/g;

--- a/packages/workbench/src/mock/data/sessions.ts
+++ b/packages/workbench/src/mock/data/sessions.ts
@@ -45,4 +45,11 @@ export const SEED_SESSIONS: SeedSession[] = [
     status: 'stopped',
     ageMs: 26 * 3_600_000,
   },
+  {
+    kind: 'opencode',
+    cwd: '/mock/scratch',
+    title: 'Prototype without git',
+    status: 'idle',
+    ageMs: 72 * 3_600_000,
+  },
 ];

--- a/packages/workbench/src/mock/data/sessions.ts
+++ b/packages/workbench/src/mock/data/sessions.ts
@@ -1,0 +1,48 @@
+import type { AgentKind, SessionStatus } from '@linkcode/schema';
+
+export const SHOWCASE_TITLE = 'Mocked streaming showcase';
+export const SHOWCASE_TERMINAL_ID = 'mock-terminal-showcase';
+
+export interface SeedSession {
+  kind: AgentKind;
+  cwd: string;
+  title: string;
+  status: SessionStatus;
+  ageMs: number;
+  showcase?: boolean;
+  terminalId?: string;
+}
+
+/** Canned sessions the host boots with, so the session list and resume flows aren't empty. */
+export const SEED_SESSIONS: SeedSession[] = [
+  {
+    kind: 'codex',
+    cwd: '/mock/linkcode',
+    title: SHOWCASE_TITLE,
+    status: 'running',
+    ageMs: 2 * 60000,
+    showcase: true,
+    terminalId: SHOWCASE_TERMINAL_ID,
+  },
+  {
+    kind: 'claude-code',
+    cwd: '/mock/linkcode',
+    title: 'Wire the workbench to the daemon',
+    status: 'idle',
+    ageMs: 20 * 60000,
+  },
+  {
+    kind: 'codex',
+    cwd: '/mock/linkcode',
+    title: 'Refactor transport reconnect backoff',
+    status: 'idle',
+    ageMs: 2 * 3_600_000,
+  },
+  {
+    kind: 'claude-code',
+    cwd: '/mock/platform',
+    title: 'Migrate fleet tables to the sdk',
+    status: 'stopped',
+    ageMs: 26 * 3_600_000,
+  },
+];

--- a/packages/workbench/src/mock/data/showcase.ts
+++ b/packages/workbench/src/mock/data/showcase.ts
@@ -85,6 +85,11 @@ export const SHOWCASE_STREAM_THOUGHT_CONTENT = textBlock(
 export const SHOWCASE_STREAM_REPLY =
   'Streaming showcase complete: messages, reasoning, plans, tool bodies, diffs, terminal output, permissions, errors, and usage all came from the mock transport.';
 
+export const SHOWCASE_SCRIPT_START_DELAY_MS = 600;
+export const SHOWCASE_SCRIPT_STEP_LATENCY_MS = 180;
+export const SHOWCASE_STREAM_START_DELAY_MS = 1000;
+export const SHOWCASE_STREAM_CHUNK_LATENCY_MS = 220;
+
 export const SHOWCASE_TERMINAL_START_OUTPUT =
   '$ pnpm vitest run packages/workbench/src/mock\n✓ dev mock transport (4)\n';
 

--- a/packages/workbench/src/mock/data/showcase.ts
+++ b/packages/workbench/src/mock/data/showcase.ts
@@ -1,0 +1,180 @@
+import type { AgentEvent, ContentBlock, PermissionOption, Plan, ToolCall } from '@linkcode/schema';
+import { textBlock } from '@linkcode/schema';
+import { SHOWCASE_TERMINAL_ID } from './sessions';
+
+export const SHOWCASE_PERMISSION_ID = 'mock-permission-edit';
+export const SHOWCASE_PERMISSION_TOOL_ID = 'mock-tool-permission-edit';
+
+const TRANSPARENT_PIXEL =
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=';
+
+export const SHOWCASE_USER_CONTENT: ContentBlock[] = [
+  textBlock('Show me every currently wired conversation surface.'),
+];
+
+export const SHOWCASE_THOUGHT_CONTENT = textBlock(
+  'Planning a compact data-plane tour: plan, tools, permission, terminal, and media.',
+);
+
+export const SHOWCASE_INTRO_CONTENT = textBlock(
+  'Here is a mocked transcript that uses the same wire events as the daemon.',
+);
+
+export const SHOWCASE_ARCHITECTURE_LINK: ContentBlock = {
+  type: 'resource_link',
+  uri: 'file:///mock/linkcode/docs/ARCHITECTURE.md',
+  name: 'docs/ARCHITECTURE.md',
+  mimeType: 'text/markdown',
+  description: 'Architecture source of truth',
+};
+
+export const SHOWCASE_EMBEDDED_RESOURCE: ContentBlock = {
+  type: 'resource',
+  resource: {
+    uri: 'mock://notes/showcase.md',
+    text: '# Mock note\n\nThis embedded resource renders through `ContentBlockView`.',
+    mimeType: 'text/markdown',
+  },
+};
+
+export const SHOWCASE_IMAGE: ContentBlock = {
+  type: 'image',
+  data: TRANSPARENT_PIXEL,
+  mimeType: 'image/png',
+};
+
+export const SHOWCASE_PLAN: Plan = {
+  entries: [
+    {
+      content: 'Seed representative conversation events',
+      priority: 'high',
+      status: 'completed',
+    },
+    {
+      content: 'Exercise tool bodies and permission UI',
+      priority: 'high',
+      status: 'in_progress',
+    },
+    { content: 'Finish with a live streamed reply', priority: 'medium', status: 'pending' },
+  ],
+};
+
+export const SHOWCASE_PERMISSION_DIFF: Extract<ToolCall['content'][number], { type: 'diff' }> = {
+  type: 'diff',
+  path: 'packages/workbench/src/mock/dev-mock-transport.ts',
+  oldText: "const coverage = 'thin';\n",
+  newText: "const coverage = 'rich';\n",
+};
+
+export const SHOWCASE_PERMISSION_OPTIONS: PermissionOption[] = [
+  { optionId: 'allow_once', name: 'Allow once', kind: 'allow_once' },
+  { optionId: 'reject_once', name: 'Reject', kind: 'reject_once' },
+];
+
+export const SHOWCASE_ERROR_EVENT: Extract<AgentEvent, { type: 'error' }> = {
+  type: 'error',
+  message: 'Recoverable mock diagnostic: preview service returned 503.',
+  code: 'MOCK_PREVIEW_UNAVAILABLE',
+  recoverable: true,
+};
+
+export const SHOWCASE_STREAM_THOUGHT_CONTENT = textBlock(
+  'Now streaming the final answer so the composer and bubble shimmer have live data.',
+);
+
+export const SHOWCASE_STREAM_REPLY =
+  'Streaming showcase complete: messages, reasoning, plans, tool bodies, diffs, terminal output, permissions, errors, and usage all came from the mock transport.';
+
+export const SHOWCASE_TERMINAL_START_OUTPUT =
+  '$ pnpm vitest run packages/workbench/src/mock\n✓ dev mock transport (4)\n';
+
+export const SHOWCASE_TERMINAL_EXIT_OUTPUT = 'mock terminal stream finished\n';
+
+export const SHOWCASE_PERMISSION_GRANTED_CONTENT = textBlock(
+  'Permission granted; mock edit applied.',
+);
+
+export const SHOWCASE_PERMISSION_DENIED_CONTENT = textBlock(
+  'Permission denied; mock edit skipped.',
+);
+
+export function createShowcaseToolSnapshots(terminalId = SHOWCASE_TERMINAL_ID): ToolCall[] {
+  return [
+    {
+      toolCallId: 'mock-tool-read',
+      title: 'Read architecture notes',
+      kind: 'read',
+      status: 'completed',
+      locations: [{ path: 'docs/ARCHITECTURE.md', line: 1 }],
+      content: [
+        {
+          type: 'content',
+          content: textBlock('Read the architecture sections for data-plane boundaries.'),
+        },
+      ],
+      rawInput: { path: 'docs/ARCHITECTURE.md' },
+    },
+    {
+      toolCallId: 'mock-tool-search',
+      title: 'Search chat renderers',
+      kind: 'search',
+      status: 'completed',
+      content: [],
+      rawInput: { query: 'permission-request|tool-call|plan' },
+      rawOutput: {
+        matches: [
+          'packages/ui/src/chat/conversation-view.tsx',
+          'packages/client-core/src/conversation.ts',
+        ],
+      },
+    },
+    {
+      toolCallId: 'mock-tool-edit-diff',
+      title: 'Preview renderer patch',
+      kind: 'edit',
+      status: 'completed',
+      content: [
+        {
+          type: 'diff',
+          path: 'packages/ui/src/chat/conversation-view.tsx',
+          oldText: 'case "tool": return null;\n',
+          newText: 'case "tool": return <ToolCallItem toolCall={item.toolCall} />;\n',
+        },
+      ],
+    },
+    {
+      toolCallId: 'mock-tool-execute',
+      title: 'Run focused mock test',
+      kind: 'execute',
+      status: 'completed',
+      content: [{ type: 'terminal', terminalId }],
+      rawInput: { command: 'pnpm vitest run packages/workbench/src/mock' },
+    },
+    {
+      toolCallId: 'mock-tool-fetch',
+      title: 'Fetch unavailable preview',
+      kind: 'fetch',
+      status: 'failed',
+      content: [],
+      rawInput: { url: 'https://mock.invalid/preview' },
+      rawOutput: { status: 503, message: 'Mocked fetch failure for error-state coverage' },
+    },
+    {
+      toolCallId: 'mock-tool-think',
+      title: 'Summarize coverage',
+      kind: 'think',
+      status: 'completed',
+      content: [
+        { type: 'content', content: textBlock('Covered all currently schema-backed chat items.') },
+      ],
+    },
+    {
+      toolCallId: SHOWCASE_PERMISSION_TOOL_ID,
+      title: 'Apply guarded edit',
+      kind: 'edit',
+      status: 'pending',
+      content: [SHOWCASE_PERMISSION_DIFF],
+      rawInput: { path: SHOWCASE_PERMISSION_DIFF.path },
+    },
+  ];
+}

--- a/packages/workbench/src/mock/data/showcase.ts
+++ b/packages/workbench/src/mock/data/showcase.ts
@@ -103,83 +103,162 @@ export const SHOWCASE_PERMISSION_DENIED_CONTENT = textBlock(
   'Permission denied; mock edit skipped.',
 );
 
-export function createShowcaseToolSnapshots(terminalId = SHOWCASE_TERMINAL_ID): ToolCall[] {
-  return [
-    {
-      toolCallId: 'mock-tool-read',
-      title: 'Read architecture notes',
-      kind: 'read',
-      status: 'completed',
-      locations: [{ path: 'docs/ARCHITECTURE.md', line: 1 }],
-      content: [
-        {
-          type: 'content',
-          content: textBlock('Read the architecture sections for data-plane boundaries.'),
+export const SHOWCASE_EXPLORE_NARRATION = textBlock(
+  'The renderer sources are mapped; patching the conversation surfaces next.',
+);
+
+export const SHOWCASE_FILES_NARRATION = textBlock(
+  'Renderer patches are in; running the focused checks to confirm nothing regressed.',
+);
+
+export const SHOWCASE_COMMANDS_NARRATION = textBlock(
+  'Typecheck flagged a stale preview import, so a last pass double-checks the preview and coverage.',
+);
+
+export interface ShowcaseToolBursts {
+  /** Contiguous read/search calls — renders as an "Explored" group. */
+  explore: ToolCall[];
+  /** Contiguous edit/delete calls with diffs — renders as an "Edited files" group with summed +/-. */
+  files: ToolCall[];
+  /** Contiguous execute calls (one failed) — renders as a "Ran commands" group. */
+  commands: ToolCall[];
+  /** Trailing singletons: failed fetch, think, and the permission-gated edit. */
+  wrapUp: ToolCall[];
+}
+
+export function createShowcaseToolBursts(terminalId = SHOWCASE_TERMINAL_ID): ShowcaseToolBursts {
+  return {
+    explore: [
+      {
+        toolCallId: 'mock-tool-read',
+        title: 'Read architecture notes',
+        kind: 'read',
+        status: 'completed',
+        locations: [{ path: 'docs/ARCHITECTURE.md', line: 1 }],
+        content: [
+          {
+            type: 'content',
+            content: textBlock('Read the architecture sections for data-plane boundaries.'),
+          },
+        ],
+        rawInput: { path: 'docs/ARCHITECTURE.md' },
+      },
+      {
+        toolCallId: 'mock-tool-search',
+        title: 'Search chat renderers',
+        kind: 'search',
+        status: 'completed',
+        content: [],
+        rawInput: { query: 'permission-request|tool-call|plan' },
+        rawOutput: {
+          matches: [
+            'packages/ui/src/chat/conversation-view.tsx',
+            'packages/client-core/src/conversation.ts',
+          ],
         },
-      ],
-      rawInput: { path: 'docs/ARCHITECTURE.md' },
-    },
-    {
-      toolCallId: 'mock-tool-search',
-      title: 'Search chat renderers',
-      kind: 'search',
-      status: 'completed',
-      content: [],
-      rawInput: { query: 'permission-request|tool-call|plan' },
-      rawOutput: {
-        matches: [
-          'packages/ui/src/chat/conversation-view.tsx',
-          'packages/client-core/src/conversation.ts',
+      },
+    ],
+    files: [
+      {
+        toolCallId: 'mock-tool-edit-diff',
+        title: 'Preview renderer patch',
+        kind: 'edit',
+        status: 'completed',
+        content: [
+          {
+            type: 'diff',
+            path: 'packages/ui/src/chat/conversation-view.tsx',
+            oldText: 'case "tool": return null;\n',
+            newText: 'case "tool": return <ToolCallItem toolCall={item.toolCall} />;\n',
+          },
         ],
       },
-    },
-    {
-      toolCallId: 'mock-tool-edit-diff',
-      title: 'Preview renderer patch',
-      kind: 'edit',
-      status: 'completed',
-      content: [
-        {
-          type: 'diff',
-          path: 'packages/ui/src/chat/conversation-view.tsx',
-          oldText: 'case "tool": return null;\n',
-          newText: 'case "tool": return <ToolCallItem toolCall={item.toolCall} />;\n',
-        },
-      ],
-    },
-    {
-      toolCallId: 'mock-tool-execute',
-      title: 'Run focused mock test',
-      kind: 'execute',
-      status: 'completed',
-      content: [{ type: 'terminal', terminalId }],
-      rawInput: { command: 'pnpm vitest run packages/workbench/src/mock' },
-    },
-    {
-      toolCallId: 'mock-tool-fetch',
-      title: 'Fetch unavailable preview',
-      kind: 'fetch',
-      status: 'failed',
-      content: [],
-      rawInput: { url: 'https://mock.invalid/preview' },
-      rawOutput: { status: 503, message: 'Mocked fetch failure for error-state coverage' },
-    },
-    {
-      toolCallId: 'mock-tool-think',
-      title: 'Summarize coverage',
-      kind: 'think',
-      status: 'completed',
-      content: [
-        { type: 'content', content: textBlock('Covered all currently schema-backed chat items.') },
-      ],
-    },
-    {
-      toolCallId: SHOWCASE_PERMISSION_TOOL_ID,
-      title: 'Apply guarded edit',
-      kind: 'edit',
-      status: 'pending',
-      content: [SHOWCASE_PERMISSION_DIFF],
-      rawInput: { path: SHOWCASE_PERMISSION_DIFF.path },
-    },
-  ];
+      {
+        toolCallId: 'mock-tool-edit-markdown',
+        title: 'Patch markdown styles',
+        kind: 'edit',
+        status: 'completed',
+        content: [
+          {
+            type: 'diff',
+            path: 'packages/ui/src/chat/markdown.tsx',
+            oldText: "const tone = 'chat';\n",
+            newText: "const tone = 'coss';\nconst scale = 'text-sm';\n",
+          },
+        ],
+      },
+      {
+        toolCallId: 'mock-tool-delete-legacy',
+        title: 'Retire legacy timeline row',
+        kind: 'delete',
+        status: 'completed',
+        content: [
+          {
+            type: 'diff',
+            path: 'packages/ui/src/chat/legacy-row.tsx',
+            oldText: 'export function LegacyRow() {\n  return null;\n}\n',
+            newText: '',
+          },
+        ],
+      },
+    ],
+    commands: [
+      {
+        toolCallId: 'mock-tool-execute',
+        title: 'Run focused mock test',
+        kind: 'execute',
+        status: 'completed',
+        content: [{ type: 'terminal', terminalId }],
+        rawInput: { command: 'pnpm vitest run packages/workbench/src/mock' },
+      },
+      {
+        toolCallId: 'mock-tool-execute-lint',
+        title: 'Run lint',
+        kind: 'execute',
+        status: 'completed',
+        content: [],
+        rawInput: { command: 'pnpm lint' },
+      },
+      {
+        toolCallId: 'mock-tool-execute-typecheck',
+        title: 'Run typecheck',
+        kind: 'execute',
+        status: 'failed',
+        content: [],
+        rawInput: { command: 'pnpm typecheck' },
+        rawOutput: { exitCode: 1, message: 'stale preview import' },
+      },
+    ],
+    wrapUp: [
+      {
+        toolCallId: 'mock-tool-fetch',
+        title: 'Fetch unavailable preview',
+        kind: 'fetch',
+        status: 'failed',
+        content: [],
+        rawInput: { url: 'https://mock.invalid/preview' },
+        rawOutput: { status: 503, message: 'Mocked fetch failure for error-state coverage' },
+      },
+      {
+        toolCallId: 'mock-tool-think',
+        title: 'Summarize coverage',
+        kind: 'think',
+        status: 'completed',
+        content: [
+          {
+            type: 'content',
+            content: textBlock('Covered all currently schema-backed chat items.'),
+          },
+        ],
+      },
+      {
+        toolCallId: SHOWCASE_PERMISSION_TOOL_ID,
+        title: 'Apply guarded edit',
+        kind: 'edit',
+        status: 'pending',
+        content: [SHOWCASE_PERMISSION_DIFF],
+        rawInput: { path: SHOWCASE_PERMISSION_DIFF.path },
+      },
+    ],
+  };
 }

--- a/packages/workbench/src/mock/dev-mock-host.ts
+++ b/packages/workbench/src/mock/dev-mock-host.ts
@@ -1,0 +1,505 @@
+import type {
+  AgentEvent,
+  AgentInput,
+  ContentBlock,
+  MessageId,
+  PermissionOutcome,
+  ProvidersConfig,
+  SessionId,
+  SessionInfo,
+  SessionStatus,
+  ToolCall,
+  WireMessage,
+  WirePayload,
+} from '@linkcode/schema';
+import { textBlock } from '@linkcode/schema';
+import type { Transport } from '@linkcode/transport';
+import { createWireMessage } from '@linkcode/transport';
+import { wait } from 'foxts/wait';
+import {
+  CHUNK_LATENCY_MS,
+  CONTROL_LATENCY_MS,
+  FAIL_PROMPT,
+  MOCK_REPLY,
+  WORD_CHUNK_PATTERN,
+} from './data/prompt';
+import { SEED_SESSIONS, SHOWCASE_TERMINAL_ID } from './data/sessions';
+import {
+  createShowcaseToolSnapshots,
+  SHOWCASE_ARCHITECTURE_LINK,
+  SHOWCASE_EMBEDDED_RESOURCE,
+  SHOWCASE_ERROR_EVENT,
+  SHOWCASE_IMAGE,
+  SHOWCASE_INTRO_CONTENT,
+  SHOWCASE_PERMISSION_DENIED_CONTENT,
+  SHOWCASE_PERMISSION_DIFF,
+  SHOWCASE_PERMISSION_GRANTED_CONTENT,
+  SHOWCASE_PERMISSION_ID,
+  SHOWCASE_PERMISSION_OPTIONS,
+  SHOWCASE_PERMISSION_TOOL_ID,
+  SHOWCASE_PLAN,
+  SHOWCASE_STREAM_REPLY,
+  SHOWCASE_STREAM_THOUGHT_CONTENT,
+  SHOWCASE_TERMINAL_EXIT_OUTPUT,
+  SHOWCASE_TERMINAL_START_OUTPUT,
+  SHOWCASE_THOUGHT_CONTENT,
+  SHOWCASE_USER_CONTENT,
+} from './data/showcase';
+
+interface MockSession extends SessionInfo {
+  /** Host-only state: keep it off `session.list` so the mock still crosses the schema boundary cleanly. */
+  model?: string;
+  /** Bumped by cancel/stop so an in-flight prompt turn knows to bail out. */
+  epoch: number;
+  showcase?: boolean;
+  showcaseSeeded?: boolean;
+  showcaseStreaming?: boolean;
+  terminalId?: string;
+}
+
+interface PendingPermission {
+  sessionId: SessionId;
+  toolCallId: string;
+  diff: Extract<ToolCall['content'][number], { type: 'diff' }>;
+}
+
+export class DevMockHost {
+  private readonly sessions = new Map<SessionId, MockSession>();
+  private providers: ProvidersConfig = {};
+  private readonly permissions = new Map<string, PendingPermission>();
+  private sessionSeq = 0;
+  private messageSeq = 0;
+
+  constructor(private readonly transport: Transport) {}
+
+  start(): void {
+    void this.transport.connect();
+    this.transport.onMessage((msg) => {
+      void this.handle(msg);
+    });
+    const now = Date.now();
+    for (const { ageMs, ...seed } of SEED_SESSIONS) {
+      this.addSession({ ...seed, createdAt: now - ageMs });
+    }
+  }
+
+  private async handle(msg: WireMessage): Promise<void> {
+    const p = msg.payload;
+    switch (p.kind) {
+      case 'session.list':
+        await wait(CONTROL_LATENCY_MS);
+        // Seed after the client is connected; LocalTransport drops frames with no listener.
+        this.startShowcase();
+        this.send({
+          kind: 'session.listed',
+          replyTo: p.clientReqId,
+          sessions: [...this.sessions.values()].map((session) => toSessionInfo(session)),
+        });
+        break;
+      case 'session.start':
+        await wait(CONTROL_LATENCY_MS);
+        this.startSession(p.clientReqId, p.opts.kind, p.opts.cwd, p.opts.model);
+        break;
+      case 'session.resume':
+        await wait(CONTROL_LATENCY_MS);
+        this.resumeSession(p.clientReqId, p.sessionId);
+        break;
+      case 'session.stop':
+        await wait(CONTROL_LATENCY_MS);
+        this.stopSession(p.clientReqId, p.sessionId);
+        break;
+      case 'agent.input':
+        await this.handleInput(p.clientReqId, p.sessionId, p.input);
+        break;
+      case 'config.get':
+        await wait(CONTROL_LATENCY_MS);
+        this.send({ kind: 'config.get.result', replyTo: p.clientReqId, providers: this.providers });
+        break;
+      case 'config.set':
+        await wait(CONTROL_LATENCY_MS);
+        this.providers = structuredClone(p.providers);
+        this.sendSuccess(p.clientReqId);
+        break;
+      case 'session.import':
+        this.sendFailure(p.clientReqId, 'Dev mock host does not support importing sessions yet.');
+        break;
+      case 'history.list':
+      case 'history.read':
+      case 'history.resume':
+        // Fail loudly for unmocked surfaces so correlated SDK calls reject instead of hanging forever.
+        this.sendFailure(p.clientReqId, 'Dev mock host does not support history yet.');
+        break;
+      case 'terminal.open':
+        this.sendFailure(p.clientReqId, 'Dev mock host does not support terminals yet.');
+        break;
+      case 'ping':
+        this.send({ kind: 'pong' });
+        break;
+      default:
+        break;
+    }
+  }
+
+  private addSession(
+    init: Omit<MockSession, 'sessionId' | 'origin' | 'epoch' | 'status'> & {
+      status: SessionStatus;
+    },
+  ): MockSession {
+    const session: MockSession = {
+      ...init,
+      sessionId: this.nextSessionId(),
+      origin: { type: 'created' },
+      epoch: 0,
+    };
+    this.sessions.set(session.sessionId, session);
+    return session;
+  }
+
+  private startSession(
+    replyTo: string,
+    kind: MockSession['kind'],
+    cwd: string,
+    model: string | undefined,
+  ): void {
+    const session = this.addSession({ kind, cwd, status: 'idle', createdAt: Date.now(), model });
+    const { sessionId } = session;
+    this.emit(sessionId, { type: 'status', status: 'starting' });
+    this.emit(sessionId, { type: 'current-mode-update', currentModeId: 'mock' });
+    this.emit(sessionId, { type: 'status', status: 'idle' });
+    this.send({ kind: 'session.started', replyTo, sessionId });
+  }
+
+  private resumeSession(replyTo: string, sessionId: SessionId): void {
+    const session = this.sessions.get(sessionId);
+    if (!session) {
+      this.sendFailure(replyTo, `Unknown session: ${sessionId}`);
+      return;
+    }
+    // Parity with the engine: only cold sessions can be resumed.
+    if (session.status !== 'stopped') {
+      this.sendFailure(replyTo, `Session is already running: ${sessionId}`);
+      return;
+    }
+    session.status = 'idle';
+    this.emit(sessionId, { type: 'status', status: 'idle' });
+    this.send({ kind: 'session.started', replyTo, sessionId });
+  }
+
+  private stopSession(replyTo: string, sessionId: SessionId): void {
+    const session = this.sessions.get(sessionId);
+    if (!session) {
+      this.sendFailure(replyTo, `Unknown session: ${sessionId}`);
+      return;
+    }
+    session.epoch += 1;
+    session.status = 'stopped';
+    this.emit(sessionId, { type: 'status', status: 'stopped' });
+    this.sendSuccess(replyTo);
+  }
+
+  private async handleInput(
+    replyTo: string,
+    sessionId: SessionId,
+    input: AgentInput,
+  ): Promise<void> {
+    const session = this.sessions.get(sessionId);
+    if (!session) {
+      this.sendFailure(replyTo, `Unknown session: ${sessionId}`);
+      return;
+    }
+    // Parity with the engine, which only routes input to live sessions.
+    if (session.status === 'stopped') {
+      this.sendFailure(replyTo, `Session is stopped, resume it first: ${sessionId}`);
+      return;
+    }
+
+    switch (input.type) {
+      case 'prompt':
+        await this.prompt(replyTo, session, input.content);
+        break;
+      case 'cancel':
+        session.epoch += 1;
+        session.status = 'idle';
+        this.emit(sessionId, { type: 'stop', stopReason: 'cancelled' });
+        this.emit(sessionId, { type: 'status', status: 'idle' });
+        this.sendSuccess(replyTo);
+        break;
+      case 'set-model':
+        session.model = input.model;
+        this.sendSuccess(replyTo);
+        break;
+      case 'set-mode':
+        this.emit(sessionId, { type: 'current-mode-update', currentModeId: input.modeId });
+        this.sendSuccess(replyTo);
+        break;
+      case 'permission-response':
+        this.respondPermission(replyTo, sessionId, input.requestId, input.outcome);
+        break;
+      default:
+        this.sendFailure(replyTo, 'Dev mock host does not support that input yet.');
+        break;
+    }
+  }
+
+  private async prompt(
+    replyTo: string,
+    session: MockSession,
+    content: ContentBlock[],
+  ): Promise<void> {
+    const text = promptText(content);
+    if (!session.title && text) session.title = text.slice(0, 80);
+    session.status = 'running';
+    this.emit(session.sessionId, { type: 'user-message', content });
+    this.emit(session.sessionId, { type: 'status', status: 'running' });
+
+    // Cancel/stop bump the session epoch; a stale epoch means this turn was cancelled and the
+    // cancel handler already emitted the terminal events — just ack the prompt and bail.
+    const epoch = session.epoch;
+    const cancelledAfter = async (ms: number): Promise<boolean> => {
+      await wait(ms);
+      return session.epoch !== epoch;
+    };
+
+    if (await cancelledAfter(200)) {
+      this.sendSuccess(replyTo);
+      return;
+    }
+    const thoughtId = this.nextMessageId('mock-thought');
+    this.emit(session.sessionId, {
+      type: 'agent-thought-chunk',
+      messageId: thoughtId,
+      content: textBlock('Reading the mocked request.'),
+    });
+
+    if (text.toLowerCase() === FAIL_PROMPT) {
+      if (await cancelledAfter(200)) {
+        this.sendSuccess(replyTo);
+        return;
+      }
+      const message = `Mock failure requested via the "${FAIL_PROMPT}" prompt.`;
+      this.emit(session.sessionId, { type: 'error', message, recoverable: true });
+      session.status = 'idle';
+      this.emit(session.sessionId, { type: 'status', status: 'idle' });
+      this.sendFailure(replyTo, message);
+      return;
+    }
+
+    const messageId = this.nextMessageId('mock-message');
+    const reply = `${MOCK_REPLY}\n\nModel: ${session.model ?? 'mock-default'}\nYou said: ${text || '(empty prompt)'}`;
+    for (const chunk of reply.match(WORD_CHUNK_PATTERN) ?? []) {
+      if (await cancelledAfter(CHUNK_LATENCY_MS)) {
+        this.sendSuccess(replyTo);
+        return;
+      }
+      this.emit(session.sessionId, {
+        type: 'agent-message-chunk',
+        messageId,
+        content: textBlock(chunk),
+      });
+    }
+    this.emit(session.sessionId, {
+      type: 'token-usage',
+      usage: {
+        inputTokens: Math.max(1, Math.ceil(text.length / 4)),
+        outputTokens: 32,
+      },
+    });
+    this.emit(session.sessionId, { type: 'stop', stopReason: 'end_turn' });
+    session.status = 'idle';
+    this.emit(session.sessionId, { type: 'status', status: 'idle' });
+    this.sendSuccess(replyTo);
+  }
+
+  private startShowcase(): void {
+    for (const session of this.sessions.values()) {
+      if (!session.showcase) continue;
+      this.emitShowcaseConversation(session);
+      void this.streamShowcaseReply(session);
+    }
+  }
+
+  private emitShowcaseConversation(session: MockSession): void {
+    if (session.showcaseSeeded) return;
+    session.showcaseSeeded = true;
+    session.status = 'running';
+
+    const introId = this.nextMessageId('mock-showcase-intro');
+    const resourceId = this.nextMessageId('mock-showcase-resource');
+    const terminalId = session.terminalId ?? SHOWCASE_TERMINAL_ID;
+    this.permissions.set(SHOWCASE_PERMISSION_ID, {
+      sessionId: session.sessionId,
+      toolCallId: SHOWCASE_PERMISSION_TOOL_ID,
+      diff: SHOWCASE_PERMISSION_DIFF,
+    });
+
+    this.emit(session.sessionId, { type: 'status', status: 'running' });
+    this.emit(session.sessionId, { type: 'current-mode-update', currentModeId: 'mock-showcase' });
+    this.emit(session.sessionId, { type: 'user-message', content: SHOWCASE_USER_CONTENT });
+    this.emit(session.sessionId, {
+      type: 'agent-thought-chunk',
+      messageId: this.nextMessageId('mock-showcase-thought'),
+      content: SHOWCASE_THOUGHT_CONTENT,
+    });
+    this.emit(session.sessionId, { type: 'plan', plan: SHOWCASE_PLAN });
+    this.emit(session.sessionId, {
+      type: 'agent-message-chunk',
+      messageId: introId,
+      content: SHOWCASE_INTRO_CONTENT,
+    });
+    this.emit(session.sessionId, {
+      type: 'agent-message-chunk',
+      messageId: introId,
+      content: SHOWCASE_ARCHITECTURE_LINK,
+    });
+    this.emit(session.sessionId, {
+      type: 'agent-message-chunk',
+      messageId: resourceId,
+      content: SHOWCASE_EMBEDDED_RESOURCE,
+    });
+    this.emit(session.sessionId, {
+      type: 'agent-message-chunk',
+      messageId: this.nextMessageId('mock-showcase-image'),
+      content: SHOWCASE_IMAGE,
+    });
+
+    for (const toolCall of createShowcaseToolSnapshots(terminalId)) {
+      this.emitToolSnapshot(session.sessionId, toolCall);
+    }
+    this.send({ kind: 'terminal.output', terminalId, data: SHOWCASE_TERMINAL_START_OUTPUT });
+    this.emit(session.sessionId, {
+      type: 'permission-request',
+      requestId: SHOWCASE_PERMISSION_ID,
+      toolCall: {
+        toolCallId: SHOWCASE_PERMISSION_TOOL_ID,
+        title: 'Apply guarded edit',
+        kind: 'edit',
+        status: 'pending',
+        content: [SHOWCASE_PERMISSION_DIFF],
+      },
+      options: SHOWCASE_PERMISSION_OPTIONS,
+    });
+    this.emit(session.sessionId, SHOWCASE_ERROR_EVENT);
+  }
+
+  private async streamShowcaseReply(session: MockSession): Promise<void> {
+    if (session.showcaseStreaming) return;
+    session.showcaseStreaming = true;
+
+    const epoch = session.epoch;
+    const terminalId = session.terminalId ?? SHOWCASE_TERMINAL_ID;
+    const thoughtId = this.nextMessageId('mock-showcase-stream-thought');
+    const messageId = this.nextMessageId('mock-showcase-stream');
+    await wait(500);
+    if (!isRunningTurn(session, epoch)) return;
+    this.emit(session.sessionId, {
+      type: 'agent-thought-chunk',
+      messageId: thoughtId,
+      content: SHOWCASE_STREAM_THOUGHT_CONTENT,
+    });
+
+    for (const chunk of SHOWCASE_STREAM_REPLY.match(WORD_CHUNK_PATTERN) ?? []) {
+      await wait(CHUNK_LATENCY_MS);
+      if (!isRunningTurn(session, epoch)) return;
+      this.emit(session.sessionId, {
+        type: 'agent-message-chunk',
+        messageId,
+        content: textBlock(chunk),
+      });
+    }
+    this.send({ kind: 'terminal.output', terminalId, data: SHOWCASE_TERMINAL_EXIT_OUTPUT });
+    this.emit(session.sessionId, {
+      type: 'token-usage',
+      usage: { inputTokens: 148, outputTokens: 96, totalCostUsd: 0 },
+    });
+    this.emit(session.sessionId, { type: 'stop', stopReason: 'end_turn' });
+    session.status = 'idle';
+    this.emit(session.sessionId, { type: 'status', status: 'idle' });
+  }
+
+  private respondPermission(
+    replyTo: string,
+    sessionId: SessionId,
+    requestId: string,
+    outcome: PermissionOutcome,
+  ): void {
+    const pending = this.permissions.get(requestId);
+    if (pending?.sessionId !== sessionId) {
+      this.sendFailure(replyTo, `Unknown permission request: ${requestId}`);
+      return;
+    }
+    this.permissions.delete(requestId);
+    const allowed = outcome.outcome === 'selected' && outcome.optionId.startsWith('allow');
+    this.emitToolSnapshot(sessionId, {
+      toolCallId: pending.toolCallId,
+      title: 'Apply guarded edit',
+      kind: 'edit',
+      status: allowed ? 'completed' : 'failed',
+      content: [
+        pending.diff,
+        {
+          type: 'content',
+          content: allowed
+            ? SHOWCASE_PERMISSION_GRANTED_CONTENT
+            : SHOWCASE_PERMISSION_DENIED_CONTENT,
+        },
+      ],
+      rawOutput: { outcome },
+    });
+    this.sendSuccess(replyTo);
+  }
+
+  private emitToolSnapshot(sessionId: SessionId, toolCall: ToolCall): void {
+    this.emit(sessionId, { type: 'tool-call', toolCall });
+  }
+
+  private emit(sessionId: SessionId, event: AgentEvent): void {
+    this.send({ kind: 'agent.event', sessionId, event });
+  }
+
+  private send(payload: WirePayload): void {
+    this.transport.send(createWireMessage(payload));
+  }
+
+  private sendSuccess(replyTo: string): void {
+    this.send({ kind: 'request.succeeded', replyTo });
+  }
+
+  private sendFailure(replyTo: string, message: string): void {
+    this.send({ kind: 'request.failed', replyTo, message });
+  }
+
+  private nextSessionId(): SessionId {
+    this.sessionSeq += 1;
+    return `mock-sess-${Date.now().toString(36)}-${this.sessionSeq.toString(36)}` as SessionId;
+  }
+
+  private nextMessageId(prefix: string): MessageId {
+    this.messageSeq += 1;
+    return `${prefix}-${Date.now().toString(36)}-${this.messageSeq.toString(36)}` as MessageId;
+  }
+}
+
+function promptText(content: readonly ContentBlock[]): string {
+  return content
+    .reduce((text, block) => {
+      if (block.type !== 'text') return text;
+      return text ? `${text}\n${block.text}` : block.text;
+    }, '')
+    .trim();
+}
+
+function toSessionInfo(session: MockSession): SessionInfo {
+  return {
+    sessionId: session.sessionId,
+    kind: session.kind,
+    cwd: session.cwd,
+    status: session.status,
+    createdAt: session.createdAt,
+    title: session.title,
+    origin: session.origin,
+  };
+}
+
+function isRunningTurn(session: MockSession, epoch: number): boolean {
+  return session.epoch === epoch && session.status === 'running';
+}

--- a/packages/workbench/src/mock/dev-mock-host.ts
+++ b/packages/workbench/src/mock/dev-mock-host.ts
@@ -2,6 +2,9 @@ import type {
   AgentEvent,
   AgentInput,
   ContentBlock,
+  GitDiff,
+  GitPullRequestStatus,
+  GitStatus,
   MessageId,
   PermissionOutcome,
   ProvidersConfig,
@@ -11,8 +14,10 @@ import type {
   ToolCall,
   WireMessage,
   WirePayload,
+  WorkspaceId,
+  WorkspaceRecord,
 } from '@linkcode/schema';
-import { textBlock } from '@linkcode/schema';
+import { normalizeCwdKey, textBlock } from '@linkcode/schema';
 import type { Transport } from '@linkcode/transport';
 import { createWireMessage } from '@linkcode/transport';
 import { wait } from 'foxts/wait';
@@ -66,12 +71,37 @@ interface PendingPermission {
   diff: Extract<ToolCall['content'][number], { type: 'diff' }>;
 }
 
+const MOCK_GIT_DIFF: GitDiff = {
+  patch:
+    "diff --git a/mock.ts b/mock.ts\nindex 0000000..1111111 100644\n--- a/mock.ts\n+++ b/mock.ts\n@@ -1 +1 @@\n-const mode = 'daemon';\n+const mode = 'mock';\n",
+  truncated: false,
+  stat: { files: 1, additions: 1, deletions: 1 },
+};
+
+const MOCK_PR_STATUS: GitPullRequestStatus = {
+  status: 'ok',
+  pullRequest: {
+    provider: 'github',
+    number: 42,
+    title: 'Mock host data-plane coverage',
+    url: 'https://github.com/linkcode/mock/pull/42',
+    state: 'open',
+    isDraft: false,
+    baseBranch: 'main',
+    headBranch: 'mock-host',
+    checks: 'passing',
+    reviewDecision: 'approved',
+  },
+};
+
 export class DevMockHost {
   private readonly sessions = new Map<SessionId, MockSession>();
+  private readonly workspaces = new Map<WorkspaceId, WorkspaceRecord>();
   private providers: ProvidersConfig = {};
   private readonly permissions = new Map<string, PendingPermission>();
   private sessionSeq = 0;
   private messageSeq = 0;
+  private workspaceSeq = 0;
 
   constructor(private readonly transport: Transport) {}
 
@@ -82,7 +112,9 @@ export class DevMockHost {
     });
     const now = Date.now();
     for (const { ageMs, ...seed } of SEED_SESSIONS) {
-      this.addSession({ ...seed, createdAt: now - ageMs });
+      const createdAt = now - ageMs;
+      this.addSession({ ...seed, createdAt });
+      this.touchWorkspace(seed.cwd, createdAt);
     }
   }
 
@@ -123,6 +155,51 @@ export class DevMockHost {
         this.providers = structuredClone(p.providers);
         this.sendSuccess(p.clientReqId);
         break;
+      case 'workspace.list':
+        await wait(CONTROL_LATENCY_MS);
+        this.send({
+          kind: 'workspace.listed',
+          replyTo: p.clientReqId,
+          workspaces: this.listWorkspaces(),
+        });
+        break;
+      case 'workspace.register':
+        await wait(CONTROL_LATENCY_MS);
+        this.send({
+          kind: 'workspace.registered',
+          replyTo: p.clientReqId,
+          record: this.touchWorkspace(p.cwd, Date.now(), p.name),
+        });
+        break;
+      case 'workspace.update':
+        await wait(CONTROL_LATENCY_MS);
+        this.updateWorkspace(p.clientReqId, p.workspaceId, p.name);
+        break;
+      case 'workspace.archive':
+        await wait(CONTROL_LATENCY_MS);
+        this.archiveWorkspace(p.workspaceId);
+        this.sendSuccess(p.clientReqId);
+        break;
+      case 'git.status.get':
+        await wait(CONTROL_LATENCY_MS);
+        this.send({
+          kind: 'git.status.get.result',
+          replyTo: p.clientReqId,
+          status: mockGitStatus(p.cwd),
+        });
+        break;
+      case 'git.pr_status.get':
+        await wait(CONTROL_LATENCY_MS);
+        this.send({
+          kind: 'git.pr_status.get.result',
+          replyTo: p.clientReqId,
+          prStatus: MOCK_PR_STATUS,
+        });
+        break;
+      case 'git.diff.get':
+        await wait(CONTROL_LATENCY_MS);
+        this.send({ kind: 'git.diff.get.result', replyTo: p.clientReqId, diff: MOCK_GIT_DIFF });
+        break;
       case 'session.import':
         this.sendFailure(p.clientReqId, 'Dev mock host does not support importing sessions yet.');
         break;
@@ -156,6 +233,42 @@ export class DevMockHost {
     };
     this.sessions.set(session.sessionId, session);
     return session;
+  }
+
+  private listWorkspaces(): WorkspaceRecord[] {
+    return [...this.workspaces.values()].sort((a, b) => b.lastUsedAt - a.lastUsedAt);
+  }
+
+  private touchWorkspace(cwd: string, now: number, name?: string): WorkspaceRecord {
+    const key = normalizeCwdKey(cwd);
+    for (const workspace of this.workspaces.values()) {
+      if (normalizeCwdKey(workspace.cwd) !== key) continue;
+      workspace.lastUsedAt = Math.max(workspace.lastUsedAt, now);
+      return workspace;
+    }
+    const workspace: WorkspaceRecord = {
+      workspaceId: this.nextWorkspaceId(),
+      cwd,
+      name: name ?? lastPathSegment(cwd),
+      createdAt: now,
+      lastUsedAt: now,
+    };
+    this.workspaces.set(workspace.workspaceId, workspace);
+    return workspace;
+  }
+
+  private updateWorkspace(replyTo: string, workspaceId: WorkspaceId, name: string): void {
+    const workspace = this.workspaces.get(workspaceId);
+    if (!workspace) {
+      this.sendFailure(replyTo, `Unknown workspace: ${workspaceId}`);
+      return;
+    }
+    workspace.name = name;
+    this.sendSuccess(replyTo);
+  }
+
+  private archiveWorkspace(workspaceId: WorkspaceId): void {
+    this.workspaces.delete(workspaceId);
   }
 
   private startSession(
@@ -503,6 +616,11 @@ export class DevMockHost {
     this.messageSeq += 1;
     return `${prefix}-${Date.now().toString(36)}-${this.messageSeq.toString(36)}` as MessageId;
   }
+
+  private nextWorkspaceId(): WorkspaceId {
+    this.workspaceSeq += 1;
+    return `mock-ws-${Date.now().toString(36)}-${this.workspaceSeq.toString(36)}` as WorkspaceId;
+  }
 }
 
 function promptText(content: readonly ContentBlock[]): string {
@@ -533,4 +651,30 @@ function isRunningTurn(session: MockSession, epoch: number): boolean {
 async function waitForShowcaseStep(session: MockSession, epoch: number): Promise<boolean> {
   await wait(SHOWCASE_SCRIPT_STEP_LATENCY_MS);
   return isRunningTurn(session, epoch);
+}
+
+function mockGitStatus(cwd: string): GitStatus {
+  return {
+    isRepo: true,
+    repoRoot: cwd,
+    branch: 'mock-host',
+    dirtyFileCount: 1,
+    ahead: 1,
+    behind: 0,
+    remote: {
+      url: 'https://github.com/linkcode/mock.git',
+      identity: {
+        provider: 'github',
+        host: 'github.com',
+        owner: 'linkcode',
+        repo: 'mock',
+      },
+    },
+  };
+}
+
+const PATH_SEPARATORS_RE = /[/\\]+/;
+
+function lastPathSegment(cwd: string): string {
+  return cwd.split(PATH_SEPARATORS_RE).findLast((part) => part.length > 0) ?? cwd;
 }

--- a/packages/workbench/src/mock/dev-mock-host.ts
+++ b/packages/workbench/src/mock/dev-mock-host.ts
@@ -38,7 +38,11 @@ import {
   SHOWCASE_PERMISSION_OPTIONS,
   SHOWCASE_PERMISSION_TOOL_ID,
   SHOWCASE_PLAN,
+  SHOWCASE_SCRIPT_START_DELAY_MS,
+  SHOWCASE_SCRIPT_STEP_LATENCY_MS,
+  SHOWCASE_STREAM_CHUNK_LATENCY_MS,
   SHOWCASE_STREAM_REPLY,
+  SHOWCASE_STREAM_START_DELAY_MS,
   SHOWCASE_STREAM_THOUGHT_CONTENT,
   SHOWCASE_TERMINAL_EXIT_OUTPUT,
   SHOWCASE_TERMINAL_START_OUTPUT,
@@ -53,7 +57,6 @@ interface MockSession extends SessionInfo {
   epoch: number;
   showcase?: boolean;
   showcaseSeeded?: boolean;
-  showcaseStreaming?: boolean;
   terminalId?: string;
 }
 
@@ -88,13 +91,13 @@ export class DevMockHost {
     switch (p.kind) {
       case 'session.list':
         await wait(CONTROL_LATENCY_MS);
-        // Seed after the client is connected; LocalTransport drops frames with no listener.
-        this.startShowcase();
         this.send({
           kind: 'session.listed',
           replyTo: p.clientReqId,
           sessions: [...this.sessions.values()].map((session) => toSessionInfo(session)),
         });
+        // Start after the list reply so the UI can subscribe before scripted frames arrive.
+        this.startShowcase();
         break;
       case 'session.start':
         await wait(CONTROL_LATENCY_MS);
@@ -313,16 +316,22 @@ export class DevMockHost {
   private startShowcase(): void {
     for (const session of this.sessions.values()) {
       if (!session.showcase) continue;
-      this.emitShowcaseConversation(session);
-      void this.streamShowcaseReply(session);
+      if (session.showcaseSeeded) continue;
+      session.showcaseSeeded = true;
+      void this.runShowcase(session);
     }
   }
 
-  private emitShowcaseConversation(session: MockSession): void {
-    if (session.showcaseSeeded) return;
-    session.showcaseSeeded = true;
+  private async runShowcase(session: MockSession): Promise<void> {
     session.status = 'running';
+    const epoch = session.epoch;
+    await wait(SHOWCASE_SCRIPT_START_DELAY_MS);
+    if (!isRunningTurn(session, epoch)) return;
+    if (!(await this.emitShowcaseConversation(session, epoch))) return;
+    await this.streamShowcaseReply(session, epoch);
+  }
 
+  private async emitShowcaseConversation(session: MockSession, epoch: number): Promise<boolean> {
     const introId = this.nextMessageId('mock-showcase-intro');
     const resourceId = this.nextMessageId('mock-showcase-resource');
     const terminalId = session.terminalId ?? SHOWCASE_TERMINAL_ID;
@@ -332,64 +341,81 @@ export class DevMockHost {
       diff: SHOWCASE_PERMISSION_DIFF,
     });
 
-    this.emit(session.sessionId, { type: 'status', status: 'running' });
-    this.emit(session.sessionId, { type: 'current-mode-update', currentModeId: 'mock-showcase' });
-    this.emit(session.sessionId, { type: 'user-message', content: SHOWCASE_USER_CONTENT });
-    this.emit(session.sessionId, {
-      type: 'agent-thought-chunk',
-      messageId: this.nextMessageId('mock-showcase-thought'),
-      content: SHOWCASE_THOUGHT_CONTENT,
-    });
-    this.emit(session.sessionId, { type: 'plan', plan: SHOWCASE_PLAN });
-    this.emit(session.sessionId, {
-      type: 'agent-message-chunk',
-      messageId: introId,
-      content: SHOWCASE_INTRO_CONTENT,
-    });
-    this.emit(session.sessionId, {
-      type: 'agent-message-chunk',
-      messageId: introId,
-      content: SHOWCASE_ARCHITECTURE_LINK,
-    });
-    this.emit(session.sessionId, {
-      type: 'agent-message-chunk',
-      messageId: resourceId,
-      content: SHOWCASE_EMBEDDED_RESOURCE,
-    });
-    this.emit(session.sessionId, {
-      type: 'agent-message-chunk',
-      messageId: this.nextMessageId('mock-showcase-image'),
-      content: SHOWCASE_IMAGE,
-    });
-
-    for (const toolCall of createShowcaseToolSnapshots(terminalId)) {
-      this.emitToolSnapshot(session.sessionId, toolCall);
-    }
-    this.send({ kind: 'terminal.output', terminalId, data: SHOWCASE_TERMINAL_START_OUTPUT });
-    this.emit(session.sessionId, {
-      type: 'permission-request',
-      requestId: SHOWCASE_PERMISSION_ID,
-      toolCall: {
-        toolCallId: SHOWCASE_PERMISSION_TOOL_ID,
-        title: 'Apply guarded edit',
-        kind: 'edit',
-        status: 'pending',
-        content: [SHOWCASE_PERMISSION_DIFF],
+    const script: AgentEvent[] = [
+      { type: 'status', status: 'running' },
+      { type: 'current-mode-update', currentModeId: 'mock-showcase' },
+      { type: 'user-message', content: SHOWCASE_USER_CONTENT },
+      {
+        type: 'agent-thought-chunk',
+        messageId: this.nextMessageId('mock-showcase-thought'),
+        content: SHOWCASE_THOUGHT_CONTENT,
       },
-      options: SHOWCASE_PERMISSION_OPTIONS,
-    });
-    this.emit(session.sessionId, SHOWCASE_ERROR_EVENT);
+      { type: 'plan', plan: SHOWCASE_PLAN },
+      {
+        type: 'agent-message-chunk',
+        messageId: introId,
+        content: SHOWCASE_INTRO_CONTENT,
+      },
+      {
+        type: 'agent-message-chunk',
+        messageId: introId,
+        content: SHOWCASE_ARCHITECTURE_LINK,
+      },
+      {
+        type: 'agent-message-chunk',
+        messageId: resourceId,
+        content: SHOWCASE_EMBEDDED_RESOURCE,
+      },
+      {
+        type: 'agent-message-chunk',
+        messageId: this.nextMessageId('mock-showcase-image'),
+        content: SHOWCASE_IMAGE,
+      },
+      ...createShowcaseToolSnapshots(terminalId).map(
+        (toolCall): AgentEvent => ({ type: 'tool-call', toolCall }),
+      ),
+    ];
+
+    for (const event of script) {
+      if (!(await waitForShowcaseStep(session, epoch))) return false;
+      this.emit(session.sessionId, event);
+    }
+    if (!(await waitForShowcaseStep(session, epoch))) return false;
+    this.send({ kind: 'terminal.output', terminalId, data: SHOWCASE_TERMINAL_START_OUTPUT });
+    if (
+      !(await this.emitShowcaseEvent(session, epoch, {
+        type: 'permission-request',
+        requestId: SHOWCASE_PERMISSION_ID,
+        toolCall: {
+          toolCallId: SHOWCASE_PERMISSION_TOOL_ID,
+          title: 'Apply guarded edit',
+          kind: 'edit',
+          status: 'pending',
+          content: [SHOWCASE_PERMISSION_DIFF],
+        },
+        options: SHOWCASE_PERMISSION_OPTIONS,
+      }))
+    ) {
+      return false;
+    }
+    return this.emitShowcaseEvent(session, epoch, SHOWCASE_ERROR_EVENT);
   }
 
-  private async streamShowcaseReply(session: MockSession): Promise<void> {
-    if (session.showcaseStreaming) return;
-    session.showcaseStreaming = true;
+  private async emitShowcaseEvent(
+    session: MockSession,
+    epoch: number,
+    event: AgentEvent,
+  ): Promise<boolean> {
+    if (!(await waitForShowcaseStep(session, epoch))) return false;
+    this.emit(session.sessionId, event);
+    return true;
+  }
 
-    const epoch = session.epoch;
+  private async streamShowcaseReply(session: MockSession, epoch: number): Promise<void> {
     const terminalId = session.terminalId ?? SHOWCASE_TERMINAL_ID;
     const thoughtId = this.nextMessageId('mock-showcase-stream-thought');
     const messageId = this.nextMessageId('mock-showcase-stream');
-    await wait(500);
+    await wait(SHOWCASE_STREAM_START_DELAY_MS);
     if (!isRunningTurn(session, epoch)) return;
     this.emit(session.sessionId, {
       type: 'agent-thought-chunk',
@@ -398,7 +424,7 @@ export class DevMockHost {
     });
 
     for (const chunk of SHOWCASE_STREAM_REPLY.match(WORD_CHUNK_PATTERN) ?? []) {
-      await wait(CHUNK_LATENCY_MS);
+      await wait(SHOWCASE_STREAM_CHUNK_LATENCY_MS);
       if (!isRunningTurn(session, epoch)) return;
       this.emit(session.sessionId, {
         type: 'agent-message-chunk',
@@ -502,4 +528,9 @@ function toSessionInfo(session: MockSession): SessionInfo {
 
 function isRunningTurn(session: MockSession, epoch: number): boolean {
   return session.epoch === epoch && session.status === 'running';
+}
+
+async function waitForShowcaseStep(session: MockSession, epoch: number): Promise<boolean> {
+  await wait(SHOWCASE_SCRIPT_STEP_LATENCY_MS);
+  return isRunningTurn(session, epoch);
 }

--- a/packages/workbench/src/mock/dev-mock-host.ts
+++ b/packages/workbench/src/mock/dev-mock-host.ts
@@ -32,10 +32,13 @@ import {
 } from './data/prompt';
 import { SEED_SESSIONS, SHOWCASE_TERMINAL_ID } from './data/sessions';
 import {
-  createShowcaseToolSnapshots,
+  createShowcaseToolBursts,
   SHOWCASE_ARCHITECTURE_LINK,
+  SHOWCASE_COMMANDS_NARRATION,
   SHOWCASE_EMBEDDED_RESOURCE,
   SHOWCASE_ERROR_EVENT,
+  SHOWCASE_EXPLORE_NARRATION,
+  SHOWCASE_FILES_NARRATION,
   SHOWCASE_IMAGE,
   SHOWCASE_INTRO_CONTENT,
   SHOWCASE_PERMISSION_DENIED_CONTENT,
@@ -524,6 +527,9 @@ export class DevMockHost {
     const introId = this.nextMessageId('mock-showcase-intro');
     const resourceId = this.nextMessageId('mock-showcase-resource');
     const terminalId = session.terminalId ?? SHOWCASE_TERMINAL_ID;
+    const bursts = createShowcaseToolBursts(terminalId);
+    const toolEvents = (toolCalls: readonly ToolCall[]): AgentEvent[] =>
+      toolCalls.map((toolCall) => ({ type: 'tool-call', toolCall }));
     this.permissions.set(SHOWCASE_PERMISSION_ID, {
       sessionId: session.sessionId,
       toolCallId: SHOWCASE_PERMISSION_TOOL_ID,
@@ -560,9 +566,25 @@ export class DevMockHost {
         messageId: this.nextMessageId('mock-showcase-image'),
         content: SHOWCASE_IMAGE,
       },
-      ...createShowcaseToolSnapshots(terminalId).map(
-        (toolCall): AgentEvent => ({ type: 'tool-call', toolCall }),
-      ),
+      ...toolEvents(bursts.explore),
+      {
+        type: 'agent-message-chunk',
+        messageId: this.nextMessageId('mock-showcase-explore-note'),
+        content: SHOWCASE_EXPLORE_NARRATION,
+      },
+      ...toolEvents(bursts.files),
+      {
+        type: 'agent-message-chunk',
+        messageId: this.nextMessageId('mock-showcase-files-note'),
+        content: SHOWCASE_FILES_NARRATION,
+      },
+      ...toolEvents(bursts.commands),
+      {
+        type: 'agent-message-chunk',
+        messageId: this.nextMessageId('mock-showcase-commands-note'),
+        content: SHOWCASE_COMMANDS_NARRATION,
+      },
+      ...toolEvents(bursts.wrapUp),
     ];
 
     for (const event of script) {

--- a/packages/workbench/src/mock/dev-mock-host.ts
+++ b/packages/workbench/src/mock/dev-mock-host.ts
@@ -1,10 +1,10 @@
 import type {
   AgentEvent,
+  AgentHistoryId,
+  AgentHistorySession,
   AgentInput,
+  AgentKind,
   ContentBlock,
-  GitDiff,
-  GitPullRequestStatus,
-  GitStatus,
   MessageId,
   PermissionOutcome,
   ProvidersConfig,
@@ -21,6 +21,8 @@ import { normalizeCwdKey, textBlock } from '@linkcode/schema';
 import type { Transport } from '@linkcode/transport';
 import { createWireMessage } from '@linkcode/transport';
 import { wait } from 'foxts/wait';
+import { gitFixtureFor } from './data/git';
+import { SEED_HISTORY } from './data/history';
 import {
   CHUNK_LATENCY_MS,
   CONTROL_LATENCY_MS,
@@ -71,37 +73,17 @@ interface PendingPermission {
   diff: Extract<ToolCall['content'][number], { type: 'diff' }>;
 }
 
-const MOCK_GIT_DIFF: GitDiff = {
-  patch:
-    "diff --git a/mock.ts b/mock.ts\nindex 0000000..1111111 100644\n--- a/mock.ts\n+++ b/mock.ts\n@@ -1 +1 @@\n-const mode = 'daemon';\n+const mode = 'mock';\n",
-  truncated: false,
-  stat: { files: 1, additions: 1, deletions: 1 },
-};
-
-const MOCK_PR_STATUS: GitPullRequestStatus = {
-  status: 'ok',
-  pullRequest: {
-    provider: 'github',
-    number: 42,
-    title: 'Mock host data-plane coverage',
-    url: 'https://github.com/linkcode/mock/pull/42',
-    state: 'open',
-    isDraft: false,
-    baseBranch: 'main',
-    headBranch: 'mock-host',
-    checks: 'passing',
-    reviewDecision: 'approved',
-  },
-};
-
 export class DevMockHost {
   private readonly sessions = new Map<SessionId, MockSession>();
   private readonly workspaces = new Map<WorkspaceId, WorkspaceRecord>();
   private providers: ProvidersConfig = {};
   private readonly permissions = new Map<string, PendingPermission>();
+  private history: AgentHistorySession[] = [];
+  private readonly terminals = new Set<string>();
   private sessionSeq = 0;
   private messageSeq = 0;
   private workspaceSeq = 0;
+  private terminalSeq = 0;
 
   constructor(private readonly transport: Transport) {}
 
@@ -116,6 +98,11 @@ export class DevMockHost {
       this.addSession({ ...seed, createdAt });
       this.touchWorkspace(seed.cwd, createdAt);
     }
+    this.history = SEED_HISTORY.map(({ ageMs, ...entry }) => ({
+      ...entry,
+      createdAt: now - ageMs,
+      updatedAt: now - ageMs,
+    }));
   }
 
   private async handle(msg: WireMessage): Promise<void> {
@@ -185,7 +172,7 @@ export class DevMockHost {
         this.send({
           kind: 'git.status.get.result',
           replyTo: p.clientReqId,
-          status: mockGitStatus(p.cwd),
+          status: gitFixtureFor(p.cwd).status,
         });
         break;
       case 'git.pr_status.get':
@@ -193,24 +180,52 @@ export class DevMockHost {
         this.send({
           kind: 'git.pr_status.get.result',
           replyTo: p.clientReqId,
-          prStatus: MOCK_PR_STATUS,
+          prStatus: gitFixtureFor(p.cwd).prStatus,
         });
         break;
       case 'git.diff.get':
         await wait(CONTROL_LATENCY_MS);
-        this.send({ kind: 'git.diff.get.result', replyTo: p.clientReqId, diff: MOCK_GIT_DIFF });
+        this.send({
+          kind: 'git.diff.get.result',
+          replyTo: p.clientReqId,
+          diff: gitFixtureFor(p.cwd).diff,
+        });
         break;
       case 'session.import':
-        this.sendFailure(p.clientReqId, 'Dev mock host does not support importing sessions yet.');
+        await wait(CONTROL_LATENCY_MS);
+        this.importSession(p.clientReqId, p.agentKind, p.historyId);
         break;
       case 'history.list':
+        await wait(CONTROL_LATENCY_MS);
+        this.send({
+          kind: 'history.listed',
+          replyTo: p.clientReqId,
+          result: { sessions: this.listHistory(p.agentKind, p.opts?.cwd) },
+        });
+        break;
       case 'history.read':
       case 'history.resume':
         // Fail loudly for unmocked surfaces so correlated SDK calls reject instead of hanging forever.
         this.sendFailure(p.clientReqId, 'Dev mock host does not support history yet.');
         break;
       case 'terminal.open':
-        this.sendFailure(p.clientReqId, 'Dev mock host does not support terminals yet.');
+        await wait(CONTROL_LATENCY_MS);
+        this.openTerminal(p.clientReqId, p.opts.cwd);
+        break;
+      case 'terminal.input':
+        // Echo PTY: no shell behind it, keystrokes come straight back; Enter draws a fresh prompt.
+        if (this.terminals.has(p.terminalId)) {
+          this.send({
+            kind: 'terminal.output',
+            terminalId: p.terminalId,
+            data: p.data.replaceAll('\r', '\r\n$ '),
+          });
+        }
+        break;
+      case 'terminal.close':
+        if (this.terminals.delete(p.terminalId)) {
+          this.send({ kind: 'terminal.exit', terminalId: p.terminalId, exitCode: 0 });
+        }
         break;
       case 'ping':
         this.send({ kind: 'pong' });
@@ -223,12 +238,14 @@ export class DevMockHost {
   private addSession(
     init: Omit<MockSession, 'sessionId' | 'origin' | 'epoch' | 'status'> & {
       status: SessionStatus;
+      origin?: SessionInfo['origin'];
     },
   ): MockSession {
+    const { origin, ...rest } = init;
     const session: MockSession = {
-      ...init,
+      ...rest,
       sessionId: this.nextSessionId(),
-      origin: { type: 'created' },
+      origin: origin ?? { type: 'created' },
       epoch: 0,
     };
     this.sessions.set(session.sessionId, session);
@@ -277,12 +294,71 @@ export class DevMockHost {
     cwd: string,
     model: string | undefined,
   ): void {
-    const session = this.addSession({ kind, cwd, status: 'idle', createdAt: Date.now(), model });
+    const now = Date.now();
+    const session = this.addSession({ kind, cwd, status: 'idle', createdAt: now, model });
+    // Parity with the engine: starting a session registers/freshens its directory's workspace.
+    this.touchWorkspace(cwd, now);
     const { sessionId } = session;
     this.emit(sessionId, { type: 'status', status: 'starting' });
     this.emit(sessionId, { type: 'current-mode-update', currentModeId: 'mock' });
     this.emit(sessionId, { type: 'status', status: 'idle' });
     this.send({ kind: 'session.started', replyTo, sessionId });
+  }
+
+  private listHistory(agentKind: AgentKind, cwd: string | undefined): AgentHistorySession[] {
+    const cwdKey = cwd === undefined ? null : normalizeCwdKey(cwd);
+    return this.history.filter(
+      (entry) =>
+        entry.kind === agentKind &&
+        (cwdKey === null || (entry.cwd !== undefined && normalizeCwdKey(entry.cwd) === cwdKey)),
+    );
+  }
+
+  /** Mint a cold (stopped, resumable) session from a canned history entry, like the engine's import. */
+  private importSession(replyTo: string, agentKind: AgentKind, historyId: AgentHistoryId): void {
+    const entry = this.history.find(
+      (item) => item.kind === agentKind && item.historyId === historyId,
+    );
+    if (!entry) {
+      this.sendFailure(replyTo, `Unknown history session: ${historyId}`);
+      return;
+    }
+    const now = Date.now();
+    const origin = { type: 'imported', historyId, importedAt: now } as const;
+    const session = this.addSession({
+      kind: entry.kind,
+      cwd: entry.cwd ?? '/mock/imported',
+      title: entry.title,
+      status: 'stopped',
+      createdAt: entry.createdAt ?? now,
+      origin,
+    });
+    this.send({
+      kind: 'session.imported',
+      replyTo,
+      record: {
+        sessionId: session.sessionId,
+        kind: session.kind,
+        cwd: session.cwd,
+        title: session.title,
+        origin,
+        createdAt: session.createdAt,
+        updatedAt: now,
+        runs: [],
+      },
+    });
+  }
+
+  private openTerminal(replyTo: string, cwd: string | undefined): void {
+    this.terminalSeq += 1;
+    const terminalId = `mock-term-${Date.now().toString(36)}-${this.terminalSeq.toString(36)}`;
+    this.terminals.add(terminalId);
+    this.send({ kind: 'terminal.opened', replyTo, terminalId });
+    this.send({
+      kind: 'terminal.output',
+      terminalId,
+      data: `mock echo terminal — no shell attached (cwd: ${cwd ?? '/'})\r\n$ `,
+    });
   }
 
   private resumeSession(replyTo: string, sessionId: SessionId): void {
@@ -651,26 +727,6 @@ function isRunningTurn(session: MockSession, epoch: number): boolean {
 async function waitForShowcaseStep(session: MockSession, epoch: number): Promise<boolean> {
   await wait(SHOWCASE_SCRIPT_STEP_LATENCY_MS);
   return isRunningTurn(session, epoch);
-}
-
-function mockGitStatus(cwd: string): GitStatus {
-  return {
-    isRepo: true,
-    repoRoot: cwd,
-    branch: 'mock-host',
-    dirtyFileCount: 1,
-    ahead: 1,
-    behind: 0,
-    remote: {
-      url: 'https://github.com/linkcode/mock.git',
-      identity: {
-        provider: 'github',
-        host: 'github.com',
-        owner: 'linkcode',
-        repo: 'mock',
-      },
-    },
-  };
 }
 
 const PATH_SEPARATORS_RE = /[/\\]+/;

--- a/packages/workbench/src/mock/dev-mock-transport.ts
+++ b/packages/workbench/src/mock/dev-mock-transport.ts
@@ -1,0 +1,11 @@
+import type { Transport } from '@linkcode/transport';
+import { createLocalTransportPair } from '@linkcode/transport';
+import { DevMockHost } from './dev-mock-host';
+
+export function createDevMockTransport(): Transport {
+  const [client, host] = createLocalTransportPair();
+  // Hand the app the client endpoint; the mock host owns the peer and speaks real wire messages.
+  const mock = new DevMockHost(host);
+  mock.start();
+  return client;
+}

--- a/packages/workbench/src/runtime/daemon-transport.ts
+++ b/packages/workbench/src/runtime/daemon-transport.ts
@@ -1,0 +1,13 @@
+import type { Transport } from '@linkcode/transport';
+import { SocketIoTransport } from '@linkcode/transport';
+import { createDevMockTransport } from '../mock/dev-mock-transport';
+
+/**
+ * Construct the transport the workbench data plane rides on. Dev-only escape hatch: running the
+ * app with `--mode mock` (`pnpm dev:mock`) swaps the daemon for the in-process mock host; the
+ * `DEV` guard makes production builds fold the mock away entirely.
+ */
+export function createDaemonTransport(daemonUrl: string): Transport {
+  if (import.meta.env.DEV && import.meta.env.MODE === 'mock') return createDevMockTransport();
+  return new SocketIoTransport({ url: daemonUrl });
+}

--- a/packages/workbench/src/vite-env.d.ts
+++ b/packages/workbench/src/vite-env.d.ts
@@ -1,0 +1,10 @@
+// Minimal Vite env surface used by this package. Workbench is consumed as source by the Vite
+// renderers, which statically replace these; the full `vite/client` types live in the apps.
+interface ImportMetaEnv {
+  readonly DEV: boolean;
+  readonly MODE: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
This pull request introduces a development mock transport for the workbench, allowing the app to run without a backend daemon by simulating the full data plane in-process. It adds comprehensive mock data, a mock transport implementation, and extensive tests to ensure parity with real daemon behavior. Additionally, it updates both the desktop and webview apps to support a new `dev:mock` mode, which leverages the mock transport for local development and testing.

**Development Mock Transport and Data Plane Simulation:**

- Added `createDevMockTransport` and `DevMockHost` to simulate the daemon's transport layer, enabling the workbench to run fully in-process for development and testing. (`packages/workbench/src/mock/dev-mock-transport.ts` [packages/workbench/src/mock/dev-mock-transport.tsR1-R11](diffhunk://#diff-06e6058b86a21bdd492839f234e1ea552aca0fa2365fc485f8e0916cf2ad745cR1-R11))
- Introduced a rich set of mock session data and showcase events to seed the app and exercise all major conversation features, including plans, tool calls, diffs, terminal output, permissions, and error states. (`packages/workbench/src/mock/data/sessions.ts` [[1]](diffhunk://#diff-aadd137afa188fdc0af004df611aec4112a42071197dced1b25513973fb67800R1-R48) `packages/workbench/src/mock/data/showcase.ts` [[2]](diffhunk://#diff-7850a36bc2589151ad79873fab51c862d3aec46b4ef572e885c735a64b4bbc61R1-R180) `packages/workbench/src/mock/data/prompt.ts` [[3]](diffhunk://#diff-3fac8575327bed917e3e4b89cdab34bdfd9bd15d0587a5890f95fc2b09ad174dR1-R12)
- Implemented a runtime transport factory (`createDaemonTransport`) that switches to the mock transport when running in `dev:mock` mode, otherwise using the real daemon connection. (`packages/workbench/src/runtime/daemon-transport.ts` [packages/workbench/src/runtime/daemon-transport.tsR1-R13](diffhunk://#diff-d4adb9558fe01459526b54a18fa24baf3bed3ab2596c848911ca9842349f5cd2R1-R13))

**App Integration and Developer Experience:**

- Updated both the desktop and webview apps to support a `dev:mock` script and mode, enabling easy switching between real and mock daemon for local development. (`apps/desktop/package.json` [[1]](diffhunk://#diff-f260cda9a89e97068b04d6627600f3e650fcff63642da2f62c7b9412a2da2646R10) `apps/webview/package.json` [[2]](diffhunk://#diff-edf6a928e9e2c4b86519694401dd5e9fde6fda489c6ec2afecc8027c1cc66887R13)
- Refactored app and provider code to use the new `createDaemonTransport` function, ensuring consistent transport selection based on environment. (`apps/desktop/src/renderer/src/app.tsx` [[1]](diffhunk://#diff-d5a0bc203dc3cca66b3d998ea0abcdab509718554dc7f6768b0dfdd8304b2d82L1-R6) [[2]](diffhunk://#diff-d5a0bc203dc3cca66b3d998ea0abcdab509718554dc7f6768b0dfdd8304b2d82L36-R40); `apps/webview/src/routes/root-layout.tsx` [[3]](diffhunk://#diff-c7144c8036bf1ed0e4ec457b57f7aafe5376a3b6bc3e679d820404142833482dL1-R5) [[4]](diffhunk://#diff-c7144c8036bf1ed0e4ec457b57f7aafe5376a3b6bc3e679d820404142833482dL29-R32); `packages/workbench/src/index.ts` [[5]](diffhunk://#diff-f7594e6ef0c43273eade9ba6022ad5f1a9aad7b810142850b4cdfa725618fb5bR5)

**Testing and Parity Verification:**

- Added thorough tests for the mock transport covering session management, event streaming, permission flows, cancellation, error handling, and parity with the real daemon wire protocol. (`packages/workbench/src/mock/__tests__/dev-mock-transport.test.ts` [packages/workbench/src/mock/__tests__/dev-mock-transport.test.tsR1-R197](diffhunk://#diff-518402680501a5afa1e37326705c738ede60b77bc80c2f7b05299ab2a7b4ba92R1-R197))