### PR TITLE
fix: entire workspace will flicker upon changing active session

### DIFF
--- a/apps/desktop/src/renderer/src/shell/desktop-shell.tsx
+++ b/apps/desktop/src/renderer/src/shell/desktop-shell.tsx
@@ -1,6 +1,6 @@
 import type { SystemBridge } from '@linkcode/ipc';
 import type { AgentKind } from '@linkcode/schema';
-import { ConversationSurface, ErrorBanner, HostFooter, SessionSidebar } from '@linkcode/ui';
+import { HostFooter, SessionSidebar } from '@linkcode/ui';
 import { getChromeSurface, getWorkspaceMinSize } from '@linkcode/ui/shell/panels';
 import type { WorkbenchShellProps } from '@linkcode/workbench';
 import { Allotment, LayoutPriority } from 'allotment';
@@ -35,19 +35,11 @@ export function DesktopShell({
   header,
   sessions,
   activeSession,
-  conversation,
-  answeredPermissions,
-  respondingPermissions,
-  errorMessage,
+  pendingPermissionCount,
+  main,
   onSelectSession,
   onStopSession,
   onCreateSession,
-  onSendPrompt,
-  onStopTurn,
-  onRespondPermission,
-  TerminalBlockComponent,
-  onDismissError,
-  onModelChange,
   onOpenSettings,
 }: WorkbenchShellProps & {
   systemBridge: SystemBridge;
@@ -143,8 +135,6 @@ export function DesktopShell({
   );
 
   const active = activeSession;
-  const isRunning = conversation.status === 'running' || conversation.status === 'starting';
-  const agentLabel = active?.kind;
   const {
     updateSidebarOpen,
     updateLayout,
@@ -184,27 +174,7 @@ export function DesktopShell({
     resetBottomPanelLayoutSize();
   }
 
-  const main = (
-    <main className="flex h-full min-h-0 min-w-0 flex-col bg-background">
-      <ConversationSurface
-        className="min-h-0 flex-1"
-        conversation={conversation}
-        agentKind={active?.kind}
-        agentLabel={agentLabel}
-        cwd={active?.cwd}
-        answeredPermissions={answeredPermissions}
-        respondingPermissions={respondingPermissions}
-        TerminalBlockComponent={TerminalBlockComponent}
-        disabled={!active || active.status === 'stopped'}
-        isRunning={isRunning}
-        topContent={<ErrorBanner errorMessage={errorMessage} onDismissError={onDismissError} />}
-        onSendPrompt={onSendPrompt}
-        onStopTurn={onStopTurn}
-        onRespondPermission={onRespondPermission}
-        onModelChange={onModelChange}
-      />
-    </main>
-  );
+  const workspaceMain = <main className="h-full min-h-0 min-w-0 bg-background">{main}</main>;
 
   // One renderer, two mount points: the docked instance (inside the Allotment,
   // owns the chrome tabs/controls) and the maximized overlay instance (chrome
@@ -323,7 +293,7 @@ export function DesktopShell({
                   <HostFooter
                     state={tConnection('connected')}
                     appVersion={appVersion}
-                    pendingPermissionCount={conversation.pendingPermissionIds.length}
+                    pendingPermissionCount={pendingPermissionCount}
                     onOpenSettings={onOpenSettings}
                   />
                 }
@@ -335,7 +305,7 @@ export function DesktopShell({
           </Allotment.Pane>
           <Allotment.Pane minSize={workspaceMinSize} priority={LayoutPriority.High}>
             <DesktopWorkspace
-              main={main}
+              main={workspaceMain}
               right={workspaceRight}
               bottom={workspaceBottom}
               rightAllotmentRef={rightAllotmentRef}

--- a/apps/webview/src/shell/web-workbench-shell.tsx
+++ b/apps/webview/src/shell/web-workbench-shell.tsx
@@ -4,7 +4,11 @@ import { Button } from 'coss-ui/components/button';
 import { SettingsIcon } from 'lucide-react';
 import { Link } from 'react-router';
 
-export function WebWorkbenchShell({ header, ...props }: WorkbenchShellProps): React.ReactNode {
+export function WebWorkbenchShell({
+  header,
+  pendingPermissionCount: _pendingPermissionCount,
+  ...props
+}: WorkbenchShellProps): React.ReactNode {
   const hasUsage =
     header.usage != null && (header.usage.inputTokens != null || header.usage.outputTokens != null);
 

--- a/packages/client-core/src/__tests__/event-buffer.test.ts
+++ b/packages/client-core/src/__tests__/event-buffer.test.ts
@@ -1,0 +1,97 @@
+import type { AgentEvent, MessageId, SessionId, WirePayload } from '@linkcode/schema';
+import { createLocalTransportPair, createWireMessage } from '@linkcode/transport';
+import { describe, expect, it } from 'vitest';
+import { LinkCodeClient } from '../client';
+
+const sessionId = 'sess-events' as SessionId;
+
+function chunk(text: string): AgentEvent {
+  return {
+    type: 'agent-message-chunk',
+    messageId: 'm1' as MessageId,
+    content: { type: 'text', text },
+  };
+}
+
+async function connectedPair() {
+  const [clientTransport, serverTransport] = createLocalTransportPair();
+  const client = new LinkCodeClient(clientTransport);
+  await client.connect();
+  await serverTransport.connect();
+  // The local pair delivers on a microtask; yield one so the client has routed the event.
+  const emit = async (event: AgentEvent, id: SessionId = sessionId) => {
+    serverTransport.send(createWireMessage({ kind: 'agent.event', sessionId: id, event }));
+    await Promise.resolve();
+  };
+  return { client, serverTransport, emit };
+}
+
+describe('LinkCodeClient event buffer snapshots', () => {
+  it('returns a stable snapshot that only changes when an event arrives', async () => {
+    const { client, serverTransport, emit } = await connectedPair();
+
+    expect(client.getEvents(sessionId)).toBe(client.getEvents('sess-other' as SessionId));
+    expect(client.getEvents(sessionId)).toEqual([]);
+
+    await emit(chunk('a'));
+    const afterFirst = client.getEvents(sessionId);
+    expect(afterFirst).toEqual([chunk('a')]);
+    expect(client.getEvents(sessionId)).toBe(afterFirst);
+
+    await emit(chunk('b'));
+    const afterSecond = client.getEvents(sessionId);
+    expect(afterSecond).not.toBe(afterFirst);
+    expect(afterSecond).toEqual([chunk('a'), chunk('b')]);
+    // The earlier snapshot is untouched — appends replace the array instead of mutating it.
+    expect(afterFirst).toEqual([chunk('a')]);
+
+    client.dispose();
+    serverTransport.close();
+  });
+
+  it('replays the buffer on subscribe and keeps notifying afterwards', async () => {
+    const { client, serverTransport, emit } = await connectedPair();
+
+    await emit(chunk('a'));
+    await emit(chunk('b'));
+
+    const seen: AgentEvent[] = [];
+    client.subscribe(sessionId, (event) => seen.push(event));
+    expect(seen).toEqual([chunk('a'), chunk('b')]);
+
+    await emit(chunk('c'));
+    expect(seen).toHaveLength(3);
+    expect(client.getEvents(sessionId)).toEqual(seen);
+
+    client.dispose();
+    serverTransport.close();
+  });
+
+  it('retains the buffer and subscriptions across stopSession', async () => {
+    const { client, serverTransport, emit } = await connectedPair();
+
+    serverTransport.onMessage((msg) => {
+      if (msg.payload.kind === 'session.stop') {
+        const payload: WirePayload = {
+          kind: 'request.succeeded',
+          replyTo: msg.payload.clientReqId,
+        };
+        serverTransport.send(createWireMessage(payload));
+      }
+    });
+
+    await emit(chunk('a'));
+    const seen: AgentEvent[] = [];
+    client.subscribe(sessionId, (event) => seen.push(event));
+
+    await client.stopSession(sessionId);
+    expect(client.getEvents(sessionId)).toEqual([chunk('a')]);
+
+    // A resumed session keeps the same id; events must still reach the live subscriber.
+    await emit(chunk('b'));
+    expect(seen).toEqual([chunk('a'), chunk('b')]);
+
+    client.dispose();
+    serverTransport.close();
+  });
+});

--- a/packages/client-core/src/client.ts
+++ b/packages/client-core/src/client.ts
@@ -44,6 +44,9 @@ export type HistoryReadClientOptions = AgentHistoryReadOptions & {
 /** Cap on per-terminal output buffered before the first subscriber, so an unread PTY can't grow unbounded. */
 const TERMINAL_PREBUFFER_CAP = 128 * 1024;
 
+/** Stable empty snapshot for sessions with no buffered events yet. */
+const NO_EVENTS: readonly AgentEvent[] = [];
+
 /**
  * Trim buffered terminal output to the cap on a line boundary. Slicing raw would leave the buffer
  * starting mid-ANSI-escape (the head byte gone, the tail rendered as literal garbage); dropping the
@@ -72,8 +75,13 @@ function nextClientReqId(): string {
  */
 export class LinkCodeClient {
   private readonly subscribers = new Map<SessionId, Set<EventCb>>();
-  /** Per-session event buffer so a re-subscribe (switching the active session back) can replay the timeline. */
-  private readonly events = new Map<SessionId, AgentEvent[]>();
+  /**
+   * Per-session event timeline: replaced (not mutated) on append so `getEvents` snapshots are
+   * referentially stable between events (safe for `useSyncExternalStore`). Retained across
+   * `stopSession` — the daemon does not replay history on resume, so this buffer is the only
+   * copy of a cold session's timeline.
+   */
+  private readonly events = new Map<SessionId, readonly AgentEvent[]>();
   private readonly pendingStarts = new Map<string, Pending<SessionId>>();
   private readonly pendingLists = new Map<string, Pending<SessionInfo[]>>();
   private readonly pendingImports = new Map<string, Pending<SessionRecord>>();
@@ -151,8 +159,7 @@ export class LinkCodeClient {
       }
       case 'agent.event': {
         const buf = this.events.get(p.sessionId);
-        if (buf) buf.push(p.event);
-        else this.events.set(p.sessionId, [p.event]);
+        this.events.set(p.sessionId, buf ? [...buf, p.event] : [p.event]);
         const subs = this.subscribers.get(p.sessionId);
         if (subs) for (const cb of subs) cb(p.event);
         break;
@@ -303,15 +310,13 @@ export class LinkCodeClient {
   }
 
   stopSession(sessionId: SessionId): Promise<RequestAck> {
+    // Subscribers and the event buffer survive the stop: the session record stays listed (cold),
+    // and resuming keeps the same id — dropping either would mute or blank a still-rendered timeline.
     return this.sendCorrelated(this.pendingAcks, (clientReqId) => ({
       kind: 'session.stop',
       clientReqId,
       sessionId,
-    })).then((ack) => {
-      this.subscribers.delete(sessionId);
-      this.events.delete(sessionId);
-      return ack;
-    });
+    }));
   }
 
   /** Read the daemon-owned provider config (data plane). */
@@ -329,6 +334,11 @@ export class LinkCodeClient {
       clientReqId,
       providers,
     }));
+  }
+
+  /** Snapshot of a session's buffered timeline; the reference only changes when an event arrives. */
+  getEvents(sessionId: SessionId): readonly AgentEvent[] {
+    return this.events.get(sessionId) ?? NO_EVENTS;
   }
 
   subscribe(sessionId: SessionId, cb: EventCb): Unsubscribe {

--- a/packages/client-core/src/react.tsx
+++ b/packages/client-core/src/react.tsx
@@ -8,7 +8,15 @@ import type {
 import { noop } from 'foxact/noop';
 import { nullthrow } from 'foxact/nullthrow';
 import type * as React from 'react';
-import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  useSyncExternalStore,
+} from 'react';
 import type { LinkCodeClient } from './client';
 import type { Conversation } from './conversation';
 import { buildConversation } from './conversation';
@@ -35,26 +43,22 @@ export function useLinkCodeClient(): LinkCodeClient {
   );
 }
 
-/** Subscribe to a session's normalized event stream, accumulating it into a list (push model). */
-export function useAgentEvents(sessionId: SessionId | null): AgentEvent[] {
+const NO_EVENTS: readonly AgentEvent[] = [];
+
+/**
+ * Subscribe to a session's normalized event stream. Reads the client's per-session buffer as an
+ * external store, so the first render of a session (mount or in-place id change) already sees the
+ * full buffered timeline — no blank frame while an effect replays it.
+ */
+export function useAgentEvents(sessionId: SessionId | null): readonly AgentEvent[] {
   const client = useLinkCodeClient();
-  const [state, setState] = useState<{ sessionId: SessionId | null; events: AgentEvent[] }>({
-    sessionId: null,
-    events: [],
-  });
-
-  useEffect(() => {
-    if (!sessionId) return;
-    return client.subscribe(sessionId, (event) => {
-      setState((prev) =>
-        prev.sessionId === sessionId
-          ? { sessionId, events: [...prev.events, event] }
-          : { sessionId, events: [event] },
-      );
-    });
-  }, [client, sessionId]);
-
-  return state.sessionId === sessionId ? state.events : [];
+  const subscribe = useCallback(
+    (onStoreChange: () => void) => (sessionId ? client.subscribe(sessionId, onStoreChange) : noop),
+    [client, sessionId],
+  );
+  return useSyncExternalStore(subscribe, () =>
+    sessionId ? client.getEvents(sessionId) : NO_EVENTS,
+  );
 }
 
 /** Subscribe to a terminal's output, accumulating it into a string for read-only display. */

--- a/packages/ui/src/shell/shell-frame.tsx
+++ b/packages/ui/src/shell/shell-frame.tsx
@@ -1,49 +1,28 @@
 import type { AgentKind, SessionId, SessionInfo } from '@linkcode/schema';
-import type { ConversationViewModel } from '../chat';
-import { ConversationSurface } from './conversation-surface';
-import { ErrorBanner } from './error-banner';
 import { DefaultHostFooter, SessionSidebar } from './session-sidebar';
 
 export interface ShellFrameProps {
   sessions: SessionInfo[];
   /** Derived once by the workbench surface; shells consume it instead of re-deriving from the list. */
   activeSession: SessionInfo | null;
-  conversation: ConversationViewModel;
-  answeredPermissions: Set<string>;
-  respondingPermissions: Set<string>;
   header?: React.ReactNode;
-  errorMessage?: string | null;
+  /** The session-scoped content (conversation + composer), owned and keyed by the workbench surface. */
+  main: React.ReactNode;
   onSelectSession: (id: SessionId) => void;
   onStopSession: (id: SessionId) => void;
   onCreateSession: (opts: { kind: AgentKind; cwd: string }) => void;
-  onSendPrompt: (text: string) => void;
-  onStopTurn: () => void;
-  onRespondPermission: (requestId: string, optionId: string) => void;
-  TerminalBlockComponent?: React.ComponentType<{ terminalId: string }>;
-  onDismissError?: () => void;
-  onModelChange?: (model: string) => Promise<void>;
 }
 
 export function ShellFrame({
   sessions,
   activeSession,
-  conversation,
-  answeredPermissions,
-  respondingPermissions,
   header,
-  errorMessage,
+  main,
   onSelectSession,
   onStopSession,
   onCreateSession,
-  onSendPrompt,
-  onStopTurn,
-  onRespondPermission,
-  TerminalBlockComponent,
-  onDismissError,
-  onModelChange,
 }: ShellFrameProps): React.ReactNode {
   const active = activeSession;
-  const isRunning = conversation.status === 'running' || conversation.status === 'starting';
   const fallbackCwd = active?.cwd ?? sessions.at(0)?.cwd ?? '/';
 
   return (
@@ -60,23 +39,7 @@ export function ShellFrame({
       </div>
       <main className="flex min-w-0 flex-1 flex-col">
         {header}
-        <ErrorBanner errorMessage={errorMessage} onDismissError={onDismissError} />
-        <ConversationSurface
-          className="min-h-0 flex-1"
-          conversation={conversation}
-          agentKind={active?.kind}
-          agentLabel={active ? active.kind : undefined}
-          disabled={!active || active.status === 'stopped'}
-          isRunning={isRunning}
-          cwd={active?.cwd}
-          answeredPermissions={answeredPermissions}
-          respondingPermissions={respondingPermissions}
-          TerminalBlockComponent={TerminalBlockComponent}
-          onSendPrompt={onSendPrompt}
-          onStopTurn={onStopTurn}
-          onRespondPermission={onRespondPermission}
-          onModelChange={onModelChange}
-        />
+        <div className="min-h-0 flex-1">{main}</div>
       </main>
     </div>
   );

--- a/packages/workbench/src/surface/shell.tsx
+++ b/packages/workbench/src/surface/shell.tsx
@@ -1,5 +1,4 @@
-import type { TokenUsage } from '@linkcode/schema';
-import type { ShellFrameProps } from '@linkcode/ui';
+import type { AgentKind, SessionId, SessionInfo, TokenUsage } from '@linkcode/schema';
 import { ShellFrame, TitleStrip } from '@linkcode/ui';
 
 export interface WorkbenchShellHeader {
@@ -8,14 +7,35 @@ export interface WorkbenchShellHeader {
   usage?: TokenUsage | null;
 }
 
-/** The contract between the workbench surface and an app-provided shell (e.g. desktop's). */
-export interface WorkbenchShellProps extends Omit<ShellFrameProps, 'header'> {
+/**
+ * The contract between the workbench surface and an app-provided shell (e.g. desktop's).
+ *
+ * The shell is session-agnostic layout that mounts once: it receives the session inbox, narrow
+ * header/badge view-models, and the session-scoped view as the pre-built `main` slot. Everything
+ * that changes per conversation (stream, composer, permissions) lives inside `main`, so switching
+ * sessions never remounts the shell.
+ */
+export interface WorkbenchShellProps {
+  sessions: SessionInfo[];
+  /** Derived once by the workbench surface; shells consume it instead of re-deriving from the list. */
+  activeSession: SessionInfo | null;
   header: WorkbenchShellHeader;
+  /** Unanswered permission requests in the active conversation (badge count). */
+  pendingPermissionCount: number;
+  /** The session-scoped view (conversation + composer), keyed by session — mount it as-is. */
+  main: React.ReactNode;
+  onSelectSession: (id: SessionId) => void;
+  onStopSession: (id: SessionId) => void;
+  onCreateSession: (opts: { kind: AgentKind; cwd: string }) => void;
 }
 
 export type WorkbenchShellComponent = (props: WorkbenchShellProps) => React.ReactNode;
 
-export function DefaultWorkbenchShell({ header, ...props }: WorkbenchShellProps): React.ReactNode {
+export function DefaultWorkbenchShell({
+  header,
+  pendingPermissionCount: _pendingPermissionCount,
+  ...props
+}: WorkbenchShellProps): React.ReactNode {
   return <ShellFrame {...props} header={<DefaultTitleStrip header={header} />} />;
 }
 

--- a/packages/workbench/src/surface/workbench.tsx
+++ b/packages/workbench/src/surface/workbench.tsx
@@ -1,6 +1,7 @@
 import { useConversation, useTerminalOutput } from '@linkcode/client-core';
+import type { SessionInfo } from '@linkcode/schema';
 import { cancelTurn, promptText, respondPermission, setModel } from '@linkcode/sdk';
-import { TerminalBlock } from '@linkcode/ui';
+import { ConversationSurface, ErrorBanner, TerminalBlock } from '@linkcode/ui';
 import { noop } from 'foxact/noop';
 import { useSet } from 'foxact/use-set';
 import { extractErrorMessage } from 'foxts/extract-error-message';
@@ -9,7 +10,6 @@ import { useTranslations } from 'use-intl';
 import { useMutation } from '../runtime/tayori';
 import type { WorkbenchShellComponent } from './shell';
 import { DefaultWorkbenchShell } from './shell';
-import type { WorkbenchSessions } from './use-workbench-sessions';
 import { useWorkbenchSessions } from './use-workbench-sessions';
 
 export interface WorkbenchProps {
@@ -23,10 +23,14 @@ export interface WorkbenchProps {
  * `TayoriProvider`, `SWRConfig`, and `LinkCodeProvider`) — see `WorkbenchProviders`.
  * Wrap it in `WorkbenchProviders` (at a layout, or inline) and mount it as a
  * routed feature page.
+ *
+ * The shell mounts once and never remounts on session switch; only the keyed
+ * `WorkbenchSessionView` in its `main` slot does.
  */
 export function Workbench({
   shellComponent: ShellComponent = DefaultWorkbenchShell,
 }: WorkbenchProps): React.ReactNode {
+  const tk = useTranslations('workbench.agentKind');
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   function handleError(err: unknown): void {
     setErrorMessage(extractErrorMessage(err));
@@ -34,73 +38,90 @@ export function Workbench({
 
   const sessions = useWorkbenchSessions(handleError);
   const conversation = useConversation(sessions.activeId);
+  const active = sessions.active;
 
   return (
-    <WorkbenchSessionSurface
-      key={sessions.activeId ?? 'no-active-session'}
-      sessions={sessions}
-      conversation={conversation}
-      errorMessage={errorMessage}
-      ShellComponent={ShellComponent}
-      onClearError={() => setErrorMessage(null)}
-      onError={handleError}
+    <ShellComponent
+      sessions={sessions.sessions}
+      activeSession={active}
+      header={{
+        title: active ? tk(active.kind) : 'Link Code',
+        subtitle: active?.cwd,
+        usage: conversation.usage,
+      }}
+      pendingPermissionCount={conversation.pendingPermissionIds.length}
+      onSelectSession={sessions.select}
+      onStopSession={sessions.stop}
+      onCreateSession={sessions.create}
+      main={
+        <WorkbenchSessionView
+          key={sessions.activeId ?? 'no-active-session'}
+          session={active}
+          conversation={conversation}
+          errorMessage={errorMessage}
+          onClearError={() => setErrorMessage(null)}
+          onError={handleError}
+        />
+      }
     />
   );
 }
 
-interface WorkbenchSessionSurfaceProps {
-  sessions: WorkbenchSessions;
+interface WorkbenchSessionViewProps {
+  session: SessionInfo | null;
   conversation: ReturnType<typeof useConversation>;
   errorMessage: string | null;
-  ShellComponent: WorkbenchShellComponent;
   onClearError: () => void;
   onError: (err: unknown) => void;
 }
 
-function WorkbenchSessionSurface({
-  sessions,
+/**
+ * The session-scoped view: conversation stream + composer + permission responses. Keyed by session
+ * in `Workbench`, so per-session state (composer draft, scroll, the permission sets below) resets
+ * on switch while the shell above stays mounted.
+ */
+function WorkbenchSessionView({
+  session,
   conversation,
   errorMessage,
-  ShellComponent,
   onClearError,
   onError,
-}: WorkbenchSessionSurfaceProps): React.ReactNode {
-  const tk = useTranslations('workbench.agentKind');
+}: WorkbenchSessionViewProps): React.ReactNode {
   const promptMutation = useMutation(promptText, { onError });
   const cancelMutation = useMutation(cancelTurn, { onError });
   const permissionMutation = useMutation(respondPermission, { onError });
   const modelMutation = useMutation(setModel, { onError });
   const [answered, addAnswered] = useSet<string>();
   const [responding, addResponding, removeResponding] = useSet<string>();
-  const active = sessions.active;
+  const sessionId = session?.sessionId ?? null;
 
   function handleSend(text: string): void {
-    if (!sessions.activeId) return;
+    if (!sessionId) return;
     onClearError();
-    void promptMutation.trigger({ sessionId: sessions.activeId, text }).catch(noop);
+    void promptMutation.trigger({ sessionId, text }).catch(noop);
   }
 
   function handleStopTurn(): void {
-    if (!sessions.activeId) return;
+    if (!sessionId) return;
     onClearError();
-    void cancelMutation.trigger({ sessionId: sessions.activeId }).catch(noop);
+    void cancelMutation.trigger({ sessionId }).catch(noop);
   }
 
   function handleModelChange(model: string): Promise<void> {
-    if (!sessions.activeId) return Promise.reject(new Error('No active session'));
+    if (!sessionId) return Promise.reject(new Error('No active session'));
     onClearError();
     // Let the rejection propagate: the composer awaits it to decide whether to reflect the pick.
     // onError (wired into modelMutation above) still reports the failure via the error banner.
-    return modelMutation.trigger({ sessionId: sessions.activeId, model }).then(noop);
+    return modelMutation.trigger({ sessionId, model }).then(noop);
   }
 
   function handleRespond(requestId: string, optionId: string): void {
-    if (!sessions.activeId) return;
+    if (!sessionId) return;
     onClearError();
     addResponding(requestId);
     void permissionMutation
       .trigger({
-        sessionId: sessions.activeId,
+        sessionId,
         requestId,
         outcome: { outcome: 'selected', optionId },
       })
@@ -113,27 +134,23 @@ function WorkbenchSessionSurface({
       });
   }
 
+  const isRunning = conversation.status === 'running' || conversation.status === 'starting';
+
   return (
-    <ShellComponent
-      sessions={sessions.sessions}
-      activeSession={active}
+    <ConversationSurface
       conversation={conversation}
+      agentKind={session?.kind}
+      agentLabel={session?.kind}
+      cwd={session?.cwd}
       answeredPermissions={answered}
       respondingPermissions={responding}
-      header={{
-        title: active ? tk(active.kind) : 'Link Code',
-        subtitle: active?.cwd,
-        usage: conversation.usage,
-      }}
-      errorMessage={errorMessage}
-      onSelectSession={sessions.select}
-      onStopSession={sessions.stop}
-      onCreateSession={sessions.create}
+      disabled={!session || session.status === 'stopped'}
+      isRunning={isRunning}
+      topContent={<ErrorBanner errorMessage={errorMessage} onDismissError={onClearError} />}
+      TerminalBlockComponent={RuntimeTerminalBlock}
       onSendPrompt={handleSend}
       onStopTurn={handleStopTurn}
       onRespondPermission={handleRespond}
-      TerminalBlockComponent={RuntimeTerminalBlock}
-      onDismissError={onClearError}
       onModelChange={handleModelChange}
     />
   );


### PR DESCRIPTION
This pull request refactors the shell and session layout system to improve separation of concerns, simplify component contracts, and optimize event handling. The main changes include moving session-scoped content into a single `main` prop, updating shell and workbench interfaces, and improving event buffer management for more efficient and stable UI updates.

Shell and session layout refactor:

* The `WorkbenchShellProps` interface has been simplified to remove conversation-specific props and now accepts a single `main` prop for session-scoped content, along with a `pendingPermissionCount` for badge display. This change ensures that shells are session-agnostic and only the session view is remounted when switching sessions. (`packages/workbench/src/surface/shell.tsx` [[1]](diffhunk://#diff-a7343eb11b7c1ac2e14bf934b58601b8e86c13bc9e0ab63e25fa55aba2d94c5cL11-R38) [[2]](diffhunk://#diff-a7343eb11b7c1ac2e14bf934b58601b8e86c13bc9e0ab63e25fa55aba2d94c5cL11-R38)
* The `ShellFrame` component and its props have been updated to accept the pre-built `main` content, removing direct handling of conversation, permissions, and error state. (`packages/ui/src/shell/shell-frame.tsx` [[1]](diffhunk://#diff-0e2f80fd59297ce50baca54da5662a49d097c494088792f0fab5f677500f9a4eL2-L46) [[2]](diffhunk://#diff-0e2f80fd59297ce50baca54da5662a49d097c494088792f0fab5f677500f9a4eL63-R42)
* The desktop and webview shell implementations have been updated to use the new `main` prop pattern, removing redundant props and logic. (`apps/desktop/src/renderer/src/shell/desktop-shell.tsx` [[1]](diffhunk://#diff-ea888f85733ccb90d7284b797a84eb822c7c1f5084fd974a7ad27c125379c6c9L3-R3) [[2]](diffhunk://#diff-ea888f85733ccb90d7284b797a84eb822c7c1f5084fd974a7ad27c125379c6c9L38-L50) [[3]](diffhunk://#diff-ea888f85733ccb90d7284b797a84eb822c7c1f5084fd974a7ad27c125379c6c9L146-L147) [[4]](diffhunk://#diff-ea888f85733ccb90d7284b797a84eb822c7c1f5084fd974a7ad27c125379c6c9L187-R177) [[5]](diffhunk://#diff-ea888f85733ccb90d7284b797a84eb822c7c1f5084fd974a7ad27c125379c6c9L326-R296) [[6]](diffhunk://#diff-ea888f85733ccb90d7284b797a84eb822c7c1f5084fd974a7ad27c125379c6c9L338-R308); `apps/webview/src/shell/web-workbench-shell.tsx` [[7]](diffhunk://#diff-0b80105f75d46d6026e5bdf8ad5d867c7843274f0b1e03bf1fa99963ce7acc6fL7-R11)

Event buffer and subscription improvements:

* The per-session event buffer in `LinkCodeClient` is now immutable and referentially stable, enabling efficient use with React's `useSyncExternalStore` and preventing unnecessary re-renders or blank frames when switching sessions. (`packages/client-core/src/client.ts` [[1]](diffhunk://#diff-3c751f25a596f54d5c2a136e90d32c34fc2db6814995052114bd7cbbf538e07aR47-R49) [[2]](diffhunk://#diff-3c751f25a596f54d5c2a136e90d32c34fc2db6814995052114bd7cbbf538e07aL75-R84) [[3]](diffhunk://#diff-3c751f25a596f54d5c2a136e90d32c34fc2db6814995052114bd7cbbf538e07aL154-R162) [[4]](diffhunk://#diff-3c751f25a596f54d5c2a136e90d32c34fc2db6814995052114bd7cbbf538e07aR313-R319) [[5]](diffhunk://#diff-3c751f25a596f54d5c2a136e90d32c34fc2db6814995052114bd7cbbf538e07aR339-R343)
* The `useAgentEvents` hook now uses `useSyncExternalStore` to subscribe to the event buffer, ensuring immediate access to the full event timeline and improved UI stability. (`packages/client-core/src/react.tsx` [[1]](diffhunk://#diff-730f54a0cfe6ec5cb15ffd23d7713cb30248894b3255958ebbb533b7ab4ceef8L11-R19) [[2]](diffhunk://#diff-730f54a0cfe6ec5cb15ffd23d7713cb30248894b3255958ebbb533b7ab4ceef8L38-L57)
* New tests verify that event buffer snapshots are stable, subscriptions replay the buffer, and events persist across session stops. (`packages/client-core/src/__tests__/event-buffer.test.ts` [packages/client-core/src/__tests__/event-buffer.test.tsR1-R97](diffhunk://#diff-47148f97c0383922b551afc7ca6072428d21fc04ece6630644169afbda1af3cdR1-R97))

Other supporting changes:

* The workbench surface now owns the conversation and error state, passing the composed session view as `main` to the shell, and updates the shell contract accordingly. (`packages/workbench/src/surface/workbench.tsx` [[1]](diffhunk://#diff-9916efc18dd3c1fd7a002cfdb28517870f62cebd12d6bce5476cefca7da1bb8fR2-R4) [[2]](diffhunk://#diff-9916efc18dd3c1fd7a002cfdb28517870f62cebd12d6bce5476cefca7da1bb8fL12)

These changes collectively make the UI more modular, efficient, and maintainable, especially as the application grows in complexity.