### PR TITLE
feat(sessions): sidebar close stops the session and deletes its record

### DIFF
--- a/apps/desktop/src/renderer/src/shell/desktop-shell.tsx
+++ b/apps/desktop/src/renderer/src/shell/desktop-shell.tsx
@@ -59,7 +59,7 @@ export function DesktopShell({
   errorMessage,
   pinnedSessionIds,
   onSelectSession,
-  onStopSession,
+  onCloseSession,
   onToggleSessionPinned,
   onReorderGroups,
   onReorderThreads,
@@ -510,7 +510,7 @@ export function DesktopShell({
                 BranchStatusComponent={BranchStatusComponent}
                 HistoryComponent={HistoryComponent}
                 onSelect={onSelectSession}
-                onStop={onStopSession}
+                onClose={onCloseSession}
                 onToggleSessionPinned={onToggleSessionPinned}
                 onReorderGroups={onReorderGroups}
                 onReorderThreads={onReorderThreads}

--- a/packages/client-core/src/__tests__/control-client.test.ts
+++ b/packages/client-core/src/__tests__/control-client.test.ts
@@ -21,6 +21,7 @@ describe('LinkCodeClient control API', () => {
     await expect(client.promptText(sessionId, 'hello')).resolves.toEqual({ ok: true });
     await expect(client.cancel(sessionId)).resolves.toEqual({ ok: true });
     await expect(client.stopSession(sessionId)).resolves.toEqual({ ok: true });
+    await expect(client.deleteSession(sessionId)).resolves.toEqual({ ok: true });
 
     client.dispose();
     serverTransport.close();
@@ -149,7 +150,13 @@ describe('LinkCodeClient event buffer', () => {
 });
 
 function successFor(payload: WirePayload): WirePayload | undefined {
-  if (payload.kind !== 'agent.input' && payload.kind !== 'session.stop') return undefined;
+  if (
+    payload.kind !== 'agent.input' &&
+    payload.kind !== 'session.stop' &&
+    payload.kind !== 'session.delete'
+  ) {
+    return undefined;
+  }
   return {
     kind: 'request.succeeded',
     replyTo: payload.clientReqId,

--- a/packages/client-core/src/client.ts
+++ b/packages/client-core/src/client.ts
@@ -219,6 +219,14 @@ export class LinkCodeClient {
     });
   }
 
+  /** Stop the session if live and remove its persisted record; provider-local history stays re-importable. */
+  deleteSession(sessionId: SessionId): Promise<RequestAck> {
+    return this.control.deleteSession(sessionId).then((ack) => {
+      this.events.clearSession(sessionId);
+      return ack;
+    });
+  }
+
   getProviderConfig(): Promise<ProvidersConfig> {
     return this.control.getProviderConfig();
   }

--- a/packages/client-core/src/client/control-channel.ts
+++ b/packages/client-core/src/client/control-channel.ts
@@ -172,6 +172,15 @@ export class ControlChannel {
     }));
   }
 
+  /** Stop the session if live and remove its persisted record; provider-local history stays re-importable. */
+  deleteSession(sessionId: SessionId): Promise<RequestAck> {
+    return this.sendCorrelated('ack', (clientReqId) => ({
+      kind: 'session.delete',
+      clientReqId,
+      sessionId,
+    }));
+  }
+
   /** Read the daemon-owned provider config (data plane). */
   getProviderConfig(): Promise<ProvidersConfig> {
     return this.sendCorrelated('configGet', (clientReqId) => ({

--- a/packages/engine/src/__tests__/engine-sessions.test.ts
+++ b/packages/engine/src/__tests__/engine-sessions.test.ts
@@ -20,6 +20,7 @@ import { nullthrow } from 'foxts/guard';
 import { noop } from 'foxts/noop';
 import { describe, expect, it } from 'vitest';
 import { Engine } from '../engine';
+import type { SessionStore } from '../session-store';
 import { InMemorySessionStore } from '../session-store';
 
 class FakeAdapter implements AgentAdapter {
@@ -32,6 +33,7 @@ class FakeAdapter implements AgentAdapter {
 
   startedWith: StartOptions | null = null;
   resumedFrom: string | null = null;
+  stopped = false;
   private readonly listeners = new Set<(e: AgentEvent) => void>();
 
   start(opts: StartOptions): Promise<void> {
@@ -73,11 +75,24 @@ class FakeAdapter implements AgentAdapter {
   }
 
   stop(): Promise<void> {
+    this.stopped = true;
     return Promise.resolve();
   }
 
   emit(event: AgentEvent): void {
     for (const cb of this.listeners) cb(event);
+  }
+}
+
+/** An adapter whose start() blocks until the test releases it, to interleave other requests. */
+class GatedStartAdapter extends FakeAdapter {
+  releaseStart: () => void = noop;
+
+  override start(opts: StartOptions): Promise<void> {
+    this.startedWith = opts;
+    return new Promise((resolve) => {
+      this.releaseStart = resolve;
+    });
   }
 }
 
@@ -88,7 +103,10 @@ function tick(): Promise<void> {
   });
 }
 
-function harness(store = new InMemorySessionStore()) {
+function harness(
+  store: SessionStore = new InMemorySessionStore(),
+  makeAdapter: () => FakeAdapter = () => new FakeAdapter(),
+) {
   const sent: WirePayload[] = [];
   let handler: ((msg: WireMessage) => void) | null = null;
   const transport: Transport = {
@@ -105,7 +123,7 @@ function harness(store = new InMemorySessionStore()) {
   };
   const adapters: FakeAdapter[] = [];
   const factory: AdapterFactory = () => {
-    const adapter = new FakeAdapter();
+    const adapter = makeAdapter();
     adapters.push(adapter);
     return adapter;
   };
@@ -222,6 +240,101 @@ describe('engine session persistence', () => {
 
     await inject({ kind: 'session.list', clientReqId: 'r2' });
     expect(listedSessions(sent, 'r2')[0].status).toBe('stopped');
+  });
+
+  it('deletes a live session: stops the adapter and drops the record', async () => {
+    const store = new InMemorySessionStore();
+    const { engine, sent, inject, adapters } = harness(store);
+    await engine.start();
+    await inject({
+      kind: 'session.start',
+      clientReqId: 'r1',
+      opts: { kind: 'claude-code', cwd: '/repo' },
+    });
+    const sessionId = startedId(sent, 'r1');
+    await inject({ kind: 'session.delete', clientReqId: 'r2', sessionId });
+
+    expect(sent.some((p) => p.kind === 'request.succeeded' && p.replyTo === 'r2')).toBe(true);
+    expect(adapters[0].stopped).toBe(true);
+    expect(await store.load()).toHaveLength(0);
+    await inject({ kind: 'session.list', clientReqId: 'r3' });
+    expect(listedSessions(sent, 'r3')).toHaveLength(0);
+  });
+
+  it('deletes a cold session idempotently instead of failing with "Unknown session"', async () => {
+    const store = new InMemorySessionStore();
+    const first = harness(store);
+    await first.engine.start();
+    await first.inject({
+      kind: 'session.start',
+      clientReqId: 'r1',
+      opts: { kind: 'claude-code', cwd: '/repo' },
+    });
+    const sessionId = startedId(first.sent, 'r1');
+
+    // A fresh engine over the same store: the session is cold, with no live adapter to stop.
+    const second = harness(store);
+    await second.engine.start();
+    await second.inject({ kind: 'session.delete', clientReqId: 'r2', sessionId });
+    expect(second.sent.some((p) => p.kind === 'request.succeeded' && p.replyTo === 'r2')).toBe(
+      true,
+    );
+    expect(await store.load()).toHaveLength(0);
+
+    // Deleting again (e.g. from a second attached client) still succeeds.
+    await second.inject({ kind: 'session.delete', clientReqId: 'r3', sessionId });
+    expect(second.sent.some((p) => p.kind === 'request.succeeded' && p.replyTo === 'r3')).toBe(
+      true,
+    );
+  });
+
+  it('fails the start instead of leaking the adapter when deleted while starting', async () => {
+    const store = new InMemorySessionStore();
+    const { engine, sent, inject, adapters } = harness(store, () => new GatedStartAdapter());
+    await engine.start();
+    // The handler suspends inside adapter.start(); the session is already registered by then.
+    await inject({
+      kind: 'session.start',
+      clientReqId: 'r1',
+      opts: { kind: 'claude-code', cwd: '/repo' },
+    });
+    const [record] = await store.load();
+    await inject({ kind: 'session.delete', clientReqId: 'r2', sessionId: record.sessionId });
+    expect(sent.some((p) => p.kind === 'request.succeeded' && p.replyTo === 'r2')).toBe(true);
+
+    (adapters[0] as GatedStartAdapter).releaseStart();
+    await tick();
+    expect(sent.some((p) => p.kind === 'session.started' && p.replyTo === 'r1')).toBe(false);
+    const failed = sent.find((p) => p.kind === 'request.failed' && p.replyTo === 'r1');
+    if (failed?.kind !== 'request.failed') throw new Error('no request.failed for r1');
+    expect(failed.message).toContain('closed while starting');
+    expect(adapters[0].stopped).toBe(true);
+    expect(await store.load()).toHaveLength(0);
+  });
+
+  it('keeps the session listed when the persisted delete fails', async () => {
+    const inner = new InMemorySessionStore();
+    const failingStore: SessionStore = {
+      load: () => inner.load(),
+      save: (record) => inner.save(record),
+      delete: () => Promise.reject(new Error('disk unavailable')),
+    };
+    const { engine, sent, inject } = harness(failingStore);
+    await engine.start();
+    await inject({
+      kind: 'session.start',
+      clientReqId: 'r1',
+      opts: { kind: 'claude-code', cwd: '/repo' },
+    });
+    const sessionId = startedId(sent, 'r1');
+    await inject({ kind: 'session.delete', clientReqId: 'r2', sessionId });
+
+    expect(sent.some((p) => p.kind === 'request.failed' && p.replyTo === 'r2')).toBe(true);
+    // The live adapter was stopped, but the record must stay listed (cold) — not half-deleted.
+    await inject({ kind: 'session.list', clientReqId: 'r3' });
+    const sessions = listedSessions(sent, 'r3');
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0].status).toBe('stopped');
   });
 
   it('wakes a never-prompted session (no provider linkage) as a fresh start under the same id', async () => {

--- a/packages/engine/src/engine.ts
+++ b/packages/engine/src/engine.ts
@@ -167,6 +167,26 @@ export class Engine {
         });
         break;
       }
+      case 'session.delete': {
+        await this.tryReply(p.clientReqId, async () => {
+          // Idempotent, unlike session.stop: the target is usually cold (the sidebar lists stopped
+          // sessions too) and another client may have deleted it already. Provider-local history is
+          // left untouched, so the conversation stays re-importable via session.import.
+          const session = this.sessions.get(p.sessionId);
+          if (session) {
+            session.unsub();
+            await session.adapter.stop();
+            this.sessions.delete(p.sessionId);
+            this.terminals?.killBySession(p.sessionId);
+          }
+          // Persisted delete first: if the store throws, the record stays listed (now cold) and the
+          // client's retry still works — dropping it from memory first would desync the two.
+          await this.sessionStore.delete(p.sessionId);
+          this.records.delete(p.sessionId);
+          this.sendSuccess(p.clientReqId);
+        });
+        break;
+      }
       case 'session.list': {
         const sessions = Array.from(this.records.values(), (record) => this.toSessionInfo(record));
         this.transport.send(
@@ -454,6 +474,12 @@ export class Engine {
       this.sealCurrentRun(sessionId);
       await adapter.stop().catch(noop);
       throw err;
+    }
+    // A session.stop/session.delete handled while the adapter was still starting has already torn
+    // this binding down; announcing it as started would leak a live adapter nothing tracks.
+    if (this.sessions.get(sessionId) !== session) {
+      await adapter.stop().catch(noop);
+      throw new Error(`Session was closed while starting: ${sessionId}`);
     }
     this.transport.send(createWireMessage({ kind: 'session.started', replyTo, sessionId }));
   }

--- a/packages/i18n/src/locales/en.ts
+++ b/packages/i18n/src/locales/en.ts
@@ -186,7 +186,7 @@ export const en = {
       chatsEmptyHint: 'No chats yet',
       pinThread: 'Pin thread',
       unpinThread: 'Unpin thread',
-      stopThread: 'Stop thread',
+      closeThread: 'Close thread',
       workspaceEmptyTitle: 'No workspaces yet',
       chooseWorkspaceTitle: 'Choose a workspace',
       chooseDirectory: 'Choose directory…',

--- a/packages/i18n/src/locales/zh-cn.ts
+++ b/packages/i18n/src/locales/zh-cn.ts
@@ -184,7 +184,7 @@ export const zhCN = {
       chatsEmptyHint: '暂无聊天',
       pinThread: '置顶线程',
       unpinThread: '取消置顶',
-      stopThread: '停止线程',
+      closeThread: '关闭线程',
       workspaceEmptyTitle: '暂无工作区',
       chooseWorkspaceTitle: '选择工作区',
       chooseDirectory: '选择目录…',

--- a/packages/schema/src/wire/index.ts
+++ b/packages/schema/src/wire/index.ts
@@ -32,7 +32,7 @@ export {
  * originating client can pair the reply despite the broadcast.
  */
 
-export const WIRE_PROTOCOL_VERSION = 10 as const;
+export const WIRE_PROTOCOL_VERSION = 11 as const;
 
 /** Envelope payload: a discriminated union keyed by `kind`. */
 export const WirePayloadSchema = z.discriminatedUnion('kind', [

--- a/packages/schema/src/wire/session.ts
+++ b/packages/schema/src/wire/session.ts
@@ -20,6 +20,12 @@ export const sessionWireVariants = [
     clientReqId: z.string().min(1),
     sessionId: SessionIdSchema,
   }),
+  /** Stop the session if live and remove its persisted record; provider-local history survives for re-import. */
+  z.object({
+    kind: z.literal('session.delete'),
+    clientReqId: z.string().min(1),
+    sessionId: SessionIdSchema,
+  }),
   z.object({ kind: z.literal('session.list'), clientReqId: z.string().min(1) }),
   z.object({
     kind: z.literal('session.listed'),

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -82,6 +82,11 @@ export class LinkCodeSdkClient {
     return toResult(this.raw.stopSession(sessionId));
   }
 
+  /** Stop the session if live and remove its persisted record; provider-local history stays re-importable. */
+  deleteSession(sessionId: SessionId): RequestResult<{ ok: true }> {
+    return toResult(this.raw.deleteSession(sessionId));
+  }
+
   /** Resume a persisted (cold) session by its Link Code id; resolves with the same id. */
   resumeSession(sessionId: SessionId): RequestResult<SessionId> {
     return toResult(this.raw.resumeSession(sessionId));

--- a/packages/sdk/src/operations.ts
+++ b/packages/sdk/src/operations.ts
@@ -37,6 +37,12 @@ export function stopSession(
   return resolveClient(options).stopSession(options.sessionId);
 }
 
+export function deleteSession(
+  options: Options<{ sessionId: SessionId }>,
+): RequestResult<{ ok: true }> {
+  return resolveClient(options).deleteSession(options.sessionId);
+}
+
 export function resumeSession(
   options: Options<{ sessionId: SessionId }>,
 ): RequestResult<SessionId> {

--- a/packages/ui/src/__tests__/turn-edits.test.ts
+++ b/packages/ui/src/__tests__/turn-edits.test.ts
@@ -54,11 +54,11 @@ describe('turn edit selectors', () => {
 
     expect(edits).toEqual({
       files: [
-        { path: 'a.ts', additions: 3, deletions: 1 },
-        { path: 'b.ts', additions: 0, deletions: 2 },
+        { path: 'a.ts', additions: 2, deletions: 1 },
+        { path: 'b.ts', additions: 0, deletions: 1 },
       ],
-      additions: 3,
-      deletions: 3,
+      additions: 2,
+      deletions: 2,
     });
   });
 

--- a/packages/ui/src/shell/session-sidebar.tsx
+++ b/packages/ui/src/shell/session-sidebar.tsx
@@ -76,7 +76,7 @@ export function SessionSidebar({
   footer,
   className,
   onSelect,
-  onStop,
+  onClose,
   onToggleSessionPinned,
   onReorderGroups,
   onReorderThreads,
@@ -128,7 +128,7 @@ export function SessionSidebar({
             activeId={activeId}
             pinnedSessionIds={pinnedSessionIds}
             onSelect={onSelect}
-            onStop={onStop}
+            onClose={onClose}
             onToggleSessionPinned={onToggleSessionPinned}
             onReorderGroups={onReorderGroups}
             onReorderThreads={onReorderThreads}

--- a/packages/ui/src/shell/shell-frame.tsx
+++ b/packages/ui/src/shell/shell-frame.tsx
@@ -14,7 +14,7 @@ import type { ThreadGroupActions, ThreadGroupState } from './sidebar';
 import type { ThreadGroupViewModel } from './threads-view';
 
 /** Session/group action field names this shell exposes under its own naming (`onSelectSession`, etc). */
-type RenamedThreadGroupActions = 'onSelect' | 'onStop' | 'onCreate';
+type RenamedThreadGroupActions = 'onSelect' | 'onClose' | 'onCreate';
 
 export interface ShellFrameProps
   extends Pick<ThreadGroupActions, Exclude<keyof ThreadGroupActions, RenamedThreadGroupActions>>,
@@ -32,7 +32,8 @@ export interface ShellFrameProps
   header?: React.ReactNode;
   errorMessage?: string | null;
   onSelectSession: (id: SessionId) => void;
-  onStopSession: (id: SessionId) => void;
+  /** Stop the session if live and remove it from the sidebar list. */
+  onCloseSession: (id: SessionId) => void;
   /** Persists a group drag: the full new project-group order, as `collapseKey`s. */
   onReorderGroups: (orderedCollapseKeys: string[]) => void;
   /** Persists a thread drag within a group: `activeId` landed before/after `overId`. */
@@ -72,7 +73,7 @@ export function ShellFrame({
   errorMessage,
   pinnedSessionIds,
   onSelectSession,
-  onStopSession,
+  onCloseSession,
   onToggleSessionPinned,
   onReorderGroups,
   onReorderThreads,
@@ -112,7 +113,7 @@ export function ShellFrame({
           pinnedSessionIds={pinnedSessionIds}
           footer={<DefaultHostFooter />}
           onSelect={onSelectSession}
-          onStop={onStopSession}
+          onClose={onCloseSession}
           onToggleSessionPinned={onToggleSessionPinned}
           onReorderGroups={onReorderGroups}
           onReorderThreads={onReorderThreads}

--- a/packages/ui/src/shell/sidebar/chats-section.tsx
+++ b/packages/ui/src/shell/sidebar/chats-section.tsx
@@ -25,7 +25,7 @@ export interface ChatsSectionProps {
   activeId: SessionId | null;
   pinnedSessionIds: readonly SessionId[];
   onSelect: (id: SessionId) => void;
-  onStop: (id: SessionId) => void;
+  onClose: (id: SessionId) => void;
   onToggleSessionPinned: (id: SessionId) => void;
   onCreate: (opts: { kind: AgentKind; cwd: string }) => void;
   onTogglePreviewExpanded: (groupKey: string) => void;
@@ -48,7 +48,7 @@ export function ChatsSection({
   activeId,
   pinnedSessionIds,
   onSelect,
-  onStop,
+  onClose,
   onToggleSessionPinned,
   onCreate,
   onTogglePreviewExpanded,
@@ -93,7 +93,7 @@ export function ChatsSection({
               sortGroup={sortKey}
               session={session}
               onSelect={() => onSelect(session.sessionId)}
-              onStop={() => onStop(session.sessionId)}
+              onClose={() => onClose(session.sessionId)}
               onTogglePin={() => onToggleSessionPinned(session.sessionId)}
             />
           ))}

--- a/packages/ui/src/shell/sidebar/thread-group-actions.ts
+++ b/packages/ui/src/shell/sidebar/thread-group-actions.ts
@@ -8,7 +8,8 @@ import type { BranchStatusComponentType } from './branch-status';
  */
 export interface ThreadGroupActions {
   onSelect: (id: SessionId) => void;
-  onStop: (id: SessionId) => void;
+  /** Stop the session if live and remove it from the list; re-importable from provider history. */
+  onClose: (id: SessionId) => void;
   onToggleSessionPinned: (id: SessionId) => void;
   onCreate: (opts: { kind: AgentKind; cwd: string }) => void;
   /** Called once a history entry finishes importing as a new thread. */

--- a/packages/ui/src/shell/sidebar/thread-row.tsx
+++ b/packages/ui/src/shell/sidebar/thread-row.tsx
@@ -27,7 +27,8 @@ export interface ThreadRowProps {
   /** The group's `collapseKey` — scopes dragging to the row's own group. */
   sortGroup: string;
   onSelect: () => void;
-  onStop: () => void;
+  /** Stop the session if live and remove it from the list; re-importable from provider history. */
+  onClose: () => void;
   onTogglePin: () => void;
 }
 
@@ -39,7 +40,7 @@ export function ThreadRow({
   sortIndex,
   sortGroup,
   onSelect,
-  onStop,
+  onClose,
   onTogglePin,
 }: ThreadRowProps): React.ReactNode {
   const t = useTranslations('workbench.sidebar');
@@ -100,9 +101,9 @@ export function ThreadRow({
         </button>
         <button
           type="button"
-          aria-label={t('stopThread')}
-          title={t('stopThread')}
-          onClick={onStop}
+          aria-label={t('closeThread')}
+          title={t('closeThread')}
+          onClick={onClose}
           className={cn(ROW_ACTION_CLASS, 'opacity-0 group-hover:opacity-100')}
         >
           <XIcon className="size-3.5" />

--- a/packages/ui/src/shell/threads-view.tsx
+++ b/packages/ui/src/shell/threads-view.tsx
@@ -62,7 +62,7 @@ export function ThreadsView({
   activeId,
   pinnedSessionIds,
   onSelect,
-  onStop,
+  onClose,
   onToggleSessionPinned,
   onReorderGroups,
   onReorderThreads,
@@ -165,7 +165,7 @@ export function ThreadsView({
               activeId={activeId}
               pinnedSessionIds={pinnedSessionIds}
               onSelect={onSelect}
-              onStop={onStop}
+              onClose={onClose}
               onToggleSessionPinned={onToggleSessionPinned}
               onCreate={onCreate}
               onImportSession={onImportSession}
@@ -195,7 +195,7 @@ export function ThreadsView({
           activeId={activeId}
           pinnedSessionIds={pinnedSessionIds}
           onSelect={onSelect}
-          onStop={onStop}
+          onClose={onClose}
           onToggleSessionPinned={onToggleSessionPinned}
           onCreate={onCreate}
           onTogglePreviewExpanded={onTogglePreviewExpanded}
@@ -211,7 +211,7 @@ function ThreadGroupSection({
   activeId,
   pinnedSessionIds,
   onSelect,
-  onStop,
+  onClose,
   onToggleSessionPinned,
   onCreate,
   onImportSession,
@@ -273,7 +273,7 @@ function ThreadGroupSection({
                 sortGroup={group.collapseKey}
                 session={session}
                 onSelect={() => onSelect(session.sessionId)}
-                onStop={() => onStop(session.sessionId)}
+                onClose={() => onClose(session.sessionId)}
                 onTogglePin={() => onToggleSessionPinned(session.sessionId)}
               />
             ))}

--- a/packages/workbench/src/surface/use-workbench-sessions.ts
+++ b/packages/workbench/src/surface/use-workbench-sessions.ts
@@ -1,5 +1,5 @@
 import type { AgentKind, SessionId, SessionInfo } from '@linkcode/schema';
-import { listSessions, resumeSession, startSession, stopSession } from '@linkcode/sdk';
+import { deleteSession, listSessions, resumeSession, startSession } from '@linkcode/sdk';
 import { noop } from 'foxact/noop';
 import { useMemo } from 'react';
 import { useData, useMutation } from '../runtime/tayori';
@@ -14,7 +14,8 @@ export interface WorkbenchSessions {
   isLoading: boolean;
   select: (id: SessionId) => void;
   create: (opts: { kind: AgentKind; cwd: string }) => void;
-  stop: (id: SessionId) => void;
+  /** Stop the session if live and remove it from the list; re-importable from provider history. */
+  close: (id: SessionId) => void;
   /** Revalidate the session list — the cue for a mutation made outside this hook (e.g. an import). */
   refresh: () => void;
 }
@@ -27,7 +28,7 @@ export interface WorkbenchSessions {
 export function useWorkbenchSessions(onError: (err: unknown) => void): WorkbenchSessions {
   const { data: remoteSessions, isLoading, mutate } = useData(listSessions, {});
   const createMutation = useMutation(startSession, { onError });
-  const stopMutation = useMutation(stopSession, { onError });
+  const closeMutation = useMutation(deleteSession, { onError });
   const resumeMutation = useMutation(resumeSession, { onError });
   const selectedId = useSessionSelectionStore((state) => state.selectedId);
   const setSelectedId = useSessionSelectionStore((state) => state.setSelectedId);
@@ -68,8 +69,8 @@ export function useWorkbenchSessions(onError: (err: unknown) => void): Workbench
       .catch(noop);
   }
 
-  function stop(id: SessionId): void {
-    void stopMutation
+  function close(id: SessionId): void {
+    void closeMutation
       .trigger({ sessionId: id })
       .then(() => {
         void mutate();
@@ -88,7 +89,7 @@ export function useWorkbenchSessions(onError: (err: unknown) => void): Workbench
     isLoading,
     select,
     create,
-    stop,
+    close,
     refresh,
   };
 }

--- a/packages/workbench/src/surface/workbench.tsx
+++ b/packages/workbench/src/surface/workbench.tsx
@@ -315,7 +315,7 @@ function WorkbenchSessionSurface({
       errorMessage={errorMessage}
       pinnedSessionIds={pinnedSessionIds}
       onSelectSession={sessions.select}
-      onStopSession={sessions.stop}
+      onCloseSession={sessions.close}
       onToggleSessionPinned={toggleSessionPinned}
       onReorderGroups={handleReorderGroups}
       onReorderThreads={handleReorderThreads}


### PR DESCRIPTION
Closes CODE-29.

## What

The sidebar X now **closes** a session — stops the live adapter if running and removes the persisted `SessionRecord` — instead of only stopping it and leaving it stuck in the list. Provider-native history (e.g. Claude Code's `~/.claude/projects/**.jsonl`) is untouched, so a closed session stays re-importable via the existing `session.import` pipeline (UI entry tracked in CODE-30).

This also removes the two errors the old semantics produced for provider-history-less sessions: `Session has no provider history to resume` (auto-resume on select) and `Unknown session` (stop on a cold session).

## How

One commit per layer:

- **schema**: new `session.delete` wire payload; `WIRE_PROTOCOL_VERSION` 5 → 6
- **engine**: `session.delete` handler — stop-if-live + terminal reap, then persisted delete, then in-memory removal; **idempotent** for cold/absent sessions (unlike `session.stop`)
- **client-core / sdk**: `deleteSession` mirroring `stopSession`, including subscriber/event-buffer cleanup
- **workbench / ui / desktop**: `close()` mutation + list revalidation; prop chain renamed `onStopSession` → `onCloseSession` through both `SessionSidebar` call sites (`ShellFrame` and `desktop-shell`)

Plus a fix commit for two issues found in adversarial review:

- `session.delete` racing an in-flight `session.start`/`session.resume` leaked a live adapter nothing tracked — `startLiveSession` now verifies the binding survived after the adapter start and fails the request otherwise
- in-memory record removal now happens only after the persisted delete succeeds, so a store failure leaves a consistent (cold, listed, retryable) state

## Notes for review

- **Protocol v5 → v6**: daemon and clients must be deployed together; a mismatched peer's frames are silently discarded by `parseWireMessage` (pre-existing behavior — no handshake/timeouts yet)
- No cross-client push invalidation for list changes — same gap as `session.stop` had; other attached clients see the removal on their next revalidation

## Testing

- 80 unit tests pass; 4 new: live delete, cold-session idempotent delete (regression for `Unknown session`), delete-during-start race, store-failure consistency
- End-to-end probe against the dev daemon (socket.io :4317): list → start → list → delete → list → repeat delete, all green