### PR TITLE
fix(client-core): permission card never renders — keep ephemeral events past the seed cut

### DIFF
--- a/packages/client-core/src/__tests__/conversation.test.ts
+++ b/packages/client-core/src/__tests__/conversation.test.ts
@@ -262,6 +262,46 @@ describe('mergeSeededEvents', () => {
     const seed = { events: [userText('only history')], uptoSeq: 0 };
     expect(mergeSeededEvents(seed, [])).toEqual([userText('only history')]);
   });
+
+  // CODE-35: a transcript snapshot can never contain ephemeral events (permission asks, status,
+  // stop, errors) — a mid-turn seed read whose uptoSeq passes them must not erase them.
+  it('keeps ephemeral live events that fall inside the snapshot cut', () => {
+    const announce: AgentEvent = {
+      type: 'tool-call',
+      toolCall: {
+        toolCallId: 't1',
+        title: 'Bash',
+        kind: 'execute',
+        status: 'in_progress',
+        content: [],
+      },
+    };
+    const ask: AgentEvent = {
+      type: 'permission-request',
+      requestId: 'req-1',
+      toolCall: { toolCallId: 't1', title: 'Bash' },
+      options: [{ optionId: 'allow', name: 'Allow', kind: 'allow_once' }],
+    };
+    // The snapshot (read mid-turn) already covers the prompt and the announce, never the ask.
+    const seed = { events: [userText('run echo'), announce], uptoSeq: 4 };
+    const events = mergeSeededEvents(seed, [
+      { event: userText('run echo'), seq: 1 },
+      { event: { type: 'status', status: 'running' }, seq: 2 },
+      { event: announce, seq: 3 },
+      { event: ask, seq: 4 },
+    ]);
+    expect(events).toEqual([
+      userText('run echo'),
+      announce,
+      { type: 'status', status: 'running' },
+      ask,
+    ]);
+
+    const c = buildConversation(events);
+    expect(c.pendingPermissionIds).toEqual(['req-1']);
+    expect(c.items.some((i) => i.kind === 'approval')).toBe(true);
+    expect(c.status).toBe('running');
+  });
 });
 
 describe('contentPreview', () => {

--- a/packages/client-core/src/conversation.ts
+++ b/packages/client-core/src/conversation.ts
@@ -282,6 +282,19 @@ export interface ConversationSeed {
  * events received at or before the moment the snapshot resolved (seq ≤ uptoSeq) are contained in
  * it and dropped; only the tail received after the snapshot is appended.
  */
+/**
+ * Event types a provider-transcript read can reproduce — the only ones the `uptoSeq` cut may drop
+ * as "already in the snapshot". Everything else (permission asks, status, stop, errors, usage …)
+ * is ephemeral: it never appears in `history.read`, so cutting it would erase it outright — a
+ * pending permission-request would vanish from the timeline and strand the turn un-answerable.
+ */
+const SEEDABLE_EVENT_TYPES = new Set<AgentEvent['type']>([
+  'user-message',
+  'agent-message-chunk',
+  'agent-thought-chunk',
+  'tool-call',
+]);
+
 export function mergeSeededEvents(
   seed: ConversationSeed | undefined,
   live: readonly SequencedAgentEvent[],
@@ -289,7 +302,7 @@ export function mergeSeededEvents(
   if (!seed) return live.map(({ event }) => event);
   const merged = [...seed.events];
   for (const { event, seq } of live) {
-    if (seq > seed.uptoSeq) merged.push(event);
+    if (seq > seed.uptoSeq || !SEEDABLE_EVENT_TYPES.has(event.type)) merged.push(event);
   }
   return merged;
 }


### PR DESCRIPTION
Fixes CODE-35.

## Problem

`mergeSeededEvents` drops every live event with `seq ≤ uptoSeq`, assuming the transcript snapshot contains them. But ephemeral event types (`permission-request`, `status`, `stop`, `error`, `token-usage`, …) never appear in `history.read` — a seed read resolving mid-turn (focus revalidation, cold-resume list refresh, mid-turn historyId rebind) permanently erased a pending `permission-request`: the tool card rendered from the snapshot, the PermissionCard never appeared, and the turn hung forever awaiting an answer.

## Fix

The `uptoSeq` cut now only applies to event types a transcript read can reproduce (`user-message`, `agent-message-chunk`, `agent-thought-chunk`, `tool-call`); everything else passes through from the live stream. Ephemeral types carry no duplicate-risk — history cannot contain them.

Regression test mirrors the exact CODE-35 scenario: a mid-turn seed whose cut covers the permission ask; asserts the ask survives, `pendingPermissionIds` is populated, and the approval item renders.