### PR TITLE
feat(agent-adapter): parse claude-code Edit/Write input into structured diff content

### DIFF
--- a/packages/agent-adapter/src/__tests__/normalize.test.ts
+++ b/packages/agent-adapter/src/__tests__/normalize.test.ts
@@ -2,10 +2,15 @@ import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { env } from 'node:process';
-import type { SessionMessage } from '@anthropic-ai/claude-agent-sdk';
+import type { SDKMessage, SessionMessage } from '@anthropic-ai/claude-agent-sdk';
+import type { AgentEvent } from '@linkcode/schema';
 import { describe, expect, it } from 'vitest';
 import { asHistoryId } from '../history-util';
-import { createClaudeHistoryEventMapper, mapClaudeStop } from '../native/claude-code';
+import {
+  ClaudeCodeAdapter,
+  createClaudeHistoryEventMapper,
+  mapClaudeStop,
+} from '../native/claude-code';
 import { CodexAdapter, mapCodexStatus, mapCodexUsage } from '../native/codex';
 import { contentToText, toolKindFromName } from '../util';
 
@@ -104,6 +109,29 @@ describe('createClaudeHistoryEventMapper', () => {
     }
   });
 
+  it('parses an Edit announce into diff content and keeps it ahead of the settle text', () => {
+    const map = createClaudeHistoryEventMapper(historyId);
+    const input = { file_path: 'src/a.ts', old_string: 'a', new_string: 'b' };
+    const announce = map(
+      row('assistant', 'u1', [{ type: 'tool_use', id: 'toolu_1', name: 'Edit', input }]),
+    );
+    if (announce[0].event.type === 'tool-call') {
+      expect(announce[0].event.toolCall.content).toEqual([
+        { type: 'diff', path: 'src/a.ts', oldText: 'a', newText: 'b' },
+      ]);
+    }
+
+    const settle = map(
+      row('user', 'u2', [{ type: 'tool_result', tool_use_id: 'toolu_1', content: 'updated' }]),
+    );
+    if (settle[0].event.type === 'tool-call') {
+      expect(settle[0].event.toolCall.content).toEqual([
+        { type: 'diff', path: 'src/a.ts', oldText: 'a', newText: 'b' },
+        { type: 'content', content: { type: 'text', text: 'updated' } },
+      ]);
+    }
+  });
+
   it('keeps plain user prompts and assistant text as message events', () => {
     const map = createClaudeHistoryEventMapper(historyId);
     const prompt = map(row('user', 'u1', 'fix the bug'));
@@ -112,6 +140,101 @@ describe('createClaudeHistoryEventMapper', () => {
 
     const reply = map(row('assistant', 'u2', [{ type: 'text', text: 'done' }]));
     expect(reply.map((e) => e.event.type)).toEqual(['agent-message-chunk']);
+  });
+});
+
+class TestClaude extends ClaudeCodeAdapter {
+  feed(value: object): void {
+    this.handleMessage(value as SDKMessage);
+  }
+}
+
+function toolSnapshots(events: AgentEvent[]) {
+  return events.filter(
+    (e): e is Extract<AgentEvent, { type: 'tool-call' }> => e.type === 'tool-call',
+  );
+}
+
+describe('ClaudeCodeAdapter Edit diff normalization', () => {
+  it('announces the Edit diff and keeps it through the settle', () => {
+    const adapter = new TestClaude();
+    const seen: AgentEvent[] = [];
+    adapter.onEvent((e) => seen.push(e));
+
+    adapter.feed({
+      type: 'assistant',
+      message: {
+        content: [
+          {
+            type: 'tool_use',
+            id: 't1',
+            name: 'Edit',
+            input: { file_path: 'src/a.ts', old_string: 'a', new_string: 'b' },
+          },
+        ],
+      },
+    });
+    adapter.feed({
+      type: 'user',
+      message: { content: [{ type: 'tool_result', tool_use_id: 't1', content: 'updated' }] },
+    });
+
+    const diff = { type: 'diff', path: 'src/a.ts', oldText: 'a', newText: 'b' };
+    const tools = toolSnapshots(seen);
+    expect(tools).toHaveLength(2);
+    expect(tools[0].toolCall.content).toEqual([diff]);
+    expect(tools[1].toolCall.status).toBe('completed');
+    expect(tools[1].toolCall.content).toEqual([
+      diff,
+      { type: 'content', content: { type: 'text', text: 'updated' } },
+    ]);
+  });
+
+  it('parses a Write announce into a whole-file diff without oldText', () => {
+    const adapter = new TestClaude();
+    const seen: AgentEvent[] = [];
+    adapter.onEvent((e) => seen.push(e));
+
+    adapter.feed({
+      type: 'assistant',
+      message: {
+        content: [
+          {
+            type: 'tool_use',
+            id: 't1',
+            name: 'Write',
+            input: { file_path: 'src/new.ts', content: 'export const a = 1;\n' },
+          },
+        ],
+      },
+    });
+
+    const tools = toolSnapshots(seen);
+    expect(tools).toHaveLength(1);
+    expect(tools[0].toolCall.content).toEqual([
+      { type: 'diff', path: 'src/new.ts', newText: 'export const a = 1;\n' },
+    ]);
+  });
+
+  it('leaves non-Edit tools and malformed Edit inputs as raw passthrough', () => {
+    const adapter = new TestClaude();
+    const seen: AgentEvent[] = [];
+    adapter.onEvent((e) => seen.push(e));
+
+    adapter.feed({
+      type: 'assistant',
+      message: {
+        content: [
+          { type: 'tool_use', id: 't1', name: 'Read', input: { file_path: 'src/a.ts' } },
+          { type: 'tool_use', id: 't2', name: 'Edit', input: { file_path: 'src/a.ts' } },
+        ],
+      },
+    });
+
+    const tools = toolSnapshots(seen);
+    expect(tools).toHaveLength(2);
+    expect(tools[0].toolCall.content).toEqual([]);
+    expect(tools[1].toolCall.content).toEqual([]);
   });
 });
 

--- a/packages/agent-adapter/src/native/claude-code.ts
+++ b/packages/agent-adapter/src/native/claude-code.ts
@@ -157,6 +157,10 @@ export class ClaudeCodeAdapter extends BaseAgentAdapter {
   /** Provider session id sniffed off the last SDK message — the resume point when an effort
    * transition into/out of `max` forces a process restart (see `onSetEffort`). */
   private lastSessionRef: string | undefined;
+  /** Diff content parsed off an Edit/Write announce, keyed by tool_use id. Re-attached at settle
+   * because `emitTool`'s merge replaces `content` wholesale — the result text must not wipe the
+   * diff. */
+  private readonly pendingEditDiffs = new Map<string, ToolCallContent[]>();
 
   protected async onStart(): Promise<void> {
     // The persistent Query is created lazily on the first onPrompt; just verify the SDK is installed.
@@ -367,6 +371,12 @@ export class ClaudeCodeAdapter extends BaseAgentAdapter {
     queue?.close();
   }
 
+  /** A cancelled/failed turn never delivers the matching tool_results; drop their stashed diffs. */
+  protected override teardown(): void {
+    this.pendingEditDiffs.clear();
+    super.teardown();
+  }
+
   private readonly canUseTool: CanUseTool = async (toolName, input, options) => {
     const outcome = await this.requestPermission(
       {
@@ -424,12 +434,15 @@ export class ClaudeCodeAdapter extends BaseAgentAdapter {
     let calledTool = false;
     for (const block of message.content) {
       if (block.type === 'tool_use') {
+        const diff = editDiffContent(block.name, block.input);
+        if (diff) this.pendingEditDiffs.set(block.id, diff);
         // Announce the tool the moment Claude requests it; the matching tool_result settles it.
         this.emitTool({
           toolCallId: block.id,
           title: block.name,
           kind: toolKindFromName(block.name),
           status: 'in_progress',
+          content: diff,
           rawInput: block.input,
         });
         calledTool = true;
@@ -450,10 +463,12 @@ export class ClaudeCodeAdapter extends BaseAgentAdapter {
     if (typeof content === 'string') return;
     for (const block of content) {
       if (block.type !== 'tool_result') continue;
+      const diff = this.pendingEditDiffs.get(block.tool_use_id) ?? [];
+      this.pendingEditDiffs.delete(block.tool_use_id);
       this.emitTool({
         toolCallId: block.tool_use_id,
         status: block.is_error === true ? 'failed' : 'completed',
-        content: toolResultContent(block.content),
+        content: [...diff, ...toolResultContent(block.content)],
         rawOutput: block.content,
       });
     }
@@ -483,6 +498,31 @@ export class ClaudeCodeAdapter extends BaseAgentAdapter {
     this.teardown();
     this.emitStatus('idle');
   }
+}
+
+/**
+ * Claude's file-mutation tools carry the exact patch in their input — Edit as `file_path` /
+ * `old_string` / `new_string`, Write as `file_path` / `content` (a whole-file write, so no
+ * oldText: the UI renders it as all-added lines). Surface it as structured diff content so the
+ * UI renders a diff instead of the raw input JSON. Returns undefined for every other tool
+ * (including NotebookEdit, whose input has no old cell source to diff against) and for a
+ * malformed input.
+ */
+function editDiffContent(toolName: string, input: unknown): ToolCallContent[] | undefined {
+  if (!isRecord(input)) return undefined;
+  if (toolName === 'Edit') {
+    const { file_path: path, old_string: oldText, new_string: newText } = input;
+    if (typeof path !== 'string' || typeof oldText !== 'string' || typeof newText !== 'string') {
+      return undefined;
+    }
+    return [{ type: 'diff', path, oldText, newText }];
+  }
+  if (toolName === 'Write') {
+    const { file_path: path, content: newText } = input;
+    if (typeof path !== 'string' || typeof newText !== 'string') return undefined;
+    return [{ type: 'diff', path, newText }];
+  }
+  return undefined;
 }
 
 /** Normalize a tool_result's payload (string or content blocks) into tool-call content. Accepts
@@ -553,7 +593,7 @@ export function createClaudeHistoryEventMapper(
             title: block.name,
             kind: toolKindFromName(block.name),
             status: 'in_progress',
-            content: [],
+            content: editDiffContent(block.name, block.input) ?? [],
             rawInput: block.input,
           }),
         );
@@ -572,7 +612,8 @@ export function createClaudeHistoryEventMapper(
           title: existing?.title ?? block.tool_use_id,
           kind: existing?.kind ?? 'other',
           status: block.is_error === true ? 'failed' : 'completed',
-          content: toolResultContent(block.content),
+          // Announce-time content is the Edit diff (or empty); keep it ahead of the result text.
+          content: [...(existing?.content ?? []), ...toolResultContent(block.content)],
           rawInput: existing?.rawInput,
           rawOutput: block.content,
         }),


### PR DESCRIPTION
Fixes CODE-40

## Problem

The `ToolCallContent` schema reserves a structured `diff` variant, but no adapter ever constructs it. The claude-code adapter passes tool input through as `rawInput` only, so an Edit tool call — whose input already carries the exact patch (`file_path` / `old_string` / `new_string`) — reaches the UI as a raw JSON dump, even though `ToolCallItem` already renders `DiffBlock` for diff content (proven by the dev mock host showcase).

There is also a non-obvious clobber: `BaseAgentAdapter.emitTool` replaces `content` wholesale on merge, and the settle path always passes the result text as `content`, so a diff attached at announce time would be wiped when the `tool_result` lands.

## Changes

All in `packages/agent-adapter`:

- New `editDiffContent(toolName, input)` parser in the claude-code adapter:
  - `Edit`: `file_path`/`old_string`/`new_string` → `[{ type: 'diff', path, oldText, newText }]`
  - `Write`: `file_path`/`content` → whole-file diff without `oldText` (renders as all-added lines)
  - any other tool or malformed input → unchanged raw passthrough
  - `NotebookEdit` deliberately excluded: its input has no old cell source, and `edit_mode: insert/delete` is not an old→new mutation (documented in the parser comment)
- Announce stashes the parsed diff in a `pendingEditDiffs` map; settle re-attaches it ahead of the result text (`[diff, ...result text]`). A `teardown()` override clears stashed diffs for turns that never settle.
- The history replay mapper (`createClaudeHistoryEventMapper`) reuses the same parser and preserves announce-time content at settle, so resumed sessions render identically to live ones.
- Also cherry-picks the lint fix for typechecking agent-adapter tests via its tsconfig project (pre-existing lint failure on master; already on the code-29 branch, git will dedupe on merge).

## Verification

- 3 new unit tests in `normalize.test.ts` (live Edit announce/settle diff persistence, Write whole-file diff, non-Edit/malformed passthrough); 27/27 adapter tests pass.
- `pnpm typecheck` / `pnpm lint` / `pnpm format` clean.