### PR TITLE
fix(agent-adapter): guard opencode consumeEvents against unhandled rejections

### DIFF
--- a/packages/agent-adapter/src/__tests__/opencode.test.ts
+++ b/packages/agent-adapter/src/__tests__/opencode.test.ts
@@ -143,17 +143,68 @@ describe('OpenCodeAdapter.consumeEvents', () => {
     }
   });
 
-  it('treats the stream ending on its own (no stop()) as a fatal, non-recoverable error', async () => {
-    const { events } = await makeAdapter();
+  it('treats the stream ending after the turn already went idle as expected, not an error', async () => {
+    const { adapter, events } = await makeAdapter();
+
+    await adapter.send({ type: 'prompt', content: [] });
+    client.stream.push({
+      id: 'e-idle',
+      type: 'session.idle',
+      properties: { sessionID: 'sess-1' },
+    });
+    await vi.waitFor(() => {
+      expect(events.some((e) => e.type === 'status' && e.status === 'idle')).toBe(true);
+    });
     events.length = 0;
 
+    // opencode closing the SSE stream right after the turn ended is the normal fallout of a
+    // completed round-trip, not a failure — there's nothing left to interrupt.
+    client.stream.end();
+
+    await vi.waitFor(() => {
+      // Give the loop a chance to run; nothing should ever land.
+      expect(events).toHaveLength(0);
+    });
+  });
+
+  it('treats the stream closing while a turn is still active as a fatal error and stops the session', async () => {
+    const { adapter, events } = await makeAdapter();
+    events.length = 0;
+
+    await adapter.send({ type: 'prompt', content: [] });
+    events.length = 0;
+
+    // The stream closes mid-turn — before `session.idle` — so the in-flight round-trip can no
+    // longer receive completion signals.
     client.stream.end();
 
     await vi.waitFor(() => {
       expect(errors(events)).toHaveLength(1);
     });
     expect(errors(events)[0].recoverable).toBe(false);
-    expect(events.some((e) => e.type === 'status' && e.status === 'idle')).toBe(true);
+    // `stopped`, not `idle` — the shell only disables the composer on `stopped`, and a session that
+    // can no longer receive events must not look usable.
+    expect(events.some((e) => e.type === 'status' && e.status === 'stopped')).toBe(true);
+    expect(events.some((e) => e.type === 'status' && e.status === 'idle')).toBe(false);
+  });
+
+  it('treats a cancel-triggered stream close as the expected fallout of the abort, not an error', async () => {
+    const { adapter, events } = await makeAdapter();
+
+    await adapter.send({ type: 'prompt', content: [] });
+    events.length = 0;
+
+    await adapter.send({ type: 'cancel' });
+    expect(client.session.abort).toHaveBeenCalledWith({ sessionID: 'sess-1' });
+
+    // Cancel aborts the turn without a matching `session.idle`; opencode then closes the stream —
+    // that's the abort's own fallout, not an unexpected disconnect.
+    client.stream.end();
+
+    await vi.waitFor(() => {
+      // Give the loop a chance to run; nothing should ever land.
+      expect(events).toHaveLength(0);
+    });
   });
 
   it('reports a subscribe() rejection without an unhandled rejection', async () => {
@@ -176,6 +227,7 @@ describe('OpenCodeAdapter.consumeEvents', () => {
       });
       expect(errors(events)[0].message).toContain('beforeRequest hook rejected');
       expect(errors(events)[0].recoverable).toBe(false);
+      expect(events.some((e) => e.type === 'status' && e.status === 'stopped')).toBe(true);
 
       await vi.waitFor(() => {
         expect(unhandled).not.toHaveBeenCalled();

--- a/packages/agent-adapter/src/__tests__/opencode.test.ts
+++ b/packages/agent-adapter/src/__tests__/opencode.test.ts
@@ -207,6 +207,27 @@ describe('OpenCodeAdapter.consumeEvents', () => {
     });
   });
 
+  it('does not latch the cancel suppression when abort() itself rejects, so a later stream failure still surfaces', async () => {
+    const { adapter, events } = await makeAdapter();
+
+    await adapter.send({ type: 'prompt', content: [] });
+    events.length = 0;
+
+    // The abort request fails: the turn was never actually cancelled, so no cancel-induced close
+    // is coming. `send('cancel')` rejects — the caller sees the failure directly.
+    client.session.abort.mockRejectedValueOnce(new Error('abort failed'));
+    await expect(adapter.send({ type: 'cancel' })).rejects.toThrow('abort failed');
+
+    // A genuine disconnect afterwards must NOT be swallowed as an expected cancel close.
+    client.stream.fail(new Error('connection dropped'));
+
+    await vi.waitFor(() => {
+      expect(errors(events)).toHaveLength(1);
+    });
+    expect(errors(events)[0].recoverable).toBe(false);
+    expect(events.some((e) => e.type === 'status' && e.status === 'stopped')).toBe(true);
+  });
+
   it('reports a subscribe() rejection without an unhandled rejection', async () => {
     const unhandled = vi.fn();
     process.on('unhandledRejection', unhandled);

--- a/packages/agent-adapter/src/__tests__/opencode.test.ts
+++ b/packages/agent-adapter/src/__tests__/opencode.test.ts
@@ -1,0 +1,204 @@
+import type { AgentEvent } from '@linkcode/schema';
+import type { Event } from '@opencode-ai/sdk/v2';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { OpenCodeAdapter } from '../native/opencode';
+
+const sdkMock = vi.hoisted(() => ({
+  createOpencode: null as ((opts: unknown) => unknown) | null,
+}));
+
+vi.mock('@opencode-ai/sdk/v2', () => ({
+  createOpencode(opts: unknown) {
+    if (!sdkMock.createOpencode) throw new Error('createOpencode mock not installed');
+    return sdkMock.createOpencode(opts);
+  },
+}));
+
+/** Stands in for the SSE `ServerSentEventsResult['stream']` `event.subscribe()` resolves to: an
+ * async-iterable queue tests push events into, mirroring the real for-await the adapter drains. */
+class FakeEventStream {
+  private readonly queued: Array<{ event: unknown } | { done: true } | { failed: unknown }> = [];
+  private waiting: (() => void) | null = null;
+
+  push(event: Event): void {
+    this.queued.push({ event });
+    this.flush();
+  }
+  /** A raw, possibly malformed payload — bypasses the `Event` shape `push()` requires, standing
+   * in for a real SSE frame that doesn't match the SDK's declared types. */
+  pushRaw(event: unknown): void {
+    this.queued.push({ event });
+    this.flush();
+  }
+  /** The server closing the stream on its own, without the adapter having stopped. */
+  end(): void {
+    this.queued.push({ done: true });
+    this.flush();
+  }
+  /** The iterator itself failing (e.g. a dropped connection). */
+  fail(err: unknown): void {
+    this.queued.push({ failed: err });
+    this.flush();
+  }
+
+  private flush(): void {
+    const wake = this.waiting;
+    this.waiting = null;
+    wake?.();
+  }
+
+  async *[Symbol.asyncIterator](): AsyncGenerator<Event> {
+    while (true) {
+      if (this.queued.length === 0) {
+        await new Promise<void>((resolve) => {
+          this.waiting = resolve;
+        });
+        continue;
+      }
+      const item = this.queued.shift()!;
+      if ('done' in item) return;
+      if ('failed' in item) throw item.failed;
+      yield item.event as Event;
+    }
+  }
+}
+
+class FakeClient {
+  readonly stream = new FakeEventStream();
+  subscribeError: Error | null = null;
+  readonly session = {
+    create: vi.fn(() => ({ data: { id: 'sess-1' } })),
+    prompt: vi.fn(() => ({})),
+    abort: vi.fn(() => ({})),
+  };
+  readonly event = {
+    subscribe: vi.fn(() => {
+      if (this.subscribeError) throw this.subscribeError;
+      return { stream: this.stream };
+    }),
+  };
+}
+
+const closeServer = vi.fn();
+let client: FakeClient;
+
+sdkMock.createOpencode = () => {
+  client = new FakeClient();
+  return Promise.resolve({ client, server: { url: 'http://fake', close: closeServer } });
+};
+
+afterEach(() => {
+  closeServer.mockClear();
+});
+
+async function makeAdapter(): Promise<{ adapter: OpenCodeAdapter; events: AgentEvent[] }> {
+  const adapter = new OpenCodeAdapter();
+  const events: AgentEvent[] = [];
+  adapter.onEvent((e) => events.push(e));
+  await adapter.start({ kind: 'opencode', cwd: '/tmp/repo' });
+  return { adapter, events };
+}
+
+function errors(events: AgentEvent[]): Array<Extract<AgentEvent, { type: 'error' }>> {
+  return events.filter((e): e is Extract<AgentEvent, { type: 'error' }> => e.type === 'error');
+}
+
+describe('OpenCodeAdapter.consumeEvents', () => {
+  it('reports a malformed event via emitError instead of throwing, and keeps consuming', async () => {
+    const unhandled = vi.fn();
+    process.on('unhandledRejection', unhandled);
+    try {
+      const { events } = await makeAdapter();
+
+      // `part` missing on a message.part.updated event — an unexpected shape handlePart cannot
+      // handle; must not escape as an unhandled rejection or kill the stream.
+      client.stream.pushRaw({
+        id: 'e1',
+        type: 'message.part.updated',
+        properties: { sessionID: 'sess-1', time: 0 },
+      });
+      await vi.waitFor(() => {
+        expect(errors(events)).toHaveLength(1);
+      });
+
+      // The stream keeps running afterwards: a well-formed event right after still gets through.
+      client.stream.push({
+        id: 'e2',
+        type: 'message.part.updated',
+        properties: {
+          sessionID: 'sess-1',
+          time: 0,
+          part: { id: 'p1', sessionID: 'sess-1', messageID: 'msg-1', type: 'text', text: 'hi' },
+        },
+      });
+      await vi.waitFor(() => {
+        expect(events.some((e) => e.type === 'agent-message-chunk')).toBe(true);
+      });
+
+      await vi.waitFor(() => {
+        expect(unhandled).not.toHaveBeenCalled();
+      });
+    } finally {
+      process.off('unhandledRejection', unhandled);
+    }
+  });
+
+  it('treats the stream ending on its own (no stop()) as a fatal, non-recoverable error', async () => {
+    const { events } = await makeAdapter();
+    events.length = 0;
+
+    client.stream.end();
+
+    await vi.waitFor(() => {
+      expect(errors(events)).toHaveLength(1);
+    });
+    expect(errors(events)[0].recoverable).toBe(false);
+    expect(events.some((e) => e.type === 'status' && e.status === 'idle')).toBe(true);
+  });
+
+  it('reports a subscribe() rejection without an unhandled rejection', async () => {
+    const unhandled = vi.fn();
+    process.on('unhandledRejection', unhandled);
+    try {
+      const adapter = new OpenCodeAdapter();
+      const events: AgentEvent[] = [];
+      adapter.onEvent((e) => events.push(e));
+
+      sdkMock.createOpencode = () => {
+        client = new FakeClient();
+        client.subscribeError = new Error('beforeRequest hook rejected');
+        return Promise.resolve({ client, server: { url: 'http://fake', close: closeServer } });
+      };
+      await adapter.start({ kind: 'opencode', cwd: '/tmp/repo' });
+
+      await vi.waitFor(() => {
+        expect(errors(events)).toHaveLength(1);
+      });
+      expect(errors(events)[0].message).toContain('beforeRequest hook rejected');
+      expect(errors(events)[0].recoverable).toBe(false);
+
+      await vi.waitFor(() => {
+        expect(unhandled).not.toHaveBeenCalled();
+      });
+    } finally {
+      process.off('unhandledRejection', unhandled);
+      sdkMock.createOpencode = () => {
+        client = new FakeClient();
+        return Promise.resolve({ client, server: { url: 'http://fake', close: closeServer } });
+      };
+    }
+  });
+
+  it('on stop(): the stream ending afterwards is the expected shutdown, not an error', async () => {
+    const { adapter, events } = await makeAdapter();
+    await adapter.stop();
+    events.length = 0;
+
+    // stop() already closed the server; the stream ending is the normal fallout, not a failure.
+    client.stream.end();
+    await vi.waitFor(() => {
+      // Give the loop a chance to run; nothing should ever land.
+      expect(events).toHaveLength(0);
+    });
+  });
+});

--- a/packages/agent-adapter/src/native/opencode.ts
+++ b/packages/agent-adapter/src/native/opencode.ts
@@ -107,7 +107,15 @@ export class OpenCodeAdapter extends BaseAgentAdapter {
     this.turnActive = false;
     this.cancelling = true;
     if (this.client && this.sessionId) {
-      await this.client.session.abort({ sessionID: this.sessionId });
+      try {
+        await this.client.session.abort({ sessionID: this.sessionId });
+      } catch (err) {
+        // The abort itself failed, so no cancel-induced idle/close is coming to reset the flag.
+        // Leaving `cancelling` latched would make `consumeEvents()` swallow a later genuine stream
+        // failure as an expected cancel close — clear it here so only a real cancel suppresses.
+        this.cancelling = false;
+        throw err;
+      }
     }
   }
 

--- a/packages/agent-adapter/src/native/opencode.ts
+++ b/packages/agent-adapter/src/native/opencode.ts
@@ -122,28 +122,56 @@ export class OpenCodeAdapter extends BaseAgentAdapter {
     return { providerID, modelID: rest.join('/') };
   }
 
+  /** Runs for the whole session, dispatching every SSE event the OpenCode server pushes over the
+   * single long-lived `event.subscribe()` stream (subscribed once in `onStart`). Only returns when
+   * that stream ends — `subscribe()` rejecting up front, the iterator throwing mid-stream, or the
+   * server just closing it. */
   private async consumeEvents(): Promise<void> {
     if (!this.client) return;
-    const sub = await this.client.event.subscribe();
-    for await (const ev of sub.stream) {
-      if (this.stopped) break;
-      this.handleEvent(ev);
+    let caught: unknown;
+    try {
+      const sub = await this.client.event.subscribe();
+      for await (const ev of sub.stream) {
+        if (this.stopped) break;
+        this.handleEvent(ev);
+      }
+    } catch (err) {
+      caught = err;
     }
+    if (this.stopped) return;
+    // Nothing resubscribes today (see CODE-9), so however the stream ended — thrown or just
+    // closed — this session can no longer receive events. Sweep in-flight state and surface it
+    // instead of going silently deaf.
+    this.teardown();
+    this.emitError(
+      caught
+        ? (extractErrorMessage(caught) ?? 'opencode: event stream failed')
+        : 'opencode: event stream ended unexpectedly',
+      undefined,
+      false,
+    );
+    this.emitStatus('idle');
   }
 
+  /** Each event is handled in its own try/catch so one malformed event (e.g. an unexpected
+   * `properties`/`part` shape) reports an error without ending the whole stream. */
   private handleEvent(ev: Event): void {
-    switch (ev.type) {
-      case 'message.part.updated':
-        if (ev.properties.sessionID === this.sessionId) this.handlePart(ev.properties.part);
-        break;
-      case 'session.idle':
-        if (ev.properties.sessionID === this.sessionId) {
-          this.emitStop('end_turn');
-          this.emitStatus('idle');
-        }
-        break;
-      default:
-        break;
+    try {
+      switch (ev.type) {
+        case 'message.part.updated':
+          if (ev.properties.sessionID === this.sessionId) this.handlePart(ev.properties.part);
+          break;
+        case 'session.idle':
+          if (ev.properties.sessionID === this.sessionId) {
+            this.emitStop('end_turn');
+            this.emitStatus('idle');
+          }
+          break;
+        default:
+          break;
+      }
+    } catch (err) {
+      this.emitError(extractErrorMessage(err) ?? `opencode: failed to handle event (${ev.type})`);
     }
   }
 

--- a/packages/agent-adapter/src/native/opencode.ts
+++ b/packages/agent-adapter/src/native/opencode.ts
@@ -53,6 +53,12 @@ export class OpenCodeAdapter extends BaseAgentAdapter {
   private closeServer: (() => void) | null = null;
   private sessionId: string | null = null;
   private stopped = false;
+  /** True while a turn is in flight (prompt sent, `session.idle` not yet seen) — gates whether the
+   * event stream ending is an unexpected failure or an expected side effect of the turn finishing. */
+  private turnActive = false;
+  /** True once `onCancel` has aborted the in-flight turn — any stream fallout until the next prompt
+   * (thrown or clean) is that abort's expected side effect, not a failure. */
+  private cancelling = false;
   /** Per-part cursor for turning OpenCode's cumulative part text into deltas. */
   private readonly textLen = new Map<string, number>();
 
@@ -86,6 +92,8 @@ export class OpenCodeAdapter extends BaseAgentAdapter {
   protected async onPrompt(content: ContentBlock[]): Promise<void> {
     if (!this.client || !this.sessionId) throw new Error('opencode: session not started');
     const parts: TextPartInput[] = [{ type: 'text', text: contentToText(content) }];
+    this.turnActive = true;
+    this.cancelling = false;
     this.emitStatus('running');
     await this.client.session.prompt({
       sessionID: this.sessionId,
@@ -96,6 +104,8 @@ export class OpenCodeAdapter extends BaseAgentAdapter {
   }
 
   protected override async onCancel(): Promise<void> {
+    this.turnActive = false;
+    this.cancelling = true;
     if (this.client && this.sessionId) {
       await this.client.session.abort({ sessionID: this.sessionId });
     }
@@ -125,7 +135,12 @@ export class OpenCodeAdapter extends BaseAgentAdapter {
   /** Runs for the whole session, dispatching every SSE event the OpenCode server pushes over the
    * single long-lived `event.subscribe()` stream (subscribed once in `onStart`). Only returns when
    * that stream ends — `subscribe()` rejecting up front, the iterator throwing mid-stream, or the
-   * server just closing it. */
+   * server just closing it.
+   *
+   * Not every ending is a failure: a turn finishing normally (`session.idle`) closes the stream just
+   * like a genuine disconnect would, and so does our own `cancel` aborting the turn — neither should
+   * be reported as an error. Only a clean close while a turn is still active (not idle, not
+   * cancelled), or the iterator itself throwing outside of a cancel, is a real, unexpected failure. */
   private async consumeEvents(): Promise<void> {
     if (!this.client) return;
     let caught: unknown;
@@ -138,10 +153,13 @@ export class OpenCodeAdapter extends BaseAgentAdapter {
     } catch (err) {
       caught = err;
     }
-    if (this.stopped) return;
-    // Nothing resubscribes today (see CODE-9), so however the stream ended — thrown or just
-    // closed — this session can no longer receive events. Sweep in-flight state and surface it
-    // instead of going silently deaf.
+    if (this.stopped || this.cancelling) return;
+    // Clean close with no turn in flight (already idle, or never started one) is expected —
+    // nothing was interrupted.
+    if (!caught && !this.turnActive) return;
+    // Nothing resubscribes today (see CODE-9), so this session can no longer receive events.
+    // Sweep in-flight state and surface it as fatal — `stopped`, not `idle`, so the UI disables
+    // the composer instead of treating this session as still usable.
     this.teardown();
     this.emitError(
       caught
@@ -150,7 +168,7 @@ export class OpenCodeAdapter extends BaseAgentAdapter {
       undefined,
       false,
     );
-    this.emitStatus('idle');
+    this.emitStatus('stopped');
   }
 
   /** Each event is handled in its own try/catch so one malformed event (e.g. an unexpected
@@ -163,6 +181,8 @@ export class OpenCodeAdapter extends BaseAgentAdapter {
           break;
         case 'session.idle':
           if (ev.properties.sessionID === this.sessionId) {
+            this.turnActive = false;
+            this.cancelling = false;
             this.emitStop('end_turn');
             this.emitStatus('idle');
           }


### PR DESCRIPTION
Closes CODE-44 (audit P0 / F01).

opencode's `void this.consumeEvents()` had no error handling — any rejection became a Node unhandled rejection and crashed the whole daemon (taking every session and client down with it).

- Outer try/catch around `consumeEvents()`: a failed subscribe / the iterator throwing mid-stream / the server closing the stream → `teardown()` + a non-recoverable error + status `idle`; a normal `stopped` shutdown stays quiet.
- Per-event try/catch in `handleEvent()`: one malformed event degrades to an error while the long-lived subscription keeps consuming later events.
- Also covers the adjacent CODE-9 surface (a silent stream end no longer goes deaf; resubscription is still left to CODE-9).
- Added opencode.test.ts cases, each asserting zero unhandledRejection leakage.

Review follow-up (aeedb5c): `onCancel` now unlatches the cancel suppression when `session.abort()` itself rejects (resets `cancelling` and rethrows), so a later genuine stream failure still surfaces as fatal instead of being swallowed. Regression test added.

Verification: agent-adapter typecheck/lint clean, `pnpm vitest run packages/agent-adapter` 30/30, pre-commit clean.

See audit finding F01 / Linear CODE-44.
