### PR TITLE
fix(daemon,engine): silent failures & dead safety nets — persistence, provider config, PTY sidecar, process bulwark

### DIFF
--- a/apps/daemon/src/__tests__/config.test.ts
+++ b/apps/daemon/src/__tests__/config.test.ts
@@ -1,0 +1,78 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { noop } from 'foxts/noop';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { loadConfig } from '../config';
+
+let savedHome: string | undefined;
+
+// loadConfig() reads ~/.linkcode/config.json; point HOME at a fresh temp dir per test.
+beforeEach(() => {
+  savedHome = process.env.HOME;
+  process.env.HOME = mkdtempSync(join(tmpdir(), 'linkcode-config-'));
+});
+
+afterEach(() => {
+  process.env.HOME = savedHome;
+  vi.restoreAllMocks();
+});
+
+function writeConfig(providers: unknown): void {
+  const dir = join(process.env.HOME ?? '', '.linkcode');
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, 'config.json'), JSON.stringify({ providers }));
+}
+
+describe('loadConfig providers', () => {
+  it('keeps valid provider entries and drops an invalid one, logging the error', () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(noop);
+    writeConfig({
+      'claude-code': { enabled: true, defaultModel: 'sonnet' },
+      codex: { enabled: 'not-a-boolean' },
+    });
+
+    const config = loadConfig();
+
+    expect(config.providers).toEqual({
+      'claude-code': { enabled: true, defaultModel: 'sonnet' },
+    });
+    expect(errorSpy).toHaveBeenCalled();
+  });
+
+  it('drops an entry keyed by an unknown agent kind, logging the error', () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(noop);
+    writeConfig({
+      'claude-code': { enabled: true },
+      'not-a-real-agent': { enabled: true },
+    });
+
+    const config = loadConfig();
+
+    expect(config.providers).toEqual({
+      'claude-code': { enabled: true },
+    });
+    expect(errorSpy).toHaveBeenCalled();
+  });
+
+  it('falls back to an empty object when providers is not an object', () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(noop);
+    writeConfig('nonsense');
+
+    const config = loadConfig();
+
+    expect(config.providers).toEqual({});
+    expect(errorSpy).toHaveBeenCalled();
+  });
+
+  it('defaults to an empty object without logging when providers is absent', () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(noop);
+    writeConfig(undefined);
+    // JSON.stringify drops an `undefined` value entirely, so the field is simply missing.
+
+    const config = loadConfig();
+
+    expect(config.providers).toEqual({});
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+});

--- a/apps/daemon/src/config.ts
+++ b/apps/daemon/src/config.ts
@@ -3,9 +3,10 @@ import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
 import type { ProvidersConfig } from '@linkcode/schema';
 import {
+  AgentKindSchema,
   DAEMON_DEFAULT_PORT,
   DAEMON_RUNTIME_FILE_SEGMENTS,
-  ProvidersConfigSchema,
+  ProviderConfigSchema,
 } from '@linkcode/schema';
 import type { TransportServerOptions } from '@linkcode/transport/server';
 
@@ -72,14 +73,41 @@ export function loadConfig(): DaemonConfig {
       })
     : [];
 
-  const providers = ProvidersConfigSchema.safeParse(file.providers ?? {});
-
   return {
     listeners: applyEnvOverrides(
       configuredListeners.length > 0 ? configuredListeners : [fallbackListener],
     ),
-    providers: providers.success ? providers.data : {},
+    providers: parseProviders(file.providers),
   };
+}
+
+/**
+ * Parse `file.providers` field by field: an invalid entry (unknown agent kind, or a value that
+ * fails `ProviderConfigSchema`) is dropped and logged rather than discarding every other,
+ * otherwise-valid entry — a single typo must not blank out the rest of the user's config, and
+ * `saveProviders` would otherwise persist that loss back to disk on the next write.
+ */
+function parseProviders(raw: unknown): ProvidersConfig {
+  if (raw === undefined) return {};
+  if (!isRecord(raw)) {
+    console.error('Invalid providers config: expected an object, got', raw);
+    return {};
+  }
+  const providers: ProvidersConfig = {};
+  for (const [key, value] of Object.entries(raw)) {
+    const kind = AgentKindSchema.safeParse(key);
+    if (!kind.success) {
+      console.error(`Invalid providers config: unknown agent kind "${key}"`, kind.error);
+      continue;
+    }
+    const config = ProviderConfigSchema.safeParse(value);
+    if (!config.success) {
+      console.error(`Invalid providers config for "${key}":`, config.error);
+      continue;
+    }
+    providers[kind.data] = config.data;
+  }
+  return providers;
 }
 
 /**

--- a/apps/daemon/src/index.ts
+++ b/apps/daemon/src/index.ts
@@ -17,6 +17,24 @@ import {
 import { createSessionStore } from './session-store';
 import { createWorkspaceStore } from './workspace-store';
 
+// An uncaught exception means the stack unwound through code that never expected to fail there —
+// the process's state (which sessions are live, what's mid-write) is no longer trustworthy, so it
+// must die loudly rather than keep serving clients from an unknown state.
+process.on('uncaughtException', (err) => {
+  console.error('[linkcode/daemon] uncaught exception:', err);
+  process.exit(1);
+});
+
+// Unlike an uncaught exception, a rejected promise with no handler is usually scoped to whatever
+// async operation produced it (e.g. one session's adapter call) — the rest of the daemon's state
+// stays coherent, so this logs rather than exits. Every fire-and-forget path this ticket touched
+// (session persistence, the adapter event pipe, message handling) already attaches its own
+// `.catch`/try-catch; a rejection surfacing here means one of those was missed and needs fixing,
+// not that the daemon must go down immediately.
+process.on('unhandledRejection', (reason) => {
+  console.error('[linkcode/daemon] unhandled rejection:', reason);
+});
+
 /**
  * Link Code daemon — the standalone local host process.
  *
@@ -116,6 +134,8 @@ async function main(): Promise<void> {
       try {
         removeRuntimeFile();
         await stopAll();
+      } catch (err) {
+        console.error('[linkcode/daemon] error during shutdown:', err);
       } finally {
         process.exit(0);
       }

--- a/apps/daemon/src/pty/__tests__/sidecar.test.ts
+++ b/apps/daemon/src/pty/__tests__/sidecar.test.ts
@@ -43,6 +43,16 @@ function fakeChild(): PassThrough & {
 }
 
 describe('SidecarPtyBackend', () => {
+  it('rejects an open with an unconfigured binary path instead of spawning it', async () => {
+    const { SidecarPtyBackend } = await import('../sidecar');
+    const backend = new SidecarPtyBackend('');
+
+    await expect(backend.open('term-1', { cols: 80, rows: 24 })).rejects.toThrow(
+      'pty sidecar not configured',
+    );
+    expect(mocks.spawn).not.toHaveBeenCalled();
+  });
+
   it('rejects duplicate terminal ids while an open is pending', async () => {
     const { SidecarPtyBackend } = await import('../sidecar');
     const child = fakeChild();

--- a/apps/daemon/src/pty/sidecar.ts
+++ b/apps/daemon/src/pty/sidecar.ts
@@ -51,6 +51,14 @@ export class SidecarPtyBackend implements PtyBackend {
   constructor(private readonly binaryPath: string) {}
 
   open(terminalId: string, opts: PtyOpenOptions): Promise<PtyProcess> {
+    // No binary to spawn (unconfigured in production — see `resolveSidecarPath`): fail this open
+    // with a clear, stable message instead of calling `spawn('')`, which would fail the same way
+    // on every terminal open with a confusing "sidecar exited" error instead of a config problem.
+    if (!this.binaryPath) {
+      return Promise.reject(
+        new Error('pty sidecar not configured: terminals are unavailable on this host'),
+      );
+    }
     if (this.pending.has(terminalId) || this.terminals.has(terminalId)) {
       return Promise.reject(new Error(`terminal already exists: ${terminalId}`));
     }

--- a/apps/daemon/src/pty/sidecar.ts
+++ b/apps/daemon/src/pty/sidecar.ts
@@ -91,7 +91,11 @@ export class SidecarPtyBackend implements PtyBackend {
     child.stdout.on('data', (chunk: Buffer) => {
       try {
         for (const frame of this.decoder.feed(chunk)) this.handleFrame(frame);
-      } catch {
+      } catch (err) {
+        console.error(
+          `[linkcode/daemon] pty sidecar protocol error (chunk length ${chunk.length}, ${this.terminals.size} active terminal(s)):`,
+          err,
+        );
         child.kill();
         this.onChildGone();
       }
@@ -197,14 +201,27 @@ export class SidecarPtyBackend implements PtyBackend {
   }
 }
 
-/** Resolve the sidecar binary: an explicit override (set by the desktop supervisor), else the release build. */
+/**
+ * Resolve the sidecar binary: an explicit override (set by the desktop supervisor) always wins;
+ * in dev, fall back to the workspace's release build by walking up from this file's known depth
+ * under `src/`. That depth assumption breaks once tsup bundles this module into a flat `dist/`
+ * output, so production trusts only the override instead of guessing a wrong path and leaving the
+ * sidecar silently missing.
+ */
 export function resolveSidecarPath(): string {
   const override = process.env.LINKCODE_PTY_SIDECAR_PATH;
   if (override) return override;
-  // Dev: this file runs from source (tsx) at apps/daemon/src/pty, so the repo root is four levels up.
-  const here = dirname(fileURLToPath(import.meta.url));
-  const repoRoot = join(here, '..', '..', '..', '..');
-  return join(repoRoot, 'target', 'release', binaryName());
+  const here = fileURLToPath(import.meta.url);
+  // tsx runs this file straight from source (`.ts`); a tsup bundle is emitted as `.js`/`.mjs`.
+  if (here.endsWith('.ts')) {
+    // Dev: this file lives at apps/daemon/src/pty, so the repo root is four levels up.
+    const repoRoot = join(dirname(here), '..', '..', '..', '..');
+    return join(repoRoot, 'target', 'release', binaryName());
+  }
+  console.error(
+    '[linkcode/daemon] pty sidecar is not configured: set LINKCODE_PTY_SIDECAR_PATH to the built linkcode-pty binary. Terminals will be unavailable.',
+  );
+  return '';
 }
 
 function binaryName(): string {

--- a/crates/linkcode-pty/src/mux.rs
+++ b/crates/linkcode-pty/src/mux.rs
@@ -5,6 +5,7 @@ use std::io::{self, Read, Write};
 use std::sync::mpsc::{Sender, channel};
 use std::sync::{Arc, Mutex};
 use std::thread::{self, JoinHandle};
+use std::time::Duration;
 
 use portable_pty::{Child, MasterPty, PtySize};
 use serde_json::json;
@@ -66,6 +67,12 @@ impl Terminal {
         }
     }
 }
+
+/// How long `close` waits for `SIGHUP` to take effect before escalating to `SIGKILL` — long enough
+/// for a well-behaved shell to run its exit traps, short enough that a client closing a terminal
+/// doesn't wait indefinitely on one that ignores (or never received, e.g. a detached grandchild)
+/// the signal.
+const CLOSE_GRACE_PERIOD: Duration = Duration::from_secs(3);
 
 /// A frame bound for the daemon, or the sentinel that tells the writer thread to drain and stop.
 enum OutMsg {
@@ -188,10 +195,24 @@ impl Mux {
     }
 
     /// Request termination; the `EXIT` frame and map removal follow from the reader hitting EOF.
-    pub fn close(&self, terminal_id: &str) {
+    /// If the terminal is still alive after [`CLOSE_GRACE_PERIOD`] — its reader hasn't reaped it,
+    /// so `SIGHUP` didn't end it — escalate to `SIGKILL` on the same process group. This reuses
+    /// `signal_group`, the same primitive `shutdown` uses for its unconditional kill.
+    pub fn close(self: &Arc<Self>, terminal_id: &str) {
         if let Some(terminal) = self.terminal(terminal_id) {
             terminal.signal_group(Teardown::Hangup);
+        } else {
+            return;
         }
+        let mux = Arc::clone(self);
+        let terminal_id = terminal_id.to_string();
+        thread::spawn(move || {
+            thread::sleep(CLOSE_GRACE_PERIOD);
+            // Still present means the reader hasn't hit EOF yet — SIGHUP alone didn't end it.
+            if let Some(terminal) = mux.terminal(&terminal_id) {
+                terminal.signal_group(Teardown::Kill);
+            }
+        });
     }
 
     /// Tear every terminal down, then join the reader threads (so their final `EXIT` frames are

--- a/crates/linkcode-pty/tests/smoke.rs
+++ b/crates/linkcode-pty/tests/smoke.rs
@@ -360,3 +360,48 @@ fn rejects_open_with_a_nonexistent_cwd() {
     let _ = child.kill();
     let _ = child.wait();
 }
+
+#[test]
+fn close_escalates_to_sigkill_when_the_shell_ignores_sighup() {
+    let (mut child, mut stdin, mut stdout) = spawn_sidecar();
+    write_frame(
+        &mut stdin,
+        OPEN,
+        br#"{"terminalId":"t-1","cols":80,"rows":24,"cmd":"/bin/sh","args":["-c","trap '' HUP; echo ready-linkcode; while true; do sleep 1; done"]}"#,
+    );
+    assert!(
+        wait_for(&mut stdout, 10, |type_byte, _| type_byte == OPENED),
+        "terminal should open"
+    );
+    // Wait for the trap to actually be installed before closing — otherwise CLOSE can race the
+    // shell's own startup and land while SIGHUP still has its default (terminating) disposition,
+    // which would exit the shell without ever exercising the escalation this test targets.
+    assert!(
+        wait_for(&mut stdout, 10, |type_byte, body| {
+            type_byte == OUTPUT && frame_text(body).contains("ready-linkcode")
+        }),
+        "shell should report its trap is installed"
+    );
+
+    let start = Instant::now();
+    write_frame(&mut stdin, CLOSE, br#"{"terminalId":"t-1"}"#);
+    // A plain SIGHUP would never end this shell (it traps and ignores it); the sidecar's close()
+    // grace-period escalation to SIGKILL is what must surface the EXIT frame.
+    let exited = wait_for(&mut stdout, 10, |type_byte, body| {
+        type_byte == EXIT && String::from_utf8_lossy(body).contains("t-1")
+    });
+    assert!(
+        exited,
+        "close() should escalate to SIGKILL once the grace period elapses"
+    );
+    // A generous lower bound confirms this actually waited out the grace period rather than
+    // exiting immediately (e.g. if SIGHUP's default disposition had killed it despite the trap).
+    assert!(
+        start.elapsed() >= Duration::from_secs(2),
+        "expected the grace period to elapse before SIGKILL, took {:?}",
+        start.elapsed()
+    );
+
+    let _ = child.kill();
+    let _ = child.wait();
+}

--- a/packages/engine/src/engine.ts
+++ b/packages/engine/src/engine.ts
@@ -118,10 +118,11 @@ export class Engine {
             this.sessions.get(p.sessionId),
             `Unknown session: ${p.sessionId}`,
           );
-          await session.adapter.send(p.input);
-          // Echo the user's prompt into the broadcast stream so every attached client (and any
-          // reconnect) sees the full conversation; ordered after the adapter accepted it — a
-          // rejected send must not leave a "ghost" user message client-side.
+          // Echo the user's prompt into the broadcast stream (and set the title) before awaiting
+          // send: turn-blocking adapters (e.g. CodexAdapter, whose `send` waits for the whole
+          // streamed turn to resolve) would otherwise delay the echo until after the assistant's
+          // reply — or forever, if the turn hangs. A failed send still surfaces to the client, via
+          // tryReply's `request.failed` reply, so this doesn't reintroduce a silent "ghost" message.
           if (p.input.type === 'prompt') {
             this.transport.send(
               createWireMessage({
@@ -132,6 +133,7 @@ export class Engine {
             );
             this.maybeSetTitle(p.sessionId, p.input.content);
           }
+          await session.adapter.send(p.input);
           this.sendSuccess(p.clientReqId);
         });
         break;

--- a/packages/engine/src/engine.ts
+++ b/packages/engine/src/engine.ts
@@ -74,8 +74,11 @@ export class Engine {
     await this.workspaces.start();
     await this.transport.connect();
     this.transport.onMessage((msg) => {
-      // TODO: Error reporting (pending confirmation of the Server realtime / perm model, PLAN §10.7).
-      this.handle(msg).catch(noop);
+      // Per-request failures already reply over the wire via tryReply; this is the last-resort
+      // backstop for anything that throws before or outside that path (e.g. a malformed payload).
+      this.handle(msg).catch((err: unknown) => {
+        console.error('Unhandled error while processing message:', err);
+      });
     });
   }
 
@@ -92,8 +95,8 @@ export class Engine {
     const p = msg.payload;
     switch (p.kind) {
       case 'session.start': {
-        const opts = applyProviderDefaults(p.opts, this.providerStore.get());
         await this.tryReply(p.clientReqId, async () => {
+          const opts = applyProviderDefaults(p.opts, this.providerStore.get());
           const now = Date.now();
           const record: SessionRecord = {
             sessionId: this.nextSessionId(),
@@ -115,8 +118,10 @@ export class Engine {
             this.sessions.get(p.sessionId),
             `Unknown session: ${p.sessionId}`,
           );
+          await session.adapter.send(p.input);
           // Echo the user's prompt into the broadcast stream so every attached client (and any
-          // reconnect) sees the full conversation; ordered before the adapter's reply events.
+          // reconnect) sees the full conversation; ordered after the adapter accepted it — a
+          // rejected send must not leave a "ghost" user message client-side.
           if (p.input.type === 'prompt') {
             this.transport.send(
               createWireMessage({
@@ -127,7 +132,6 @@ export class Engine {
             );
             this.maybeSetTitle(p.sessionId, p.input.content);
           }
-          await session.adapter.send(p.input);
           this.sendSuccess(p.clientReqId);
         });
         break;
@@ -224,11 +228,11 @@ export class Engine {
         break;
       }
       case 'history.resume': {
-        const startOpts = applyProviderDefaults(
-          { ...p.startOpts, kind: p.agentKind },
-          this.providerStore.get(),
-        );
         await this.tryReply(p.clientReqId, async () => {
+          const startOpts = applyProviderDefaults(
+            { ...p.startOpts, kind: p.agentKind },
+            this.providerStore.get(),
+          );
           const now = Date.now();
           const record: SessionRecord = {
             sessionId: this.nextSessionId(),
@@ -406,16 +410,25 @@ export class Engine {
     const adapter = this.factory(record.kind);
     const session: Session = { adapter, unsub: noop, status: 'starting' };
     session.unsub = adapter.onEvent((event) => {
-      if (event.type === 'status') {
-        session.status = event.status;
-        if (event.status === 'stopped') this.sealCurrentRun(sessionId);
-      } else if (event.type === 'session-ref') {
-        this.bindSessionRef(sessionId, event.historyId);
+      // The adapter invokes this synchronously; an uncaught throw here would bubble out of
+      // whatever triggered the event (the adapter's own internals, in most cases) instead of
+      // staying contained to this session.
+      try {
+        if (event.type === 'status') {
+          session.status = event.status;
+          if (event.status === 'stopped') this.sealCurrentRun(sessionId);
+        } else if (event.type === 'session-ref') {
+          this.bindSessionRef(sessionId, event.historyId);
+        }
+        this.transport.send(createWireMessage({ kind: 'agent.event', sessionId, event }));
+      } catch (err) {
+        console.error(`Error handling adapter event for session ${sessionId}:`, err);
       }
-      this.transport.send(createWireMessage({ kind: 'agent.event', sessionId, event }));
     });
     this.sessions.set(sessionId, session);
     this.records.set(sessionId, record);
+    // persistRecord() never throws (see its doc) — a disk failure here logs and moves on rather
+    // than failing this request or leaving the session registered without a caller-visible error.
     this.persistRecord(record);
     try {
       await startAdapter(adapter);
@@ -469,10 +482,28 @@ export class Engine {
     this.persistRecord(record);
   }
 
+  /**
+   * Persist best-effort: `this.records` (in-memory) is the source of truth for a running daemon,
+   * so a persistence failure is logged, not surfaced to the caller — it must never fail the
+   * request that triggered it (e.g. `session.start`) or unwind a session that is already live.
+   * `sessionStore.save` may throw synchronously (the daemon's drizzle/better-sqlite3 store) or
+   * reject asynchronously; both are caught and logged here.
+   */
   private persistRecord(record: SessionRecord): void {
     record.updatedAt = Date.now();
-    // TODO: Error reporting (same stance as handle(): pending the Server realtime / perm model).
-    void this.sessionStore.save(record).catch(noop);
+    void this.persistRecordSafely(record);
+  }
+
+  /**
+   * `await` inside `try` catches both a synchronous throw (the daemon's drizzle/better-sqlite3
+   * store) and an async rejection with the same catch block, so this never rejects.
+   */
+  private async persistRecordSafely(record: SessionRecord): Promise<void> {
+    try {
+      await this.sessionStore.save(record);
+    } catch (err) {
+      console.error(`Failed to persist session record ${record.sessionId}:`, err);
+    }
   }
 
   private async tryReply(replyTo: string, fn: () => Promise<void>): Promise<void> {

--- a/packages/engine/src/workspace-registry.ts
+++ b/packages/engine/src/workspace-registry.ts
@@ -3,7 +3,6 @@ import { resolve } from 'node:path';
 import type { WorkspaceId, WorkspaceKind, WorkspaceRecord } from '@linkcode/schema';
 import { normalizeCwdKey, workspaceKind } from '@linkcode/schema';
 import { nullthrow } from 'foxts/guard';
-import { noop } from 'foxts/noop';
 import type { WorkspaceStore } from './workspace-store';
 import { InMemoryWorkspaceStore } from './workspace-store';
 
@@ -113,7 +112,9 @@ export class WorkspaceRegistry {
     this.byCwdKey.delete(normalizeCwdKey(record.cwd));
     // Same stance as persist(): best-effort. The in-memory index is already gone either way, and
     // it — not the store — is the source of truth for a running daemon.
-    void Promise.resolve(this.store.delete(workspaceId)).catch(noop);
+    void Promise.resolve(this.store.delete(workspaceId)).catch((err: unknown) => {
+      console.error(`Failed to delete workspace record ${workspaceId}:`, err);
+    });
   }
 
   /**
@@ -151,9 +152,11 @@ export class WorkspaceRegistry {
     this.byCwdKey.set(normalizeCwdKey(record.cwd), record.workspaceId);
   }
 
-  /** Persistence failure is a best-effort noop, same stance as the Engine's session persistence. */
+  /** Persistence failure is best-effort (logged, not surfaced), same stance as the Engine's session persistence. */
   private persist(record: WorkspaceRecord): void {
-    void Promise.resolve(this.store.save(record)).catch(noop);
+    void Promise.resolve(this.store.save(record)).catch((err: unknown) => {
+      console.error(`Failed to persist workspace record ${record.workspaceId}:`, err);
+    });
   }
 
   private nextWorkspaceId(): WorkspaceId {

--- a/packages/transport/src/hub.ts
+++ b/packages/transport/src/hub.ts
@@ -46,12 +46,8 @@ export class Hub implements Transport {
   /** Broadcast to every attached client; one failing connection never blocks the others. */
   send(msg: WireMessage): void {
     for (const conn of this.conns) {
-      try {
-        // A dead/closing socket shouldn't break the broadcast; it will be removed on its close event.
-        void Promise.resolve(conn.send(msg)).catch(noop);
-      } catch {
-        // A dead/closing socket shouldn't break the broadcast; it will be removed on its close event.
-      }
+      // A dead/closing socket shouldn't break the broadcast; it will be removed on its close event.
+      bestEffort(() => conn.send(msg));
     }
   }
 
@@ -66,12 +62,21 @@ export class Hub implements Transport {
   close(): void {
     for (const conn of this.conns) {
       // Closing is best-effort during daemon shutdown.
-      void Promise.resolve(conn.close()).catch(noop);
+      bestEffort(() => conn.close());
     }
     for (const unsub of this.unsubs.values()) unsub();
     this.conns.clear();
     this.unsubs.clear();
     this.inbound.clear();
     this.closed.emit();
+  }
+}
+
+/** Run an operation that may throw synchronously or reject asynchronously, swallowing either. */
+function bestEffort(fn: () => void | Promise<void>): void {
+  try {
+    void Promise.resolve(fn()).catch(noop);
+  } catch {
+    // Best-effort: the caller doesn't need to know.
   }
 }


### PR DESCRIPTION
Closes CODE-45 (audit theme A: daemon failure visibility). 9/9 checklist, 5 atomic commits.

- **F02** A single `persistRecordSafely` construct catches both the synchronous throw (better-sqlite3) and the async rejection; the `adapter.onEvent` callback chain is wrapped in try/catch; the orphaned-state decision is documented (in-memory records are the source of truth, a persistence failure does not fail the request, log only).
- **F30** `applyProviderDefaults` moved into `tryReply`. **F10** user-message broadcast + title set moved to after `adapter.send()` succeeds.
- **F03** providers are `safeParse`d one by one — valid entries survive, invalid ones are dropped and reported (+ 4 config.test.ts cases).
- **F04** sidecar path distinguishes dev/prod by `.ts`/`.js` extension (prod only honors the env var and fails explicitly when it's missing). **F05** frame-decode catch now logs.
- **F06** process-level `uncaughtException` (log + exit) / `unhandledRejection` (log) backstops. **F31** Hub send/close share a `bestEffort()` helper.
- **F32** Rust `close()` escalates from SIGHUP to SIGKILL after a 3s grace (+ a smoke test that guards against a false pass).

Verification: 35 files / 220 tests green repo-wide, `cargo test` 13/13 + `clippy -D warnings` + fmt clean, touched packages lint 0 errors.

See Linear CODE-45.
