### PR TITLE
fix(desktop): lock down window navigation for agent-authored links + single-instance lock

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -14,30 +14,46 @@ Sentry.init({
 
 app.setName(APP_NAME);
 
-app
-  .whenReady()
-  .then(() => {
-    // Dev only: brand the macOS Dock (the stock Electron binary has no icon). Use a static,
-    // macOS-grid-margined glass render of the .icon — a full-bleed raster looks oversized in the
-    // Dock. Loaded by path so this dev-only image isn't bundled into prod; packaged builds render
-    // live Liquid Glass from the .icon.
-    if (process.platform === 'darwin' && !app.isPackaged) {
-      app.dock?.setIcon(join(__dirname, '../../../../assets/icon-dock.png'));
+// settings.ts caches settings in memory and rewrites the whole file on save, so two instances
+// would last-write-wins clobber each other. Only one instance may run; a second launch just
+// focuses the existing window instead.
+if (app.requestSingleInstanceLock()) {
+  app.on('second-instance', () => {
+    const win = BrowserWindow.getAllWindows().at(0);
+    if (win) {
+      if (win.isMinimized()) win.restore();
+      win.show();
+      win.focus();
     }
-    // Apply the stored color scheme before the window exists so its chrome paints correctly first time.
-    applyThemePreference(getSettings().theme);
-    Menu.setApplicationMenu(buildAppMenu());
-    createDesktopWindow();
-    initAutoUpdates();
-
-    app.on('activate', () => {
-      if (BrowserWindow.getAllWindows().length === 0) createDesktopWindow();
-    });
-  })
-  .catch((err) => {
-    console.error('[link-code/desktop] failed to start:', err);
   });
 
-app.on('window-all-closed', () => {
-  if (process.platform !== 'darwin') app.quit();
-});
+  app
+    .whenReady()
+    .then(() => {
+      // Dev only: brand the macOS Dock (the stock Electron binary has no icon). Use a static,
+      // macOS-grid-margined glass render of the .icon — a full-bleed raster looks oversized in the
+      // Dock. Loaded by path so this dev-only image isn't bundled into prod; packaged builds render
+      // live Liquid Glass from the .icon.
+      if (process.platform === 'darwin' && !app.isPackaged) {
+        app.dock?.setIcon(join(__dirname, '../../../../assets/icon-dock.png'));
+      }
+      // Apply the stored color scheme before the window exists so its chrome paints correctly first time.
+      applyThemePreference(getSettings().theme);
+      Menu.setApplicationMenu(buildAppMenu());
+      createDesktopWindow();
+      initAutoUpdates();
+
+      app.on('activate', () => {
+        if (BrowserWindow.getAllWindows().length === 0) createDesktopWindow();
+      });
+    })
+    .catch((err) => {
+      console.error('[link-code/desktop] failed to start:', err);
+    });
+
+  app.on('window-all-closed', () => {
+    if (process.platform !== 'darwin') app.quit();
+  });
+} else {
+  app.quit();
+}

--- a/apps/desktop/src/main/window.ts
+++ b/apps/desktop/src/main/window.ts
@@ -1,7 +1,8 @@
 import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
 import { UPDATER_STATUS_CHANNEL } from '@linkcode/ipc';
 import { bindElectronSystemIpc } from '@linkcode/ipc/electron-main';
-import { BrowserWindow, ipcMain, nativeTheme } from 'electron';
+import { BrowserWindow, ipcMain, nativeTheme, shell } from 'electron';
 import { extractErrorMessage } from 'foxts/extract-error-message';
 // electron-vite resolves `?asset` to a runtime file path. Used as the Win/Linux window icon in dev
 // (packaged builds get the real icon from the bundle). macOS uses a separate Dock image set at bootstrap.
@@ -64,8 +65,47 @@ function createWindow(): BrowserWindow {
     });
   });
 
+  // Agent-authored content (e.g. markdown links in chat) can render `<a target="_blank">` to
+  // untrusted URLs. Without a handler Electron opens a new window that inherits the preload —
+  // deny every popup and hand http(s) targets to the OS browser instead.
+  win.webContents.setWindowOpenHandler(({ url }) => {
+    if (isHttpUrl(url)) void shell.openExternal(url);
+    return { action: 'deny' };
+  });
+
+  // Same untrusted-link surface via in-page navigation (no target="_blank"): only allow the
+  // renderer to navigate within itself (the dev server origin or the packaged entry file).
+  win.webContents.on('will-navigate', (event, url) => {
+    if (isSelfNavigation(url)) return;
+    event.preventDefault();
+    if (isHttpUrl(url)) void shell.openExternal(url);
+  });
+
   void loadRenderer(win);
   return win;
+}
+
+function isHttpUrl(url: string): boolean {
+  try {
+    const { protocol } = new URL(url);
+    return protocol === 'http:' || protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+/** Mirrors {@link loadRenderer}'s allowed targets: the dev server origin, or the packaged entry file. */
+function isSelfNavigation(url: string): boolean {
+  let target: URL;
+  try {
+    target = new URL(url);
+  } catch {
+    return false;
+  }
+  const devUrl = process.env.ELECTRON_RENDERER_URL;
+  if (devUrl) return target.origin === new URL(devUrl).origin;
+  const entry = pathToFileURL(join(__dirname, '../renderer/index.html'));
+  return target.protocol === 'file:' && target.pathname === entry.pathname;
 }
 
 async function loadRenderer(win: BrowserWindow): Promise<void> {


### PR DESCRIPTION
Closes CODE-46 (audit theme B: Electron security). 2 commits.

- **F07** `setWindowOpenHandler` denies everything; http(s) is handed to `shell.openExternal` and any other scheme is swallowed. `will-navigate` only allows the app's own origin (compared against `ELECTRON_RENDERER_URL` in dev / the packaged `renderer/index.html` file:// path in prod). This closes the exposure where an agent-authored `target=_blank` link could open an arbitrary origin carrying the systemBridge preload.
- **F48** `requestSingleInstanceLock` + `second-instance` focuses the existing window.

Verification: desktop typecheck/lint clean, pre-commit clean; `pnpm -F @linkcode/desktop dev` launches, the window is created normally with no did-fail-load. **Known gap**: no end-to-end verification of a real link click (to avoid stealing physical desktop focus) — reviewers may want to click an external link and confirm it opens the system browser.

See Linear CODE-46.
