### PR TITLE
refactor(ui): dedupe repeated visual recipes — copy button, tooltip button, panel tabs, git cards, thread-nav props

### DIFF
--- a/packages/ui/src/chat/artifact.tsx
+++ b/packages/ui/src/chat/artifact.tsx
@@ -1,7 +1,8 @@
 import { Button } from 'coss-ui/components/button';
-import { Tooltip, TooltipContent, TooltipTrigger } from 'coss-ui/components/tooltip';
 import { XIcon } from 'lucide-react';
 import { cn } from '../lib/cn';
+import type { TooltipIconButtonProps } from './tooltip-icon-button';
+import { TooltipIconButton } from './tooltip-icon-button';
 
 // TODO(linkcode-schema): Provisional UI-only artifact metadata, not yet wired to daemon/client schema.
 // Move or replace with @linkcode/schema types when generated artifacts are emitted by the data plane.
@@ -87,38 +88,10 @@ export function ArtifactActions({ className, ...props }: ArtifactActionsProps): 
   return <div className={cn('flex items-center gap-1', className)} {...props} />;
 }
 
-export type ArtifactActionProps = React.ComponentProps<typeof Button> & {
-  tooltip?: string;
-};
+export type ArtifactActionProps = TooltipIconButtonProps;
 
-export function ArtifactAction({
-  className,
-  tooltip,
-  children,
-  size = 'icon-xs',
-  variant = 'ghost',
-  ...props
-}: ArtifactActionProps): React.ReactNode {
-  const button = (
-    <Button
-      className={cn('size-7', className)}
-      size={size}
-      type="button"
-      variant={variant}
-      {...props}
-    >
-      {children}
-    </Button>
-  );
-
-  if (!tooltip) return button;
-
-  return (
-    <Tooltip>
-      <TooltipTrigger render={button} />
-      <TooltipContent>{tooltip}</TooltipContent>
-    </Tooltip>
-  );
+export function ArtifactAction({ className, ...props }: ArtifactActionProps): React.ReactNode {
+  return <TooltipIconButton className={cn('size-7', className)} {...props} />;
 }
 
 export type ArtifactCloseProps = React.ComponentProps<typeof Button>;

--- a/packages/ui/src/chat/checkpoint.tsx
+++ b/packages/ui/src/chat/checkpoint.tsx
@@ -1,8 +1,8 @@
-import { Button } from 'coss-ui/components/button';
 import { Separator } from 'coss-ui/components/separator';
-import { Tooltip, TooltipContent, TooltipTrigger } from 'coss-ui/components/tooltip';
 import { BookmarkIcon, RotateCcwIcon } from 'lucide-react';
 import { cn } from '../lib/cn';
+import type { TooltipIconButtonProps } from './tooltip-icon-button';
+import { TooltipIconButton } from './tooltip-icon-button';
 
 // TODO(linkcode-schema): Provisional UI-only checkpoint metadata, not yet wired to daemon/client schema.
 // Move or replace with @linkcode/schema types when restore/checkpoint events exist in the data plane.
@@ -61,36 +61,16 @@ export function CheckpointIcon({ className, ...props }: CheckpointIconProps): Re
   return <BookmarkIcon className={cn('size-4 shrink-0', className)} {...props} />;
 }
 
-export type CheckpointTriggerProps = React.ComponentProps<typeof Button> & {
-  tooltip?: string;
-};
+export type CheckpointTriggerProps = TooltipIconButtonProps;
 
 export function CheckpointTrigger({
   className,
-  tooltip,
   children,
-  size = 'icon-xs',
-  variant = 'ghost',
   ...props
 }: CheckpointTriggerProps): React.ReactNode {
-  const button = (
-    <Button
-      className={cn('size-7', className)}
-      size={size}
-      type="button"
-      variant={variant}
-      {...props}
-    >
-      {children ?? <RotateCcwIcon className="size-3.5" />}
-    </Button>
-  );
-
-  if (!tooltip) return button;
-
   return (
-    <Tooltip>
-      <TooltipTrigger render={button} />
-      <TooltipContent>{tooltip}</TooltipContent>
-    </Tooltip>
+    <TooltipIconButton className={cn('size-7', className)} {...props}>
+      {children ?? <RotateCcwIcon className="size-3.5" />}
+    </TooltipIconButton>
   );
 }

--- a/packages/ui/src/chat/code-block.tsx
+++ b/packages/ui/src/chat/code-block.tsx
@@ -1,7 +1,6 @@
-import { Button } from 'coss-ui/components/button';
-import { CheckIcon, CopyIcon } from 'lucide-react';
 import { cn } from '../lib/cn';
-import { useCopyButton } from './use-copy-button';
+import type { CopyIconButtonProps } from './copy-icon-button';
+import { CopyIconButton } from './copy-icon-button';
 
 export interface CodeBlockProps extends React.ComponentProps<'div'> {
   code: string;
@@ -64,31 +63,10 @@ export function CodeBlockActions({ className, ...props }: CodeBlockActionsProps)
   return <div className={cn('-my-1 flex items-center gap-1', className)} {...props} />;
 }
 
-export type CodeBlockCopyButtonProps = React.ComponentProps<typeof Button> & {
+export type CodeBlockCopyButtonProps = Omit<CopyIconButtonProps, 'value'> & {
   code: string;
-  timeout?: number;
 };
 
-export function CodeBlockCopyButton({
-  code,
-  timeout = 1600,
-  children,
-  className,
-  ...props
-}: CodeBlockCopyButtonProps): React.ReactNode {
-  const { copied, copyValue } = useCopyButton(code, timeout);
-
-  return (
-    <Button
-      aria-label={copied ? 'Copied' : 'Copy'}
-      className={cn('size-6', className)}
-      onClick={copyValue}
-      size="icon-xs"
-      type="button"
-      variant="ghost"
-      {...props}
-    >
-      {children ?? (copied ? <CheckIcon /> : <CopyIcon />)}
-    </Button>
-  );
+export function CodeBlockCopyButton({ code, ...props }: CodeBlockCopyButtonProps): React.ReactNode {
+  return <CopyIconButton value={code} {...props} />;
 }

--- a/packages/ui/src/chat/commit.tsx
+++ b/packages/ui/src/chat/commit.tsx
@@ -1,13 +1,13 @@
 import { Badge } from 'coss-ui/components/badge';
-import { Button } from 'coss-ui/components/button';
 import {
   Collapsible,
   CollapsibleContent,
   CollapsibleTrigger,
 } from 'coss-ui/components/collapsible';
-import { CheckIcon, CopyIcon, FileIcon, GitCommitIcon, MinusIcon, PlusIcon } from 'lucide-react';
+import { FileIcon, GitCommitIcon, MinusIcon, PlusIcon } from 'lucide-react';
 import { cn } from '../lib/cn';
-import { useCopyButton } from './use-copy-button';
+import type { CopyIconButtonProps } from './copy-icon-button';
+import { CopyIconButton } from './copy-icon-button';
 
 // TODO(linkcode-schema): Provisional UI-only commit metadata, not yet wired to daemon/client schema.
 // Move or replace with @linkcode/schema types when git/checkpoint events expose structured commits.
@@ -132,36 +132,27 @@ export function CommitHash({ className, hash, ...props }: CommitHashProps): Reac
   );
 }
 
-export type CommitCopyButtonProps = React.ComponentProps<typeof Button> & {
+export type CommitCopyButtonProps = Omit<
+  CopyIconButtonProps,
+  'value' | 'label' | 'stopPropagation' | 'iconClassName'
+> & {
   hash: string;
-  timeout?: number;
 };
 
 export function CommitCopyButton({
   className,
   hash,
-  timeout = 1600,
-  children,
   ...props
 }: CommitCopyButtonProps): React.ReactNode {
-  const { copied, copyValue } = useCopyButton(hash, timeout);
-
   return (
-    <Button
-      aria-label={copied ? 'Copied commit hash' : 'Copy commit hash'}
-      className={cn('size-6 shrink-0', className)}
-      onClick={(event) => {
-        event.stopPropagation();
-        copyValue();
-      }}
-      size="icon-xs"
-      type="button"
-      variant="ghost"
+    <CopyIconButton
+      className={cn('shrink-0', className)}
+      iconClassName="size-3.5"
+      label="commit hash"
+      stopPropagation
+      value={hash}
       {...props}
-    >
-      {children ??
-        (copied ? <CheckIcon className="size-3.5" /> : <CopyIcon className="size-3.5" />)}
-    </Button>
+    />
   );
 }
 

--- a/packages/ui/src/chat/copy-icon-button.tsx
+++ b/packages/ui/src/chat/copy-icon-button.tsx
@@ -1,0 +1,45 @@
+import { Button } from 'coss-ui/components/button';
+import { CheckIcon, CopyIcon } from 'lucide-react';
+import { cn } from '../lib/cn';
+import { useCopyButton } from './use-copy-button';
+
+export type CopyIconButtonProps = Omit<React.ComponentProps<typeof Button>, 'onClick'> & {
+  value: string;
+  label?: string;
+  timeout?: number;
+  stopPropagation?: boolean;
+  iconClassName?: string;
+};
+
+/** Internal icon-button recipe shared by the chat copy actions (code block, snippet, commit, stack trace). */
+export function CopyIconButton({
+  value,
+  label,
+  timeout = 1600,
+  stopPropagation = false,
+  iconClassName,
+  className,
+  children,
+  ...props
+}: CopyIconButtonProps): React.ReactNode {
+  const { copied, copyValue } = useCopyButton(value, timeout);
+  const suffix = label ? ` ${label}` : '';
+
+  return (
+    <Button
+      aria-label={copied ? `Copied${suffix}` : `Copy${suffix}`}
+      className={cn('size-6', className)}
+      onClick={(event) => {
+        if (stopPropagation) event.stopPropagation();
+        copyValue();
+      }}
+      size="icon-xs"
+      type="button"
+      variant="ghost"
+      {...props}
+    >
+      {children ??
+        (copied ? <CheckIcon className={iconClassName} /> : <CopyIcon className={iconClassName} />)}
+    </Button>
+  );
+}

--- a/packages/ui/src/chat/snippet.tsx
+++ b/packages/ui/src/chat/snippet.tsx
@@ -1,8 +1,7 @@
-import { Button } from 'coss-ui/components/button';
 import { InputGroup, InputGroupAddon, InputGroupInput } from 'coss-ui/components/input-group';
-import { CheckIcon, CopyIcon } from 'lucide-react';
 import { cn } from '../lib/cn';
-import { useCopyButton } from './use-copy-button';
+import type { CopyIconButtonProps } from './copy-icon-button';
+import { CopyIconButton } from './copy-icon-button';
 
 // TODO(linkcode-schema): Provisional UI-only snippet model, not yet wired to daemon/client schema.
 // Move or replace with @linkcode/schema types when tool outputs expose reusable command/code snippets.
@@ -55,32 +54,10 @@ export function SnippetInput({ className, code, ...props }: SnippetInputProps): 
   );
 }
 
-export type SnippetCopyButtonProps = React.ComponentProps<typeof Button> & {
+export type SnippetCopyButtonProps = Omit<CopyIconButtonProps, 'value' | 'iconClassName'> & {
   code: string;
-  timeout?: number;
 };
 
-export function SnippetCopyButton({
-  className,
-  code,
-  timeout = 1600,
-  children,
-  ...props
-}: SnippetCopyButtonProps): React.ReactNode {
-  const { copied, copyValue } = useCopyButton(code, timeout);
-
-  return (
-    <Button
-      aria-label={copied ? 'Copied' : 'Copy'}
-      className={cn('size-6', className)}
-      onClick={copyValue}
-      size="icon-xs"
-      type="button"
-      variant="ghost"
-      {...props}
-    >
-      {children ??
-        (copied ? <CheckIcon className="size-3.5" /> : <CopyIcon className="size-3.5" />)}
-    </Button>
-  );
+export function SnippetCopyButton({ code, ...props }: SnippetCopyButtonProps): React.ReactNode {
+  return <CopyIconButton iconClassName="size-3.5" value={code} {...props} />;
 }

--- a/packages/ui/src/chat/stack-trace.tsx
+++ b/packages/ui/src/chat/stack-trace.tsx
@@ -1,13 +1,13 @@
-import { Button } from 'coss-ui/components/button';
 import {
   Collapsible,
   CollapsibleContent,
   CollapsibleTrigger,
 } from 'coss-ui/components/collapsible';
-import { AlertTriangleIcon, CheckIcon, ChevronRightIcon, CopyIcon } from 'lucide-react';
+import { AlertTriangleIcon, ChevronRightIcon } from 'lucide-react';
 import { useMemo, useState } from 'react';
 import { cn } from '../lib/cn';
-import { useCopyButton } from './use-copy-button';
+import type { CopyIconButtonProps } from './copy-icon-button';
+import { CopyIconButton } from './copy-icon-button';
 
 // TODO(linkcode-schema): Provisional UI-only stack trace model, not yet wired to daemon/client schema.
 // Move or replace with @linkcode/schema types when test/tool outputs expose structured stack traces.
@@ -208,36 +208,27 @@ export function StackTraceRaw({ className, trace, ...props }: StackTraceRawProps
   );
 }
 
-export type StackTraceCopyButtonProps = React.ComponentProps<typeof Button> & {
+export type StackTraceCopyButtonProps = Omit<
+  CopyIconButtonProps,
+  'value' | 'label' | 'stopPropagation' | 'iconClassName'
+> & {
   trace: string;
-  timeout?: number;
 };
 
 export function StackTraceCopyButton({
   className,
   trace,
-  timeout = 1600,
-  children,
   ...props
 }: StackTraceCopyButtonProps): React.ReactNode {
-  const { copied, copyValue } = useCopyButton(trace, timeout);
-
   return (
-    <Button
-      aria-label={copied ? 'Copied stack trace' : 'Copy stack trace'}
-      className={cn('size-6 shrink-0', className)}
-      onClick={(event) => {
-        event.stopPropagation();
-        copyValue();
-      }}
-      size="icon-xs"
-      type="button"
-      variant="ghost"
+    <CopyIconButton
+      className={cn('shrink-0', className)}
+      iconClassName="size-3.5"
+      label="stack trace"
+      stopPropagation
+      value={trace}
       {...props}
-    >
-      {children ??
-        (copied ? <CheckIcon className="size-3.5" /> : <CopyIcon className="size-3.5" />)}
-    </Button>
+    />
   );
 }
 

--- a/packages/ui/src/chat/tooltip-icon-button.tsx
+++ b/packages/ui/src/chat/tooltip-icon-button.tsx
@@ -1,0 +1,30 @@
+import { Button } from 'coss-ui/components/button';
+import { Tooltip, TooltipContent, TooltipTrigger } from 'coss-ui/components/tooltip';
+
+export type TooltipIconButtonProps = React.ComponentProps<typeof Button> & {
+  tooltip?: string;
+};
+
+/** Internal icon-button recipe: a coss-ui Button, wrapped in a Tooltip only when `tooltip` is set. */
+export function TooltipIconButton({
+  tooltip,
+  children,
+  size = 'icon-xs',
+  variant = 'ghost',
+  ...props
+}: TooltipIconButtonProps): React.ReactNode {
+  const button = (
+    <Button size={size} type="button" variant={variant} {...props}>
+      {children}
+    </Button>
+  );
+
+  if (!tooltip) return button;
+
+  return (
+    <Tooltip>
+      <TooltipTrigger render={button} />
+      <TooltipContent>{tooltip}</TooltipContent>
+    </Tooltip>
+  );
+}

--- a/packages/ui/src/chat/web-preview.tsx
+++ b/packages/ui/src/chat/web-preview.tsx
@@ -1,13 +1,13 @@
-import { Button } from 'coss-ui/components/button';
 import {
   Collapsible,
   CollapsibleContent,
   CollapsibleTrigger,
 } from 'coss-ui/components/collapsible';
-import { Tooltip, TooltipContent, TooltipTrigger } from 'coss-ui/components/tooltip';
 import { ChevronRightIcon, ExternalLinkIcon, GlobeIcon, RotateCwIcon } from 'lucide-react';
 import { useState } from 'react';
 import { cn } from '../lib/cn';
+import type { TooltipIconButtonProps } from './tooltip-icon-button';
+import { TooltipIconButton } from './tooltip-icon-button';
 
 const EMPTY_WEB_PREVIEW_LOGS: readonly ChatWebPreviewLog[] = [];
 
@@ -110,31 +110,12 @@ export function WebPreviewNavigation({
   );
 }
 
-export type WebPreviewNavigationButtonProps = React.ComponentProps<typeof Button> & {
-  tooltip?: string;
-};
+export type WebPreviewNavigationButtonProps = TooltipIconButtonProps;
 
-export function WebPreviewNavigationButton({
-  tooltip,
-  children,
-  size = 'icon-xs',
-  variant = 'ghost',
-  ...props
-}: WebPreviewNavigationButtonProps): React.ReactNode {
-  const button = (
-    <Button size={size} type="button" variant={variant} {...props}>
-      {children}
-    </Button>
-  );
-
-  if (!tooltip) return button;
-
-  return (
-    <Tooltip>
-      <TooltipTrigger render={button} />
-      <TooltipContent>{tooltip}</TooltipContent>
-    </Tooltip>
-  );
+export function WebPreviewNavigationButton(
+  props: WebPreviewNavigationButtonProps,
+): React.ReactNode {
+  return <TooltipIconButton {...props} />;
 }
 
 export type WebPreviewUrlProps = Omit<React.ComponentProps<'input'>, 'onKeyDown'> & {

--- a/packages/ui/src/shell/git/branch-summary.tsx
+++ b/packages/ui/src/shell/git/branch-summary.tsx
@@ -3,7 +3,7 @@ import { Badge } from 'coss-ui/components/badge';
 import { Skeleton } from 'coss-ui/components/skeleton';
 import { GitBranchIcon } from 'lucide-react';
 import { useTranslations } from 'use-intl';
-import { cn } from '../../lib/cn';
+import { GitCardShell } from './git-card-shell';
 
 type RepoGitStatus = Extract<GitStatus, { isRepo: true }>;
 
@@ -17,9 +17,7 @@ export function GitBranchSummary({
   const t = useTranslations('workbench.git');
 
   return (
-    <div
-      className={cn('flex flex-col gap-2 rounded-lg border border-border bg-card p-3', className)}
-    >
+    <GitCardShell className={className}>
       <div className="flex flex-wrap items-center gap-2 text-sm">
         <GitBranchIcon className="size-4 shrink-0 text-muted-foreground" />
         <span className="min-w-0 truncate font-medium">{status.branch ?? t('detachedHead')}</span>
@@ -42,17 +40,15 @@ export function GitBranchSummary({
           ? `${status.remote.identity.owner}/${status.remote.identity.repo}`
           : t('noRemote')}
       </div>
-    </div>
+    </GitCardShell>
   );
 }
 
 export function GitBranchSummarySkeleton({ className }: { className?: string }): React.ReactNode {
   return (
-    <div
-      className={cn('flex flex-col gap-2 rounded-lg border border-border bg-card p-3', className)}
-    >
+    <GitCardShell className={className}>
       <Skeleton className="h-4 w-32" />
       <Skeleton className="h-3 w-24" />
-    </div>
+    </GitCardShell>
   );
 }

--- a/packages/ui/src/shell/git/git-card-shell.tsx
+++ b/packages/ui/src/shell/git/git-card-shell.tsx
@@ -1,0 +1,13 @@
+import { cn } from '../../lib/cn';
+
+export type GitCardShellProps = React.ComponentProps<'div'>;
+
+/** Shared card shell for the branch/pull-request summaries — skeletons use the same shell so loading never shifts layout. */
+export function GitCardShell({ className, ...props }: GitCardShellProps): React.ReactNode {
+  return (
+    <div
+      className={cn('flex flex-col gap-2 rounded-lg border border-border bg-card p-3', className)}
+      {...props}
+    />
+  );
+}

--- a/packages/ui/src/shell/git/pull-request-section.tsx
+++ b/packages/ui/src/shell/git/pull-request-section.tsx
@@ -7,6 +7,7 @@ import { Badge } from 'coss-ui/components/badge';
 import { Skeleton } from 'coss-ui/components/skeleton';
 import { useTranslations } from 'use-intl';
 import { cn } from '../../lib/cn';
+import { GitCardShell } from './git-card-shell';
 
 export function GitPullRequestSection({
   pullRequest,
@@ -54,9 +55,7 @@ function GitPullRequestCard({
   const tReviewDecision = useTranslations('workbench.git.reviewDecision');
 
   return (
-    <div
-      className={cn('flex flex-col gap-2 rounded-lg border border-border bg-card p-3', className)}
-    >
+    <GitCardShell className={className}>
       <div className="flex items-start gap-2">
         <a
           href={pullRequest.url}
@@ -75,7 +74,7 @@ function GitPullRequestCard({
         <span>{tChecksState(pullRequest.checks)}</span>
         <span>{tReviewDecision(pullRequest.reviewDecision)}</span>
       </div>
-    </div>
+    </GitCardShell>
   );
 }
 
@@ -138,11 +137,9 @@ function GitNoPullRequestNotice({ className }: { className?: string }): React.Re
 
 function GitPullRequestSectionSkeleton({ className }: { className?: string }): React.ReactNode {
   return (
-    <div
-      className={cn('flex flex-col gap-2 rounded-lg border border-border bg-card p-3', className)}
-    >
+    <GitCardShell className={className}>
       <Skeleton className="h-4 w-48" />
       <Skeleton className="h-3 w-32" />
-    </div>
+    </GitCardShell>
   );
 }

--- a/packages/ui/src/shell/panels/panel-tab-close-button.tsx
+++ b/packages/ui/src/shell/panels/panel-tab-close-button.tsx
@@ -1,0 +1,24 @@
+import { XIcon } from 'lucide-react';
+
+export interface PanelTabCloseButtonProps {
+  label: string;
+  onClick: () => void;
+}
+
+/** The small "x" affordance inside a closable panel tab; stops the click from also selecting the tab. */
+export function PanelTabCloseButton({ label, onClick }: PanelTabCloseButtonProps): React.ReactNode {
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      title={label}
+      className="mr-1 flex size-4 shrink-0 items-center justify-center rounded-sm text-muted-foreground opacity-50 outline-none hover:bg-muted hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring group-hover:opacity-100"
+      onClick={(event) => {
+        event.stopPropagation();
+        onClick();
+      }}
+    >
+      <XIcon className="size-3" />
+    </button>
+  );
+}

--- a/packages/ui/src/shell/panels/section-panel.tsx
+++ b/packages/ui/src/shell/panels/section-panel.tsx
@@ -5,7 +5,12 @@ import { getPanelChromePlacement, PanelContextualChromePortal } from './chrome-p
 import { PanelContextualControls } from './panel-controls';
 import { SectionTerminalTabStrip } from './section-terminal-tabs';
 import type { PanelSection, PanelSectionTab } from './vocabulary';
-import { PANEL_SECTIONS, PANEL_WINDOW_ICONS } from './vocabulary';
+import {
+  PANEL_SECTIONS,
+  PANEL_TAB_ACTIVE_CLASSNAME,
+  PANEL_TAB_INACTIVE_CLASSNAME,
+  PANEL_WINDOW_ICONS,
+} from './vocabulary';
 
 export interface SectionPanelState {
   open: boolean;
@@ -145,9 +150,7 @@ function SectionTabStrip({
           aria-pressed={section === activeSection}
           className={cn(
             'flex h-7 shrink-0 items-center gap-1.5 rounded-md border px-2.5 text-xs outline-none [-webkit-app-region:no-drag] focus-visible:ring-2 focus-visible:ring-ring',
-            section === activeSection
-              ? 'border-border bg-card font-semibold text-foreground shadow-xs'
-              : 'border-transparent text-muted-foreground hover:bg-accent hover:text-foreground',
+            section === activeSection ? PANEL_TAB_ACTIVE_CLASSNAME : PANEL_TAB_INACTIVE_CLASSNAME,
           )}
           onClick={() => onSelectSection(section)}
         >

--- a/packages/ui/src/shell/panels/section-terminal-tabs.tsx
+++ b/packages/ui/src/shell/panels/section-terminal-tabs.tsx
@@ -1,9 +1,14 @@
-import { PlusIcon, XIcon } from 'lucide-react';
+import { PlusIcon } from 'lucide-react';
 import { useTranslations } from 'use-intl';
 import { cn } from '../../lib/cn';
 import { ShellIconButton } from '../shell-control';
+import { PanelTabCloseButton } from './panel-tab-close-button';
 import type { PanelSectionTab } from './vocabulary';
-import { PANEL_WINDOW_ICONS } from './vocabulary';
+import {
+  PANEL_TAB_ACTIVE_CLASSNAME,
+  PANEL_TAB_INACTIVE_CLASSNAME,
+  PANEL_WINDOW_ICONS,
+} from './vocabulary';
 
 /** The terminal section's own sub-tab strip, one tab per PTY instance. */
 export function SectionTerminalTabStrip({
@@ -70,9 +75,7 @@ function SectionTerminalTabButton({
     <div
       className={cn(
         'group flex h-7 max-w-40 shrink-0 items-center overflow-hidden rounded-md border text-xs [-webkit-app-region:no-drag]',
-        active
-          ? 'border-border bg-card font-semibold text-foreground shadow-xs'
-          : 'border-transparent text-muted-foreground hover:bg-accent hover:text-foreground',
+        active ? PANEL_TAB_ACTIVE_CLASSNAME : PANEL_TAB_INACTIVE_CLASSNAME,
       )}
     >
       <button
@@ -83,18 +86,7 @@ function SectionTerminalTabButton({
         <span className="shrink-0 [&_svg]:size-3.5">{PANEL_WINDOW_ICONS.terminal}</span>
         <span className="min-w-0 truncate">{label}</span>
       </button>
-      <button
-        type="button"
-        aria-label={closeLabel}
-        title={closeLabel}
-        className="mr-1 flex size-4 shrink-0 items-center justify-center rounded-sm text-muted-foreground opacity-50 outline-none hover:bg-muted hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring group-hover:opacity-100"
-        onClick={(event) => {
-          event.stopPropagation();
-          onClose();
-        }}
-      >
-        <XIcon className="size-3" />
-      </button>
+      <PanelTabCloseButton label={closeLabel} onClick={onClose} />
     </div>
   );
 }

--- a/packages/ui/src/shell/panels/tab-strip.tsx
+++ b/packages/ui/src/shell/panels/tab-strip.tsx
@@ -6,12 +6,18 @@ import {
   MenuPopup,
   MenuTrigger,
 } from 'coss-ui/components/menu';
-import { PlusIcon, XIcon } from 'lucide-react';
+import { PlusIcon } from 'lucide-react';
 import { useTranslations } from 'use-intl';
 import { cn } from '../../lib/cn';
 import { PanelControlButton, ShellIconButton } from '../shell-control';
+import { PanelTabCloseButton } from './panel-tab-close-button';
 import type { PanelControl, PanelTab, PanelWindowType } from './vocabulary';
-import { PANEL_WINDOW_ICONS, PANEL_WINDOW_TYPES } from './vocabulary';
+import {
+  PANEL_TAB_ACTIVE_CLASSNAME,
+  PANEL_TAB_INACTIVE_CLASSNAME,
+  PANEL_WINDOW_ICONS,
+  PANEL_WINDOW_TYPES,
+} from './vocabulary';
 
 export interface PanelTabStripProps {
   tabs: PanelTab[];
@@ -117,9 +123,7 @@ function PanelTabButton({
     <div
       className={cn(
         'group flex h-7 max-w-44 shrink-0 items-center overflow-hidden rounded-md border text-xs [-webkit-app-region:no-drag]',
-        active
-          ? 'border-border bg-card font-semibold text-foreground shadow-xs'
-          : 'border-transparent text-muted-foreground hover:bg-accent hover:text-foreground',
+        active ? PANEL_TAB_ACTIVE_CLASSNAME : PANEL_TAB_INACTIVE_CLASSNAME,
       )}
     >
       <button
@@ -130,18 +134,7 @@ function PanelTabButton({
         <span className="shrink-0 [&_svg]:size-3.5">{PANEL_WINDOW_ICONS[tab.type]}</span>
         <span className="min-w-0 truncate">{label}</span>
       </button>
-      <button
-        type="button"
-        aria-label={closeLabel}
-        title={closeLabel}
-        className="mr-1 flex size-4 shrink-0 items-center justify-center rounded-sm text-muted-foreground opacity-50 outline-none hover:bg-muted hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring group-hover:opacity-100"
-        onClick={(event) => {
-          event.stopPropagation();
-          onClose();
-        }}
-      >
-        <XIcon className="size-3" />
-      </button>
+      <PanelTabCloseButton label={closeLabel} onClick={onClose} />
     </div>
   );
 }

--- a/packages/ui/src/shell/panels/vocabulary.tsx
+++ b/packages/ui/src/shell/panels/vocabulary.tsx
@@ -36,3 +36,9 @@ export const PANEL_WINDOW_ICONS: Record<PanelWindowType, React.ReactNode> = {
   browser: <GlobeIcon />,
   files: <FilesIcon />,
 };
+
+/** Shared tab recipe: the active/inactive halves of every panel tab button's className. */
+export const PANEL_TAB_ACTIVE_CLASSNAME =
+  'border-border bg-card font-semibold text-foreground shadow-xs';
+export const PANEL_TAB_INACTIVE_CLASSNAME =
+  'border-transparent text-muted-foreground hover:bg-accent hover:text-foreground';

--- a/packages/ui/src/shell/session-sidebar.tsx
+++ b/packages/ui/src/shell/session-sidebar.tsx
@@ -1,4 +1,4 @@
-import type { AgentKind, SessionId, WorkspaceId, WorkspaceRecord } from '@linkcode/schema';
+import type { AgentKind, SessionId, WorkspaceRecord } from '@linkcode/schema';
 import { Avatar, AvatarFallback } from 'coss-ui/components/avatar';
 import { Badge } from 'coss-ui/components/badge';
 import { Button } from 'coss-ui/components/button';
@@ -27,7 +27,7 @@ import { useTranslations } from 'use-intl';
 import { cn } from '../lib/cn';
 import { repositoryLabel } from './repository-label';
 import { ShellSidebar, shellSidebarItemClassName } from './shell-sidebar';
-import type { BranchStatusComponentType } from './sidebar';
+import type { ThreadGroupActions, ThreadGroupState } from './sidebar';
 import { AgentKindList } from './sidebar';
 import type { ThreadGroupViewModel } from './threads-view';
 import { ThreadsView } from './threads-view';
@@ -35,19 +35,13 @@ import { ThreadsView } from './threads-view';
 export { repositoryLabel } from './repository-label';
 export type { ThreadGroupViewModel } from './threads-view';
 
-export interface SessionSidebarProps {
+export interface SessionSidebarProps extends ThreadGroupActions, ThreadGroupState {
   threadGroups: ThreadGroupViewModel[];
   workspaces: WorkspaceRecord[];
   workspacesLoading?: boolean;
-  activeId: SessionId | null;
-  /** Threads pinned to the top of their group, in pin order. */
-  pinnedSessionIds: readonly SessionId[];
   topInsetClassName?: string;
   footer?: React.ReactNode;
   className?: string;
-  onSelect: (id: SessionId) => void;
-  onStop: (id: SessionId) => void;
-  onToggleSessionPinned: (id: SessionId) => void;
   /** Persists a group drag: the full new project-group order, as `collapseKey`s. */
   onReorderGroups: (orderedCollapseKeys: string[]) => void;
   /** Persists a thread drag within a group: `activeId` landed before/after `overId`. */
@@ -57,9 +51,6 @@ export interface SessionSidebarProps {
     overId: SessionId,
     placement: 'before' | 'after',
   ) => void;
-  onCreate: (opts: { kind: AgentKind; cwd: string }) => void;
-  /** Called once a history entry finishes importing as a new thread. */
-  onImportSession?: (sessionId: SessionId) => void;
   /** Opens the native directory picker; desktop only — omit to hide "Choose directory…". */
   onPickDirectory?: () => Promise<string | null>;
   /** Opens the command palette — the Search entry stays disabled without it. */
@@ -68,16 +59,6 @@ export interface SessionSidebarProps {
   searchShortcut?: string;
   /** Registers a directory as a workspace — the top "New Task" menu and the Add workspace row. */
   onRegisterWorkspace: (cwd: string) => Promise<WorkspaceRecord>;
-  onRenameWorkspace: (workspaceId: WorkspaceId, name: string) => Promise<void>;
-  onArchiveWorkspace: (workspaceId: WorkspaceId) => Promise<void>;
-  onToggleGroupCollapsed: (collapseKey: string) => void;
-  onTogglePreviewExpanded: (groupKey: string) => void;
-  onToggleImportHistory: (groupKey: string) => void;
-  BranchStatusComponent?: BranchStatusComponentType;
-  HistoryComponent?: React.ComponentType<{
-    cwd: string;
-    onImported: (sessionId: SessionId) => void;
-  }>;
 }
 
 const ORGS = [{ label: 'ArcBox Labs', value: 'arcbox' }];

--- a/packages/ui/src/shell/shell-frame.tsx
+++ b/packages/ui/src/shell/shell-frame.tsx
@@ -3,17 +3,21 @@ import type {
   EffortLevel,
   SessionId,
   SessionInfo,
-  WorkspaceId,
   WorkspaceRecord,
 } from '@linkcode/schema';
 import type { ConversationViewModel } from '../chat';
 import { ConversationSurface } from './conversation-surface';
 import { ErrorBanner } from './error-banner';
 import { DefaultHostFooter, SessionSidebar } from './session-sidebar';
-import type { BranchStatusComponentType } from './sidebar';
+import type { ThreadGroupActions, ThreadGroupState } from './sidebar';
 import type { ThreadGroupViewModel } from './threads-view';
 
-export interface ShellFrameProps {
+/** Session/group action field names this shell exposes under its own naming (`onSelectSession`, etc). */
+type RenamedThreadGroupActions = 'onSelect' | 'onStop' | 'onCreate';
+
+export interface ShellFrameProps
+  extends Pick<ThreadGroupActions, Exclude<keyof ThreadGroupActions, RenamedThreadGroupActions>>,
+    Pick<ThreadGroupState, 'pinnedSessionIds'> {
   threadGroups: ThreadGroupViewModel[];
   workspaces: WorkspaceRecord[];
   workspacesLoading?: boolean;
@@ -24,11 +28,8 @@ export interface ShellFrameProps {
   respondingPermissions: Set<string>;
   header?: React.ReactNode;
   errorMessage?: string | null;
-  /** Threads pinned to the top of their sidebar group, in pin order. */
-  pinnedSessionIds: readonly SessionId[];
   onSelectSession: (id: SessionId) => void;
   onStopSession: (id: SessionId) => void;
-  onToggleSessionPinned: (id: SessionId) => void;
   /** Persists a group drag: the full new project-group order, as `collapseKey`s. */
   onReorderGroups: (orderedCollapseKeys: string[]) => void;
   /** Persists a thread drag within a group: `activeId` landed before/after `overId`. */
@@ -39,14 +40,8 @@ export interface ShellFrameProps {
     placement: 'before' | 'after',
   ) => void;
   onCreateSession: (opts: { kind: AgentKind; cwd: string }) => void;
-  onImportSession?: (sessionId: SessionId) => void;
   /** Registers a directory as a workspace; every shell wires this into the sidebar's Add workspace row. */
   onRegisterWorkspace: (cwd: string) => Promise<WorkspaceRecord>;
-  onRenameWorkspace: (workspaceId: WorkspaceId, name: string) => Promise<void>;
-  onArchiveWorkspace: (workspaceId: WorkspaceId) => Promise<void>;
-  onToggleGroupCollapsed: (collapseKey: string) => void;
-  onTogglePreviewExpanded: (groupKey: string) => void;
-  onToggleImportHistory: (groupKey: string) => void;
   onSendPrompt: (text: string) => void;
   onStopTurn: () => void;
   onRespondPermission: (requestId: string, optionId: string) => void;
@@ -55,11 +50,6 @@ export interface ShellFrameProps {
   /** Platform-formatted hint next to the Search entry, e.g. `⌘K`. */
   searchShortcut?: string;
   TerminalBlockComponent?: React.ComponentType<{ terminalId: string }>;
-  BranchStatusComponent?: BranchStatusComponentType;
-  HistoryComponent?: React.ComponentType<{
-    cwd: string;
-    onImported: (sessionId: SessionId) => void;
-  }>;
   onDismissError?: () => void;
   onModeChange?: (modeId: string) => Promise<void>;
   onModelChange?: (model: string) => Promise<void>;

--- a/packages/ui/src/shell/sidebar/index.ts
+++ b/packages/ui/src/shell/sidebar/index.ts
@@ -13,5 +13,6 @@ export { HistoryList } from './history-list';
 export type { ShowMoreToggleProps } from './show-more-toggle';
 export { ShowMoreToggle } from './show-more-toggle';
 export { SIDEBAR_SORTABLE_SENSORS } from './sortable-sensors';
+export type { ThreadGroupActions, ThreadGroupState } from './thread-group-actions';
 export type { ThreadRowProps } from './thread-row';
 export { ThreadRow } from './thread-row';

--- a/packages/ui/src/shell/sidebar/thread-group-actions.ts
+++ b/packages/ui/src/shell/sidebar/thread-group-actions.ts
@@ -1,0 +1,33 @@
+import type { AgentKind, SessionId, WorkspaceId } from '@linkcode/schema';
+import type { BranchStatusComponentType } from './branch-status';
+
+/**
+ * Session/group interaction callbacks shared verbatim by `SessionSidebar`, `ThreadsView`, and the
+ * per-group section they both render. `ShellFrame` renames a few of these at its public boundary
+ * (`onSelect` → `onSelectSession`, etc.) and reassembles them with `Pick` instead of extending.
+ */
+export interface ThreadGroupActions {
+  onSelect: (id: SessionId) => void;
+  onStop: (id: SessionId) => void;
+  onToggleSessionPinned: (id: SessionId) => void;
+  onCreate: (opts: { kind: AgentKind; cwd: string }) => void;
+  /** Called once a history entry finishes importing as a new thread. */
+  onImportSession?: (sessionId: SessionId) => void;
+  onRenameWorkspace: (workspaceId: WorkspaceId, name: string) => Promise<void>;
+  onArchiveWorkspace: (workspaceId: WorkspaceId) => Promise<void>;
+  onToggleGroupCollapsed: (collapseKey: string) => void;
+  onTogglePreviewExpanded: (groupKey: string) => void;
+  onToggleImportHistory: (groupKey: string) => void;
+  BranchStatusComponent?: BranchStatusComponentType;
+  HistoryComponent?: React.ComponentType<{
+    cwd: string;
+    onImported: (sessionId: SessionId) => void;
+  }>;
+}
+
+/** The per-group selection/pin state that travels alongside `ThreadGroupActions`. */
+export interface ThreadGroupState {
+  activeId: SessionId | null;
+  /** Threads pinned to the top of their group, in pin order. */
+  pinnedSessionIds: readonly SessionId[];
+}

--- a/packages/ui/src/shell/threads-view.tsx
+++ b/packages/ui/src/shell/threads-view.tsx
@@ -2,18 +2,12 @@ import { move } from '@dnd-kit/helpers';
 import type { DragEndEvent, DragOverEvent } from '@dnd-kit/react';
 import { DragDropProvider } from '@dnd-kit/react';
 import { useSortable } from '@dnd-kit/react/sortable';
-import type {
-  AgentKind,
-  SessionId,
-  SessionInfo,
-  WorkspaceId,
-  WorkspaceRecord,
-} from '@linkcode/schema';
+import type { SessionId, SessionInfo, WorkspaceRecord } from '@linkcode/schema';
 import { Skeleton } from 'coss-ui/components/skeleton';
 import { createFixedArray } from 'foxact/create-fixed-array';
 import { useTranslations } from 'use-intl';
 import { repositoryLabel } from './repository-label';
-import type { BranchStatusComponentType } from './sidebar';
+import type { ThreadGroupActions, ThreadGroupState } from './sidebar';
 import {
   AddWorkspaceRow,
   ChatsSection,
@@ -42,15 +36,9 @@ export interface ThreadGroupViewModel {
   isChat: boolean;
 }
 
-export interface ThreadsViewProps {
+export interface ThreadsViewProps extends ThreadGroupActions, ThreadGroupState {
   groups: ThreadGroupViewModel[];
   workspacesLoading?: boolean;
-  activeId: SessionId | null;
-  /** Threads pinned to the top of their group, in pin order. */
-  pinnedSessionIds: readonly SessionId[];
-  onSelect: (id: SessionId) => void;
-  onStop: (id: SessionId) => void;
-  onToggleSessionPinned: (id: SessionId) => void;
   /** Persists a group drag: the full new project-group order, as `collapseKey`s. */
   onReorderGroups: (orderedCollapseKeys: string[]) => void;
   /** Persists a thread drag within a group: `activeId` landed before/after `overId`. */
@@ -60,20 +48,8 @@ export interface ThreadsViewProps {
     overId: SessionId,
     placement: 'before' | 'after',
   ) => void;
-  onCreate: (opts: { kind: AgentKind; cwd: string }) => void;
-  onImportSession?: (sessionId: SessionId) => void;
   onPickDirectory?: () => Promise<string | null>;
   onRegisterWorkspace: (cwd: string) => Promise<WorkspaceRecord>;
-  onRenameWorkspace: (workspaceId: WorkspaceId, name: string) => Promise<void>;
-  onArchiveWorkspace: (workspaceId: WorkspaceId) => Promise<void>;
-  onToggleGroupCollapsed: (collapseKey: string) => void;
-  onTogglePreviewExpanded: (groupKey: string) => void;
-  onToggleImportHistory: (groupKey: string) => void;
-  BranchStatusComponent?: BranchStatusComponentType;
-  HistoryComponent?: React.ComponentType<{
-    cwd: string;
-    onImported: (sessionId: SessionId) => void;
-  }>;
 }
 
 /** The sidebar's two sections: "Projects" (the grouped tree) and the flat "Chats" list. */
@@ -242,28 +218,12 @@ function ThreadGroupSection({
   onToggleImportHistory,
   BranchStatusComponent,
   HistoryComponent,
-}: {
-  group: ThreadGroupViewModel;
-  /** The group's index among the rendered project groups — feeds the sortable. */
-  sortIndex: number;
-  activeId: SessionId | null;
-  pinnedSessionIds: readonly SessionId[];
-  onSelect: (id: SessionId) => void;
-  onStop: (id: SessionId) => void;
-  onToggleSessionPinned: (id: SessionId) => void;
-  onCreate: (opts: { kind: AgentKind; cwd: string }) => void;
-  onImportSession?: (sessionId: SessionId) => void;
-  onRenameWorkspace: (workspaceId: WorkspaceId, name: string) => Promise<void>;
-  onArchiveWorkspace: (workspaceId: WorkspaceId) => Promise<void>;
-  onToggleGroupCollapsed: (collapseKey: string) => void;
-  onTogglePreviewExpanded: (groupKey: string) => void;
-  onToggleImportHistory: (groupKey: string) => void;
-  BranchStatusComponent?: BranchStatusComponentType;
-  HistoryComponent?: React.ComponentType<{
-    cwd: string;
-    onImported: (sessionId: SessionId) => void;
-  }>;
-}): React.ReactNode {
+}: ThreadGroupActions &
+  ThreadGroupState & {
+    group: ThreadGroupViewModel;
+    /** The group's index among the rendered project groups — feeds the sortable. */
+    sortIndex: number;
+  }): React.ReactNode {
   const t = useTranslations('workbench.sidebar');
   const { workspace } = group;
   const title = workspace


### PR DESCRIPTION
Closes CODE-53 (audit theme I: UI style/component DRY). 5 atomic commits, all in packages/ui.

- **F41** `CopyIconButton` (four CopyButton variants become thin shells). **F42** `TooltipIconButton` (three call sites).
- **F43** shared `ThreadGroupActions`/`ThreadGroupState` interfaces, four layers of components reuse via extends/Pick — **zero changes in workbench/desktop/webview**.
- **F44** panel tab class constants moved into the vocabulary + `PanelTabCloseButton`. **F45** `GitCardShell` (the real card and the skeleton share one shell).

Verification: `pnpm run check:ci` (format + lint + typecheck, 17 packages) clean, `pnpm run test` 216 green. Visuals preserved pixel-for-pixel.

See Linear CODE-53.
