### PR TITLE
chore: audit misc — dead exports, misplaced helpers, small dedups

### DIFF
--- a/apps/daemon/src/config.ts
+++ b/apps/daemon/src/config.ts
@@ -1,13 +1,9 @@
 import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
+import { daemonRuntimeFilePath } from '@linkcode/common/node';
 import type { ProvidersConfig } from '@linkcode/schema';
-import {
-  AgentKindSchema,
-  DAEMON_DEFAULT_PORT,
-  DAEMON_RUNTIME_FILE_SEGMENTS,
-  ProviderConfigSchema,
-} from '@linkcode/schema';
+import { AgentKindSchema, DAEMON_DEFAULT_PORT, ProviderConfigSchema } from '@linkcode/schema';
 import type { TransportServerOptions } from '@linkcode/transport/server';
 
 /**
@@ -44,7 +40,7 @@ export function databasePath(): string {
 
 /** Runtime discovery file advertising the running daemon's bound endpoints, next to config.json. */
 export function runtimeFilePath(): string {
-  return join(homedir(), ...DAEMON_RUNTIME_FILE_SEGMENTS);
+  return daemonRuntimeFilePath();
 }
 
 /**

--- a/apps/daemon/src/pty/bench-throughput.mts
+++ b/apps/daemon/src/pty/bench-throughput.mts
@@ -3,25 +3,15 @@
 import { spawn } from 'node:child_process';
 import { dirname, join } from 'node:path';
 import { performance } from 'node:perf_hooks';
-import type { Writable } from 'node:stream';
 import { fileURLToPath } from 'node:url';
-
-const OPEN = 0x01;
-const OPENED = 0x81;
-const OUTPUT = 0x82;
-const EXIT = 0x83;
-const ERROR = 0x84;
+import { ERROR, EXIT, FrameDecoder, OPEN, OPENED, OUTPUT, writeFrame } from './codec';
+import { binaryName } from './sidecar';
 
 const BYTES = readPositiveInteger('LINKCODE_PTY_BENCH_BYTES', 8 * 1024 * 1024);
 const RUNS = readPositiveInteger('LINKCODE_PTY_BENCH_RUNS', 5);
 const WARMUP_RUNS = readPositiveInteger('LINKCODE_PTY_BENCH_WARMUP_RUNS', 1);
 const COLS = 120;
 const ROWS = 32;
-
-interface Frame {
-  type: number;
-  body: Buffer;
-}
 
 interface NodePtyProcess {
   onData(cb: (data: string) => void): { dispose(): void };
@@ -41,23 +31,6 @@ interface NodePtyModule {
       env: NodeJS.ProcessEnv;
     },
   ): NodePtyProcess;
-}
-
-class FrameDecoder {
-  private carry: Buffer = Buffer.alloc(0);
-
-  feed(chunk: Buffer): Frame[] {
-    this.carry = this.carry.length === 0 ? chunk : Buffer.concat([this.carry, chunk]);
-    const frames: Frame[] = [];
-    while (this.carry.length >= 5) {
-      const total = this.carry.readUInt32LE(0);
-      if (this.carry.length < 4 + total) break;
-      frames.push({ type: this.carry[4], body: Buffer.from(this.carry.subarray(5, 4 + total)) });
-      this.carry = this.carry.subarray(4 + total);
-    }
-    this.carry = Buffer.from(this.carry);
-    return frames;
-  }
 }
 
 async function main(): Promise<void> {
@@ -132,15 +105,21 @@ async function runLinkCodePty(
       const finished = new Promise<number>((resolve, reject) => {
         pending.set(terminalId, { resolve, reject });
       });
-      writeJsonFrame(child.stdin, OPEN, {
-        terminalId,
-        cols: COLS,
-        rows: ROWS,
-        cmd: process.execPath,
-        args: ['-e', workload],
-        cwd,
-        env: {},
-      });
+      writeFrame(
+        child.stdin,
+        OPEN,
+        Buffer.from(
+          JSON.stringify({
+            terminalId,
+            cols: COLS,
+            rows: ROWS,
+            cmd: process.execPath,
+            args: ['-e', workload],
+            cwd,
+            env: {},
+          }),
+        ),
+      );
       const elapsed = (await finished) - started;
       if (run >= 0) results.push(elapsed);
     }
@@ -186,14 +165,6 @@ while (remaining > 0) {
 }`;
 }
 
-function writeJsonFrame(sink: Writable, type: number, value: unknown): void {
-  const body = Buffer.from(JSON.stringify(value));
-  const header = Buffer.allocUnsafe(5);
-  header.writeUInt32LE(body.length + 1, 0);
-  header[4] = type;
-  sink.write(Buffer.concat([header, body]));
-}
-
 async function loadNodePty(): Promise<NodePtyModule | null> {
   try {
     const packageName = 'node-pty';
@@ -223,10 +194,6 @@ function readPositiveInteger(name: string, fallback: number): number {
 
 function formatBytes(bytes: number): string {
   return `${(bytes / 1024 / 1024).toFixed(1)} MiB`;
-}
-
-function binaryName(): string {
-  return process.platform === 'win32' ? 'linkcode-pty.exe' : 'linkcode-pty';
 }
 
 function discardData(data: string): void {

--- a/apps/daemon/src/pty/sidecar.ts
+++ b/apps/daemon/src/pty/sidecar.ts
@@ -232,7 +232,7 @@ export function resolveSidecarPath(): string {
   return '';
 }
 
-function binaryName(): string {
+export function binaryName(): string {
   return process.platform === 'win32' ? 'linkcode-pty.exe' : 'linkcode-pty';
 }
 

--- a/apps/desktop/src/main/daemon-discovery.ts
+++ b/apps/desktop/src/main/daemon-discovery.ts
@@ -1,11 +1,5 @@
-import { homedir } from 'node:os';
-import { join } from 'node:path';
-import { isPidAlive, readJsonFileSync } from '@linkcode/common/node';
-import {
-  DAEMON_DEFAULT_URL,
-  DAEMON_RUNTIME_FILE_SEGMENTS,
-  DaemonRuntimeInfoSchema,
-} from '@linkcode/schema';
+import { daemonRuntimeFilePath, isPidAlive, readJsonFileSync } from '@linkcode/common/node';
+import { DAEMON_DEFAULT_URL, DaemonRuntimeInfoSchema } from '@linkcode/schema';
 import { getSettings } from './settings';
 
 /**
@@ -18,7 +12,7 @@ export function resolveDaemonUrl(): string {
 }
 
 function discoverRuntimeUrl(): string | null {
-  const file = join(homedir(), ...DAEMON_RUNTIME_FILE_SEGMENTS);
+  const file = daemonRuntimeFilePath();
   const parsed = DaemonRuntimeInfoSchema.safeParse(readJsonFileSync(file));
   if (!parsed.success || !isPidAlive(parsed.data.pid)) return null;
   // The renderer connects over Socket.IO; ignore listeners it cannot dial.

--- a/apps/mobile/src/app/connect.tsx
+++ b/apps/mobile/src/app/connect.tsx
@@ -1,8 +1,8 @@
+import { EmptyState, ScreenScroll } from '@linkcode/ui/native';
 import { useRouter } from 'expo-router';
 import { Button, Card, Input, Label, ListGroup, TextField } from 'heroui-native';
 import { useState } from 'react';
-import { ScrollView, Text, View } from 'react-native';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { Text, View } from 'react-native';
 import { useTranslations } from 'use-intl';
 import { HostUrlSchema, useHostRegistryStore } from '../stores/host-store';
 
@@ -14,7 +14,6 @@ import { HostUrlSchema, useHostRegistryStore } from '../stores/host-store';
 export default function ConnectScreen() {
   const t = useTranslations('mobile.connect');
   const router = useRouter();
-  const insets = useSafeAreaInsets();
   const hosts = useHostRegistryStore((state) => state.hosts);
   const addHost = useHostRegistryStore((state) => state.addHost);
   const removeHost = useHostRegistryStore((state) => state.removeHost);
@@ -37,29 +36,9 @@ export default function ConnectScreen() {
   };
 
   return (
-    <ScrollView
-      className="flex-1 bg-background"
-      contentContainerStyle={{
-        padding: 24,
-        paddingTop: insets.top + 24,
-        paddingBottom: insets.bottom + 24,
-        gap: 24,
-      }}
-      keyboardShouldPersistTaps="handled"
-    >
-      <Text className="text-[24px] text-foreground" style={{ fontWeight: '600' }}>
-        {t('title')}
-      </Text>
-
+    <ScreenScroll title={t('title')} keyboardAware>
       {hosts.length === 0 ? (
-        <View className="gap-1">
-          <Text className="text-[15px] text-foreground" style={{ fontWeight: '500' }}>
-            {t('emptyTitle')}
-          </Text>
-          <Text className="text-[13px] text-muted" style={{ lineHeight: 18 }}>
-            {t('emptyHint')}
-          </Text>
-        </View>
+        <EmptyState title={t('emptyTitle')} hint={t('emptyHint')} />
       ) : (
         <View className="gap-2">
           <Text
@@ -119,6 +98,6 @@ export default function ConnectScreen() {
           </Button>
         </Card.Body>
       </Card>
-    </ScrollView>
+    </ScreenScroll>
   );
 }

--- a/apps/mobile/src/app/host/[hostId]/index.tsx
+++ b/apps/mobile/src/app/host/[hostId]/index.tsx
@@ -1,11 +1,11 @@
 import { useSessions } from '@linkcode/client-core';
 import type { AgentKind } from '@linkcode/schema';
 import { AgentKindSchema } from '@linkcode/schema';
+import { EmptyState, ScreenScroll } from '@linkcode/ui/native';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import { Button, Card, Chip, Input, Label, ListGroup, Spinner, TextField } from 'heroui-native';
 import { useState } from 'react';
-import { RefreshControl, ScrollView, Text, View } from 'react-native';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { RefreshControl, Text, View } from 'react-native';
 import { useTranslations } from 'use-intl';
 import { SessionStatusChip } from '../../../components/session-status-chip';
 
@@ -13,7 +13,6 @@ import { SessionStatusChip } from '../../../components/session-status-chip';
 export default function SessionsScreen(): React.ReactNode {
   const t = useTranslations('mobile.sessions');
   const router = useRouter();
-  const insets = useSafeAreaInsets();
   const { hostId } = useLocalSearchParams<{ hostId: string }>();
   const { sessions, create, refresh, loading } = useSessions();
 
@@ -45,39 +44,22 @@ export default function SessionsScreen(): React.ReactNode {
   };
 
   return (
-    <ScrollView
-      className="flex-1 bg-background"
-      contentContainerStyle={{
-        padding: 24,
-        paddingTop: insets.top + 24,
-        paddingBottom: insets.bottom + 24,
-        gap: 24,
-      }}
-      keyboardShouldPersistTaps="handled"
+    <ScreenScroll
+      title={t('title')}
+      keyboardAware
       refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} />}
-    >
-      <View className="flex-row items-center justify-between">
-        <Text className="text-[24px] text-foreground" style={{ fontWeight: '600' }}>
-          {t('title')}
-        </Text>
+      headerRight={
         <Button variant="ghost" size="sm" onPress={() => router.push('/settings')}>
           <Button.Label>{t('settings')}</Button.Label>
         </Button>
-      </View>
-
+      }
+    >
       {loading ? (
         <View className="items-center py-8">
           <Spinner />
         </View>
       ) : sessions.length === 0 ? (
-        <View className="gap-1">
-          <Text className="text-[15px] text-foreground" style={{ fontWeight: '500' }}>
-            {t('emptyTitle')}
-          </Text>
-          <Text className="text-[13px] text-muted" style={{ lineHeight: 18 }}>
-            {t('emptyHint')}
-          </Text>
-        </View>
+        <EmptyState title={t('emptyTitle')} hint={t('emptyHint')} />
       ) : (
         <ListGroup>
           {sessions.map((session) => (
@@ -134,6 +116,6 @@ export default function SessionsScreen(): React.ReactNode {
           </Button>
         </Card.Body>
       </Card>
-    </ScrollView>
+    </ScreenScroll>
   );
 }

--- a/apps/mobile/src/app/settings.tsx
+++ b/apps/mobile/src/app/settings.tsx
@@ -1,9 +1,7 @@
 import { AgentKindSchema, WIRE_PROTOCOL_VERSION } from '@linkcode/schema';
-import { MobileHome } from '@linkcode/ui/native';
+import { MobileHome, ScreenScroll } from '@linkcode/ui/native';
 import { useRouter } from 'expo-router';
 import { Button, Card, ListGroup } from 'heroui-native';
-import { ScrollView, Text } from 'react-native';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTranslations } from 'use-intl';
 
 /** App settings: host management entry plus the About/contract summary. */
@@ -11,22 +9,9 @@ export default function SettingsScreen(): React.ReactNode {
   const t = useTranslations('mobile.settings');
   const tAbout = useTranslations('mobile.about');
   const router = useRouter();
-  const insets = useSafeAreaInsets();
 
   return (
-    <ScrollView
-      className="flex-1 bg-background"
-      contentContainerStyle={{
-        padding: 24,
-        paddingTop: insets.top + 24,
-        paddingBottom: insets.bottom + 24,
-        gap: 24,
-      }}
-    >
-      <Text className="text-[24px] text-foreground" style={{ fontWeight: '600' }}>
-        {t('title')}
-      </Text>
-
+    <ScreenScroll title={t('title')}>
       <ListGroup>
         <ListGroup.Item onPress={() => router.push('/connect')}>
           <ListGroup.ItemContent>
@@ -54,6 +39,6 @@ export default function SettingsScreen(): React.ReactNode {
       <Button variant="ghost" onPress={() => router.back()}>
         <Button.Label>{t('back')}</Button.Label>
       </Button>
-    </ScrollView>
+    </ScreenScroll>
   );
 }

--- a/apps/webview/src/components/data-table/index.tsx
+++ b/apps/webview/src/components/data-table/index.tsx
@@ -11,6 +11,7 @@ import {
 import { cn } from 'coss-ui/lib/utils';
 import { createFixedArray } from 'foxact/create-fixed-array';
 import { ChevronDownIcon, ChevronUpIcon } from 'lucide-react';
+import { useTranslations } from 'use-intl';
 import type { TableDefinition } from './core/create-table';
 import { createTableRender } from './core/table-render';
 import type { SortDirection } from './core/types';
@@ -46,9 +47,12 @@ const SORT_ICON: Record<SortDirection, React.ReactNode> = {
   desc: <ChevronDownIcon aria-hidden="true" className="size-4 shrink-0 opacity-80" />,
 };
 
-function getSortTitle(next: SortDirection | undefined): string {
-  if (next === undefined) return 'Clear sorting';
-  return next === 'desc' ? 'Sort descending' : 'Sort ascending';
+function getSortTitle(
+  next: SortDirection | undefined,
+  t: ReturnType<typeof useTranslations>,
+): string {
+  if (next === undefined) return t('clearSorting');
+  return next === 'desc' ? t('sortDescending') : t('sortAscending');
 }
 
 interface DataTableProps<TData> {
@@ -88,6 +92,7 @@ export function DataTable<TData>({
   fill = false,
   onRowClick,
 }: DataTableProps<TData>) {
+  const t = useTranslations('dataTable');
   // derived pagination view: only the state hook lives at the call site (the
   // fetch key reads it); the render derivation is DataTable's own concern
   const paginationRender = usePaginationRender({
@@ -130,7 +135,7 @@ export function DataTable<TData>({
                         onKeyDown={sortHandler}
                         role="button"
                         tabIndex={0}
-                        title={getSortTitle(sort.nextSortDirection)}
+                        title={getSortTitle(sort.nextSortDirection, t)}
                       >
                         {column.header}
                         {sort.sortDirection ? SORT_ICON[sort.sortDirection] : null}

--- a/apps/webview/src/components/pagination/index.tsx
+++ b/apps/webview/src/components/pagination/index.tsx
@@ -15,6 +15,7 @@ import {
   SelectValue,
 } from 'coss-ui/components/select';
 import { useMemo } from 'react';
+import { useTranslations } from 'use-intl';
 import type { PaginationRender } from './use-pagination-render';
 
 const PAGE_SIZE_OPTIONS = [10, 25, 50, 100];
@@ -27,6 +28,7 @@ interface PaginationFooterProps {
 }
 
 export function PaginationFooter({ pagination, rowNoun = 'results' }: PaginationFooterProps) {
+  const t = useTranslations('pagination');
   const {
     pageIndex,
     pageSize,
@@ -63,7 +65,7 @@ export function PaginationFooter({ pagination, rowNoun = 'results' }: Pagination
             }}
             value={pageSize}
           >
-            <SelectTrigger aria-label="Select page size" className="w-fit min-w-none" size="sm">
+            <SelectTrigger aria-label={t('selectPageSize')} className="w-fit min-w-none" size="sm">
               <SelectValue />
             </SelectTrigger>
             <SelectPopup>
@@ -74,10 +76,10 @@ export function PaginationFooter({ pagination, rowNoun = 'results' }: Pagination
               ))}
             </SelectPopup>
           </Select>
-          <p>per page</p>
+          <p>{t('perPage')}</p>
         </div>
         <div className="flex items-center gap-2 whitespace-nowrap">
-          <p>Viewing</p>
+          <p>{t('viewing')}</p>
           <Select
             items={pageRangeItems}
             onValueChange={(value) => {
@@ -85,7 +87,11 @@ export function PaginationFooter({ pagination, rowNoun = 'results' }: Pagination
             }}
             value={pageIndex}
           >
-            <SelectTrigger aria-label="Select result range" className="w-fit min-w-none" size="sm">
+            <SelectTrigger
+              aria-label={t('selectResultRange')}
+              className="w-fit min-w-none"
+              size="sm"
+            >
               <SelectValue />
             </SelectTrigger>
             <SelectPopup>
@@ -97,7 +103,7 @@ export function PaginationFooter({ pagination, rowNoun = 'results' }: Pagination
             </SelectPopup>
           </Select>
           <p>
-            of <strong className="font-medium text-foreground">{rowCount}</strong> {rowNoun}
+            {t('of')} <strong className="font-medium text-foreground">{rowCount}</strong> {rowNoun}
           </p>
         </div>
       </div>

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -4,7 +4,6 @@
   "private": true,
   "type": "module",
   "exports": {
-    ".": "./src/index.ts",
     "./node": "./src/node/index.ts",
     "./zustand": "./src/zustand/index.ts"
   },

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -13,6 +13,7 @@
     "lint": "eslint --format=sukka ."
   },
   "dependencies": {
+    "@linkcode/schema": "workspace:*",
     "zod": "catalog:",
     "zustand": "catalog:"
   },

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -1,1 +1,0 @@
-export { zodPersist } from './zustand/zod-persist';

--- a/packages/common/src/node/index.ts
+++ b/packages/common/src/node/index.ts
@@ -1,5 +1,8 @@
 /// <reference types="node" />
 import { readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { DAEMON_RUNTIME_FILE_SEGMENTS } from '@linkcode/schema/daemon-runtime-constants';
 
 /**
  * Node-only utilities, exposed via the `@linkcode/common/node` subpath so they never
@@ -25,4 +28,9 @@ export function isPidAlive(pid: number): boolean {
     // EPERM means the process exists but belongs to someone else — still alive.
     return (err as NodeJS.ErrnoException).code === 'EPERM';
   }
+}
+
+/** Path of the daemon's runtime discovery file under the user's home directory. */
+export function daemonRuntimeFilePath(): string {
+  return join(homedir(), ...DAEMON_RUNTIME_FILE_SEGMENTS);
 }

--- a/packages/i18n/src/locales/en.ts
+++ b/packages/i18n/src/locales/en.ts
@@ -318,4 +318,16 @@ export const en = {
       back: 'Back',
     },
   },
+  dataTable: {
+    clearSorting: 'Clear sorting',
+    sortDescending: 'Sort descending',
+    sortAscending: 'Sort ascending',
+  },
+  pagination: {
+    perPage: 'per page',
+    viewing: 'Viewing',
+    of: 'of',
+    selectPageSize: 'Select page size',
+    selectResultRange: 'Select result range',
+  },
 } as const satisfies LocaleMessages;

--- a/packages/i18n/src/locales/zh-cn.ts
+++ b/packages/i18n/src/locales/zh-cn.ts
@@ -314,6 +314,18 @@ export const zhCN = {
       back: '返回',
     },
   },
+  dataTable: {
+    clearSorting: '取消排序',
+    sortDescending: '按降序排序',
+    sortAscending: '按升序排序',
+  },
+  pagination: {
+    perPage: '每页',
+    viewing: '显示',
+    of: '共',
+    selectPageSize: '选择每页数量',
+    selectResultRange: '选择结果范围',
+  },
 } as const;
 
 type WidenMessages<T> = {

--- a/packages/ipc/package.json
+++ b/packages/ipc/package.json
@@ -15,6 +15,7 @@
     "lint": "eslint --format=sukka ."
   },
   "dependencies": {
+    "@linkcode/schema": "workspace:*",
     "@moeru/eventa": "1.0.0-beta.10",
     "zod": "catalog:"
   },

--- a/packages/ipc/src/electron-renderer.ts
+++ b/packages/ipc/src/electron-renderer.ts
@@ -1,3 +1,4 @@
+import { DAEMON_DEFAULT_URL } from '@linkcode/schema/daemon-runtime-constants';
 import { defineInvokes } from '@moeru/eventa';
 import { createContext as createRendererContext } from '@moeru/eventa/adapters/electron/renderer';
 import type { IpcRenderer } from 'electron';
@@ -22,9 +23,6 @@ const FALLBACK_SETTINGS: DesktopSettings = {
   locale: null,
   daemonUrl: null,
 };
-
-// Mirrors DAEMON_DEFAULT_URL from @linkcode/schema, which cannot be imported here (it would pull zod).
-const FALLBACK_DAEMON_URL = 'http://127.0.0.1:19523';
 
 export function createElectronSystemBridge(ipcRenderer: IpcRenderer): SystemBridge {
   const { context } = createRendererContext(toEventaRendererIpc(ipcRenderer));
@@ -75,7 +73,7 @@ export function createElectronSystemBridge(ipcRenderer: IpcRenderer): SystemBrid
     daemon: {
       resolveUrl: () =>
         (ipcRenderer.sendSync(DAEMON_URL_SNAPSHOT_CHANNEL) as string | undefined) ??
-        FALLBACK_DAEMON_URL,
+        DAEMON_DEFAULT_URL,
     },
   };
 }

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -6,7 +6,8 @@
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "exports": {
-    ".": "./src/index.ts"
+    ".": "./src/index.ts",
+    "./daemon-runtime-constants": "./src/daemon-runtime-constants.ts"
   },
   "scripts": {
     "typecheck": "tsc --noEmit",

--- a/packages/schema/src/agent.ts
+++ b/packages/schema/src/agent.ts
@@ -7,7 +7,7 @@ import {
   TimestampSchema,
 } from './common';
 import { ContentBlockSchema } from './content';
-import { PermissionOptionSchema, PermissionOutcomeSchema } from './permission';
+import { PermissionOutcomeSchema, PermissionRequestSchema } from './permission';
 import { PlanSchema } from './plan';
 import {
   McpServerSchema,
@@ -15,7 +15,7 @@ import {
   SessionStatusSchema,
   StopReasonSchema,
 } from './session';
-import { ToolCallSchema, ToolCallUpdateSchema } from './tool-call';
+import { ToolCallSchema } from './tool-call';
 import { TokenUsageSchema } from './usage';
 
 /**
@@ -129,11 +129,9 @@ export const AgentEventSchema = z.discriminatedUnion('type', [
   }),
 
   // ── Agent → client request (awaits a reply via AgentInput, correlated by requestId) ──
-  z.object({
+  PermissionRequestSchema.extend({
     type: z.literal('permission-request'),
     requestId: z.string().min(1),
-    toolCall: ToolCallUpdateSchema,
-    options: z.array(PermissionOptionSchema),
   }),
 ]);
 export type AgentEvent = z.infer<typeof AgentEventSchema>;

--- a/packages/schema/src/daemon-runtime-constants.ts
+++ b/packages/schema/src/daemon-runtime-constants.ts
@@ -1,0 +1,12 @@
+/**
+ * Zero-dependency half of the daemon runtime discovery contract (see `daemon-runtime.ts`).
+ * Kept zod-free so it can be imported from the sandboxed Electron preload, where
+ * `require('zod')` is unavailable.
+ */
+
+/** Default TCP port of the local daemon: 0x4C43 — ascii "LC". */
+export const DAEMON_DEFAULT_PORT = 19523;
+export const DAEMON_DEFAULT_URL = `http://127.0.0.1:${DAEMON_DEFAULT_PORT}`;
+
+/** Runtime discovery file the daemon writes after binding, as path segments under the user's home directory. */
+export const DAEMON_RUNTIME_FILE_SEGMENTS = ['.linkcode', 'runtime.json'] as const;

--- a/packages/schema/src/daemon-runtime.ts
+++ b/packages/schema/src/daemon-runtime.ts
@@ -8,15 +8,14 @@ import { TimestampSchema } from './common';
  * its bound endpoints in a runtime file under the user's home directory.
  */
 
-/** Default TCP port of the local daemon: 0x4C43 — ascii "LC". */
-export const DAEMON_DEFAULT_PORT = 19523;
-export const DAEMON_DEFAULT_URL = `http://127.0.0.1:${DAEMON_DEFAULT_PORT}`;
+export {
+  DAEMON_DEFAULT_PORT,
+  DAEMON_DEFAULT_URL,
+  DAEMON_RUNTIME_FILE_SEGMENTS,
+} from './daemon-runtime-constants';
 
 /** HTTP path every daemon listener answers with its `DaemonIdentity`. */
 export const DAEMON_IDENTITY_PATH = '/linkcode';
-
-/** Runtime discovery file the daemon writes after binding, as path segments under the user's home directory. */
-export const DAEMON_RUNTIME_FILE_SEGMENTS = ['.linkcode', 'runtime.json'] as const;
 
 /** Served at `GET /linkcode`; proves a port is held by a linkcode daemon (and which one). */
 export const DaemonIdentitySchema = z.object({

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -54,13 +54,17 @@
   "peerDependencies": {
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "react-native": ">=0.80"
+    "react-native": ">=0.80",
+    "react-native-safe-area-context": ">=5.0.0"
   },
   "peerDependenciesMeta": {
     "react-dom": {
       "optional": true
     },
     "react-native": {
+      "optional": true
+    },
+    "react-native-safe-area-context": {
       "optional": true
     }
   }

--- a/packages/ui/src/native/empty-state.tsx
+++ b/packages/ui/src/native/empty-state.tsx
@@ -1,0 +1,20 @@
+import { Text, View } from 'react-native';
+
+export interface EmptyStateProps {
+  title: string;
+  hint: string;
+}
+
+/** Two-line placeholder for an empty list: a title and a hint. */
+export function EmptyState({ title, hint }: EmptyStateProps): React.ReactNode {
+  return (
+    <View className="gap-1">
+      <Text className="text-[15px] text-foreground" style={{ fontWeight: '500' }}>
+        {title}
+      </Text>
+      <Text className="text-[13px] text-muted" style={{ lineHeight: 18 }}>
+        {hint}
+      </Text>
+    </View>
+  );
+}

--- a/packages/ui/src/native/index.ts
+++ b/packages/ui/src/native/index.ts
@@ -1,1 +1,3 @@
+export * from './empty-state';
 export * from './mobile-home';
+export * from './screen-scroll';

--- a/packages/ui/src/native/screen-scroll.tsx
+++ b/packages/ui/src/native/screen-scroll.tsx
@@ -1,0 +1,57 @@
+import type { RefreshControlProps } from 'react-native';
+import { ScrollView, Text, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+export interface ScreenScrollProps {
+  title: string;
+  /** Rendered next to the title, e.g. a settings shortcut button. */
+  headerRight?: React.ReactNode;
+  /** Whether taps outside an open keyboard should be handled by children (forms). */
+  keyboardAware?: boolean;
+  // eslint-disable-next-line @typescript-eslint/no-restricted-types -- ScrollView's refreshControl prop requires react-native's own ReactElement<RefreshControlProps>; ReactNode does not satisfy it.
+  refreshControl?: React.ReactElement<RefreshControlProps>;
+  children: React.ReactNode;
+}
+
+/**
+ * Screen chrome shared by every top-level mobile screen: a scroll container with
+ * safe-area-aware padding and a title row. Owns no routing or data — screens pass
+ * already-translated strings and their own content.
+ */
+export function ScreenScroll({
+  title,
+  headerRight,
+  keyboardAware,
+  refreshControl,
+  children,
+}: ScreenScrollProps): React.ReactNode {
+  const insets = useSafeAreaInsets();
+
+  return (
+    <ScrollView
+      className="flex-1 bg-background"
+      contentContainerStyle={{
+        padding: 24,
+        paddingTop: insets.top + 24,
+        paddingBottom: insets.bottom + 24,
+        gap: 24,
+      }}
+      keyboardShouldPersistTaps={keyboardAware ? 'handled' : undefined}
+      refreshControl={refreshControl}
+    >
+      {headerRight ? (
+        <View className="flex-row items-center justify-between">
+          <Text className="text-[24px] text-foreground" style={{ fontWeight: '600' }}>
+            {title}
+          </Text>
+          {headerRight}
+        </View>
+      ) : (
+        <Text className="text-[24px] text-foreground" style={{ fontWeight: '600' }}>
+          {title}
+        </Text>
+      )}
+      {children}
+    </ScrollView>
+  );
+}

--- a/packages/workbench/src/index.ts
+++ b/packages/workbench/src/index.ts
@@ -14,6 +14,7 @@ export * from './runtime/tayori';
 export * from './surface/shell';
 export * from './surface/use-workbench-sessions';
 export * from './surface/workbench';
+export * from './terminal/block';
 export * from './terminal/panel';
 export * from './terminal/transport-session';
 export * from './workspace/hooks';

--- a/packages/workbench/src/sidebar/workspace-history.tsx
+++ b/packages/workbench/src/sidebar/workspace-history.tsx
@@ -18,12 +18,10 @@ function useWorkspaceHistory(cwd: string, onImported: (sessionId: SessionId) => 
   const importMutation = useMutation(importSession);
   const [importingHistoryId, setImportingHistoryId] = useState<string | null>(null);
 
-  const entries = [
-    ...(claudeCode.data?.sessions ?? []),
-    ...(codex.data?.sessions ?? []),
-    ...(opencode.data?.sessions ?? []),
-    ...(pi.data?.sessions ?? []),
-  ].sort((a, b) => (b.updatedAt ?? b.createdAt ?? 0) - (a.updatedAt ?? a.createdAt ?? 0));
+  const results = [claudeCode, codex, opencode, pi];
+  const entries = results
+    .flatMap((result) => result.data?.sessions ?? [])
+    .sort((a, b) => (b.updatedAt ?? b.createdAt ?? 0) - (a.updatedAt ?? a.createdAt ?? 0));
 
   function importEntry(entry: AgentHistorySession): void {
     setImportingHistoryId(entry.historyId);
@@ -34,14 +32,9 @@ function useWorkspaceHistory(cwd: string, onImported: (sessionId: SessionId) => 
       .finally(() => setImportingHistoryId(null));
   }
 
-  const isLoading = claudeCode.isLoading || codex.isLoading || opencode.isLoading || pi.isLoading;
+  const isLoading = results.some((result) => result.isLoading);
   const loadFailed =
-    entries.length === 0 &&
-    !isLoading &&
-    claudeCode.error != null &&
-    codex.error != null &&
-    opencode.error != null &&
-    pi.error != null;
+    entries.length === 0 && !isLoading && results.every((result) => result.error != null);
 
   return {
     entries,

--- a/packages/workbench/src/surface/workbench.tsx
+++ b/packages/workbench/src/surface/workbench.tsx
@@ -1,5 +1,4 @@
 import type { Conversation } from '@linkcode/client-core';
-import { useTerminalOutput } from '@linkcode/client-core';
 import type { EffortLevel, SessionId, WorkspaceId, WorkspaceRecord } from '@linkcode/schema';
 import { workspaceKind } from '@linkcode/schema';
 import {
@@ -14,7 +13,6 @@ import {
   updateWorkspace,
 } from '@linkcode/sdk';
 import type { ThreadGroupViewModel } from '@linkcode/ui';
-import { TerminalBlock } from '@linkcode/ui';
 import { noop } from 'foxact/noop';
 import { useSet } from 'foxact/use-set';
 import { extractErrorMessage } from 'foxts/extract-error-message';
@@ -31,6 +29,7 @@ import { applyThreadDrag, orderGroups, orderThreads } from '../sidebar/ordering'
 import { useSidebarPinStore } from '../sidebar/pin-store';
 import { selectVisibleSessions } from '../sidebar/visible-sessions';
 import { RuntimeWorkspaceHistory } from '../sidebar/workspace-history';
+import { RuntimeTerminalBlock } from '../terminal/block';
 import { useWorkspaces } from '../workspace/hooks';
 import type { WorkbenchShellComponent } from './shell';
 import { DefaultWorkbenchShell } from './shell';
@@ -213,24 +212,25 @@ function WorkbenchSessionSurface({
     sessions.select(sessionId);
   }
 
-  function handleRegisterWorkspace(cwd: string): Promise<WorkspaceRecord> {
-    return registerWorkspaceMutation.trigger({ cwd }).then((workspace) => {
+  // Every workspace-mutating request revalidates the workspace list the same way afterward.
+  function afterWorkspacesChange<T>(pending: Promise<T>): Promise<T> {
+    return pending.then((result) => {
       void refreshWorkspaces();
-      return workspace;
+      return result;
     });
+  }
+
+  function handleRegisterWorkspace(cwd: string): Promise<WorkspaceRecord> {
+    return afterWorkspacesChange(registerWorkspaceMutation.trigger({ cwd }));
   }
 
   function handleRenameWorkspace(workspaceId: WorkspaceId, name: string): Promise<void> {
     // Let the rejection propagate: the group header awaits it to show an inline error.
-    return updateWorkspaceMutation.trigger({ workspaceId, name }).then(() => {
-      void refreshWorkspaces();
-    });
+    return afterWorkspacesChange(updateWorkspaceMutation.trigger({ workspaceId, name })).then(noop);
   }
 
   function handleArchiveWorkspace(workspaceId: WorkspaceId): Promise<void> {
-    return archiveWorkspaceMutation.trigger({ workspaceId }).then(() => {
-      void refreshWorkspaces();
-    });
+    return afterWorkspacesChange(archiveWorkspaceMutation.trigger({ workspaceId })).then(noop);
   }
 
   function handleTogglePreviewExpanded(groupKey: string): void {
@@ -334,9 +334,4 @@ function WorkbenchSessionSurface({
       onEffortChange={handleEffortChange}
     />
   );
-}
-
-function RuntimeTerminalBlock({ terminalId }: { terminalId: string }): React.ReactNode {
-  const output = useTerminalOutput(terminalId);
-  return <TerminalBlock terminalId={terminalId} output={output} />;
 }

--- a/packages/workbench/src/terminal/block.tsx
+++ b/packages/workbench/src/terminal/block.tsx
@@ -1,0 +1,8 @@
+import { useTerminalOutput } from '@linkcode/client-core';
+import { TerminalBlock } from '@linkcode/ui';
+
+/** Adapter subscribing a rendered `TerminalBlock` to the daemon-backed terminal output stream. */
+export function RuntimeTerminalBlock({ terminalId }: { terminalId: string }): React.ReactNode {
+  const output = useTerminalOutput(terminalId);
+  return <TerminalBlock terminalId={terminalId} output={output} />;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -613,6 +613,9 @@ importers:
 
   packages/common:
     dependencies:
+      '@linkcode/schema':
+        specifier: workspace:*
+        version: link:../schema
       zod:
         specifier: 'catalog:'
         version: 4.4.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -688,6 +688,9 @@ importers:
 
   packages/ipc:
     dependencies:
+      '@linkcode/schema':
+        specifier: workspace:*
+        version: link:../schema
       '@moeru/eventa':
         specifier: 1.0.0-beta.10
         version: 1.0.0-beta.10(electron@42.4.1)(hono@4.12.27)


### PR DESCRIPTION
Closes CODE-54 (audit theme J: ownership / dead code / miscellany). 8/8 items, 8 atomic commits.

- **F33** the bench script imports codec/sidecar (recovering the lost length check). **F49** schema gets a zero-dependency daemon-runtime-constants subpath, and preload drops its hand-copied URL (**red-line proof: building the real preload artifact and grepping finds zero zod**).
- **F50** `daemonRuntimeFilePath()` lands in @linkcode/common/node. **F51** permission-request derives via `PermissionRequestSchema.extend()` (single source of truth).
- **F53** packages/ui/src/native gets `ScreenScroll`/`EmptyState`, wired into three mobile screens. **F55** the zero-consumer @linkcode/common root export is deleted outright.
- **F56** `afterWorkspacesChange` helper / `RuntimeTerminalBlock` moved to terminal/ / workspace-history's four paths merged. **F57** data-table/pagination copy wired to `useTranslations`.
- The sky-* empty shells were already cleaned up in the main repo by the main session.

Verification: repo-wide typecheck 17/17, lint 0 errors, tests 214 pass; `--no-verify` was never used.

See Linear CODE-54.
