### PR TITLE
refactor(agent-adapter): lift duplicated segment/delta machinery into BaseAgentAdapter

### DIFF
--- a/packages/agent-adapter/src/__tests__/message-grouping.test.ts
+++ b/packages/agent-adapter/src/__tests__/message-grouping.test.ts
@@ -46,31 +46,72 @@ function claudeTextDelta(text: string): object {
   };
 }
 
-describe('PiAdapter message grouping', () => {
+/** Drives an adapter's narration/tool events through equivalent scenarios so the shared
+ * fresh-segment-after-a-tool-call contract (`BaseAgentAdapter#freshSegment`) can be exercised once
+ * against every adapter that implements it, instead of duplicating the scenario per adapter. */
+interface AdapterDriver {
+  seen: AgentEvent[];
+  text(delta: string): void;
+  toolCall(): void;
+}
+
+function piDriver(): AdapterDriver {
+  const adapter = new TestPi();
+  const seen = record(adapter);
+  adapter.feed({ type: 'agent_start' });
+  return {
+    seen,
+    text: (delta) =>
+      adapter.feed({
+        type: 'message_update',
+        assistantMessageEvent: { type: 'text_delta', delta },
+      }),
+    toolCall() {
+      adapter.feed({ type: 'tool_execution_start', toolCallId: 't1', toolName: 'read', args: {} });
+      adapter.feed({ type: 'tool_execution_end', toolCallId: 't1', isError: false, result: 'ok' });
+    },
+  };
+}
+
+function claudeDriver(): AdapterDriver {
+  const adapter = new TestClaude();
+  const seen = record(adapter);
+  return {
+    seen,
+    text: (delta) => adapter.feed(claudeTextDelta(delta)),
+    toolCall() {
+      adapter.feed({
+        type: 'assistant',
+        message: { content: [{ type: 'tool_use', id: 't1', name: 'Read', input: {} }] },
+      });
+      adapter.feed({
+        type: 'user',
+        message: { content: [{ type: 'tool_result', tool_use_id: 't1', content: 'ok' }] },
+      });
+    },
+  };
+}
+
+describe.each([
+  { name: 'PiAdapter', make: piDriver },
+  { name: 'ClaudeCodeAdapter', make: claudeDriver },
+])('$name message grouping', ({ make }) => {
   it('opens a fresh messageId for narration after a tool call', () => {
-    const adapter = new TestPi();
-    const seen = record(adapter);
+    const driver = make();
+    driver.text('before');
+    driver.toolCall();
+    driver.text('after');
 
-    adapter.feed({ type: 'agent_start' });
-    adapter.feed({
-      type: 'message_update',
-      assistantMessageEvent: { type: 'text_delta', delta: 'before' },
-    });
-    adapter.feed({ type: 'tool_execution_start', toolCallId: 't1', toolName: 'read', args: {} });
-    adapter.feed({ type: 'tool_execution_end', toolCallId: 't1', isError: false, result: 'ok' });
-    adapter.feed({
-      type: 'message_update',
-      assistantMessageEvent: { type: 'text_delta', delta: 'after' },
-    });
-
-    const chunks = agentChunks(seen);
+    const chunks = agentChunks(driver.seen);
     expect(chunks.map((c) => c.content)).toEqual([
       { type: 'text', text: 'before' },
       { type: 'text', text: 'after' },
     ]);
     expect(chunks[0].messageId).not.toBe(chunks[1].messageId);
   });
+});
 
+describe('PiAdapter message grouping', () => {
   it('keeps consecutive narration (no tool between) under one messageId', () => {
     const adapter = new TestPi();
     const seen = record(adapter);
@@ -88,30 +129,5 @@ describe('PiAdapter message grouping', () => {
     const chunks = agentChunks(seen);
     expect(chunks).toHaveLength(2);
     expect(chunks[0].messageId).toBe(chunks[1].messageId);
-  });
-});
-
-describe('ClaudeCodeAdapter message grouping', () => {
-  it('opens a fresh messageId for narration after a tool_use', () => {
-    const adapter = new TestClaude();
-    const seen = record(adapter);
-
-    adapter.feed(claudeTextDelta('before'));
-    adapter.feed({
-      type: 'assistant',
-      message: { content: [{ type: 'tool_use', id: 't1', name: 'Read', input: {} }] },
-    });
-    adapter.feed({
-      type: 'user',
-      message: { content: [{ type: 'tool_result', tool_use_id: 't1', content: 'ok' }] },
-    });
-    adapter.feed(claudeTextDelta('after'));
-
-    const chunks = agentChunks(seen);
-    expect(chunks.map((c) => c.content)).toEqual([
-      { type: 'text', text: 'before' },
-      { type: 'text', text: 'after' },
-    ]);
-    expect(chunks[0].messageId).not.toBe(chunks[1].messageId);
   });
 });

--- a/packages/agent-adapter/src/base.ts
+++ b/packages/agent-adapter/src/base.ts
@@ -170,9 +170,6 @@ export abstract class BaseAgentAdapter implements AgentAdapter {
     if (text.length === 0) return;
     this.emit({ type: 'agent-message-chunk', messageId, content: textBlock(text) });
   }
-  protected emitAssistantContent(content: ContentBlock, messageId: MessageId): void {
-    this.emit({ type: 'agent-message-chunk', messageId, content });
-  }
   protected emitThought(text: string, messageId: MessageId): void {
     if (text.length === 0) return;
     this.emit({ type: 'agent-thought-chunk', messageId, content: textBlock(text) });

--- a/packages/agent-adapter/src/base.ts
+++ b/packages/agent-adapter/src/base.ts
@@ -26,7 +26,7 @@ import type { Unsubscribe } from '@linkcode/transport';
 import { Listeners } from '@linkcode/transport';
 import { extractErrorMessage } from 'foxts/extract-error-message';
 import type { AgentAdapter } from './adapter';
-import { nextRequestId } from './adapter';
+import { nextMessageId, nextRequestId } from './adapter';
 
 type PermissionResolver = (outcome: PermissionOutcome) => void;
 
@@ -61,6 +61,10 @@ export abstract class BaseAgentAdapter implements AgentAdapter {
   private readonly pending = new Map<string, PermissionResolver>();
   /** Running tool-call snapshots, keyed by toolCallId — the source for `emitTool`'s full-snapshot emits. */
   private readonly toolCalls = new Map<string, ToolCall>();
+  /** Current segment's ids, refreshed via `freshSegment()` at each turn/tool boundary so text /
+   * thinking emitted before and after a tool render as separate bubbles instead of merging into one. */
+  protected messageId: MessageId = nextMessageId();
+  protected thoughtId: MessageId = nextMessageId();
 
   async start(opts: StartOptions): Promise<void> {
     this.opts = opts;
@@ -152,6 +156,13 @@ export abstract class BaseAgentAdapter implements AgentAdapter {
   }
   protected emitStatus(status: SessionStatus): void {
     this.emit({ type: 'status', status });
+  }
+  /** Opens a fresh message/thought segment: call at a turn boundary (prompt start) and after every
+   * tool call so narration emitted after renders as a new bubble instead of merging with what came
+   * before it. */
+  protected freshSegment(): void {
+    this.messageId = nextMessageId();
+    this.thoughtId = nextMessageId();
   }
   protected emitAssistantText(text: string, messageId: MessageId): void {
     if (text.length === 0) return;

--- a/packages/agent-adapter/src/base.ts
+++ b/packages/agent-adapter/src/base.ts
@@ -65,6 +65,8 @@ export abstract class BaseAgentAdapter implements AgentAdapter {
    * thinking emitted before and after a tool render as separate bubbles instead of merging into one. */
   protected messageId: MessageId = nextMessageId();
   protected thoughtId: MessageId = nextMessageId();
+  /** Per-item cursor for turning a provider's cumulative item text into deltas — see `streamDelta`. */
+  private readonly textDeltaLen = new Map<string, number>();
 
   async start(opts: StartOptions): Promise<void> {
     this.opts = opts;
@@ -174,6 +176,20 @@ export abstract class BaseAgentAdapter implements AgentAdapter {
   protected emitThought(text: string, messageId: MessageId): void {
     if (text.length === 0) return;
     this.emit({ type: 'agent-thought-chunk', messageId, content: textBlock(text) });
+  }
+
+  /**
+   * Convert a provider's cumulative per-item text into an incremental chunk, keyed by `id` (e.g. an
+   * item/part id), and emit it as assistant text or thought depending on `kind`. For providers (Codex,
+   * OpenCode) that report the whole text seen so far on every update rather than the new slice alone.
+   */
+  protected streamDelta(id: string, fullText: string, kind: 'message' | 'thought'): void {
+    const prev = this.textDeltaLen.get(id) ?? 0;
+    if (fullText.length <= prev) return;
+    const delta = fullText.slice(prev);
+    this.textDeltaLen.set(id, fullText.length);
+    if (kind === 'message') this.emitAssistantText(delta, id as MessageId);
+    else this.emitThought(delta, id as MessageId);
   }
 
   /**

--- a/packages/agent-adapter/src/native/claude-code.ts
+++ b/packages/agent-adapter/src/native/claude-code.ts
@@ -20,7 +20,6 @@ import type {
   AgentHistorySession,
   ContentBlock,
   EffortLevel,
-  MessageId,
   PermissionOption,
   StartOptions,
   StopReason,
@@ -30,7 +29,6 @@ import type {
 import { textBlock } from '@linkcode/schema';
 import { extractErrorMessage } from 'foxts/extract-error-message';
 import { invariant, nullthrow } from 'foxts/guard';
-import { nextMessageId } from '../adapter';
 import { BaseAgentAdapter } from '../base';
 import {
   asHistoryId,
@@ -159,10 +157,6 @@ export class ClaudeCodeAdapter extends BaseAgentAdapter {
   /** Provider session id sniffed off the last SDK message — the resume point when an effort
    * transition into/out of `max` forces a process restart (see `onSetEffort`). */
   private lastSessionRef: string | undefined;
-  /** Current segment's ids, refreshed each turn and after every tool call so text / thinking emitted
-   * before and after a tool render as separate bubbles instead of merging into one. */
-  private messageId: MessageId = nextMessageId();
-  private thoughtId: MessageId = nextMessageId();
 
   protected async onStart(): Promise<void> {
     // The persistent Query is created lazily on the first onPrompt; just verify the SDK is installed.
@@ -224,8 +218,7 @@ export class ClaudeCodeAdapter extends BaseAgentAdapter {
 
   protected async onPrompt(content: ContentBlock[]): Promise<void> {
     const opts = nullthrow(this.opts, 'claude-code: session not started');
-    this.messageId = nextMessageId();
-    this.thoughtId = nextMessageId();
+    this.freshSegment();
     this.emitStatus('running');
     const message: SDKUserMessage = {
       type: 'user',
@@ -444,10 +437,7 @@ export class ClaudeCodeAdapter extends BaseAgentAdapter {
     }
     // A tool call closes this assistant segment; text Claude streams after the tool_result groups into a
     // fresh bubble rather than merging with the pre-tool narration.
-    if (calledTool) {
-      this.messageId = nextMessageId();
-      this.thoughtId = nextMessageId();
-    }
+    if (calledTool) this.freshSegment();
   }
 
   /**

--- a/packages/agent-adapter/src/native/codex-history.ts
+++ b/packages/agent-adapter/src/native/codex-history.ts
@@ -1,0 +1,285 @@
+import type { Stats } from 'node:fs';
+import { readdir, readFile, stat } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { basename, join } from 'node:path';
+import { env } from 'node:process';
+import type { AgentHistoryEvent, AgentHistoryId, AgentHistorySession } from '@linkcode/schema';
+import { appendArrayInPlace } from 'foxts/append-array-in-place';
+import { not } from 'foxts/guard';
+import {
+  asHistoryId,
+  compactRecord,
+  firstText,
+  isRecord,
+  recordField,
+  stringField,
+  textFromUnknown,
+  textHistoryEvent,
+  timestampMs,
+} from '../history-util';
+
+const WHITESPACE_RUN_RE = /\s+/g;
+
+type JsonRecord = Record<string, unknown>;
+
+interface CodexIndexEntry {
+  id: string;
+  title?: string;
+  updatedAt?: number;
+}
+
+interface CodexTranscriptSummary {
+  id: string;
+  path?: string;
+  title?: string;
+  cwd?: string;
+  model?: string;
+  createdAt?: number;
+  updatedAt?: number;
+  messageCount?: number;
+  metadata?: Record<string, unknown>;
+}
+
+interface DirectoryEntry {
+  name: string;
+  isDirectory(): boolean;
+  isFile(): boolean;
+}
+
+function codexHome(): string {
+  return env.CODEX_HOME ?? join(homedir(), '.codex');
+}
+
+export async function readCodexIndex(): Promise<Map<string, CodexIndexEntry>> {
+  const rows = await readJsonlFile(join(codexHome(), 'session_index.jsonl'));
+  const index = new Map<string, CodexIndexEntry>();
+  for (const row of rows) {
+    const id = stringField(row, 'id');
+    if (!id) continue;
+    index.set(id, {
+      id,
+      title: firstText(stringField(row, 'thread_name'), stringField(row, 'title')),
+      updatedAt: timestampMs(row.updated_at) ?? timestampMs(row.updatedAt),
+    });
+  }
+  return index;
+}
+
+export async function readCodexTranscriptSummaries(
+  index: Map<string, CodexIndexEntry>,
+): Promise<CodexTranscriptSummary[]> {
+  const roots = [join(codexHome(), 'sessions'), join(codexHome(), 'archived_sessions')];
+  const fileSets = await Promise.all(roots.map((root) => collectJsonlFiles(root)));
+  const files = fileSets.flat();
+  const summaries = await Promise.all(files.map((file) => readCodexTranscriptSummary(file, index)));
+  return summaries.filter(not(undefined));
+}
+
+export async function findCodexTranscript(
+  historyId: AgentHistoryId,
+): Promise<CodexTranscriptSummary | undefined> {
+  const index = await readCodexIndex();
+  const summaries = await readCodexTranscriptSummaries(index);
+  const id = historyId;
+  return summaries.find((summary) => summary.id === id || summary.path === id);
+}
+
+async function collectJsonlFiles(root: string, depth = 8): Promise<string[]> {
+  if (depth < 0) return [];
+  let entries: DirectoryEntry[];
+  try {
+    entries = await readdir(root, { withFileTypes: true, encoding: 'utf8' });
+  } catch {
+    return [];
+  }
+  const files: string[] = [];
+  const pendingDirs: Array<Promise<string[]>> = [];
+  for (const entry of entries) {
+    const path = join(root, entry.name);
+    if (entry.isDirectory()) pendingDirs.push(collectJsonlFiles(path, depth - 1));
+    else if (entry.isFile() && entry.name.endsWith('.jsonl')) files.push(path);
+  }
+  for (const nestedFiles of await Promise.all(pendingDirs)) appendArrayInPlace(files, nestedFiles);
+  return files;
+}
+
+export async function readJsonlFile(path: string): Promise<JsonRecord[]> {
+  let raw: string;
+  try {
+    raw = await readFile(path, 'utf8');
+  } catch {
+    return [];
+  }
+  const rows: JsonRecord[] = [];
+  for (const line of raw.split('\n')) {
+    if (line.trim().length === 0) continue;
+    try {
+      const parsed: unknown = JSON.parse(line);
+      if (isRecord(parsed)) rows.push(parsed);
+    } catch {
+      // Ignore corrupt partial lines; Codex may be writing the active transcript.
+    }
+  }
+  return rows;
+}
+
+async function readCodexTranscriptSummary(
+  path: string,
+  index: Map<string, CodexIndexEntry>,
+): Promise<CodexTranscriptSummary | undefined> {
+  const [rows, fileStat] = await Promise.all([readJsonlFile(path), statOrUndefined(path)]);
+  if (rows.length === 0) return undefined;
+
+  let id: string | undefined;
+  let title: string | undefined;
+  let cwd: string | undefined;
+  let model: string | undefined;
+  let createdAt: number | undefined;
+  let updatedAt: number | undefined;
+  let firstUserText: string | undefined;
+  let firstAssistantText: string | undefined;
+  let messageCount = 0;
+  let cliVersion: string | undefined;
+  let originator: string | undefined;
+  let threadSource: string | undefined;
+  let modelProvider: string | undefined;
+  let gitBranch: string | undefined;
+
+  for (const row of rows) {
+    const rowType = stringField(row, 'type');
+    const rowTs = timestampMs(row.timestamp);
+    if (rowTs !== undefined) {
+      createdAt ??= rowTs;
+      updatedAt = Math.max(updatedAt ?? 0, rowTs);
+    }
+
+    const payload = recordField(row, 'payload');
+    if (!payload) continue;
+
+    switch (rowType) {
+      case 'session_meta': {
+        id = stringField(payload, 'id') ?? id;
+        cwd = stringField(payload, 'cwd') ?? cwd;
+        model = stringField(payload, 'model') ?? model;
+        originator = stringField(payload, 'originator') ?? originator;
+        threadSource = stringField(payload, 'thread_source') ?? threadSource;
+        cliVersion = stringField(payload, 'cli_version') ?? cliVersion;
+        modelProvider = stringField(payload, 'model_provider') ?? modelProvider;
+        const git = recordField(payload, 'git');
+        if (git) gitBranch = stringField(git, 'branch') ?? gitBranch;
+        createdAt = timestampMs(payload.timestamp) ?? createdAt;
+
+        break;
+      }
+      case 'turn_context': {
+        cwd = stringField(payload, 'cwd') ?? cwd;
+        model = stringField(payload, 'model') ?? model;
+        title = stringField(payload, 'summary') ?? title;
+
+        break;
+      }
+      case 'response_item': {
+        const role = stringField(payload, 'role');
+        if (role !== 'user' && role !== 'assistant') continue;
+        const text = textFromUnknown(payload);
+        if (text.trim().length === 0) continue;
+        messageCount += 1;
+        if (role === 'user') firstUserText ??= previewText(text);
+        else firstAssistantText ??= previewText(text);
+
+        break;
+      }
+      default:
+        break;
+    }
+  }
+
+  id ??= idFromFilename(path);
+  const indexEntry = index.get(id);
+  return {
+    id,
+    path,
+    title: firstText(indexEntry?.title, title, firstUserText, firstAssistantText),
+    cwd,
+    model,
+    createdAt,
+    updatedAt:
+      indexEntry?.updatedAt ?? updatedAt ?? (fileStat ? Math.trunc(fileStat.mtimeMs) : undefined),
+    messageCount,
+    metadata: compactRecord({
+      source: 'codex-local-jsonl',
+      transcriptPath: path,
+      fileSize: fileStat?.size,
+      cliVersion,
+      originator,
+      threadSource,
+      modelProvider,
+      gitBranch,
+    }),
+  };
+}
+
+async function statOrUndefined(path: string): Promise<Stats | undefined> {
+  try {
+    return await stat(path);
+  } catch {
+    // Transcript files can disappear while Codex is rotating or archiving sessions.
+  }
+}
+
+export function codexSummaryToSession(summary: CodexTranscriptSummary): AgentHistorySession {
+  return {
+    historyId: asHistoryId(summary.id),
+    kind: 'codex',
+    title: summary.title,
+    cwd: summary.cwd,
+    model: summary.model,
+    createdAt: summary.createdAt,
+    updatedAt: summary.updatedAt,
+    messageCount: summary.messageCount,
+    metadata: summary.metadata,
+  };
+}
+
+export function codexIndexEntryToSession(entry: CodexIndexEntry): AgentHistorySession {
+  return {
+    historyId: asHistoryId(entry.id),
+    kind: 'codex',
+    title: entry.title,
+    updatedAt: entry.updatedAt,
+    metadata: {
+      source: 'codex-session-index',
+      missingTranscript: true,
+    },
+  };
+}
+
+export function mapCodexHistoryEvents(
+  historyId: AgentHistoryId,
+  rows: JsonRecord[],
+): AgentHistoryEvent[] {
+  const events: AgentHistoryEvent[] = [];
+  rows.forEach((row, index) => {
+    if (stringField(row, 'type') !== 'response_item') return;
+    const payload = recordField(row, 'payload');
+    if (!payload) return;
+    const role = stringField(payload, 'role');
+    if (role !== 'user' && role !== 'assistant') return;
+    const itemId =
+      stringField(payload, 'id') ?? stringField(row, 'id') ?? `${role}-${index.toString(36)}`;
+    const event = textHistoryEvent(historyId, role, itemId, payload, timestampMs(row.timestamp));
+    if (event) events.push(event);
+  });
+  return events;
+}
+
+function idFromFilename(path: string): string {
+  const name = basename(path, '.jsonl');
+  return name.length > 0 ? name : path;
+}
+
+function previewText(text: string): string {
+  const flat = text.replaceAll(WHITESPACE_RUN_RE, ' ').trim();
+  if (flat.length <= 120) return flat;
+  return `${flat.slice(0, 117)}...`;
+}

--- a/packages/agent-adapter/src/native/codex.ts
+++ b/packages/agent-adapter/src/native/codex.ts
@@ -1,18 +1,10 @@
-import type { Stats } from 'node:fs';
-import { readdir, readFile, stat } from 'node:fs/promises';
-import { homedir } from 'node:os';
-import { basename, join } from 'node:path';
-import { env } from 'node:process';
 import type {
   AgentHistoryCapabilities,
-  AgentHistoryEvent,
-  AgentHistoryId,
   AgentHistoryListOptions,
   AgentHistoryListResult,
   AgentHistoryReadOptions,
   AgentHistoryReadResult,
   AgentHistoryResumeOptions,
-  AgentHistorySession,
   ContentBlock,
   StartOptions,
   TokenUsage,
@@ -20,30 +12,24 @@ import type {
   ToolCallStatus,
 } from '@linkcode/schema';
 import type { ThreadEvent, ThreadItem, ThreadOptions, Usage } from '@openai/codex-sdk';
-import { appendArrayInPlace } from 'foxts/append-array-in-place';
 import { extractErrorMessage } from 'foxts/extract-error-message';
-import { invariant, not } from 'foxts/guard';
+import { invariant } from 'foxts/guard';
 import { BaseAgentAdapter } from '../base';
-import {
-  asHistoryId,
-  boundedLimit,
-  compactRecord,
-  cursorFromTotal,
-  cursorOffset,
-  firstText,
-  isRecord,
-  recordField,
-  stringField,
-  textFromUnknown,
-  textHistoryEvent,
-  timestampMs,
-} from '../history-util';
+import { asHistoryId, boundedLimit, cursorFromTotal, cursorOffset } from '../history-util';
 import { contentToText } from '../util';
+import {
+  codexIndexEntryToSession,
+  codexSummaryToSession,
+  findCodexTranscript,
+  mapCodexHistoryEvents,
+  readCodexIndex,
+  readCodexTranscriptSummaries,
+  readJsonlFile,
+} from './codex-history';
 
 type CodexModule = typeof import('@openai/codex-sdk');
 type CodexInstance = InstanceType<CodexModule['Codex']>;
 type CodexThread = ReturnType<CodexInstance['startThread']>;
-const WHITESPACE_RUN_RE = /\s+/g;
 
 /** Map a Codex command/MCP status to our ToolCallStatus. */
 export function mapCodexStatus(status: 'in_progress' | 'completed' | 'failed'): ToolCallStatus {
@@ -280,265 +266,4 @@ export class CodexAdapter extends BaseAgentAdapter {
 function textContent(text: string): ToolCallContent[] {
   if (text.length === 0) return [];
   return [{ type: 'content', content: { type: 'text', text } }];
-}
-
-type JsonRecord = Record<string, unknown>;
-
-interface CodexIndexEntry {
-  id: string;
-  title?: string;
-  updatedAt?: number;
-}
-
-interface CodexTranscriptSummary {
-  id: string;
-  path?: string;
-  title?: string;
-  cwd?: string;
-  model?: string;
-  createdAt?: number;
-  updatedAt?: number;
-  messageCount?: number;
-  metadata?: Record<string, unknown>;
-}
-
-interface DirectoryEntry {
-  name: string;
-  isDirectory(): boolean;
-  isFile(): boolean;
-}
-
-function codexHome(): string {
-  return env.CODEX_HOME ?? join(homedir(), '.codex');
-}
-
-async function readCodexIndex(): Promise<Map<string, CodexIndexEntry>> {
-  const rows = await readJsonlFile(join(codexHome(), 'session_index.jsonl'));
-  const index = new Map<string, CodexIndexEntry>();
-  for (const row of rows) {
-    const id = stringField(row, 'id');
-    if (!id) continue;
-    index.set(id, {
-      id,
-      title: firstText(stringField(row, 'thread_name'), stringField(row, 'title')),
-      updatedAt: timestampMs(row.updated_at) ?? timestampMs(row.updatedAt),
-    });
-  }
-  return index;
-}
-
-async function readCodexTranscriptSummaries(
-  index: Map<string, CodexIndexEntry>,
-): Promise<CodexTranscriptSummary[]> {
-  const roots = [join(codexHome(), 'sessions'), join(codexHome(), 'archived_sessions')];
-  const fileSets = await Promise.all(roots.map((root) => collectJsonlFiles(root)));
-  const files = fileSets.flat();
-  const summaries = await Promise.all(files.map((file) => readCodexTranscriptSummary(file, index)));
-  return summaries.filter(not(undefined));
-}
-
-async function findCodexTranscript(
-  historyId: AgentHistoryId,
-): Promise<CodexTranscriptSummary | undefined> {
-  const index = await readCodexIndex();
-  const summaries = await readCodexTranscriptSummaries(index);
-  const id = historyId;
-  return summaries.find((summary) => summary.id === id || summary.path === id);
-}
-
-async function collectJsonlFiles(root: string, depth = 8): Promise<string[]> {
-  if (depth < 0) return [];
-  let entries: DirectoryEntry[];
-  try {
-    entries = await readdir(root, { withFileTypes: true, encoding: 'utf8' });
-  } catch {
-    return [];
-  }
-  const files: string[] = [];
-  const pendingDirs: Array<Promise<string[]>> = [];
-  for (const entry of entries) {
-    const path = join(root, entry.name);
-    if (entry.isDirectory()) pendingDirs.push(collectJsonlFiles(path, depth - 1));
-    else if (entry.isFile() && entry.name.endsWith('.jsonl')) files.push(path);
-  }
-  for (const nestedFiles of await Promise.all(pendingDirs)) appendArrayInPlace(files, nestedFiles);
-  return files;
-}
-
-async function readJsonlFile(path: string): Promise<JsonRecord[]> {
-  let raw: string;
-  try {
-    raw = await readFile(path, 'utf8');
-  } catch {
-    return [];
-  }
-  const rows: JsonRecord[] = [];
-  for (const line of raw.split('\n')) {
-    if (line.trim().length === 0) continue;
-    try {
-      const parsed: unknown = JSON.parse(line);
-      if (isRecord(parsed)) rows.push(parsed);
-    } catch {
-      // Ignore corrupt partial lines; Codex may be writing the active transcript.
-    }
-  }
-  return rows;
-}
-
-async function readCodexTranscriptSummary(
-  path: string,
-  index: Map<string, CodexIndexEntry>,
-): Promise<CodexTranscriptSummary | undefined> {
-  const [rows, fileStat] = await Promise.all([readJsonlFile(path), statOrUndefined(path)]);
-  if (rows.length === 0) return undefined;
-
-  let id: string | undefined;
-  let title: string | undefined;
-  let cwd: string | undefined;
-  let model: string | undefined;
-  let createdAt: number | undefined;
-  let updatedAt: number | undefined;
-  let firstUserText: string | undefined;
-  let firstAssistantText: string | undefined;
-  let messageCount = 0;
-  let cliVersion: string | undefined;
-  let originator: string | undefined;
-  let threadSource: string | undefined;
-  let modelProvider: string | undefined;
-  let gitBranch: string | undefined;
-
-  for (const row of rows) {
-    const rowType = stringField(row, 'type');
-    const rowTs = timestampMs(row.timestamp);
-    if (rowTs !== undefined) {
-      createdAt ??= rowTs;
-      updatedAt = Math.max(updatedAt ?? 0, rowTs);
-    }
-
-    const payload = recordField(row, 'payload');
-    if (!payload) continue;
-
-    switch (rowType) {
-      case 'session_meta': {
-        id = stringField(payload, 'id') ?? id;
-        cwd = stringField(payload, 'cwd') ?? cwd;
-        model = stringField(payload, 'model') ?? model;
-        originator = stringField(payload, 'originator') ?? originator;
-        threadSource = stringField(payload, 'thread_source') ?? threadSource;
-        cliVersion = stringField(payload, 'cli_version') ?? cliVersion;
-        modelProvider = stringField(payload, 'model_provider') ?? modelProvider;
-        const git = recordField(payload, 'git');
-        if (git) gitBranch = stringField(git, 'branch') ?? gitBranch;
-        createdAt = timestampMs(payload.timestamp) ?? createdAt;
-
-        break;
-      }
-      case 'turn_context': {
-        cwd = stringField(payload, 'cwd') ?? cwd;
-        model = stringField(payload, 'model') ?? model;
-        title = stringField(payload, 'summary') ?? title;
-
-        break;
-      }
-      case 'response_item': {
-        const role = stringField(payload, 'role');
-        if (role !== 'user' && role !== 'assistant') continue;
-        const text = textFromUnknown(payload);
-        if (text.trim().length === 0) continue;
-        messageCount += 1;
-        if (role === 'user') firstUserText ??= previewText(text);
-        else firstAssistantText ??= previewText(text);
-
-        break;
-      }
-      default:
-        break;
-    }
-  }
-
-  id ??= idFromFilename(path);
-  const indexEntry = index.get(id);
-  return {
-    id,
-    path,
-    title: firstText(indexEntry?.title, title, firstUserText, firstAssistantText),
-    cwd,
-    model,
-    createdAt,
-    updatedAt:
-      indexEntry?.updatedAt ?? updatedAt ?? (fileStat ? Math.trunc(fileStat.mtimeMs) : undefined),
-    messageCount,
-    metadata: compactRecord({
-      source: 'codex-local-jsonl',
-      transcriptPath: path,
-      fileSize: fileStat?.size,
-      cliVersion,
-      originator,
-      threadSource,
-      modelProvider,
-      gitBranch,
-    }),
-  };
-}
-
-async function statOrUndefined(path: string): Promise<Stats | undefined> {
-  try {
-    return await stat(path);
-  } catch {
-    // Transcript files can disappear while Codex is rotating or archiving sessions.
-  }
-}
-
-function codexSummaryToSession(summary: CodexTranscriptSummary): AgentHistorySession {
-  return {
-    historyId: asHistoryId(summary.id),
-    kind: 'codex',
-    title: summary.title,
-    cwd: summary.cwd,
-    model: summary.model,
-    createdAt: summary.createdAt,
-    updatedAt: summary.updatedAt,
-    messageCount: summary.messageCount,
-    metadata: summary.metadata,
-  };
-}
-
-function codexIndexEntryToSession(entry: CodexIndexEntry): AgentHistorySession {
-  return {
-    historyId: asHistoryId(entry.id),
-    kind: 'codex',
-    title: entry.title,
-    updatedAt: entry.updatedAt,
-    metadata: {
-      source: 'codex-session-index',
-      missingTranscript: true,
-    },
-  };
-}
-
-function mapCodexHistoryEvents(historyId: AgentHistoryId, rows: JsonRecord[]): AgentHistoryEvent[] {
-  const events: AgentHistoryEvent[] = [];
-  rows.forEach((row, index) => {
-    if (stringField(row, 'type') !== 'response_item') return;
-    const payload = recordField(row, 'payload');
-    if (!payload) return;
-    const role = stringField(payload, 'role');
-    if (role !== 'user' && role !== 'assistant') return;
-    const itemId =
-      stringField(payload, 'id') ?? stringField(row, 'id') ?? `${role}-${index.toString(36)}`;
-    const event = textHistoryEvent(historyId, role, itemId, payload, timestampMs(row.timestamp));
-    if (event) events.push(event);
-  });
-  return events;
-}
-
-function idFromFilename(path: string): string {
-  const name = basename(path, '.jsonl');
-  return name.length > 0 ? name : path;
-}
-
-function previewText(text: string): string {
-  const flat = text.replaceAll(WHITESPACE_RUN_RE, ' ').trim();
-  if (flat.length <= 120) return flat;
-  return `${flat.slice(0, 117)}...`;
 }

--- a/packages/agent-adapter/src/native/codex.ts
+++ b/packages/agent-adapter/src/native/codex.ts
@@ -14,7 +14,6 @@ import type {
   AgentHistoryResumeOptions,
   AgentHistorySession,
   ContentBlock,
-  MessageId,
   StartOptions,
   TokenUsage,
   ToolCallContent,
@@ -77,8 +76,6 @@ export class CodexAdapter extends BaseAgentAdapter {
   private thread: CodexThread | null = null;
   private abort: AbortController | null = null;
   private resumeThreadId: string | undefined;
-  /** Per-item cursor for turning Codex's cumulative text into deltas. */
-  private readonly textLen = new Map<string, number>();
 
   protected async onStart(opts: StartOptions): Promise<void> {
     const codex = await this.createCodex();
@@ -214,10 +211,10 @@ export class CodexAdapter extends BaseAgentAdapter {
   private handleItem(item: ThreadItem): void {
     switch (item.type) {
       case 'agent_message':
-        this.streamText(item.id, item.text, 'message');
+        this.streamDelta(item.id, item.text, 'message');
         break;
       case 'reasoning':
-        this.streamText(item.id, item.text, 'thought');
+        this.streamDelta(item.id, item.text, 'thought');
         break;
       case 'command_execution':
         this.emitTool({
@@ -277,16 +274,6 @@ export class CodexAdapter extends BaseAgentAdapter {
       default:
         break;
     }
-  }
-
-  /** Convert Codex's cumulative item text into an incremental chunk. */
-  private streamText(itemId: string, fullText: string, kind: 'message' | 'thought'): void {
-    const prev = this.textLen.get(itemId) ?? 0;
-    if (fullText.length <= prev) return;
-    const delta = fullText.slice(prev);
-    this.textLen.set(itemId, fullText.length);
-    if (kind === 'message') this.emitAssistantText(delta, itemId as MessageId);
-    else this.emitThought(delta, itemId as MessageId);
   }
 }
 

--- a/packages/agent-adapter/src/native/opencode.ts
+++ b/packages/agent-adapter/src/native/opencode.ts
@@ -1,10 +1,4 @@
-import type {
-  ContentBlock,
-  MessageId,
-  StartOptions,
-  ToolCallContent,
-  ToolCallStatus,
-} from '@linkcode/schema';
+import type { ContentBlock, StartOptions, ToolCallContent, ToolCallStatus } from '@linkcode/schema';
 import { textBlock } from '@linkcode/schema';
 import type { Event, Part, TextPartInput } from '@opencode-ai/sdk/v2';
 import { extractErrorMessage } from 'foxts/extract-error-message';
@@ -59,8 +53,6 @@ export class OpenCodeAdapter extends BaseAgentAdapter {
   /** True once `onCancel` has aborted the in-flight turn — any stream fallout until the next prompt
    * (thrown or clean) is that abort's expected side effect, not a failure. */
   private cancelling = false;
-  /** Per-part cursor for turning OpenCode's cumulative part text into deltas. */
-  private readonly textLen = new Map<string, number>();
 
   protected async onStart(opts: StartOptions): Promise<void> {
     const mod = await this.loadSdk('@opencode-ai/sdk', () => import('@opencode-ai/sdk/v2'));
@@ -206,12 +198,12 @@ export class OpenCodeAdapter extends BaseAgentAdapter {
   private handlePart(part: Part): void {
     switch (part.type) {
       case 'text': {
-        this.streamPartText(part.id, part.text, 'message');
+        this.streamDelta(part.id, part.text, 'message');
 
         break;
       }
       case 'reasoning': {
-        this.streamPartText(part.id, part.text, 'thought');
+        this.streamDelta(part.id, part.text, 'thought');
 
         break;
       }
@@ -231,14 +223,5 @@ export class OpenCodeAdapter extends BaseAgentAdapter {
       default:
         break;
     }
-  }
-
-  private streamPartText(partId: string, full: string, kind: 'message' | 'thought'): void {
-    const prev = this.textLen.get(partId) ?? 0;
-    if (full.length <= prev) return;
-    const delta = full.slice(prev);
-    this.textLen.set(partId, full.length);
-    if (kind === 'message') this.emitAssistantText(delta, partId as MessageId);
-    else this.emitThought(delta, partId as MessageId);
   }
 }

--- a/packages/agent-adapter/src/native/pi.ts
+++ b/packages/agent-adapter/src/native/pi.ts
@@ -1,7 +1,6 @@
 import type { AgentSession, AgentSessionEvent } from '@earendil-works/pi-coding-agent';
-import type { ContentBlock, MessageId, StartOptions } from '@linkcode/schema';
+import type { ContentBlock, StartOptions } from '@linkcode/schema';
 import { invariant } from 'foxts/guard';
-import { nextMessageId } from '../adapter';
 import { BaseAgentAdapter } from '../base';
 import { contentToText, toolKindFromName } from '../util';
 
@@ -15,10 +14,6 @@ export class PiAdapter extends BaseAgentAdapter {
 
   private session: AgentSession | null = null;
   private unsub: (() => void) | null = null;
-  /** Current segment's ids, refreshed each turn and at every tool boundary so text / thinking emitted
-   * before and after a tool render as separate bubbles instead of merging into one. */
-  private messageId: MessageId = nextMessageId();
-  private thoughtId: MessageId = nextMessageId();
 
   protected async onStart(opts: StartOptions): Promise<void> {
     const pi = await this.loadSdk(
@@ -81,8 +76,7 @@ export class PiAdapter extends BaseAgentAdapter {
     switch (ev.type) {
       case 'agent_start':
         // Fresh ids at the turn start; a tool boundary later opens the next segment (see below).
-        this.messageId = nextMessageId();
-        this.thoughtId = nextMessageId();
+        this.freshSegment();
         this.emitStatus('running');
         break;
       case 'agent_end':
@@ -104,8 +98,7 @@ export class PiAdapter extends BaseAgentAdapter {
           rawInput: ev.args,
         });
         // The tool closes the current segment; narration after it groups into a new bubble.
-        this.messageId = nextMessageId();
-        this.thoughtId = nextMessageId();
+        this.freshSegment();
         break;
       case 'tool_execution_end':
         this.emitTool({


### PR DESCRIPTION
Closes CODE-49 (audit theme E: adapter-layer duplication). 4 commits.

⚠️ **Stacked PR, base = code-44 (#22)**; GitHub retargets it to master once the parent merges.

- **F11** `BaseAgentAdapter` gains messageId/thoughtId + `freshSegment()`; claude-code/pi drop their private copies; the message-grouping test is parameterized with `describe.each`.
- **F23** the base gains `streamDelta(id, fullText, kind)` (a private `textDeltaLen` Map, preserving the existing no-cleanup behavior).
- **F22** the zero-call `emitAssistantContent` is deleted. **F52** the 13 JSONL-history functions move into codex-history.ts (pure move).

Verification: per commit, agent-adapter typecheck + lint + vitest 27/27 (including the cases added on code-44) green, pre-commit clean.

See Linear CODE-49.
