### PR TITLE
refactor(client-core,engine): split god files, PendingRegistry, options-object Engine ctor

### DIFF
--- a/apps/daemon/src/index.ts
+++ b/apps/daemon/src/index.ts
@@ -61,15 +61,12 @@ async function main(): Promise<void> {
   };
   const hub = new Hub();
   const store = createProviderConfigStore(config.providers ?? {});
-  const engine = new Engine(
-    hub,
-    undefined,
-    store,
-    new SidecarPtyBackend(resolveSidecarPath()),
-    createSessionStore(databasePath()),
-    undefined,
-    createWorkspaceStore(databasePath()),
-  );
+  const engine = new Engine(hub, {
+    providerStore: store,
+    ptyBackend: new SidecarPtyBackend(resolveSidecarPath()),
+    sessionStore: createSessionStore(databasePath()),
+    workspaceStore: createWorkspaceStore(databasePath()),
+  });
   await engine.start();
   // Runs before any listener binds, so `workspace.list` always includes the chat workspace by the
   // time a client can connect.

--- a/apps/desktop/src/renderer/src/shell/chrome/chrome.tsx
+++ b/apps/desktop/src/renderer/src/shell/chrome/chrome.tsx
@@ -153,11 +153,6 @@ export function DesktopChrome({
   const chromeRootRef = useRef<HTMLDivElement | null>(null);
   const leftRailContentRef = useRef<HTMLDivElement | null>(null);
   const rightRailContentRef = useRef<HTMLDivElement | null>(null);
-  const activeExpandedPanel = getActiveExpandedPanel({
-    expandedPanel,
-    rightPanelOpen,
-    bottomPanelOpen,
-  });
   useChromeRailInsets({ rootRef: chromeRootRef, leftRailContentRef, rightRailContentRef });
   const setPortalTarget = useCallback<SetChromePortalTarget>((key, target) => {
     setPortalTargets((current) => {
@@ -179,7 +174,7 @@ export function DesktopChrome({
       >
         <ChromeSegmentGrid
           header={header}
-          activeExpandedPanel={activeExpandedPanel}
+          expandedPanel={expandedPanel}
           hasNativeBackdrop={hasNativeBackdrop}
           titleContent={titleContent}
           titleChip={titleChip}
@@ -222,14 +217,14 @@ export function DesktopChrome({
 
 function ChromeSegmentGrid({
   header,
-  activeExpandedPanel,
+  expandedPanel,
   hasNativeBackdrop,
   titleContent,
   titleChip,
   setPortalTarget,
 }: {
   header: WorkbenchShellHeader;
-  activeExpandedPanel: DesktopPanelSide | null;
+  expandedPanel: DesktopPanelSide | null;
   hasNativeBackdrop: boolean;
   titleContent?: React.ReactNode;
   titleChip?: React.ReactNode;
@@ -238,9 +233,7 @@ function ChromeSegmentGrid({
   return (
     <div
       className="absolute inset-0 grid overflow-hidden"
-      style={
-        activeExpandedPanel ? MAXIMIZED_CHROME_BACKGROUND_GRID_STYLE : CHROME_BACKGROUND_GRID_STYLE
-      }
+      style={expandedPanel ? MAXIMIZED_CHROME_BACKGROUND_GRID_STYLE : CHROME_BACKGROUND_GRID_STYLE}
     >
       <ChromeSegment
         segment="sidebar"
@@ -262,7 +255,7 @@ function ChromeSegmentGrid({
         // While any panel is maximized the main segment hosts that panel's tabs
         // and controls, so the document title/actions step aside entirely.
         defaultSlots={{
-          left: activeExpandedPanel ? null : titleContent === undefined ? (
+          left: expandedPanel ? null : titleContent === undefined ? (
             <MainChromeTitle header={header} chip={titleChip} />
           ) : (
             titleContent
@@ -489,20 +482,6 @@ function DefaultRightChromeControls({
 
 function NativeTrafficLightInset(): React.ReactNode {
   return <div aria-hidden className="w-(--lc-chrome-traffic-inset) shrink-0" />;
-}
-
-function getActiveExpandedPanel({
-  expandedPanel,
-  rightPanelOpen,
-  bottomPanelOpen,
-}: {
-  expandedPanel: DesktopPanelSide | null;
-  rightPanelOpen: boolean;
-  bottomPanelOpen: boolean;
-}): DesktopPanelSide | null {
-  if (expandedPanel === 'right' && rightPanelOpen) return 'right';
-  if (expandedPanel === 'bottom' && bottomPanelOpen) return 'bottom';
-  return null;
 }
 
 function createChromeSlotKey(

--- a/apps/desktop/src/renderer/src/shell/desktop-shell.tsx
+++ b/apps/desktop/src/renderer/src/shell/desktop-shell.tsx
@@ -6,10 +6,9 @@ import {
   PanelStubContent,
   PanelTabContentStack,
 } from '@linkcode/ui/shell/panels';
-import type { PaletteCommand, WorkbenchShellProps } from '@linkcode/workbench';
-import { TerminalPanel, useCommandPaletteStore } from '@linkcode/workbench';
+import type { WorkbenchShellProps } from '@linkcode/workbench';
+import { TerminalPanel } from '@linkcode/workbench';
 import { Allotment, LayoutPriority } from 'allotment';
-import { noop } from 'foxact/noop';
 import { useEffect as useAbortableEffect } from 'foxact/use-abortable-effect';
 import { useLayoutEffect } from 'foxact/use-isomorphic-layout-effect';
 import { useSingleton } from 'foxact/use-singleton';
@@ -17,7 +16,6 @@ import { useCallback, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { useTranslations } from 'use-intl';
 import { useShallow } from 'zustand/react/shallow';
-import { useDesktopSettingsStore } from '../settings/store';
 import { DesktopChrome } from './chrome/chrome';
 import { DiffStatChip } from './chrome/diff-stat-chip';
 import { DESKTOP_CHROME_SPACER_CLASS } from './chrome/metrics';
@@ -38,6 +36,8 @@ import {
   SIDEBAR_MIN_SIZE,
 } from './store/model';
 import { useDesktopShellStore } from './store/store';
+import { useDesktopPaletteCommands } from './use-desktop-palette-commands';
+import { getPanelToggleShortcuts, useDesktopShellShortcuts } from './use-desktop-shell-shortcuts';
 
 export function DesktopShell({
   systemBridge,
@@ -222,116 +222,21 @@ export function DesktopShell({
     resetBottomPanelSize: resetBottomPanelLayoutSize,
   } = shellState;
 
-  // Cmd+J (Ctrl+J off-mac) toggles the bottom terminal panel, Cmd+B (Ctrl+B) the sidebar,
-  // Option+Cmd+B (Ctrl+Alt+B) the right side panel, and Cmd+K (Ctrl+K) the command palette.
-  // Captured at the window so they win even while the terminal canvas holds focus; on mac the
-  // Ctrl variants stay with the shell (Ctrl+J is a real terminal keystroke there). Matched on
-  // `code` because Option rewrites `key` on mac (⌥B yields "∫").
-  useAbortableEffect(
-    (signal) => {
-      if (desktopPlatform === null) return;
-      const isMac = desktopPlatform === 'darwin';
-      window.addEventListener(
-        'keydown',
-        (event) => {
-          // `inert` on the hidden workbench doesn't stop window-level listeners, so Settings
-          // being open must be checked here at event time — not in the effect deps, or the
-          // listener would re-register on every open/close.
-          if (useDesktopSettingsStore.getState().settingsOpen) return;
-          const modifier = isMac
-            ? event.metaKey && !event.ctrlKey
-            : event.ctrlKey && !event.metaKey;
-          if (!modifier || event.shiftKey) return;
-          const toggle =
-            event.code === 'KeyJ' && !event.altKey
-              ? () => togglePanel('bottom')
-              : event.code === 'KeyB'
-                ? event.altKey
-                  ? () => togglePanel('right')
-                  : () => updateSidebarOpen((open) => !open)
-                : event.code === 'KeyK' && !event.altKey
-                  ? () => useCommandPaletteStore.getState().toggle()
-                  : null;
-          if (toggle === null) return;
-          event.preventDefault();
-          event.stopPropagation();
-          toggle();
-        },
-        { capture: true, signal },
-      );
-    },
-    [desktopPlatform, togglePanel, updateSidebarOpen],
-  );
+  useDesktopShellShortcuts({ desktopPlatform, togglePanel, updateSidebarOpen });
 
   const pickDirectory = useCallback(
     () => systemBridge.fs.pickFile({ title: 'Choose working folder', directory: true }),
     [systemBridge],
   );
 
-  const tPalette = useTranslations('workbench.palette');
-  // Desktop-owned palette entries: native folder pick, the Settings overlay, and the panel
-  // toggles. Registered into the shared palette store so the workbench-rendered palette lists
-  // them without desktop threading props through the surface.
-  useAbortableEffect(() => {
-    const shortcuts = getPanelToggleShortcuts(desktopPlatform);
-    const commands: PaletteCommand[] = [
-      {
-        id: 'desktop.open-folder',
-        label: tPalette('openFolder'),
-        keywords: ['folder', 'workspace'],
-        run() {
-          // The native picker only yields existing directories, so registration failing is a
-          // transport-level problem already surfaced by the data layer's error reporting.
-          void pickDirectory()
-            .then((picked) => (picked ? onRegisterWorkspace(picked) : null))
-            .catch(noop);
-        },
-      },
-      {
-        id: 'desktop.toggle-sidebar',
-        label: tPalette('toggleSidebar'),
-        shortcut: shortcuts.sidebar,
-        run() {
-          updateSidebarOpen((open) => !open);
-        },
-      },
-      {
-        id: 'desktop.toggle-bottom-panel',
-        label: tPalette('toggleBottomPanel'),
-        shortcut: shortcuts.bottom,
-        run() {
-          togglePanel('bottom');
-        },
-      },
-      {
-        id: 'desktop.toggle-right-panel',
-        label: tPalette('toggleRightPanel'),
-        shortcut: shortcuts.right,
-        run() {
-          togglePanel('right');
-        },
-      },
-    ];
-    if (onOpenSettings) {
-      commands.splice(1, 0, {
-        id: 'desktop.settings',
-        label: tPalette('openSettings'),
-        shortcut: shortcuts.settings,
-        run: onOpenSettings,
-      });
-    }
-    const { registerCommands, unregisterCommands } = useCommandPaletteStore.getState();
-    registerCommands('desktop', commands);
-    return () => unregisterCommands('desktop');
-  }, [
+  useDesktopPaletteCommands({
     desktopPlatform,
-    tPalette,
     pickDirectory,
     onRegisterWorkspace,
     onOpenSettings,
     togglePanel,
     updateSidebarOpen,
-  ]);
+  });
 
   function resetSidebarSize(): void {
     sidebarSplit.setPaneSize(DEFAULT_LAYOUT.sidebarW);
@@ -616,24 +521,4 @@ function createPanelContentHost(): HTMLDivElement {
   const host = document.createElement('div');
   host.className = 'absolute inset-0';
   return host;
-}
-
-function getPanelToggleShortcuts(platform: NodeJS.Platform | null): {
-  sidebar?: string;
-  bottom?: string;
-  right?: string;
-  palette?: string;
-  settings?: string;
-} {
-  if (platform === null) return {};
-  if (platform === 'darwin') {
-    return { sidebar: '⌘B', bottom: '⌘J', right: '⌥⌘B', palette: '⌘K', settings: '⌘,' };
-  }
-  return {
-    sidebar: 'Ctrl+B',
-    bottom: 'Ctrl+J',
-    right: 'Ctrl+Alt+B',
-    palette: 'Ctrl+K',
-    settings: 'Ctrl+,',
-  };
 }

--- a/apps/desktop/src/renderer/src/shell/use-desktop-palette-commands.ts
+++ b/apps/desktop/src/renderer/src/shell/use-desktop-palette-commands.ts
@@ -1,0 +1,93 @@
+import type { PanelSide } from '@linkcode/ui/shell/panels';
+import type { PaletteCommand } from '@linkcode/workbench';
+import { useCommandPaletteStore } from '@linkcode/workbench';
+import { noop } from 'foxact/noop';
+import { useAbortableEffect } from 'foxact/use-abortable-effect';
+import { useTranslations } from 'use-intl';
+import { getPanelToggleShortcuts } from './use-desktop-shell-shortcuts';
+
+interface UseDesktopPaletteCommandsOptions {
+  desktopPlatform: NodeJS.Platform | null;
+  pickDirectory: () => Promise<string | null>;
+  onRegisterWorkspace: (cwd: string) => void;
+  onOpenSettings?: () => void;
+  togglePanel: (side: PanelSide) => void;
+  updateSidebarOpen: (updater: boolean | ((current: boolean) => boolean)) => void;
+}
+
+/**
+ * Desktop-owned palette entries: native folder pick, the Settings overlay, and the panel
+ * toggles. Registered into the shared palette store so the workbench-rendered palette lists
+ * them without desktop threading props through the surface.
+ */
+export function useDesktopPaletteCommands({
+  desktopPlatform,
+  pickDirectory,
+  onRegisterWorkspace,
+  onOpenSettings,
+  togglePanel,
+  updateSidebarOpen,
+}: UseDesktopPaletteCommandsOptions): void {
+  const tPalette = useTranslations('workbench.palette');
+
+  useAbortableEffect(() => {
+    const shortcuts = getPanelToggleShortcuts(desktopPlatform);
+    const commands: PaletteCommand[] = [
+      {
+        id: 'desktop.open-folder',
+        label: tPalette('openFolder'),
+        keywords: ['folder', 'workspace'],
+        run() {
+          // The native picker only yields existing directories, so registration failing is a
+          // transport-level problem already surfaced by the data layer's error reporting.
+          void pickDirectory()
+            .then((picked) => (picked ? onRegisterWorkspace(picked) : null))
+            .catch(noop);
+        },
+      },
+      {
+        id: 'desktop.toggle-sidebar',
+        label: tPalette('toggleSidebar'),
+        shortcut: shortcuts.sidebar,
+        run() {
+          updateSidebarOpen((open) => !open);
+        },
+      },
+      {
+        id: 'desktop.toggle-bottom-panel',
+        label: tPalette('toggleBottomPanel'),
+        shortcut: shortcuts.bottom,
+        run() {
+          togglePanel('bottom');
+        },
+      },
+      {
+        id: 'desktop.toggle-right-panel',
+        label: tPalette('toggleRightPanel'),
+        shortcut: shortcuts.right,
+        run() {
+          togglePanel('right');
+        },
+      },
+    ];
+    if (onOpenSettings) {
+      commands.splice(1, 0, {
+        id: 'desktop.settings',
+        label: tPalette('openSettings'),
+        shortcut: shortcuts.settings,
+        run: onOpenSettings,
+      });
+    }
+    const { registerCommands, unregisterCommands } = useCommandPaletteStore.getState();
+    registerCommands('desktop', commands);
+    return () => unregisterCommands('desktop');
+  }, [
+    desktopPlatform,
+    tPalette,
+    pickDirectory,
+    onRegisterWorkspace,
+    onOpenSettings,
+    togglePanel,
+    updateSidebarOpen,
+  ]);
+}

--- a/apps/desktop/src/renderer/src/shell/use-desktop-shell-shortcuts.ts
+++ b/apps/desktop/src/renderer/src/shell/use-desktop-shell-shortcuts.ts
@@ -1,0 +1,79 @@
+import type { PanelSide } from '@linkcode/ui/shell/panels';
+import { useCommandPaletteStore } from '@linkcode/workbench';
+import { useAbortableEffect } from 'foxact/use-abortable-effect';
+import { useDesktopSettingsStore } from '../settings/store';
+
+export function getPanelToggleShortcuts(platform: NodeJS.Platform | null): {
+  sidebar?: string;
+  bottom?: string;
+  right?: string;
+  palette?: string;
+  settings?: string;
+} {
+  if (platform === null) return {};
+  if (platform === 'darwin') {
+    return { sidebar: '⌘B', bottom: '⌘J', right: '⌥⌘B', palette: '⌘K', settings: '⌘,' };
+  }
+  return {
+    sidebar: 'Ctrl+B',
+    bottom: 'Ctrl+J',
+    right: 'Ctrl+Alt+B',
+    palette: 'Ctrl+K',
+    settings: 'Ctrl+,',
+  };
+}
+
+interface UseDesktopShellShortcutsOptions {
+  desktopPlatform: NodeJS.Platform | null;
+  togglePanel: (side: PanelSide) => void;
+  updateSidebarOpen: (updater: boolean | ((current: boolean) => boolean)) => void;
+}
+
+/**
+ * Cmd+J (Ctrl+J off-mac) toggles the bottom terminal panel, Cmd+B (Ctrl+B) the sidebar,
+ * Option+Cmd+B (Ctrl+Alt+B) the right side panel, and Cmd+K (Ctrl+K) the command palette.
+ * Captured at the window so they win even while the terminal canvas holds focus; on mac the
+ * Ctrl variants stay with the shell (Ctrl+J is a real terminal keystroke there). Matched on
+ * `code` because Option rewrites `key` on mac (⌥B yields "∫").
+ */
+export function useDesktopShellShortcuts({
+  desktopPlatform,
+  togglePanel,
+  updateSidebarOpen,
+}: UseDesktopShellShortcutsOptions): void {
+  useAbortableEffect(
+    (signal) => {
+      if (desktopPlatform === null) return;
+      const isMac = desktopPlatform === 'darwin';
+      window.addEventListener(
+        'keydown',
+        (event) => {
+          // `inert` on the hidden workbench doesn't stop window-level listeners, so Settings
+          // being open must be checked here at event time — not in the effect deps, or the
+          // listener would re-register on every open/close.
+          if (useDesktopSettingsStore.getState().settingsOpen) return;
+          const modifier = isMac
+            ? event.metaKey && !event.ctrlKey
+            : event.ctrlKey && !event.metaKey;
+          if (!modifier || event.shiftKey) return;
+          const toggle =
+            event.code === 'KeyJ' && !event.altKey
+              ? () => togglePanel('bottom')
+              : event.code === 'KeyB'
+                ? event.altKey
+                  ? () => togglePanel('right')
+                  : () => updateSidebarOpen((open) => !open)
+                : event.code === 'KeyK' && !event.altKey
+                  ? () => useCommandPaletteStore.getState().toggle()
+                  : null;
+          if (toggle === null) return;
+          event.preventDefault();
+          event.stopPropagation();
+          toggle();
+        },
+        { capture: true, signal },
+      );
+    },
+    [desktopPlatform, togglePanel, updateSidebarOpen],
+  );
+}

--- a/packages/client-core/src/client.ts
+++ b/packages/client-core/src/client.ts
@@ -1,9 +1,7 @@
 import type {
   AgentEvent,
   AgentHistoryId,
-  AgentHistoryListOptions,
   AgentHistoryListResult,
-  AgentHistoryReadOptions,
   AgentHistoryReadResult,
   AgentInput,
   AgentKind,
@@ -20,67 +18,26 @@ import type {
   SessionRecord,
   StartOptions,
   WireMessage,
-  WirePayload,
   WorkspaceId,
   WorkspaceKind,
   WorkspaceRecord,
 } from '@linkcode/schema';
 import type { Transport, Unsubscribe } from '@linkcode/transport';
-import { createWireMessage } from '@linkcode/transport';
-import { extractErrorMessage } from 'foxts/extract-error-message';
+import type { HistoryListClientOptions, HistoryReadClientOptions } from './client/control-channel';
+import { ControlChannel } from './client/control-channel';
+import type { SequencedAgentEvent } from './client/event-buffer';
+import { EventBuffer } from './client/event-buffer';
+import type { RequestAck } from './client/pending-registry';
+import { PendingRegistry } from './client/pending-registry';
+import { TerminalChannel } from './client/terminal-channel';
 
-/**
- * An event paired with its connection-scoped receive sequence number: the Nth `agent.event` this
- * client received for its session (1-based, monotone for the lifetime of the connection). A
- * transcript snapshot taken when the counter read N supersedes exactly the events with seq ≤ N.
- */
-export interface SequencedAgentEvent {
-  event: AgentEvent;
-  seq: number;
-}
+export type { HistoryListClientOptions, HistoryReadClientOptions } from './client/control-channel';
+export type { SequencedAgentEvent } from './client/event-buffer';
 
 type EventCb = (event: AgentEvent, seq: number) => void;
 type TerminalOutputCb = (data: string) => void;
 type TerminalExitCb = (exitCode: number | null) => void;
 type TerminalErrorCb = (err: Error) => void;
-interface Pending<T> {
-  resolve(value: T): void;
-  reject(err: Error): void;
-}
-interface RequestAck {
-  ok: true;
-}
-
-export type HistoryListClientOptions = AgentHistoryListOptions & {
-  forceRefresh?: boolean;
-};
-
-export type HistoryReadClientOptions = AgentHistoryReadOptions & {
-  forceRefresh?: boolean;
-};
-
-/** Cap on per-terminal output buffered before the first subscriber, so an unread PTY can't grow unbounded. */
-const TERMINAL_PREBUFFER_CAP = 128 * 1024;
-
-const EMPTY_EVENTS: readonly SequencedAgentEvent[] = [];
-
-/**
- * Trim buffered terminal output to the cap on a line boundary. Slicing raw would leave the buffer
- * starting mid-ANSI-escape (the head byte gone, the tail rendered as literal garbage); dropping the
- * partial leading line keeps the replay parseable.
- */
-function capPrebuffer(text: string): string {
-  if (text.length <= TERMINAL_PREBUFFER_CAP) return text;
-  const sliced = text.slice(-TERMINAL_PREBUFFER_CAP);
-  const nl = sliced.indexOf('\n');
-  return nl === -1 ? sliced : sliced.slice(nl + 1);
-}
-
-let __reqSeq = 0;
-function nextClientReqId(): string {
-  __reqSeq += 1;
-  return `creq-${Date.now().toString(36)}-${__reqSeq.toString(36)}`;
-}
 
 /**
  * LinkCodeClient: the data-plane client shared across all platforms
@@ -89,42 +46,24 @@ function nextClientReqId(): string {
  * whether it's a LocalTransport or a WsTransport to the daemon (docs/ARCHITECTURE.md#core-principles).
  *
  * The daemon broadcasts events to every client, so control replies are paired by correlation id rather
- * than by order: each request carries a `clientReqId` and the reply echoes it as `replyTo`.
+ * than by order: each request carries a `clientReqId` and the reply echoes it as `replyTo`. Composed
+ * from four collaborators: a {@link PendingRegistry} for correlated request/reply bookkeeping, a
+ * {@link ControlChannel} for session/history/config/git/workspace requests, an {@link EventBuffer}
+ * for per-session agent events, and a {@link TerminalChannel} for PTY sessions.
  */
 export class LinkCodeClient {
-  private readonly subscribers = new Map<SessionId, Set<EventCb>>();
-  /** Per-session event buffer so a re-subscribe (switching the active session back) can replay the timeline. */
-  private readonly events = new Map<SessionId, SequencedAgentEvent[]>();
-  /** Cached immutable copies of {@link events}, invalidated per event — `getSnapshot` sources. */
-  private readonly eventSnapshots = new Map<SessionId, readonly SequencedAgentEvent[]>();
-  /** Per-session receive counters. Deliberately NOT cleared with the buffer on `stopSession`: a
-   * stop→resume in the same connection must keep seq monotone, or a seed's `uptoSeq` sampled
-   * before the stop would swallow the resumed session's fresh events. */
-  private readonly eventSeqs = new Map<SessionId, number>();
-  private readonly pendingStarts = new Map<string, Pending<SessionId>>();
-  private readonly pendingLists = new Map<string, Pending<SessionInfo[]>>();
-  private readonly pendingImports = new Map<string, Pending<SessionRecord>>();
-  private readonly pendingHistoryLists = new Map<string, Pending<AgentHistoryListResult>>();
-  private readonly pendingHistoryReads = new Map<string, Pending<AgentHistoryReadResult>>();
-  private readonly pendingConfigGets = new Map<string, Pending<ProvidersConfig>>();
-  private readonly pendingGitStatuses = new Map<string, Pending<GitStatus>>();
-  private readonly pendingGitPrStatuses = new Map<string, Pending<GitPullRequestStatus>>();
-  private readonly pendingGitDiffs = new Map<string, Pending<GitDiff>>();
-  private readonly pendingWorkspaceLists = new Map<string, Pending<WorkspaceRecord[]>>();
-  private readonly pendingWorkspaceRegisters = new Map<string, Pending<WorkspaceRecord>>();
-  private readonly pendingAcks = new Map<string, Pending<RequestAck>>();
-  private readonly pendingTerminalOpens = new Map<string, Pending<string>>();
-  private readonly terminalOutputSubs = new Map<string, Set<TerminalOutputCb>>();
-  private readonly terminalExitSubs = new Map<string, Set<TerminalExitCb>>();
-  /** Notified when a fire-and-forget terminal frame (input/resize/close) fails to send. */
-  private readonly terminalErrorSubs = new Map<string, Set<TerminalErrorCb>>();
-  /** Output seen before anyone subscribed (covers the open→subscribe gap and late mounts); capped. */
-  private readonly terminalPrebuffer = new Map<string, string>();
+  private readonly pending = new PendingRegistry();
+  private readonly control: ControlChannel;
+  private readonly events = new EventBuffer();
+  private readonly terminals: TerminalChannel;
   private unsub: Unsubscribe | null = null;
   private offClose: Unsubscribe | null = null;
   private closed = false;
 
-  constructor(private readonly transport: Transport) {}
+  constructor(private readonly transport: Transport) {
+    this.control = new ControlChannel(transport, this.pending);
+    this.terminals = new TerminalChannel(transport, this.pending);
+  }
 
   async connect(): Promise<void> {
     this.closed = false;
@@ -135,174 +74,96 @@ export class LinkCodeClient {
     this.unsub = this.transport.onMessage((msg) => this.route(msg));
     this.offClose?.();
     this.offClose = this.transport.onClose(() =>
-      this.failAllPending(new Error('transport connection closed')),
+      this.pending.failAll(new Error('transport connection closed')),
     );
   }
 
   private route(msg: WireMessage): void {
     const p = msg.payload;
     switch (p.kind) {
-      case 'session.started': {
-        this.pendingStarts.get(p.replyTo)?.resolve(p.sessionId);
-        this.pendingStarts.delete(p.replyTo);
+      case 'session.started':
+        this.pending.resolve('start', p.replyTo, p.sessionId);
         break;
-      }
-      case 'session.listed': {
-        this.pendingLists.get(p.replyTo)?.resolve(p.sessions);
-        this.pendingLists.delete(p.replyTo);
+      case 'session.listed':
+        this.pending.resolve('list', p.replyTo, p.sessions);
         break;
-      }
-      case 'session.imported': {
-        this.pendingImports.get(p.replyTo)?.resolve(p.record);
-        this.pendingImports.delete(p.replyTo);
+      case 'session.imported':
+        this.pending.resolve('import', p.replyTo, p.record);
         break;
-      }
-      case 'history.listed': {
-        this.pendingHistoryLists.get(p.replyTo)?.resolve(p.result);
-        this.pendingHistoryLists.delete(p.replyTo);
+      case 'history.listed':
+        this.pending.resolve('historyList', p.replyTo, p.result);
         break;
-      }
-      case 'history.read.result': {
-        this.pendingHistoryReads.get(p.replyTo)?.resolve(p.result);
-        this.pendingHistoryReads.delete(p.replyTo);
+      case 'history.read.result':
+        this.pending.resolve('historyRead', p.replyTo, p.result);
         break;
-      }
-      case 'config.get.result': {
-        this.pendingConfigGets.get(p.replyTo)?.resolve(p.providers);
-        this.pendingConfigGets.delete(p.replyTo);
+      case 'config.get.result':
+        this.pending.resolve('configGet', p.replyTo, p.providers);
         break;
-      }
-      case 'git.status.get.result': {
-        this.pendingGitStatuses.get(p.replyTo)?.resolve(p.status);
-        this.pendingGitStatuses.delete(p.replyTo);
+      case 'git.status.get.result':
+        this.pending.resolve('gitStatus', p.replyTo, p.status);
         break;
-      }
-      case 'git.pr_status.get.result': {
-        this.pendingGitPrStatuses.get(p.replyTo)?.resolve(p.prStatus);
-        this.pendingGitPrStatuses.delete(p.replyTo);
+      case 'git.pr_status.get.result':
+        this.pending.resolve('gitPrStatus', p.replyTo, p.prStatus);
         break;
-      }
-      case 'git.diff.get.result': {
-        this.pendingGitDiffs.get(p.replyTo)?.resolve(p.diff);
-        this.pendingGitDiffs.delete(p.replyTo);
+      case 'git.diff.get.result':
+        this.pending.resolve('gitDiff', p.replyTo, p.diff);
         break;
-      }
-      case 'workspace.listed': {
-        this.pendingWorkspaceLists.get(p.replyTo)?.resolve(p.workspaces);
-        this.pendingWorkspaceLists.delete(p.replyTo);
+      case 'workspace.listed':
+        this.pending.resolve('workspaceList', p.replyTo, p.workspaces);
         break;
-      }
-      case 'workspace.registered': {
-        this.pendingWorkspaceRegisters.get(p.replyTo)?.resolve(p.record);
-        this.pendingWorkspaceRegisters.delete(p.replyTo);
+      case 'workspace.registered':
+        this.pending.resolve('workspaceRegister', p.replyTo, p.record);
         break;
-      }
       case 'request.failed': {
-        this.rejectPending(p.replyTo, p.message, p.code);
+        const err = new Error(p.message);
+        if (p.code) Object.assign(err, { code: p.code });
+        this.pending.reject(p.replyTo, err);
         break;
       }
-      case 'request.succeeded': {
-        this.pendingAcks.get(p.replyTo)?.resolve({ ok: true });
-        this.pendingAcks.delete(p.replyTo);
+      case 'request.succeeded':
+        this.pending.resolve('ack', p.replyTo, { ok: true });
         break;
-      }
-      case 'agent.event': {
-        const seq = (this.eventSeqs.get(p.sessionId) ?? 0) + 1;
-        this.eventSeqs.set(p.sessionId, seq);
-        const sequenced: SequencedAgentEvent = { event: p.event, seq };
-        const buf = this.events.get(p.sessionId);
-        if (buf) buf.push(sequenced);
-        else this.events.set(p.sessionId, [sequenced]);
-        this.eventSnapshots.delete(p.sessionId);
-        const subs = this.subscribers.get(p.sessionId);
-        if (subs) for (const cb of subs) cb(sequenced.event, sequenced.seq);
+      case 'agent.event':
+        this.events.ingest(p.sessionId, p.event);
         break;
-      }
-      case 'terminal.opened': {
-        this.pendingTerminalOpens.get(p.replyTo)?.resolve(p.terminalId);
-        this.pendingTerminalOpens.delete(p.replyTo);
+      case 'terminal.opened':
+      case 'terminal.output':
+      case 'terminal.exit':
+        this.terminals.handleMessage(p);
         break;
-      }
-      case 'terminal.output': {
-        const subs = this.terminalOutputSubs.get(p.terminalId);
-        if (subs && subs.size > 0) {
-          for (const cb of subs) cb(p.data);
-        } else {
-          const prev = this.terminalPrebuffer.get(p.terminalId) ?? '';
-          this.terminalPrebuffer.set(p.terminalId, capPrebuffer(prev + p.data));
-        }
-        break;
-      }
-      case 'terminal.exit': {
-        const subs = this.terminalExitSubs.get(p.terminalId);
-        if (subs) for (const cb of subs) cb(p.exitCode);
-        this.terminalOutputSubs.delete(p.terminalId);
-        this.terminalExitSubs.delete(p.terminalId);
-        this.terminalErrorSubs.delete(p.terminalId);
-        this.terminalPrebuffer.delete(p.terminalId);
-        break;
-      }
       default:
         break;
     }
   }
 
   startSession(opts: StartOptions): Promise<SessionId> {
-    return this.sendCorrelated(this.pendingStarts, (clientReqId) => ({
-      kind: 'session.start',
-      clientReqId,
-      opts,
-    }));
+    return this.control.startSession(opts);
   }
 
   listSessions(): Promise<SessionInfo[]> {
-    return this.sendCorrelated(this.pendingLists, (clientReqId) => ({
-      kind: 'session.list',
-      clientReqId,
-    }));
+    return this.control.listSessions();
   }
 
-  /** Resume a persisted (cold) session by its Link Code id; resolves with the same id. */
   resumeSession(sessionId: SessionId): Promise<SessionId> {
-    return this.sendCorrelated(this.pendingStarts, (clientReqId) => ({
-      kind: 'session.resume',
-      clientReqId,
-      sessionId,
-    }));
+    return this.control.resumeSession(sessionId);
   }
 
-  /** Import a provider-local history session as a cold record (listed, not started). */
   importSession(agentKind: AgentKind, historyId: AgentHistoryId): Promise<SessionRecord> {
-    return this.sendCorrelated(this.pendingImports, (clientReqId) => ({
-      kind: 'session.import',
-      clientReqId,
-      agentKind,
-      historyId,
-    }));
+    return this.control.importSession(agentKind, historyId);
   }
 
   listHistory(
     agentKind: AgentKind,
     opts?: HistoryListClientOptions,
   ): Promise<AgentHistoryListResult> {
-    return this.sendCorrelated(this.pendingHistoryLists, (clientReqId) => ({
-      kind: 'history.list',
-      clientReqId,
-      agentKind,
-      opts,
-    }));
+    return this.control.listHistory(agentKind, opts);
   }
 
   readHistory(
     agentKind: AgentKind,
     opts: HistoryReadClientOptions,
   ): Promise<AgentHistoryReadResult> {
-    return this.sendCorrelated(this.pendingHistoryReads, (clientReqId) => ({
-      kind: 'history.read',
-      clientReqId,
-      agentKind,
-      opts,
-    }));
+    return this.control.readHistory(agentKind, opts);
   }
 
   resumeHistory(
@@ -310,194 +171,100 @@ export class LinkCodeClient {
     historyId: AgentHistoryId,
     startOpts: StartOptions,
   ): Promise<SessionId> {
-    return this.sendCorrelated(this.pendingStarts, (clientReqId) => ({
-      kind: 'history.resume',
-      clientReqId,
-      agentKind,
-      historyId,
-      startOpts: { ...startOpts, kind: agentKind },
-    }));
+    return this.control.resumeHistory(agentKind, historyId, startOpts);
   }
 
   /** Low-level: send any normalized input to a session. */
   send(sessionId: SessionId, input: AgentInput): Promise<RequestAck> {
-    return this.sendCorrelated(this.pendingAcks, (clientReqId) => ({
-      kind: 'agent.input',
-      clientReqId,
-      sessionId,
-      input,
-    }));
+    return this.control.send(sessionId, input);
   }
 
-  /** Send a prompt as content blocks. */
   prompt(sessionId: SessionId, content: ContentBlock[]): Promise<RequestAck> {
-    return this.send(sessionId, { type: 'prompt', content });
+    return this.control.prompt(sessionId, content);
   }
 
-  /** Convenience: send a plain-text prompt. */
   promptText(sessionId: SessionId, text: string): Promise<RequestAck> {
-    return this.prompt(sessionId, [{ type: 'text', text }]);
+    return this.control.promptText(sessionId, text);
   }
 
-  /** Cancel the in-flight turn. */
   cancel(sessionId: SessionId): Promise<RequestAck> {
-    return this.send(sessionId, { type: 'cancel' });
+    return this.control.cancel(sessionId);
   }
 
-  /** Switch the session mode. */
   setMode(sessionId: SessionId, modeId: string): Promise<RequestAck> {
-    return this.send(sessionId, { type: 'set-mode', modeId });
+    return this.control.setMode(sessionId, modeId);
   }
 
-  /** Switch the session's model, going forward. Rejects if the adapter can't rebind a live session. */
   setModel(sessionId: SessionId, model: string): Promise<RequestAck> {
-    return this.send(sessionId, { type: 'set-model', model });
+    return this.control.setModel(sessionId, model);
   }
 
-  /** Switch the session's reasoning-effort level, going forward. Same acceptance rule as setModel. */
   setEffort(sessionId: SessionId, effort: EffortLevel): Promise<RequestAck> {
-    return this.send(sessionId, { type: 'set-effort', effort });
+    return this.control.setEffort(sessionId, effort);
   }
 
-  /** Answer a pending permission-request. */
   respondPermission(
     sessionId: SessionId,
     requestId: string,
     outcome: PermissionOutcome,
   ): Promise<RequestAck> {
-    return this.send(sessionId, { type: 'permission-response', requestId, outcome });
+    return this.control.respondPermission(sessionId, requestId, outcome);
   }
 
+  /** Stop a session and drop its buffered events (its receive counter survives, see {@link EventBuffer}). */
   stopSession(sessionId: SessionId): Promise<RequestAck> {
-    return this.sendCorrelated(this.pendingAcks, (clientReqId) => ({
-      kind: 'session.stop',
-      clientReqId,
-      sessionId,
-    })).then((ack) => {
-      this.subscribers.delete(sessionId);
-      this.events.delete(sessionId);
-      this.eventSnapshots.delete(sessionId);
+    return this.control.stopSession(sessionId).then((ack) => {
+      this.events.clearSession(sessionId);
       return ack;
     });
   }
 
-  /** Read the daemon-owned provider config (data plane). */
   getProviderConfig(): Promise<ProvidersConfig> {
-    return this.sendCorrelated(this.pendingConfigGets, (clientReqId) => ({
-      kind: 'config.get',
-      clientReqId,
-    }));
+    return this.control.getProviderConfig();
   }
 
-  /** Persist the daemon-owned provider config (data plane). */
   setProviderConfig(providers: ProvidersConfig): Promise<RequestAck> {
-    return this.sendCorrelated(this.pendingAcks, (clientReqId) => ({
-      kind: 'config.set',
-      clientReqId,
-      providers,
-    }));
+    return this.control.setProviderConfig(providers);
   }
 
-  /** Local git facts for a directory (directory-backed: keyed by cwd, not by session). */
   getGitStatus(cwd: string): Promise<GitStatus> {
-    return this.sendCorrelated(this.pendingGitStatuses, (clientReqId) => ({
-      kind: 'git.status.get',
-      clientReqId,
-      cwd,
-    }));
+    return this.control.getGitStatus(cwd);
   }
 
-  /** Hosting-provider PR state for a directory's current branch. */
   getGitPullRequestStatus(cwd: string): Promise<GitPullRequestStatus> {
-    return this.sendCorrelated(this.pendingGitPrStatuses, (clientReqId) => ({
-      kind: 'git.pr_status.get',
-      clientReqId,
-      cwd,
-    }));
+    return this.control.getGitPullRequestStatus(cwd);
   }
 
-  /** A unified-diff patch for a directory (directory-backed: keyed by cwd, not by session). */
   getGitDiff(cwd: string, mode: GitDiffMode): Promise<GitDiff> {
-    return this.sendCorrelated(this.pendingGitDiffs, (clientReqId) => ({
-      kind: 'git.diff.get',
-      clientReqId,
-      cwd,
-      mode,
-    }));
+    return this.control.getGitDiff(cwd, mode);
   }
 
-  /** Every registered workspace (directory), most recently used first. */
   listWorkspaces(): Promise<WorkspaceRecord[]> {
-    return this.sendCorrelated(this.pendingWorkspaceLists, (clientReqId) => ({
-      kind: 'workspace.list',
-      clientReqId,
-    }));
+    return this.control.listWorkspaces();
   }
 
-  /** Register a directory as a workspace; idempotent for an already-registered directory. */
   registerWorkspace(cwd: string, name?: string, kind?: WorkspaceKind): Promise<WorkspaceRecord> {
-    return this.sendCorrelated(this.pendingWorkspaceRegisters, (clientReqId) => ({
-      kind: 'workspace.register',
-      clientReqId,
-      cwd,
-      name,
-      workspaceKind: kind,
-    }));
+    return this.control.registerWorkspace(cwd, name, kind);
   }
 
   updateWorkspace(workspaceId: WorkspaceId, name: string): Promise<RequestAck> {
-    return this.sendCorrelated(this.pendingAcks, (clientReqId) => ({
-      kind: 'workspace.update',
-      clientReqId,
-      workspaceId,
-      name,
-    }));
+    return this.control.updateWorkspace(workspaceId, name);
   }
 
-  /** Drop a workspace from the registry; never touches the directory on disk. */
   archiveWorkspace(workspaceId: WorkspaceId): Promise<RequestAck> {
-    return this.sendCorrelated(this.pendingAcks, (clientReqId) => ({
-      kind: 'workspace.archive',
-      clientReqId,
-      workspaceId,
-    }));
+    return this.control.archiveWorkspace(workspaceId);
   }
 
   subscribe(sessionId: SessionId, cb: EventCb): Unsubscribe {
-    let set = this.subscribers.get(sessionId);
-    if (!set) {
-      set = new Set();
-      this.subscribers.set(sessionId, set);
-    }
-    set.add(cb);
-    // Replay any buffered events (with their original sequence numbers) so a late subscriber sees
-    // the full timeline, not a blank pane.
-    const buf = this.events.get(sessionId);
-    if (buf) for (const { event, seq } of buf) cb(event, seq);
-    return () => set.delete(cb);
+    return this.events.subscribe(sessionId, cb);
   }
 
-  /**
-   * The receive counter for a session: how many `agent.event`s this client has seen for it on this
-   * connection. Sampled right after a transcript read resolves, it becomes that snapshot's
-   * `uptoSeq` — the ordered cut "everything at or before this is already in the snapshot".
-   */
   eventSeq(sessionId: SessionId): number {
-    return this.eventSeqs.get(sessionId) ?? 0;
+    return this.events.eventSeq(sessionId);
   }
 
-  /**
-   * Immutable snapshot of a session's buffered events, cached until the next event arrives.
-   * Stable identity between changes makes it a valid `useSyncExternalStore` getSnapshot source.
-   */
   eventsSnapshot(sessionId: SessionId): readonly SequencedAgentEvent[] {
-    const cached = this.eventSnapshots.get(sessionId);
-    if (cached) return cached;
-    const buf = this.events.get(sessionId);
-    if (!buf || buf.length === 0) return EMPTY_EVENTS;
-    const snapshot: readonly SequencedAgentEvent[] = [...buf];
-    this.eventSnapshots.set(sessionId, snapshot);
-    return snapshot;
+    return this.events.snapshot(sessionId);
   }
 
   openTerminal(opts: {
@@ -507,62 +274,42 @@ export class LinkCodeClient {
     shell?: string;
     sessionId?: SessionId;
   }): Promise<string> {
-    return this.sendCorrelated(this.pendingTerminalOpens, (clientReqId) => ({
-      kind: 'terminal.open',
-      clientReqId,
-      opts,
-    }));
+    return this.terminals.open(opts);
   }
 
   terminalInput(terminalId: string, data: string): void {
-    this.sendTerminalFrame(terminalId, { kind: 'terminal.input', terminalId, data });
+    this.terminals.input(terminalId, data);
   }
 
   resizeTerminal(terminalId: string, cols: number, rows: number): void {
-    this.sendTerminalFrame(terminalId, { kind: 'terminal.resize', terminalId, cols, rows });
+    this.terminals.resize(terminalId, cols, rows);
   }
 
   closeTerminal(terminalId: string): void {
-    this.sendTerminalFrame(terminalId, { kind: 'terminal.close', terminalId });
+    this.terminals.close(terminalId);
   }
 
   subscribeTerminalOutput(terminalId: string, cb: TerminalOutputCb): Unsubscribe {
-    let set = this.terminalOutputSubs.get(terminalId);
-    if (!set) {
-      set = new Set();
-      this.terminalOutputSubs.set(terminalId, set);
-    }
-    set.add(cb);
-    // Replay output buffered before a subscriber attached. Kept (not deleted) until `terminal.exit`
-    // so a remount/second subscriber still gets the initial prompt instead of a blank pane.
-    const buffered = this.terminalPrebuffer.get(terminalId);
-    if (buffered !== undefined) cb(buffered);
-    return () => set.delete(cb);
+    return this.terminals.subscribeOutput(terminalId, cb);
   }
 
   subscribeTerminalExit(terminalId: string, cb: TerminalExitCb): Unsubscribe {
-    let set = this.terminalExitSubs.get(terminalId);
-    if (!set) {
-      set = new Set();
-      this.terminalExitSubs.set(terminalId, set);
-    }
-    set.add(cb);
-    return () => set.delete(cb);
+    return this.terminals.subscribeExit(terminalId, cb);
   }
 
-  /**
-   * Observe transport-send failures for a terminal's fire-and-forget frames (input/resize/close).
-   * Those carry no reply to await, so without this a dropped keystroke would vanish silently; a
-   * subscriber can surface the drop instead (e.g. flag the pane as disconnected).
-   */
+  /** Observe transport-send failures for a terminal's fire-and-forget frames (input/resize/close). */
   subscribeTerminalError(terminalId: string, cb: TerminalErrorCb): Unsubscribe {
-    let set = this.terminalErrorSubs.get(terminalId);
-    if (!set) {
-      set = new Set();
-      this.terminalErrorSubs.set(terminalId, set);
-    }
-    set.add(cb);
-    return () => set.delete(cb);
+    return this.terminals.subscribeError(terminalId, cb);
+  }
+
+  /** See {@link TerminalChannel.outputSnapshot}. */
+  terminalOutputSnapshot(terminalId: string): string {
+    return this.terminals.outputSnapshot(terminalId);
+  }
+
+  /** See {@link TerminalChannel.subscribeOutputSnapshot}. */
+  subscribeTerminalOutputSnapshot(terminalId: string, cb: () => void): Unsubscribe {
+    return this.terminals.subscribeOutputSnapshot(terminalId, cb);
   }
 
   dispose(): void {
@@ -571,104 +318,13 @@ export class LinkCodeClient {
     this.unsub = null;
     this.offClose?.();
     this.offClose = null;
-    this.failAllPending(new Error('client disposed'));
-    this.subscribers.clear();
-    this.events.clear();
-    this.eventSnapshots.clear();
-    this.eventSeqs.clear();
-    this.terminalOutputSubs.clear();
-    this.terminalExitSubs.clear();
-    this.terminalErrorSubs.clear();
-    this.terminalPrebuffer.clear();
+    this.pending.failAll(new Error('client disposed'));
+    this.events.clearAll();
+    this.terminals.disposeAll();
     this.transport.close();
-  }
-
-  /** Reject every in-flight request so awaiters get an error instead of hanging forever. */
-  private failAllPending(err: Error): void {
-    for (const map of [
-      this.pendingStarts,
-      this.pendingLists,
-      this.pendingImports,
-      this.pendingHistoryLists,
-      this.pendingHistoryReads,
-      this.pendingConfigGets,
-      this.pendingGitStatuses,
-      this.pendingGitPrStatuses,
-      this.pendingGitDiffs,
-      this.pendingWorkspaceLists,
-      this.pendingWorkspaceRegisters,
-      this.pendingAcks,
-      this.pendingTerminalOpens,
-    ]) {
-      for (const pending of map.values()) pending.reject(err);
-      map.clear();
-    }
-  }
-
-  private rejectPending(replyTo: string, message: string, code?: string): void {
-    const err = new Error(message);
-    if (code) Object.assign(err, { code });
-    if (rejectFrom(this.pendingStarts, replyTo, err)) return;
-    if (rejectFrom(this.pendingLists, replyTo, err)) return;
-    if (rejectFrom(this.pendingImports, replyTo, err)) return;
-    if (rejectFrom(this.pendingHistoryLists, replyTo, err)) return;
-    if (rejectFrom(this.pendingHistoryReads, replyTo, err)) return;
-    if (rejectFrom(this.pendingConfigGets, replyTo, err)) return;
-    if (rejectFrom(this.pendingGitStatuses, replyTo, err)) return;
-    if (rejectFrom(this.pendingGitPrStatuses, replyTo, err)) return;
-    if (rejectFrom(this.pendingGitDiffs, replyTo, err)) return;
-    if (rejectFrom(this.pendingWorkspaceLists, replyTo, err)) return;
-    if (rejectFrom(this.pendingWorkspaceRegisters, replyTo, err)) return;
-    if (rejectFrom(this.pendingAcks, replyTo, err)) return;
-    rejectFrom(this.pendingTerminalOpens, replyTo, err);
-  }
-
-  /** Send a fire-and-forget terminal frame, routing any send failure to the terminal's error subs. */
-  private sendTerminalFrame(terminalId: string, payload: WirePayload): void {
-    const onFail = (err: unknown) => this.emitTerminalError(terminalId, toError(err));
-    try {
-      void Promise.resolve(this.transport.send(createWireMessage(payload))).catch(onFail);
-    } catch (err) {
-      onFail(err);
-    }
-  }
-
-  private emitTerminalError(terminalId: string, err: Error): void {
-    const subs = this.terminalErrorSubs.get(terminalId);
-    if (subs) for (const cb of subs) cb(err);
-  }
-
-  private sendCorrelated<T>(
-    pendingMap: Map<string, Pending<T>>,
-    makePayload: (clientReqId: string) => WirePayload,
-  ): Promise<T> {
-    const clientReqId = nextClientReqId();
-    return new Promise<T>((resolve, reject) => {
-      pendingMap.set(clientReqId, { resolve, reject });
-      try {
-        const sent = this.transport.send(createWireMessage(makePayload(clientReqId)));
-        void Promise.resolve(sent).catch((err) => {
-          rejectFrom(pendingMap, clientReqId, toError(err));
-        });
-      } catch (err) {
-        rejectFrom(pendingMap, clientReqId, toError(err));
-      }
-    });
   }
 
   private isClosed(): boolean {
     return this.closed;
   }
-}
-
-function rejectFrom<T>(map: Map<string, Pending<T>>, id: string, err: Error): boolean {
-  const pending = map.get(id);
-  if (!pending) return false;
-  map.delete(id);
-  pending.reject(err);
-  return true;
-}
-
-function toError(err: unknown): Error {
-  return new Error(extractErrorMessage(err) ?? 'Unknown error');
 }

--- a/packages/client-core/src/client/control-channel.ts
+++ b/packages/client-core/src/client/control-channel.ts
@@ -1,0 +1,263 @@
+import type {
+  AgentHistoryId,
+  AgentHistoryListOptions,
+  AgentHistoryListResult,
+  AgentHistoryReadOptions,
+  AgentHistoryReadResult,
+  AgentInput,
+  AgentKind,
+  ContentBlock,
+  EffortLevel,
+  GitDiff,
+  GitDiffMode,
+  GitPullRequestStatus,
+  GitStatus,
+  PermissionOutcome,
+  ProvidersConfig,
+  SessionId,
+  SessionInfo,
+  SessionRecord,
+  StartOptions,
+  WirePayload,
+  WorkspaceId,
+  WorkspaceKind,
+  WorkspaceRecord,
+} from '@linkcode/schema';
+import type { Transport } from '@linkcode/transport';
+import type { PendingRegistry, PendingValueMap, RequestAck } from './pending-registry';
+import { sendCorrelated } from './pending-registry';
+
+export type HistoryListClientOptions = AgentHistoryListOptions & {
+  forceRefresh?: boolean;
+};
+
+export type HistoryReadClientOptions = AgentHistoryReadOptions & {
+  forceRefresh?: boolean;
+};
+
+/**
+ * The correlated control-plane requests: session lifecycle, history, provider config, git facts,
+ * and workspaces. Each method builds the matching `WirePayload` and hands it to the shared
+ * {@link PendingRegistry} for request/reply correlation (see {@link sendCorrelated}).
+ */
+export class ControlChannel {
+  constructor(
+    private readonly transport: Transport,
+    private readonly pending: PendingRegistry,
+  ) {}
+
+  startSession(opts: StartOptions): Promise<SessionId> {
+    return this.sendCorrelated('start', (clientReqId) => ({
+      kind: 'session.start',
+      clientReqId,
+      opts,
+    }));
+  }
+
+  listSessions(): Promise<SessionInfo[]> {
+    return this.sendCorrelated('list', (clientReqId) => ({ kind: 'session.list', clientReqId }));
+  }
+
+  /** Resume a persisted (cold) session by its Link Code id; resolves with the same id. */
+  resumeSession(sessionId: SessionId): Promise<SessionId> {
+    return this.sendCorrelated('start', (clientReqId) => ({
+      kind: 'session.resume',
+      clientReqId,
+      sessionId,
+    }));
+  }
+
+  /** Import a provider-local history session as a cold record (listed, not started). */
+  importSession(agentKind: AgentKind, historyId: AgentHistoryId): Promise<SessionRecord> {
+    return this.sendCorrelated('import', (clientReqId) => ({
+      kind: 'session.import',
+      clientReqId,
+      agentKind,
+      historyId,
+    }));
+  }
+
+  listHistory(
+    agentKind: AgentKind,
+    opts?: HistoryListClientOptions,
+  ): Promise<AgentHistoryListResult> {
+    return this.sendCorrelated('historyList', (clientReqId) => ({
+      kind: 'history.list',
+      clientReqId,
+      agentKind,
+      opts,
+    }));
+  }
+
+  readHistory(
+    agentKind: AgentKind,
+    opts: HistoryReadClientOptions,
+  ): Promise<AgentHistoryReadResult> {
+    return this.sendCorrelated('historyRead', (clientReqId) => ({
+      kind: 'history.read',
+      clientReqId,
+      agentKind,
+      opts,
+    }));
+  }
+
+  resumeHistory(
+    agentKind: AgentKind,
+    historyId: AgentHistoryId,
+    startOpts: StartOptions,
+  ): Promise<SessionId> {
+    return this.sendCorrelated('start', (clientReqId) => ({
+      kind: 'history.resume',
+      clientReqId,
+      agentKind,
+      historyId,
+      startOpts: { ...startOpts, kind: agentKind },
+    }));
+  }
+
+  /** Low-level: send any normalized input to a session. */
+  send(sessionId: SessionId, input: AgentInput): Promise<RequestAck> {
+    return this.sendCorrelated('ack', (clientReqId) => ({
+      kind: 'agent.input',
+      clientReqId,
+      sessionId,
+      input,
+    }));
+  }
+
+  /** Send a prompt as content blocks. */
+  prompt(sessionId: SessionId, content: ContentBlock[]): Promise<RequestAck> {
+    return this.send(sessionId, { type: 'prompt', content });
+  }
+
+  /** Convenience: send a plain-text prompt. */
+  promptText(sessionId: SessionId, text: string): Promise<RequestAck> {
+    return this.prompt(sessionId, [{ type: 'text', text }]);
+  }
+
+  /** Cancel the in-flight turn. */
+  cancel(sessionId: SessionId): Promise<RequestAck> {
+    return this.send(sessionId, { type: 'cancel' });
+  }
+
+  /** Switch the session mode. */
+  setMode(sessionId: SessionId, modeId: string): Promise<RequestAck> {
+    return this.send(sessionId, { type: 'set-mode', modeId });
+  }
+
+  /** Switch the session's model, going forward. Rejects if the adapter can't rebind a live session. */
+  setModel(sessionId: SessionId, model: string): Promise<RequestAck> {
+    return this.send(sessionId, { type: 'set-model', model });
+  }
+
+  /** Switch the session's reasoning-effort level, going forward. Same acceptance rule as setModel. */
+  setEffort(sessionId: SessionId, effort: EffortLevel): Promise<RequestAck> {
+    return this.send(sessionId, { type: 'set-effort', effort });
+  }
+
+  /** Answer a pending permission-request. */
+  respondPermission(
+    sessionId: SessionId,
+    requestId: string,
+    outcome: PermissionOutcome,
+  ): Promise<RequestAck> {
+    return this.send(sessionId, { type: 'permission-response', requestId, outcome });
+  }
+
+  stopSession(sessionId: SessionId): Promise<RequestAck> {
+    return this.sendCorrelated('ack', (clientReqId) => ({
+      kind: 'session.stop',
+      clientReqId,
+      sessionId,
+    }));
+  }
+
+  /** Read the daemon-owned provider config (data plane). */
+  getProviderConfig(): Promise<ProvidersConfig> {
+    return this.sendCorrelated('configGet', (clientReqId) => ({
+      kind: 'config.get',
+      clientReqId,
+    }));
+  }
+
+  /** Persist the daemon-owned provider config (data plane). */
+  setProviderConfig(providers: ProvidersConfig): Promise<RequestAck> {
+    return this.sendCorrelated('ack', (clientReqId) => ({
+      kind: 'config.set',
+      clientReqId,
+      providers,
+    }));
+  }
+
+  /** Local git facts for a directory (directory-backed: keyed by cwd, not by session). */
+  getGitStatus(cwd: string): Promise<GitStatus> {
+    return this.sendCorrelated('gitStatus', (clientReqId) => ({
+      kind: 'git.status.get',
+      clientReqId,
+      cwd,
+    }));
+  }
+
+  /** Hosting-provider PR state for a directory's current branch. */
+  getGitPullRequestStatus(cwd: string): Promise<GitPullRequestStatus> {
+    return this.sendCorrelated('gitPrStatus', (clientReqId) => ({
+      kind: 'git.pr_status.get',
+      clientReqId,
+      cwd,
+    }));
+  }
+
+  /** A unified-diff patch for a directory (directory-backed: keyed by cwd, not by session). */
+  getGitDiff(cwd: string, mode: GitDiffMode): Promise<GitDiff> {
+    return this.sendCorrelated('gitDiff', (clientReqId) => ({
+      kind: 'git.diff.get',
+      clientReqId,
+      cwd,
+      mode,
+    }));
+  }
+
+  /** Every registered workspace (directory), most recently used first. */
+  listWorkspaces(): Promise<WorkspaceRecord[]> {
+    return this.sendCorrelated('workspaceList', (clientReqId) => ({
+      kind: 'workspace.list',
+      clientReqId,
+    }));
+  }
+
+  /** Register a directory as a workspace; idempotent for an already-registered directory. */
+  registerWorkspace(cwd: string, name?: string, kind?: WorkspaceKind): Promise<WorkspaceRecord> {
+    return this.sendCorrelated('workspaceRegister', (clientReqId) => ({
+      kind: 'workspace.register',
+      clientReqId,
+      cwd,
+      name,
+      workspaceKind: kind,
+    }));
+  }
+
+  updateWorkspace(workspaceId: WorkspaceId, name: string): Promise<RequestAck> {
+    return this.sendCorrelated('ack', (clientReqId) => ({
+      kind: 'workspace.update',
+      clientReqId,
+      workspaceId,
+      name,
+    }));
+  }
+
+  /** Drop a workspace from the registry; never touches the directory on disk. */
+  archiveWorkspace(workspaceId: WorkspaceId): Promise<RequestAck> {
+    return this.sendCorrelated('ack', (clientReqId) => ({
+      kind: 'workspace.archive',
+      clientReqId,
+      workspaceId,
+    }));
+  }
+
+  private sendCorrelated<K extends keyof PendingValueMap>(
+    kind: K,
+    makePayload: (clientReqId: string) => WirePayload,
+  ): Promise<PendingValueMap[K]> {
+    return sendCorrelated(this.transport, this.pending, kind, makePayload);
+  }
+}

--- a/packages/client-core/src/client/event-buffer.ts
+++ b/packages/client-core/src/client/event-buffer.ts
@@ -1,0 +1,98 @@
+import type { AgentEvent, SessionId } from '@linkcode/schema';
+import type { Unsubscribe } from '@linkcode/transport';
+
+/**
+ * An event paired with its connection-scoped receive sequence number: the Nth `agent.event` this
+ * client received for its session (1-based, monotone for the lifetime of the connection). A
+ * transcript snapshot taken when the counter read N supersedes exactly the events with seq ≤ N.
+ */
+export interface SequencedAgentEvent {
+  event: AgentEvent;
+  seq: number;
+}
+
+type EventCb = (event: AgentEvent, seq: number) => void;
+
+const EMPTY_EVENTS: readonly SequencedAgentEvent[] = [];
+
+/**
+ * Per-session buffer of received `agent.event`s, their receive sequence numbers, and the
+ * subscribers replaying/watching them. Backs both the push-model `subscribe` callback and the
+ * `useSyncExternalStore`-shaped `snapshot`/`eventSeq` pair.
+ */
+export class EventBuffer {
+  private readonly subscribers = new Map<SessionId, Set<EventCb>>();
+  /** Per-session event buffer so a re-subscribe (switching the active session back) can replay the timeline. */
+  private readonly events = new Map<SessionId, SequencedAgentEvent[]>();
+  /** Cached immutable copies of {@link events}, invalidated per event — `snapshot`'s source. */
+  private readonly snapshots = new Map<SessionId, readonly SequencedAgentEvent[]>();
+  /** Per-session receive counters. Deliberately NOT cleared with the buffer on `clearSession`: a
+   * stop→resume in the same connection must keep seq monotone, or a seed's `uptoSeq` sampled
+   * before the stop would swallow the resumed session's fresh events. */
+  private readonly seqs = new Map<SessionId, number>();
+
+  /** Record an incoming event, assigning it the session's next receive sequence number. */
+  ingest(sessionId: SessionId, event: AgentEvent): SequencedAgentEvent {
+    const seq = (this.seqs.get(sessionId) ?? 0) + 1;
+    this.seqs.set(sessionId, seq);
+    const sequenced: SequencedAgentEvent = { event, seq };
+    const buf = this.events.get(sessionId);
+    if (buf) buf.push(sequenced);
+    else this.events.set(sessionId, [sequenced]);
+    this.snapshots.delete(sessionId);
+    const subs = this.subscribers.get(sessionId);
+    if (subs) for (const cb of subs) cb(sequenced.event, sequenced.seq);
+    return sequenced;
+  }
+
+  subscribe(sessionId: SessionId, cb: EventCb): Unsubscribe {
+    let set = this.subscribers.get(sessionId);
+    if (!set) {
+      set = new Set();
+      this.subscribers.set(sessionId, set);
+    }
+    set.add(cb);
+    // Replay any buffered events (with their original sequence numbers) so a late subscriber sees
+    // the full timeline, not a blank pane.
+    const buf = this.events.get(sessionId);
+    if (buf) for (const { event, seq } of buf) cb(event, seq);
+    return () => set.delete(cb);
+  }
+
+  /**
+   * The receive counter for a session: how many `agent.event`s this client has seen for it on this
+   * connection. Sampled right after a transcript read resolves, it becomes that snapshot's
+   * `uptoSeq` — the ordered cut "everything at or before this is already in the snapshot".
+   */
+  eventSeq(sessionId: SessionId): number {
+    return this.seqs.get(sessionId) ?? 0;
+  }
+
+  /**
+   * Immutable snapshot of a session's buffered events, cached until the next event arrives.
+   * Stable identity between changes makes it a valid `useSyncExternalStore` getSnapshot source.
+   */
+  snapshot(sessionId: SessionId): readonly SequencedAgentEvent[] {
+    const cached = this.snapshots.get(sessionId);
+    if (cached) return cached;
+    const buf = this.events.get(sessionId);
+    if (!buf || buf.length === 0) return EMPTY_EVENTS;
+    const snapshot: readonly SequencedAgentEvent[] = [...buf];
+    this.snapshots.set(sessionId, snapshot);
+    return snapshot;
+  }
+
+  /** Drop a stopped session's subscribers and buffer, keeping its receive counter (see {@link seqs}). */
+  clearSession(sessionId: SessionId): void {
+    this.subscribers.delete(sessionId);
+    this.events.delete(sessionId);
+    this.snapshots.delete(sessionId);
+  }
+
+  clearAll(): void {
+    this.subscribers.clear();
+    this.events.clear();
+    this.snapshots.clear();
+    this.seqs.clear();
+  }
+}

--- a/packages/client-core/src/client/pending-registry.ts
+++ b/packages/client-core/src/client/pending-registry.ts
@@ -1,0 +1,149 @@
+import type {
+  AgentHistoryListResult,
+  AgentHistoryReadResult,
+  GitDiff,
+  GitPullRequestStatus,
+  GitStatus,
+  ProvidersConfig,
+  SessionId,
+  SessionInfo,
+  SessionRecord,
+  WirePayload,
+  WorkspaceRecord,
+} from '@linkcode/schema';
+import type { Transport } from '@linkcode/transport';
+import { createWireMessage } from '@linkcode/transport';
+import { extractErrorMessage } from 'foxts/extract-error-message';
+
+interface Pending<T> {
+  resolve(value: T): void;
+  reject(err: Error): void;
+}
+
+export interface RequestAck {
+  ok: true;
+}
+
+/**
+ * The value each correlated request kind resolves with. One entry per distinct control request the
+ * client can have in flight, keyed by a short tag rather than the wire message kind (several kinds,
+ * e.g. `session.start`/`session.resume`/`history.resume`, share the same reply and the same tag).
+ */
+export interface PendingValueMap {
+  start: SessionId;
+  list: SessionInfo[];
+  import: SessionRecord;
+  historyList: AgentHistoryListResult;
+  historyRead: AgentHistoryReadResult;
+  configGet: ProvidersConfig;
+  gitStatus: GitStatus;
+  gitPrStatus: GitPullRequestStatus;
+  gitDiff: GitDiff;
+  workspaceList: WorkspaceRecord[];
+  workspaceRegister: WorkspaceRecord;
+  ack: RequestAck;
+  terminalOpen: string;
+}
+
+type PendingMaps = { [K in keyof PendingValueMap]: Map<string, Pending<PendingValueMap[K]>> };
+
+let __reqSeq = 0;
+export function nextClientReqId(): string {
+  __reqSeq += 1;
+  return `creq-${Date.now().toString(36)}-${__reqSeq.toString(36)}`;
+}
+
+/**
+ * One map per correlated request kind (see {@link PendingValueMap}), so each kind keeps its own
+ * strong result type while `register`/`resolve`/`reject`/`failAll` are implemented once instead of
+ * once per kind. Replaces the client's former 13 parallel `pendingXxx` maps.
+ */
+export class PendingRegistry {
+  private readonly maps: PendingMaps = {
+    start: new Map(),
+    list: new Map(),
+    import: new Map(),
+    historyList: new Map(),
+    historyRead: new Map(),
+    configGet: new Map(),
+    gitStatus: new Map(),
+    gitPrStatus: new Map(),
+    gitDiff: new Map(),
+    workspaceList: new Map(),
+    workspaceRegister: new Map(),
+    ack: new Map(),
+    terminalOpen: new Map(),
+  };
+
+  /** Register a new in-flight request and return the promise its eventual `resolve`/`reject` settles. */
+  register<K extends keyof PendingValueMap>(kind: K, id: string): Promise<PendingValueMap[K]> {
+    return new Promise((resolve, reject) => {
+      this.maps[kind].set(id, { resolve, reject });
+    });
+  }
+
+  resolve<K extends keyof PendingValueMap>(kind: K, id: string, value: PendingValueMap[K]): void {
+    const pending = this.maps[kind].get(id);
+    if (!pending) return;
+    this.maps[kind].delete(id);
+    pending.resolve(value);
+  }
+
+  /** Reject a specific kind's pending request (the request's kind is known statically at the call site). */
+  rejectFrom<K extends keyof PendingValueMap>(kind: K, id: string, err: Error): void {
+    const map = this.maps[kind];
+    const pending = map.get(id);
+    if (!pending) return;
+    map.delete(id);
+    pending.reject(err);
+  }
+
+  /** Reject a pending request by id alone — a `request.failed` reply doesn't carry which kind it was. */
+  reject(id: string, err: Error): boolean {
+    for (const map of Object.values(this.maps)) {
+      const pending = map.get(id);
+      if (pending) {
+        map.delete(id);
+        pending.reject(err);
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /** Reject every in-flight request across every kind, so awaiters get an error instead of hanging forever. */
+  failAll(err: Error): void {
+    for (const map of Object.values(this.maps)) {
+      for (const pending of map.values()) pending.reject(err);
+      map.clear();
+    }
+  }
+}
+
+function toError(err: unknown): Error {
+  return new Error(extractErrorMessage(err) ?? 'Unknown error');
+}
+
+/**
+ * Send a request correlated by a fresh `clientReqId`, registering it with `pending` before the send
+ * so a reply that races the send (same tick, e.g. a local transport) can never resolve before the
+ * awaiter exists. A send failure (sync throw or rejected promise) rejects the same pending entry.
+ */
+export function sendCorrelated<K extends keyof PendingValueMap>(
+  transport: Transport,
+  pending: PendingRegistry,
+  kind: K,
+  makePayload: (clientReqId: string) => WirePayload,
+): Promise<PendingValueMap[K]> {
+  const clientReqId = nextClientReqId();
+  const promise = pending.register(kind, clientReqId);
+  try {
+    const sent = transport.send(createWireMessage(makePayload(clientReqId)));
+    void Promise.resolve(sent).catch((err) => {
+      pending.rejectFrom(kind, clientReqId, toError(err));
+    });
+  } catch (err) {
+    pending.rejectFrom(kind, clientReqId, toError(err));
+  }
+  return promise;
+}

--- a/packages/client-core/src/client/terminal-channel.ts
+++ b/packages/client-core/src/client/terminal-channel.ts
@@ -1,0 +1,201 @@
+import type { SessionId, WirePayload } from '@linkcode/schema';
+import type { Transport, Unsubscribe } from '@linkcode/transport';
+import { createWireMessage } from '@linkcode/transport';
+import { extractErrorMessage } from 'foxts/extract-error-message';
+import type { PendingRegistry } from './pending-registry';
+import { sendCorrelated } from './pending-registry';
+
+type TerminalOutputCb = (data: string) => void;
+type TerminalExitCb = (exitCode: number | null) => void;
+type TerminalErrorCb = (err: Error) => void;
+type SnapshotCb = () => void;
+
+/** Cap on per-terminal output buffered before the first subscriber, so an unread PTY can't grow unbounded. */
+const TERMINAL_PREBUFFER_CAP = 128 * 1024;
+
+/**
+ * Cap on retained accumulated output, in characters (see {@link TerminalChannel.outputSnapshot}).
+ * This backs a read-only display buffer, so unbounded agent output would otherwise grow memory and
+ * per-chunk re-render cost without limit.
+ */
+const TERMINAL_OUTPUT_CAP = 200000;
+
+/**
+ * Trim buffered terminal output to a cap on a line boundary. Slicing raw would leave the buffer
+ * starting mid-ANSI-escape (the head byte gone, the tail rendered as literal garbage); dropping the
+ * partial leading line keeps the replay parseable.
+ */
+function capOutput(text: string, cap: number): string {
+  if (text.length <= cap) return text;
+  const sliced = text.slice(-cap);
+  const nl = sliced.indexOf('\n');
+  return nl === -1 ? sliced : sliced.slice(nl + 1);
+}
+
+function toError(err: unknown): Error {
+  return new Error(extractErrorMessage(err) ?? 'Unknown error');
+}
+
+/**
+ * Terminal open/input/resize/close plus the output/exit/error subscriptions and the accumulated
+ * output snapshot `useTerminalOutput` reads via `useSyncExternalStore`.
+ */
+export class TerminalChannel {
+  private readonly outputSubs = new Map<string, Set<TerminalOutputCb>>();
+  private readonly exitSubs = new Map<string, Set<TerminalExitCb>>();
+  /** Notified when a fire-and-forget terminal frame (input/resize/close) fails to send. */
+  private readonly errorSubs = new Map<string, Set<TerminalErrorCb>>();
+  /** Output seen before anyone subscribed (covers the open→subscribe gap and late mounts); capped. */
+  private readonly prebuffer = new Map<string, string>();
+  /** Accumulated output per terminal, capped — the `outputSnapshot` source. Kept after `terminal.exit`
+   * so a still-mounted viewer keeps the final output instead of going blank. */
+  private readonly output = new Map<string, string>();
+  private readonly snapshotSubs = new Map<string, Set<SnapshotCb>>();
+
+  constructor(
+    private readonly transport: Transport,
+    private readonly pending: PendingRegistry,
+  ) {}
+
+  /** Route a `terminal.*` reply/event. Returns false if `payload` wasn't a terminal message. */
+  handleMessage(p: WirePayload): boolean {
+    switch (p.kind) {
+      case 'terminal.opened': {
+        this.pending.resolve('terminalOpen', p.replyTo, p.terminalId);
+        return true;
+      }
+      case 'terminal.output': {
+        const subs = this.outputSubs.get(p.terminalId);
+        if (subs && subs.size > 0) {
+          for (const cb of subs) cb(p.data);
+        } else {
+          const prev = this.prebuffer.get(p.terminalId) ?? '';
+          this.prebuffer.set(p.terminalId, capOutput(prev + p.data, TERMINAL_PREBUFFER_CAP));
+        }
+        const prevOutput = this.output.get(p.terminalId) ?? '';
+        this.output.set(p.terminalId, capOutput(prevOutput + p.data, TERMINAL_OUTPUT_CAP));
+        this.notifySnapshotChange(p.terminalId);
+        return true;
+      }
+      case 'terminal.exit': {
+        const subs = this.exitSubs.get(p.terminalId);
+        if (subs) for (const cb of subs) cb(p.exitCode);
+        this.outputSubs.delete(p.terminalId);
+        this.exitSubs.delete(p.terminalId);
+        this.errorSubs.delete(p.terminalId);
+        this.prebuffer.delete(p.terminalId);
+        return true;
+      }
+      default:
+        return false;
+    }
+  }
+
+  open(opts: {
+    cols: number;
+    rows: number;
+    cwd?: string;
+    shell?: string;
+    sessionId?: SessionId;
+  }): Promise<string> {
+    return sendCorrelated(this.transport, this.pending, 'terminalOpen', (clientReqId) => ({
+      kind: 'terminal.open',
+      clientReqId,
+      opts,
+    }));
+  }
+
+  input(terminalId: string, data: string): void {
+    this.sendFrame(terminalId, { kind: 'terminal.input', terminalId, data });
+  }
+
+  resize(terminalId: string, cols: number, rows: number): void {
+    this.sendFrame(terminalId, { kind: 'terminal.resize', terminalId, cols, rows });
+  }
+
+  close(terminalId: string): void {
+    this.sendFrame(terminalId, { kind: 'terminal.close', terminalId });
+  }
+
+  subscribeOutput(terminalId: string, cb: TerminalOutputCb): Unsubscribe {
+    let set = this.outputSubs.get(terminalId);
+    if (!set) {
+      set = new Set();
+      this.outputSubs.set(terminalId, set);
+    }
+    set.add(cb);
+    // Replay output buffered before a subscriber attached. Kept (not deleted) until `terminal.exit`
+    // so a remount/second subscriber still gets the initial prompt instead of a blank pane.
+    const buffered = this.prebuffer.get(terminalId);
+    if (buffered !== undefined) cb(buffered);
+    return () => set.delete(cb);
+  }
+
+  subscribeExit(terminalId: string, cb: TerminalExitCb): Unsubscribe {
+    let set = this.exitSubs.get(terminalId);
+    if (!set) {
+      set = new Set();
+      this.exitSubs.set(terminalId, set);
+    }
+    set.add(cb);
+    return () => set.delete(cb);
+  }
+
+  subscribeError(terminalId: string, cb: TerminalErrorCb): Unsubscribe {
+    let set = this.errorSubs.get(terminalId);
+    if (!set) {
+      set = new Set();
+      this.errorSubs.set(terminalId, set);
+    }
+    set.add(cb);
+    return () => set.delete(cb);
+  }
+
+  /**
+   * Accumulated output for a terminal, capped at {@link TERMINAL_OUTPUT_CAP}. A plain string is
+   * always a stable `useSyncExternalStore` snapshot — two calls with no new output return equal
+   * (by value) primitives — without needing a cached array-like wrapper.
+   */
+  outputSnapshot(terminalId: string): string {
+    return this.output.get(terminalId) ?? '';
+  }
+
+  subscribeOutputSnapshot(terminalId: string, cb: SnapshotCb): Unsubscribe {
+    let set = this.snapshotSubs.get(terminalId);
+    if (!set) {
+      set = new Set();
+      this.snapshotSubs.set(terminalId, set);
+    }
+    set.add(cb);
+    return () => set.delete(cb);
+  }
+
+  disposeAll(): void {
+    this.outputSubs.clear();
+    this.exitSubs.clear();
+    this.errorSubs.clear();
+    this.prebuffer.clear();
+    this.output.clear();
+    this.snapshotSubs.clear();
+  }
+
+  /** Send a fire-and-forget terminal frame, routing any send failure to the terminal's error subs. */
+  private sendFrame(terminalId: string, payload: WirePayload): void {
+    const onFail = (err: unknown) => this.emitError(terminalId, toError(err));
+    try {
+      void Promise.resolve(this.transport.send(createWireMessage(payload))).catch(onFail);
+    } catch (err) {
+      onFail(err);
+    }
+  }
+
+  private emitError(terminalId: string, err: Error): void {
+    const subs = this.errorSubs.get(terminalId);
+    if (subs) for (const cb of subs) cb(err);
+  }
+
+  private notifySnapshotChange(terminalId: string): void {
+    const subs = this.snapshotSubs.get(terminalId);
+    if (subs) for (const cb of subs) cb();
+  }
+}

--- a/packages/client-core/src/react.tsx
+++ b/packages/client-core/src/react.tsx
@@ -13,7 +13,6 @@ import {
   createContext,
   useCallback,
   useContext,
-  useEffect,
   useMemo,
   useState,
   useSyncExternalStore,
@@ -46,12 +45,7 @@ export function useLinkCodeClient(): LinkCodeClient {
 
 const NO_SEQUENCED_EVENTS: readonly SequencedAgentEvent[] = [];
 const NO_EVENTS: AgentEvent[] = [];
-
-/**
- * Cap on retained terminal output, in characters. This is a read-only display buffer, so
- * unbounded agent output would otherwise grow memory and per-chunk re-render cost without limit.
- */
-const TERMINAL_OUTPUT_CAP = 200000;
+const NO_TERMINAL_OUTPUT = '';
 
 /**
  * Subscribe to a session's normalized event stream (push model). The client's per-session buffer
@@ -76,28 +70,23 @@ export function useAgentEvents(sessionId: SessionId | null): AgentEvent[] {
   );
 }
 
-/** Subscribe to a terminal's output, accumulating it into a string for read-only display. */
+/**
+ * Subscribe to a terminal's accumulated output (read-only display). The client's per-terminal
+ * buffer is the store: `useSyncExternalStore` reads its capped string snapshot, mirroring
+ * `useAgentEvents`'s use of the client's per-session event buffer.
+ */
 export function useTerminalOutput(terminalId: string | null): string {
   const client = useLinkCodeClient();
-  const [state, setState] = useState<{ id: string | null; output: string }>({
-    id: null,
-    output: '',
-  });
-
-  useEffect(() => {
-    if (!terminalId) return;
-    return client.subscribeTerminalOutput(terminalId, (data) => {
-      setState((prev) => {
-        const output = prev.id === terminalId ? prev.output + data : data;
-        return {
-          id: terminalId,
-          output: output.length > TERMINAL_OUTPUT_CAP ? output.slice(-TERMINAL_OUTPUT_CAP) : output,
-        };
-      });
-    });
-  }, [client, terminalId]);
-
-  return state.id === terminalId ? state.output : '';
+  const subscribe = useCallback(
+    (onStoreChange: () => void) => {
+      if (!terminalId) return noop;
+      return client.subscribeTerminalOutputSnapshot(terminalId, onStoreChange);
+    },
+    [client, terminalId],
+  );
+  return useSyncExternalStore(subscribe, () =>
+    terminalId ? client.terminalOutputSnapshot(terminalId) : NO_TERMINAL_OUTPUT,
+  );
 }
 
 /** Return a function that sends input to the current session. */

--- a/packages/engine/src/__tests__/engine-sessions.test.ts
+++ b/packages/engine/src/__tests__/engine-sessions.test.ts
@@ -109,7 +109,7 @@ function harness(store = new InMemorySessionStore()) {
     adapters.push(adapter);
     return adapter;
   };
-  const engine = new Engine(transport, factory, undefined, undefined, store);
+  const engine = new Engine(transport, { factory, sessionStore: store });
 
   async function inject(payload: WirePayload): Promise<void> {
     nullthrow(handler, 'engine not started')(createWireMessage(payload));

--- a/packages/engine/src/__tests__/history-service.test.ts
+++ b/packages/engine/src/__tests__/history-service.test.ts
@@ -150,7 +150,7 @@ describe('Engine history wire API', () => {
   it('lists, reads, and resumes history over transport', async () => {
     const state = { listCalls: 0, readCalls: 0, resumeCalls: 0 };
     const [clientTransport, engineTransport] = createLocalTransportPair();
-    const engine = new Engine(engineTransport, fakeFactory(state));
+    const engine = new Engine(engineTransport, { factory: fakeFactory(state) });
     const received: WireMessage[] = [];
 
     clientTransport.onMessage((msg) => received.push(msg));

--- a/packages/engine/src/engine.ts
+++ b/packages/engine/src/engine.ts
@@ -32,6 +32,16 @@ interface Session {
   status: SessionInfo['status'];
 }
 
+/** Optional collaborators the daemon injects; each defaults to an in-memory/no-op implementation. */
+export interface EngineDeps {
+  factory?: AdapterFactory;
+  sessionStore?: SessionStore;
+  ptyBackend?: PtyBackend;
+  providerStore?: ProviderConfigStore;
+  git?: GitService;
+  workspaceStore?: WorkspaceStore;
+}
+
 /**
  * Engine: the local core engine — the "host" that runs the agents
  * (docs/ARCHITECTURE.md#the-host-engine-adapters-abstraction).
@@ -50,22 +60,25 @@ export class Engine {
   private readonly history: HistoryService;
   private readonly terminals?: TerminalService;
   private readonly workspaces: WorkspaceRegistry;
+  private readonly factory: AdapterFactory;
+  private readonly providerStore: ProviderConfigStore;
+  private readonly sessionStore: SessionStore;
+  private readonly git: GitService;
   private seq = 0;
 
   constructor(
     private readonly transport: Transport,
-    private readonly factory: AdapterFactory = createAdapter,
-    private readonly providerStore: ProviderConfigStore = new InMemoryProviderConfigStore(),
-    ptyBackend?: PtyBackend,
-    private readonly sessionStore: SessionStore = new InMemorySessionStore(),
-    private readonly git: GitService = new GitService(),
-    workspaceStore: WorkspaceStore = new InMemoryWorkspaceStore(),
+    deps: EngineDeps = {},
   ) {
-    this.history = new HistoryService(factory);
-    this.terminals = ptyBackend
-      ? new TerminalService(ptyBackend, transport, (id) => this.sessions.has(id))
+    this.factory = deps.factory ?? createAdapter;
+    this.providerStore = deps.providerStore ?? new InMemoryProviderConfigStore();
+    this.sessionStore = deps.sessionStore ?? new InMemorySessionStore();
+    this.git = deps.git ?? new GitService();
+    this.history = new HistoryService(this.factory);
+    this.terminals = deps.ptyBackend
+      ? new TerminalService(deps.ptyBackend, transport, (id) => this.sessions.has(id))
       : undefined;
-    this.workspaces = new WorkspaceRegistry(workspaceStore);
+    this.workspaces = new WorkspaceRegistry(deps.workspaceStore ?? new InMemoryWorkspaceStore());
   }
 
   async start(): Promise<void> {

--- a/packages/ui/src/__tests__/stack-trace-parser.test.ts
+++ b/packages/ui/src/__tests__/stack-trace-parser.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest';
+import { formatStackLocationPart, parseStackTrace } from '../chat/stack-trace-parser';
+
+describe('parseStackTrace error line', () => {
+  it('recognizes a leading `SomethingError:` prefix as the error type', () => {
+    const parsed = parseStackTrace('TypeError: value is not a function');
+    expect(parsed.errorType).toBe('TypeError');
+    expect(parsed.errorMessage).toBe('value is not a function');
+  });
+
+  it('recognizes the bare `Error:` prefix as the error type', () => {
+    const parsed = parseStackTrace('Error: boom');
+    expect(parsed.errorType).toBe('Error');
+    expect(parsed.errorMessage).toBe('boom');
+  });
+
+  it('treats a colon-bearing line with a non-Error prefix as plain message text', () => {
+    const parsed = parseStackTrace('unexpected: yes');
+    expect(parsed.errorType).toBeUndefined();
+    expect(parsed.errorMessage).toBe('unexpected: yes');
+  });
+
+  it('treats a line with no colon as plain message text', () => {
+    const parsed = parseStackTrace('something failed');
+    expect(parsed.errorType).toBeUndefined();
+    expect(parsed.errorMessage).toBe('something failed');
+  });
+
+  it('drops blank lines before finding the error line', () => {
+    const parsed = parseStackTrace('\n\n  RangeError: out of bounds\n');
+    expect(parsed.errorType).toBe('RangeError');
+    expect(parsed.errorMessage).toBe('out of bounds');
+  });
+});
+
+describe('parseStackTrace frames', () => {
+  it('splits a parenthesized frame into function name, file path, line, and column', () => {
+    const parsed = parseStackTrace(
+      ['Error: boom', 'at Object.doThing (/app/src/index.js:10:5)'].join('\n'),
+    );
+    expect(parsed.frames).toEqual([
+      {
+        raw: 'at Object.doThing (/app/src/index.js:10:5)',
+        functionName: 'Object.doThing',
+        filePath: '/app/src/index.js',
+        lineNumber: 10,
+        columnNumber: 5,
+        isInternal: false,
+      },
+    ]);
+  });
+
+  it('parses a bare `at file:line:column` frame with no function name', () => {
+    const parsed = parseStackTrace(['Error: boom', 'at /app/src/index.js:12:34'].join('\n'));
+    expect(parsed.frames).toEqual([
+      {
+        raw: 'at /app/src/index.js:12:34',
+        functionName: undefined,
+        filePath: '/app/src/index.js',
+        lineNumber: 12,
+        columnNumber: 34,
+        isInternal: false,
+      },
+    ]);
+  });
+
+  it('ignores non-frame lines interleaved with `at` frames', () => {
+    const parsed = parseStackTrace(
+      ['Error: boom', 'caused by:', 'at /app/src/index.js:1:1'].join('\n'),
+    );
+    expect(parsed.frames).toHaveLength(1);
+    expect(parsed.frames[0]?.filePath).toBe('/app/src/index.js');
+  });
+
+  it('falls back to the raw line when the location has no line:column suffix', () => {
+    const parsed = parseStackTrace(['Error: boom', 'at eval'].join('\n'));
+    expect(parsed.frames).toEqual([
+      {
+        raw: 'at eval',
+        functionName: undefined,
+        isInternal: false,
+      },
+    ]);
+  });
+
+  it('falls back to the raw line when the location is missing a column', () => {
+    const parsed = parseStackTrace(['Error: boom', 'at foo (/app/src/index.js:10)'].join('\n'));
+    const [frame] = parsed.frames;
+    expect(frame?.filePath).toBeUndefined();
+    expect(frame?.lineNumber).toBeUndefined();
+  });
+
+  it('flags frames under node_modules, node: built-ins, and internal/ as internal', () => {
+    const parsed = parseStackTrace(
+      [
+        'Error: boom',
+        'at dep (/app/node_modules/pkg/index.js:1:1)',
+        'at internalFn (node:internal/process:5:5)',
+        'at other (/app/internal/util.js:2:2)',
+      ].join('\n'),
+    );
+    expect(parsed.frames.map((f) => f.isInternal)).toEqual([true, true, true]);
+  });
+});
+
+describe('formatStackLocationPart', () => {
+  it('prefixes a defined number with a colon', () => {
+    expect(formatStackLocationPart(5)).toBe(':5');
+    expect(formatStackLocationPart(0)).toBe(':0');
+  });
+
+  it('returns an empty string for undefined', () => {
+    expect(formatStackLocationPart(undefined)).toBe('');
+  });
+});

--- a/packages/ui/src/chat/stack-trace-parser.ts
+++ b/packages/ui/src/chat/stack-trace-parser.ts
@@ -1,0 +1,108 @@
+export interface ParsedStackFrame {
+  raw: string;
+  functionName?: string;
+  filePath?: string;
+  lineNumber?: number;
+  columnNumber?: number;
+  isInternal: boolean;
+}
+
+export interface ParsedStackTrace {
+  errorType?: string;
+  errorMessage: string;
+  frames: ParsedStackFrame[];
+}
+
+interface ParsedStackLocation {
+  filePath: string;
+  lineNumber: number;
+  columnNumber: number;
+}
+
+export function parseStackTrace(trace: string): ParsedStackTrace {
+  const lines: string[] = [];
+  for (const line of trace.split('\n')) {
+    const trimmed = line.trim();
+    if (trimmed.length > 0) lines.push(trimmed);
+  }
+
+  const firstLine = lines[0]?.trim() ?? '';
+  const error = parseErrorLine(firstLine);
+  const frames: ParsedStackFrame[] = [];
+  for (const line of lines.slice(1)) {
+    if (line.startsWith('at ')) frames.push(parseStackFrame(line));
+  }
+
+  return {
+    errorType: error.errorType,
+    errorMessage: error.errorMessage,
+    frames,
+  };
+}
+
+function parseErrorLine(line: string): Pick<ParsedStackTrace, 'errorMessage' | 'errorType'> {
+  const separator = line.indexOf(':');
+  if (separator <= 0) return { errorMessage: line };
+
+  const possibleType = line.slice(0, separator);
+  if (possibleType === 'Error' || possibleType.endsWith('Error')) {
+    return {
+      errorType: possibleType,
+      errorMessage: line.slice(separator + 1).trimStart(),
+    };
+  }
+
+  return { errorMessage: line };
+}
+
+function parseStackFrame(line: string): ParsedStackFrame {
+  const trimmed = line.trim();
+  const body = trimmed.startsWith('at ') ? trimmed.slice(3) : trimmed;
+  let functionName: string | undefined;
+  let frameLocation = body;
+
+  const locationStart = body.lastIndexOf(' (');
+  if (locationStart >= 0 && body.endsWith(')')) {
+    functionName = body.slice(0, locationStart);
+    frameLocation = body.slice(locationStart + 2, -1);
+  }
+
+  const parsedLocation = parseStackLocation(frameLocation);
+  if (parsedLocation) {
+    return {
+      raw: trimmed,
+      functionName,
+      ...parsedLocation,
+      isInternal: isInternalPath(parsedLocation.filePath),
+    };
+  }
+
+  return {
+    raw: trimmed,
+    functionName,
+    isInternal: isInternalPath(trimmed),
+  };
+}
+
+function parseStackLocation(location: string): ParsedStackLocation | null {
+  const columnSeparator = location.lastIndexOf(':');
+  if (columnSeparator < 0) return null;
+
+  const lineSeparator = location.lastIndexOf(':', columnSeparator - 1);
+  if (lineSeparator < 0) return null;
+
+  const filePath = location.slice(0, lineSeparator);
+  const lineNumber = Number.parseInt(location.slice(lineSeparator + 1, columnSeparator), 10);
+  const columnNumber = Number.parseInt(location.slice(columnSeparator + 1), 10);
+  if (!Number.isFinite(lineNumber) || !Number.isFinite(columnNumber)) return null;
+
+  return { columnNumber, filePath, lineNumber };
+}
+
+function isInternalPath(path: string): boolean {
+  return path.includes('node_modules') || path.startsWith('node:') || path.includes('internal/');
+}
+
+export function formatStackLocationPart(value: number | undefined): string {
+  return typeof value === 'number' ? `:${value}` : '';
+}

--- a/packages/ui/src/chat/stack-trace.tsx
+++ b/packages/ui/src/chat/stack-trace.tsx
@@ -8,6 +8,8 @@ import { useMemo, useState } from 'react';
 import { cn } from '../lib/cn';
 import type { CopyIconButtonProps } from './copy-icon-button';
 import { CopyIconButton } from './copy-icon-button';
+import type { ParsedStackFrame, ParsedStackTrace } from './stack-trace-parser';
+import { formatStackLocationPart, parseStackTrace } from './stack-trace-parser';
 
 // TODO(linkcode-schema): Provisional UI-only stack trace model, not yet wired to daemon/client schema.
 // Move or replace with @linkcode/schema types when test/tool outputs expose structured stack traces.
@@ -16,27 +18,6 @@ export interface ChatStackTrace {
   trace: string;
   title?: string;
   language?: string;
-}
-
-interface ParsedStackFrame {
-  raw: string;
-  functionName?: string;
-  filePath?: string;
-  lineNumber?: number;
-  columnNumber?: number;
-  isInternal: boolean;
-}
-
-interface ParsedStackTrace {
-  errorType?: string;
-  errorMessage: string;
-  frames: ParsedStackFrame[];
-}
-
-interface ParsedStackLocation {
-  filePath: string;
-  lineNumber: number;
-  columnNumber: number;
 }
 
 export type StackTraceProps = React.ComponentProps<typeof Collapsible> & {
@@ -230,92 +211,4 @@ export function StackTraceCopyButton({
       {...props}
     />
   );
-}
-
-function parseStackTrace(trace: string): ParsedStackTrace {
-  const lines: string[] = [];
-  for (const line of trace.split('\n')) {
-    const trimmed = line.trim();
-    if (trimmed.length > 0) lines.push(trimmed);
-  }
-
-  const firstLine = lines[0]?.trim() ?? '';
-  const error = parseErrorLine(firstLine);
-  const frames: ParsedStackFrame[] = [];
-  for (const line of lines.slice(1)) {
-    if (line.startsWith('at ')) frames.push(parseStackFrame(line));
-  }
-
-  return {
-    errorType: error.errorType,
-    errorMessage: error.errorMessage,
-    frames,
-  };
-}
-
-function parseErrorLine(line: string): Pick<ParsedStackTrace, 'errorMessage' | 'errorType'> {
-  const separator = line.indexOf(':');
-  if (separator <= 0) return { errorMessage: line };
-
-  const possibleType = line.slice(0, separator);
-  if (possibleType === 'Error' || possibleType.endsWith('Error')) {
-    return {
-      errorType: possibleType,
-      errorMessage: line.slice(separator + 1).trimStart(),
-    };
-  }
-
-  return { errorMessage: line };
-}
-
-function parseStackFrame(line: string): ParsedStackFrame {
-  const trimmed = line.trim();
-  const body = trimmed.startsWith('at ') ? trimmed.slice(3) : trimmed;
-  let functionName: string | undefined;
-  let frameLocation = body;
-
-  const locationStart = body.lastIndexOf(' (');
-  if (locationStart >= 0 && body.endsWith(')')) {
-    functionName = body.slice(0, locationStart);
-    frameLocation = body.slice(locationStart + 2, -1);
-  }
-
-  const parsedLocation = parseStackLocation(frameLocation);
-  if (parsedLocation) {
-    return {
-      raw: trimmed,
-      functionName,
-      ...parsedLocation,
-      isInternal: isInternalPath(parsedLocation.filePath),
-    };
-  }
-
-  return {
-    raw: trimmed,
-    functionName,
-    isInternal: isInternalPath(trimmed),
-  };
-}
-
-function parseStackLocation(location: string): ParsedStackLocation | null {
-  const columnSeparator = location.lastIndexOf(':');
-  if (columnSeparator < 0) return null;
-
-  const lineSeparator = location.lastIndexOf(':', columnSeparator - 1);
-  if (lineSeparator < 0) return null;
-
-  const filePath = location.slice(0, lineSeparator);
-  const lineNumber = Number.parseInt(location.slice(lineSeparator + 1, columnSeparator), 10);
-  const columnNumber = Number.parseInt(location.slice(columnSeparator + 1), 10);
-  if (!Number.isFinite(lineNumber) || !Number.isFinite(columnNumber)) return null;
-
-  return { columnNumber, filePath, lineNumber };
-}
-
-function isInternalPath(path: string): boolean {
-  return path.includes('node_modules') || path.startsWith('node:') || path.includes('internal/');
-}
-
-function formatStackLocationPart(value: number | undefined): string {
-  return typeof value === 'number' ? `:${value}` : '';
 }


### PR DESCRIPTION
Closes CODE-51; also lands F09 of CODE-47 and F37 of CODE-52. 6 commits.

⚠️ **Stacked PR, base = code-45 (#23)**; GitHub retargets it to master once the parent merges.

- **F12** `new Engine(transport, deps?: EngineDeps)`, clearing the bare `undefined` placeholders.
- **F08+F09** client.ts split into client/{pending-registry,event-buffer,terminal-channel,control-channel}.ts; `PendingRegistry` (a mapped type) collapses the four parallel-maintained sites of the 13 maps.
- **F37** useTerminalOutput → useSyncExternalStore (TerminalChannel keeps a 200k accumulated snapshot; a string compares by value, so identity is naturally stable).
- **F34** stack-trace-parser.ts + 13 unit tests. **F35** two desktop hooks extracted. **F36** the dead `getActiveExpandedPanel` check deleted.

Verification: repo-wide typecheck 17/17 + lint 0 errors; tests 220 → 233 green with no weakened assertions. Trade-off: client.ts is 329 lines (> the 250 target) — line count sacrificed to keep the discriminated-union boundaries (Biome requires ≥3 lines per function). Post-merge follow-up: terminal-channel opts switch to code-47's `TerminalOpenOptionsSchema`-derived type.

See Linear CODE-51.
