### PR TITLE
fix(workbench,ui): sidebar loading skeleton + composer caret layout effect

### DIFF
--- a/apps/desktop/src/renderer/src/shell/desktop-shell.tsx
+++ b/apps/desktop/src/renderer/src/shell/desktop-shell.tsx
@@ -45,6 +45,7 @@ export function DesktopShell({
   threadGroups,
   workspaces,
   workspacesLoading,
+  sessionsLoading,
   activeSession,
   conversation,
   answeredPermissions,
@@ -465,6 +466,7 @@ export function DesktopShell({
                 threadGroups={threadGroups}
                 workspaces={workspaces}
                 workspacesLoading={workspacesLoading}
+                sessionsLoading={sessionsLoading}
                 activeId={active?.sessionId ?? null}
                 pinnedSessionIds={pinnedSessionIds}
                 topInsetClassName={DESKTOP_CHROME_SPACER_CLASS}

--- a/packages/ui/src/shell/composer.tsx
+++ b/packages/ui/src/shell/composer.tsx
@@ -1,7 +1,8 @@
 import type { AgentKind, EffortLevel, SessionMode } from '@linkcode/schema';
 import { noop } from 'foxact/noop';
+import { useLayoutEffect } from 'foxact/use-isomorphic-layout-effect';
 import { clamp } from 'foxts/clamp';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useMemo, useRef, useState } from 'react';
 import { useTranslations } from 'use-intl';
 import {
   PromptInput,
@@ -155,7 +156,11 @@ export function Composer({
     if (!computeMenu(nextValue, nextCaret)) setDismissedStart(null);
   }
 
-  useEffect(() => {
+  // Layout effect (not a passive one) so the caret lands before paint — a mention insertion
+  // must never flash the old caret position for a frame. Deliberately no dependency array: it
+  // checks the pendingCaretRef command imperatively on every render rather than reacting to a
+  // dependency, so it fires exactly once per render that actually set the ref.
+  useLayoutEffect(() => {
     if (pendingCaretRef.current !== null && textareaRef.current) {
       const pos = pendingCaretRef.current;
       textareaRef.current.focus();

--- a/packages/ui/src/shell/session-sidebar.tsx
+++ b/packages/ui/src/shell/session-sidebar.tsx
@@ -39,6 +39,8 @@ export interface SessionSidebarProps extends ThreadGroupActions, ThreadGroupStat
   threadGroups: ThreadGroupViewModel[];
   workspaces: WorkspaceRecord[];
   workspacesLoading?: boolean;
+  /** First load of the session list — the "Chats" section shows a skeleton, not the empty hint. */
+  sessionsLoading?: boolean;
   topInsetClassName?: string;
   footer?: React.ReactNode;
   className?: string;
@@ -67,6 +69,7 @@ export function SessionSidebar({
   threadGroups,
   workspaces,
   workspacesLoading,
+  sessionsLoading,
   activeId,
   pinnedSessionIds,
   topInsetClassName,
@@ -121,6 +124,7 @@ export function SessionSidebar({
           <ThreadsView
             groups={threadGroups}
             workspacesLoading={workspacesLoading}
+            sessionsLoading={sessionsLoading}
             activeId={activeId}
             pinnedSessionIds={pinnedSessionIds}
             onSelect={onSelect}

--- a/packages/ui/src/shell/shell-frame.tsx
+++ b/packages/ui/src/shell/shell-frame.tsx
@@ -21,6 +21,8 @@ export interface ShellFrameProps
   threadGroups: ThreadGroupViewModel[];
   workspaces: WorkspaceRecord[];
   workspacesLoading?: boolean;
+  /** First load of the session list — the sidebar's "Chats" section shows a skeleton, not the empty hint. */
+  sessionsLoading?: boolean;
   /** Derived once by the workbench surface; shells consume it instead of re-deriving from the list. */
   activeSession: SessionInfo | null;
   conversation: ConversationViewModel;
@@ -60,6 +62,7 @@ export function ShellFrame({
   threadGroups,
   workspaces,
   workspacesLoading,
+  sessionsLoading,
   activeSession,
   conversation,
   answeredPermissions,
@@ -103,6 +106,7 @@ export function ShellFrame({
           threadGroups={threadGroups}
           workspaces={workspaces}
           workspacesLoading={workspacesLoading}
+          sessionsLoading={sessionsLoading}
           activeId={active?.sessionId ?? null}
           pinnedSessionIds={pinnedSessionIds}
           footer={<DefaultHostFooter />}

--- a/packages/ui/src/shell/sidebar/chats-section.tsx
+++ b/packages/ui/src/shell/sidebar/chats-section.tsx
@@ -1,5 +1,7 @@
 import type { AgentKind, SessionId, SessionInfo, WorkspaceRecord } from '@linkcode/schema';
 import { Popover, PopoverPopup, PopoverTrigger } from 'coss-ui/components/popover';
+import { Skeleton } from 'coss-ui/components/skeleton';
+import { createFixedArray } from 'foxact/create-fixed-array';
 import { PlusIcon } from 'lucide-react';
 import { useState } from 'react';
 import { useTranslations } from 'use-intl';
@@ -12,6 +14,8 @@ export interface ChatsSectionProps {
   workspace: WorkspaceRecord | null;
   /** The subset of the chat workspace's sessions to render, honoring preview truncation. */
   sessions: SessionInfo[];
+  /** First load of the session list — renders a row-shaped skeleton instead of the empty hint. */
+  isLoading?: boolean;
   hasOverflow: boolean;
   previewExpanded: boolean;
   /** The group key `onTogglePreviewExpanded` is called with. */
@@ -36,6 +40,7 @@ export interface ChatsSectionProps {
 export function ChatsSection({
   workspace,
   sessions,
+  isLoading,
   hasOverflow,
   previewExpanded,
   groupKey,
@@ -91,6 +96,12 @@ export function ChatsSection({
               onStop={() => onStop(session.sessionId)}
               onTogglePin={() => onToggleSessionPinned(session.sessionId)}
             />
+          ))}
+        </div>
+      ) : isLoading ? (
+        <div className="space-y-0.5">
+          {createFixedArray(3).map((i) => (
+            <Skeleton key={i} className="h-7 w-full rounded-md" />
           ))}
         </div>
       ) : (

--- a/packages/ui/src/shell/threads-view.tsx
+++ b/packages/ui/src/shell/threads-view.tsx
@@ -39,6 +39,8 @@ export interface ThreadGroupViewModel {
 export interface ThreadsViewProps extends ThreadGroupActions, ThreadGroupState {
   groups: ThreadGroupViewModel[];
   workspacesLoading?: boolean;
+  /** First load of the session list — the "Chats" section shows a skeleton, not the empty hint. */
+  sessionsLoading?: boolean;
   /** Persists a group drag: the full new project-group order, as `collapseKey`s. */
   onReorderGroups: (orderedCollapseKeys: string[]) => void;
   /** Persists a thread drag within a group: `activeId` landed before/after `overId`. */
@@ -56,6 +58,7 @@ export interface ThreadsViewProps extends ThreadGroupActions, ThreadGroupState {
 export function ThreadsView({
   groups,
   workspacesLoading,
+  sessionsLoading,
   activeId,
   pinnedSessionIds,
   onSelect,
@@ -184,6 +187,7 @@ export function ThreadsView({
         <ChatsSection
           workspace={chatGroup?.workspace ?? null}
           sessions={chatGroup?.visibleSessions ?? []}
+          isLoading={sessionsLoading}
           hasOverflow={chatGroup?.hasOverflow ?? false}
           previewExpanded={chatGroup?.previewExpanded ?? false}
           groupKey={chatGroup?.key ?? 'chat'}

--- a/packages/workbench/src/surface/use-workbench-sessions.ts
+++ b/packages/workbench/src/surface/use-workbench-sessions.ts
@@ -10,6 +10,8 @@ export interface WorkbenchSessions {
   /** The resolved active session — derived once here; consumers never re-derive it. */
   active: SessionInfo | null;
   activeId: SessionId | null;
+  /** First load of the session list — the cue for the sidebar to show a skeleton, not an empty state. */
+  isLoading: boolean;
   select: (id: SessionId) => void;
   create: (opts: { kind: AgentKind; cwd: string }) => void;
   stop: (id: SessionId) => void;
@@ -23,7 +25,7 @@ export interface WorkbenchSessions {
  * bookkeeping; mutations just revalidate. Selecting a cold session resumes it in place (same id).
  */
 export function useWorkbenchSessions(onError: (err: unknown) => void): WorkbenchSessions {
-  const { data: remoteSessions, mutate } = useData(listSessions, {});
+  const { data: remoteSessions, isLoading, mutate } = useData(listSessions, {});
   const createMutation = useMutation(startSession, { onError });
   const stopMutation = useMutation(stopSession, { onError });
   const resumeMutation = useMutation(resumeSession, { onError });
@@ -83,6 +85,7 @@ export function useWorkbenchSessions(onError: (err: unknown) => void): Workbench
     sessions,
     active,
     activeId,
+    isLoading,
     select,
     create,
     stop,

--- a/packages/workbench/src/surface/workbench.tsx
+++ b/packages/workbench/src/surface/workbench.tsx
@@ -296,6 +296,7 @@ function WorkbenchSessionSurface({
       threadGroups={threadGroups}
       workspaces={projectWorkspaces}
       workspacesLoading={workspacesLoading}
+      sessionsLoading={sessions.isLoading}
       activeSession={active}
       conversation={conversation}
       answeredPermissions={answered}


### PR DESCRIPTION
Closes CODE-52 (audit theme H: React details). F37 landed in CODE-51; this PR carries F38/F39. 2 commits.

- **F38** `WorkbenchSessions` gains `isLoading` (named destructure, honoring tayori's no-spread rule); `sessionsLoading` threads through five layers as a sibling prop to `workspacesLoading`; the Chats first-load renders 3 rows of `Skeleton` aligned to `ThreadRow` instead of the empty-state copy (including the desktop-shell gotcha where field-by-field destructuring requires explicit forwarding).
- **F39** the composer caret restore switches to `use-isomorphic-layout-effect` + a comment.

Verification: ui/workbench/desktop/webview all typecheck + lint green, tests 214 pass, pre-commit clean.

See Linear CODE-52.
