### PR TITLE
feat: subagent (Task/Agent tool) support — nested transcript card + viewer (CODE-80)

### DIFF
--- a/packages/agent-adapter/src/__tests__/claude-code-subagent.test.ts
+++ b/packages/agent-adapter/src/__tests__/claude-code-subagent.test.ts
@@ -67,6 +67,21 @@ describe('ClaudeCodeAdapter subagent routing', () => {
     expect(task.parentToolCallId).toBeUndefined();
   });
 
+  it('classifies the renamed Agent spawn tool as task-kind too', () => {
+    const h = harness();
+    h.feed({
+      type: 'assistant',
+      parent_tool_use_id: null,
+      uuid: 'uuid-main-2',
+      message: {
+        content: [
+          { type: 'tool_use', id: 'toolu_agent', name: 'Agent', input: { description: 'x' } },
+        ],
+      },
+    });
+    expect(h.tools()[0].kind).toBe('task');
+  });
+
   it('stamps parentToolCallId on subagent tool calls and their settles', () => {
     const h = harness();
     h.feed(taskAnnounce());

--- a/packages/agent-adapter/src/__tests__/claude-code-subagent.test.ts
+++ b/packages/agent-adapter/src/__tests__/claude-code-subagent.test.ts
@@ -1,0 +1,181 @@
+import type { SDKMessage } from '@anthropic-ai/claude-agent-sdk';
+import type { AgentEvent, ToolCall } from '@linkcode/schema';
+import { describe, expect, it } from 'vitest';
+import { ClaudeCodeAdapter } from '../native/claude-code';
+
+/**
+ * Subagent (Task tool) routing: every frame a subagent produces arrives with `parent_tool_use_id`
+ * set to the spawning Task's tool_use id. The adapter must (a) stamp that id onto the emitted tool
+ * calls / narration so the client can nest them, (b) render subagent text message-level from the
+ * forwarded assistant frames while dropping their stream deltas (no double render), and (c) keep
+ * the main agent's messageId cursor untouched so a subagent running mid-turn cannot break the main
+ * streaming bubble.
+ */
+
+type AgentMessageChunk = Extract<AgentEvent, { type: 'agent-message-chunk' }>;
+type AgentThoughtChunk = Extract<AgentEvent, { type: 'agent-thought-chunk' }>;
+
+class TestClaude extends ClaudeCodeAdapter {
+  feed(value: object): void {
+    this.handleMessage(value as SDKMessage);
+  }
+}
+
+function harness() {
+  const adapter = new TestClaude();
+  const seen: AgentEvent[] = [];
+  adapter.onEvent((e) => seen.push(e));
+  return {
+    feed: (value: object) => adapter.feed(value),
+    chunks: () => seen.filter((e): e is AgentMessageChunk => e.type === 'agent-message-chunk'),
+    thoughts: () => seen.filter((e): e is AgentThoughtChunk => e.type === 'agent-thought-chunk'),
+    tools: () =>
+      seen.reduce<ToolCall[]>((acc, e) => {
+        if (e.type === 'tool-call') acc.push(e.toolCall);
+        return acc;
+      }, []),
+  };
+}
+
+const TASK_ID = 'toolu_task1';
+
+function taskAnnounce(): object {
+  return {
+    type: 'assistant',
+    parent_tool_use_id: null,
+    uuid: 'uuid-main-1',
+    message: {
+      content: [
+        {
+          type: 'tool_use',
+          id: TASK_ID,
+          name: 'Task',
+          input: { description: 'map repo', prompt: 'map the repo', subagent_type: 'Explore' },
+        },
+      ],
+    },
+  };
+}
+
+describe('ClaudeCodeAdapter subagent routing', () => {
+  it('classifies the Task announce as a task-kind tool call', () => {
+    const h = harness();
+    h.feed(taskAnnounce());
+    const [task] = h.tools();
+    expect(task.kind).toBe('task');
+    expect(task.status).toBe('in_progress');
+    expect(task.parentToolCallId).toBeUndefined();
+  });
+
+  it('stamps parentToolCallId on subagent tool calls and their settles', () => {
+    const h = harness();
+    h.feed(taskAnnounce());
+    h.feed({
+      type: 'assistant',
+      parent_tool_use_id: TASK_ID,
+      uuid: 'uuid-sub-1',
+      message: { content: [{ type: 'tool_use', id: 'toolu_sub1', name: 'Read', input: {} }] },
+    });
+    h.feed({
+      type: 'user',
+      parent_tool_use_id: TASK_ID,
+      message: { content: [{ type: 'tool_result', tool_use_id: 'toolu_sub1', content: 'ok' }] },
+    });
+    const sub = h.tools().filter((t) => t.toolCallId === 'toolu_sub1');
+    expect(sub.map((t) => t.status)).toEqual(['in_progress', 'completed']);
+    expect(sub.every((t) => t.parentToolCallId === TASK_ID)).toBe(true);
+    expect(sub[0].kind).toBe('read');
+  });
+
+  it('renders subagent text message-level under the frame uuid, thinking under a distinct id', () => {
+    const h = harness();
+    h.feed({
+      type: 'assistant',
+      parent_tool_use_id: TASK_ID,
+      uuid: 'uuid-sub-2',
+      message: {
+        content: [
+          { type: 'thinking', thinking: 'hmm' },
+          { type: 'text', text: 'found it' },
+        ],
+      },
+    });
+    const [chunk] = h.chunks();
+    expect(chunk.content).toEqual({ type: 'text', text: 'found it' });
+    expect(chunk.messageId).toBe('uuid-sub-2');
+    expect(chunk.parentToolCallId).toBe(TASK_ID);
+    const [thought] = h.thoughts();
+    expect(thought.messageId).toBe('uuid-sub-2:think');
+    expect(thought.parentToolCallId).toBe(TASK_ID);
+  });
+
+  it('drops subagent stream deltas but keeps main-agent deltas flowing', () => {
+    const h = harness();
+    h.feed({
+      type: 'stream_event',
+      parent_tool_use_id: TASK_ID,
+      event: { type: 'content_block_delta', delta: { type: 'text_delta', text: 'sub' } },
+    });
+    expect(h.chunks()).toHaveLength(0);
+    h.feed({
+      type: 'stream_event',
+      parent_tool_use_id: null,
+      event: { type: 'content_block_delta', delta: { type: 'text_delta', text: 'main' } },
+    });
+    expect(h.chunks().map((c) => c.content)).toEqual([{ type: 'text', text: 'main' }]);
+  });
+
+  it('keeps the main messageId cursor across an interleaved subagent frame', () => {
+    const h = harness();
+    const mainDelta = (text: string) => ({
+      type: 'stream_event',
+      parent_tool_use_id: null,
+      event: { type: 'content_block_delta', delta: { type: 'text_delta', text } },
+    });
+    h.feed(mainDelta('before '));
+    h.feed({
+      type: 'assistant',
+      parent_tool_use_id: TASK_ID,
+      uuid: 'uuid-sub-3',
+      message: { content: [{ type: 'text', text: 'subagent says' }] },
+    });
+    h.feed(mainDelta('after'));
+    const main = h.chunks().filter((c) => c.parentToolCallId === undefined);
+    expect(main).toHaveLength(2);
+    expect(main[0].messageId).toBe(main[1].messageId);
+  });
+
+  it('settles the Task tool itself via its top-level tool_result', () => {
+    const h = harness();
+    h.feed(taskAnnounce());
+    h.feed({
+      type: 'user',
+      parent_tool_use_id: null,
+      message: { content: [{ type: 'tool_result', tool_use_id: TASK_ID, content: 'report' }] },
+    });
+    const task = h.tools().at(-1);
+    expect(task?.toolCallId).toBe(TASK_ID);
+    expect(task?.status).toBe('completed');
+    expect(task?.kind).toBe('task');
+  });
+
+  it('keeps parentToolCallId when a subagent tool is auto-denied', () => {
+    const h = harness();
+    h.feed({
+      type: 'assistant',
+      parent_tool_use_id: TASK_ID,
+      uuid: 'uuid-sub-4',
+      message: { content: [{ type: 'tool_use', id: 'toolu_sub2', name: 'Bash', input: {} }] },
+    });
+    h.feed({
+      type: 'system',
+      subtype: 'permission_denied',
+      tool_use_id: 'toolu_sub2',
+      tool_name: 'Bash',
+      decision_reason: 'blocked by policy',
+    });
+    const denied = h.tools().at(-1);
+    expect(denied?.status).toBe('failed');
+    expect(denied?.parentToolCallId).toBe(TASK_ID);
+  });
+});

--- a/packages/agent-adapter/src/__tests__/claude-code-subagent.test.ts
+++ b/packages/agent-adapter/src/__tests__/claude-code-subagent.test.ts
@@ -1,6 +1,7 @@
-import type { SDKMessage } from '@anthropic-ai/claude-agent-sdk';
+import type { SDKMessage, SessionMessage } from '@anthropic-ai/claude-agent-sdk';
 import type { AgentEvent, ToolCall } from '@linkcode/schema';
 import { describe, expect, it } from 'vitest';
+import { asHistoryId } from '../history-util';
 import { ClaudeCodeAdapter } from '../native/claude-code';
 
 /**
@@ -192,5 +193,113 @@ describe('ClaudeCodeAdapter subagent routing', () => {
     const denied = h.tools().at(-1);
     expect(denied?.status).toBe('failed');
     expect(denied?.parentToolCallId).toBe(TASK_ID);
+  });
+});
+
+describe('ClaudeCodeAdapter readHistory subagent splice', () => {
+  const SESSION = 'session-1';
+
+  function mainRow(type: 'user' | 'assistant', uuid: string, content: unknown[]): SessionMessage {
+    return { type, uuid, session_id: SESSION, parent_tool_use_id: null, message: { content } };
+  }
+
+  function subRow(
+    type: 'user' | 'assistant',
+    uuid: string,
+    content: string | unknown[],
+  ): SessionMessage {
+    return { type, uuid, session_id: SESSION, parent_tool_use_id: TASK_ID, message: { content } };
+  }
+
+  /** The trimmed slice of the SDK module surface readHistory touches. */
+  function fakeSdk(overrides: {
+    messages: SessionMessage[];
+    subagents?: Record<string, SessionMessage[]>;
+  }) {
+    const subagents = overrides.subagents ?? {};
+    return {
+      getSessionInfo: () => Promise.resolve(undefined),
+      getSessionMessages: () => Promise.resolve(overrides.messages),
+      listSubagents: () => Promise.resolve(Object.keys(subagents)),
+      getSubagentMessages: (_sessionId: string, agentId: string) =>
+        Promise.resolve(subagents[agentId] ?? []),
+    };
+  }
+
+  class HistoryClaude extends ClaudeCodeAdapter {
+    constructor(private readonly sdk: ReturnType<typeof fakeSdk>) {
+      super();
+    }
+
+    protected override loadSdk<T>(): Promise<T> {
+      return Promise.resolve(this.sdk as T);
+    }
+  }
+
+  const mainMessages = [
+    mainRow('user', 'u0', [{ type: 'text', text: 'go' }]),
+    mainRow('assistant', 'u1', [
+      { type: 'tool_use', id: TASK_ID, name: 'Agent', input: { description: 'explore' } },
+    ]),
+    mainRow('user', 'u2', [{ type: 'tool_result', tool_use_id: TASK_ID, content: 'report' }]),
+    mainRow('assistant', 'u3', [{ type: 'text', text: 'summary' }]),
+  ];
+
+  it('splices the subagent transcript right after the spawn announce, parent-linked', async () => {
+    const adapter = new HistoryClaude(
+      fakeSdk({
+        messages: mainMessages,
+        subagents: {
+          agent1: [
+            subRow('user', 's0', 'injected prompt'),
+            subRow('assistant', 's1', [{ type: 'text', text: 'nested narration' }]),
+            subRow('assistant', 's2', [
+              { type: 'tool_use', id: 'toolu_sub', name: 'Bash', input: {} },
+            ]),
+            subRow('user', 's3', [
+              { type: 'tool_result', tool_use_id: 'toolu_sub', content: 'ok' },
+            ]),
+          ],
+        },
+      }),
+    );
+    const result = await adapter.readHistory({ historyId: asHistoryId(SESSION) });
+
+    const kinds = result.events.map((e) =>
+      e.event.type === 'tool-call'
+        ? `${e.event.type}:${e.event.toolCall.toolCallId}:${e.event.toolCall.status}`
+        : `${e.event.type}:${e.itemId ?? ''}`,
+    );
+    expect(kinds).toEqual([
+      'user-message:u0',
+      `tool-call:${TASK_ID}:in_progress`,
+      // Spliced subagent transcript (injected prompt skipped, rest parent-linked):
+      'agent-message-chunk:s1',
+      'tool-call:toolu_sub:in_progress',
+      'tool-call:toolu_sub:completed',
+      // Main transcript resumes:
+      `tool-call:${TASK_ID}:completed`,
+      'agent-message-chunk:u3',
+    ]);
+
+    for (const e of result.events) {
+      if (e.event.type === 'tool-call' && e.event.toolCall.toolCallId === 'toolu_sub') {
+        expect(e.event.toolCall.parentToolCallId).toBe(TASK_ID);
+      }
+      if (e.event.type === 'agent-message-chunk' && e.itemId === 's1') {
+        expect(e.event.parentToolCallId).toBe(TASK_ID);
+      }
+    }
+  });
+
+  it('leaves sessions without subagents untouched', async () => {
+    const adapter = new HistoryClaude(fakeSdk({ messages: mainMessages }));
+    const result = await adapter.readHistory({ historyId: asHistoryId(SESSION) });
+    expect(result.events.map((e) => e.event.type)).toEqual([
+      'user-message',
+      'tool-call',
+      'tool-call',
+      'agent-message-chunk',
+    ]);
   });
 });

--- a/packages/agent-adapter/src/__tests__/claude-code-subagent.test.ts
+++ b/packages/agent-adapter/src/__tests__/claude-code-subagent.test.ts
@@ -292,6 +292,57 @@ describe('ClaudeCodeAdapter readHistory subagent splice', () => {
     }
   });
 
+  it('splices nested spawns recursively under their inner announce', async () => {
+    const INNER_ID = 'toolu_inner';
+    const innerSubRow = (
+      type: 'user' | 'assistant',
+      uuid: string,
+      content: string | unknown[],
+    ): SessionMessage => ({
+      type,
+      uuid,
+      session_id: SESSION,
+      parent_tool_use_id: INNER_ID,
+      message: { content },
+    });
+    const adapter = new HistoryClaude(
+      fakeSdk({
+        messages: mainMessages,
+        subagents: {
+          outer: [
+            subRow('assistant', 's1', [
+              { type: 'tool_use', id: INNER_ID, name: 'Agent', input: { description: 'deeper' } },
+            ]),
+            subRow('user', 's2', [{ type: 'tool_result', tool_use_id: INNER_ID, content: 'done' }]),
+          ],
+          inner: [innerSubRow('assistant', 'n1', [{ type: 'text', text: 'grandchild says' }])],
+        },
+      }),
+    );
+    const result = await adapter.readHistory({ historyId: asHistoryId(SESSION) });
+
+    const ids = result.events.map((e) =>
+      e.event.type === 'tool-call'
+        ? `${e.event.toolCall.toolCallId}:${e.event.toolCall.status}`
+        : (e.itemId ?? ''),
+    );
+    expect(ids).toEqual([
+      'u0',
+      `${TASK_ID}:in_progress`,
+      `${INNER_ID}:in_progress`,
+      // Grandchild transcript nests right under the inner announce:
+      'n1',
+      `${INNER_ID}:completed`,
+      `${TASK_ID}:completed`,
+      'u3',
+    ]);
+    const grandchild = result.events.find((e) => e.itemId === 'n1');
+    expect(grandchild?.event).toMatchObject({
+      type: 'agent-message-chunk',
+      parentToolCallId: INNER_ID,
+    });
+  });
+
   it('leaves sessions without subagents untouched', async () => {
     const adapter = new HistoryClaude(fakeSdk({ messages: mainMessages }));
     const result = await adapter.readHistory({ historyId: asHistoryId(SESSION) });

--- a/packages/agent-adapter/src/__tests__/normalize.test.ts
+++ b/packages/agent-adapter/src/__tests__/normalize.test.ts
@@ -41,12 +41,13 @@ function row(
   type: 'user' | 'assistant',
   uuid: string,
   content: string | unknown[],
+  parentToolUseId: string | null = null,
 ): SessionMessage {
   return {
     type,
     uuid,
     session_id: 'h1',
-    parent_tool_use_id: null,
+    parent_tool_use_id: parentToolUseId,
     message: { content },
   };
 }
@@ -140,6 +141,59 @@ describe('createClaudeHistoryEventMapper', () => {
 
     const reply = map(row('assistant', 'u2', [{ type: 'text', text: 'done' }]));
     expect(reply.map((e) => e.event.type)).toEqual(['agent-message-chunk']);
+  });
+
+  it('stamps parentToolCallId on subagent rows and classifies Task as task-kind', () => {
+    const map = createClaudeHistoryEventMapper(historyId);
+    const announce = map(
+      row('assistant', 'u1', [
+        { type: 'tool_use', id: 'toolu_task', name: 'Task', input: { description: 'explore' } },
+      ]),
+    );
+    if (announce[0].event.type === 'tool-call') {
+      expect(announce[0].event.toolCall).toMatchObject({ kind: 'task', toolCallId: 'toolu_task' });
+    }
+
+    const subText = map(
+      row('assistant', 'u2', [{ type: 'text', text: 'looking around' }], 'toolu_task'),
+    );
+    expect(subText[0].event).toMatchObject({
+      type: 'agent-message-chunk',
+      parentToolCallId: 'toolu_task',
+    });
+
+    const subTool = map(
+      row(
+        'assistant',
+        'u3',
+        [{ type: 'tool_use', id: 'toolu_sub', name: 'Read', input: {} }],
+        'toolu_task',
+      ),
+    );
+    if (subTool[0].event.type === 'tool-call') {
+      expect(subTool[0].event.toolCall.parentToolCallId).toBe('toolu_task');
+    }
+
+    const subSettle = map(
+      row(
+        'user',
+        'u4',
+        [{ type: 'tool_result', tool_use_id: 'toolu_sub', content: 'ok' }],
+        'toolu_task',
+      ),
+    );
+    if (subSettle[0].event.type === 'tool-call') {
+      expect(subSettle[0].event.toolCall).toMatchObject({
+        status: 'completed',
+        parentToolCallId: 'toolu_task',
+      });
+    }
+  });
+
+  it('skips the injected subagent prompt on subagent user rows', () => {
+    const map = createClaudeHistoryEventMapper(historyId);
+    const events = map(row('user', 'u1', 'map the repo structure', 'toolu_task'));
+    expect(events).toEqual([]);
   });
 });
 

--- a/packages/agent-adapter/src/base.ts
+++ b/packages/agent-adapter/src/base.ts
@@ -174,13 +174,23 @@ export abstract class BaseAgentAdapter implements AgentAdapter {
     this.messageId = nextMessageId();
     this.thoughtId = nextMessageId();
   }
-  protected emitAssistantText(text: string, messageId: MessageId): void {
+  protected emitAssistantText(text: string, messageId: MessageId, parentToolCallId?: string): void {
     if (text.length === 0) return;
-    this.emit({ type: 'agent-message-chunk', messageId, content: textBlock(text) });
+    this.emit({
+      type: 'agent-message-chunk',
+      messageId,
+      parentToolCallId,
+      content: textBlock(text),
+    });
   }
-  protected emitThought(text: string, messageId: MessageId): void {
+  protected emitThought(text: string, messageId: MessageId, parentToolCallId?: string): void {
     if (text.length === 0) return;
-    this.emit({ type: 'agent-thought-chunk', messageId, content: textBlock(text) });
+    this.emit({
+      type: 'agent-thought-chunk',
+      messageId,
+      parentToolCallId,
+      content: textBlock(text),
+    });
   }
 
   /**
@@ -214,6 +224,7 @@ export abstract class BaseAgentAdapter implements AgentAdapter {
           title: patch.title ?? existing.title,
           kind: patch.kind ?? existing.kind,
           status: patch.status ?? existing.status,
+          parentToolCallId: patch.parentToolCallId ?? existing.parentToolCallId,
           content: patch.content ?? existing.content,
           locations: patch.locations ?? existing.locations,
           rawInput: patch.rawInput ?? existing.rawInput,
@@ -224,6 +235,7 @@ export abstract class BaseAgentAdapter implements AgentAdapter {
           title: patch.title ?? patch.toolCallId,
           kind: patch.kind ?? 'other',
           status: patch.status ?? 'in_progress',
+          parentToolCallId: patch.parentToolCallId,
           content: patch.content ?? [],
           locations: patch.locations,
           rawInput: patch.rawInput,

--- a/packages/agent-adapter/src/history-util.ts
+++ b/packages/agent-adapter/src/history-util.ts
@@ -44,6 +44,7 @@ export function textHistoryEvent(
   itemId: string | undefined,
   value: unknown,
   ts?: Timestamp,
+  parentToolCallId?: string,
 ): AgentHistoryEvent | undefined {
   const text = textFromUnknown(value);
   if (text.trim().length === 0) return undefined;
@@ -56,7 +57,7 @@ export function textHistoryEvent(
     event:
       role === 'user'
         ? { type: 'user-message', messageId, content: [textBlock(text)] }
-        : { type: 'agent-message-chunk', messageId, content: textBlock(text) },
+        : { type: 'agent-message-chunk', messageId, parentToolCallId, content: textBlock(text) },
   };
 }
 

--- a/packages/agent-adapter/src/native/claude-code.ts
+++ b/packages/agent-adapter/src/native/claude-code.ts
@@ -779,17 +779,27 @@ export function createClaudeHistoryEventMapper(
     if (message.type !== 'user' && message.type !== 'assistant') return [];
     const events: AgentHistoryEvent[] = [];
     const blocks = messageContentBlocks(message.message);
+    // Subagent transcript rows carry the spawning Task's tool_use id, same as live frames.
+    const parent = message.parent_tool_use_id ?? undefined;
 
     if (message.type === 'assistant') {
-      const text = textHistoryEvent(historyId, 'assistant', message.uuid, message.message);
+      const text = textHistoryEvent(
+        historyId,
+        'assistant',
+        message.uuid,
+        message.message,
+        undefined,
+        parent,
+      );
       if (text) events.push(text);
       for (const block of blocks) {
         if (!isToolUseBlock(block)) continue;
         events.push(
           toolEvent({
             toolCallId: block.id,
+            parentToolCallId: parent,
             title: block.name,
-            kind: toolKindFromName(block.name),
+            kind: claudeToolKind(block.name),
             status: 'in_progress',
             content: editDiffContent(block.name, block.input) ?? [],
             rawInput: block.input,
@@ -805,6 +815,7 @@ export function createClaudeHistoryEventMapper(
       events.push(
         toolEvent({
           toolCallId: block.tool_use_id,
+          parentToolCallId: parent ?? existing?.parentToolCallId,
           // The announce can sit beyond this read's page window; fall back to emitTool's
           // first-sight defaults rather than dropping the settle.
           title: existing?.title ?? block.tool_use_id,
@@ -817,6 +828,9 @@ export function createClaudeHistoryEventMapper(
         }),
       );
     }
+    // A subagent's user rows are only tool_results plus its injected prompt — never something the
+    // user typed; emitting that prompt would fake a user turn inside the nested transcript.
+    if (parent) return events;
     // Tool-result rows are synthetic user messages; only what remains after removing the
     // tool_results is a prompt the user actually typed.
     const promptValue =

--- a/packages/agent-adapter/src/native/claude-code.ts
+++ b/packages/agent-adapter/src/native/claude-code.ts
@@ -34,7 +34,6 @@ import type {
   ToolCallContent,
 } from '@linkcode/schema';
 import { textBlock } from '@linkcode/schema';
-import { appendArrayInPlace } from 'foxts/append-array-in-place';
 import { extractErrorMessage } from 'foxts/extract-error-message';
 import { invariant, nullthrow } from 'foxts/guard';
 import { BaseAgentAdapter } from '../base';
@@ -323,25 +322,28 @@ export class ClaudeCodeAdapter extends BaseAgentAdapter {
     const historyId = opts.historyId;
     const mapper = createClaudeHistoryEventMapper(historyId);
     const events: AgentHistoryEvent[] = [];
-    for (const message of messages.slice(0, limit)) {
-      for (const event of mapper(message)) {
-        events.push(event);
-        // Splice each subagent's transcript in right after its spawn announce, so the seeded
-        // order matches the live stream and the children land inside the parent's turn (the
-        // UI's per-segment partition depends on that). Keyed off the announce (in_progress)
-        // only — the later settle re-emits the same tool-call id in a terminal state.
-        if (
-          event.event.type === 'tool-call' &&
-          event.event.toolCall.kind === 'task' &&
-          event.event.toolCall.status === 'in_progress'
-        ) {
-          const children = subagentEvents.get(event.event.toolCall.toolCallId);
-          if (children) {
-            appendArrayInPlace(events, children);
-            subagentEvents.delete(event.event.toolCall.toolCallId);
-          }
+    // Splice each subagent's transcript in right after its spawn announce, so the seeded order
+    // matches the live stream and the children land inside the parent's turn (the UI's per-segment
+    // partition depends on that). Keyed off the announce (in_progress) only — the later settle
+    // re-emits the same tool-call id in a terminal state. Recursive: a subagent's own transcript
+    // can announce a further spawn, whose transcript must nest the same way (delete-before-recurse
+    // also guards against a malformed self-referential parent id looping forever).
+    const pushWithSubagents = (event: AgentHistoryEvent): void => {
+      events.push(event);
+      if (
+        event.event.type === 'tool-call' &&
+        event.event.toolCall.kind === 'task' &&
+        event.event.toolCall.status === 'in_progress'
+      ) {
+        const children = subagentEvents.get(event.event.toolCall.toolCallId);
+        if (children) {
+          subagentEvents.delete(event.event.toolCall.toolCallId);
+          for (const child of children) pushWithSubagents(child);
         }
       }
+    };
+    for (const message of messages.slice(0, limit)) {
+      for (const event of mapper(message)) pushWithSubagents(event);
     }
     return {
       session: info

--- a/packages/agent-adapter/src/native/claude-code.ts
+++ b/packages/agent-adapter/src/native/claude-code.ts
@@ -34,6 +34,7 @@ import type {
   ToolCallContent,
 } from '@linkcode/schema';
 import { textBlock } from '@linkcode/schema';
+import { appendArrayInPlace } from 'foxts/append-array-in-place';
 import { extractErrorMessage } from 'foxts/extract-error-message';
 import { invariant, nullthrow } from 'foxts/guard';
 import { BaseAgentAdapter } from '../base';
@@ -311,19 +312,42 @@ export class ClaudeCodeAdapter extends BaseAgentAdapter {
     );
     const offset = cursorOffset(opts.cursor);
     const limit = boundedLimit(opts.limit, 1000, 1000);
-    const [info, messages] = await Promise.all([
+    const [info, messages, subagentEvents] = await Promise.all([
       mod.getSessionInfo(opts.historyId),
       mod.getSessionMessages(opts.historyId, {
         limit: limit + 1,
         offset,
       }),
+      readSubagentTranscripts(mod, opts.historyId),
     ]);
     const historyId = opts.historyId;
+    const mapper = createClaudeHistoryEventMapper(historyId);
+    const events: AgentHistoryEvent[] = [];
+    for (const message of messages.slice(0, limit)) {
+      for (const event of mapper(message)) {
+        events.push(event);
+        // Splice each subagent's transcript in right after its spawn announce, so the seeded
+        // order matches the live stream and the children land inside the parent's turn (the
+        // UI's per-segment partition depends on that). Keyed off the announce (in_progress)
+        // only — the later settle re-emits the same tool-call id in a terminal state.
+        if (
+          event.event.type === 'tool-call' &&
+          event.event.toolCall.kind === 'task' &&
+          event.event.toolCall.status === 'in_progress'
+        ) {
+          const children = subagentEvents.get(event.event.toolCall.toolCallId);
+          if (children) {
+            appendArrayInPlace(events, children);
+            subagentEvents.delete(event.event.toolCall.toolCallId);
+          }
+        }
+      }
+    }
     return {
       session: info
         ? mapClaudeHistorySession(info)
         : { historyId, kind: this.kind, title: historyId },
-      events: messages.slice(0, limit).flatMap(createClaudeHistoryEventMapper(historyId)),
+      events,
       cursor: cursorFromFetched(offset, messages.length, limit),
     };
   }
@@ -758,6 +782,30 @@ function mapClaudeHistorySession(session: SDKSessionInfo): AgentHistorySession {
       tag: session.tag,
     }),
   };
+}
+
+/**
+ * Subagent transcripts live beside the main one (`subagents/agent-{id}.jsonl`) and are not part of
+ * `getSessionMessages`. Every row `getSubagentMessages` returns carries `parent_tool_use_id` — the
+ * spawning Task/Agent tool_use id (verified against the vendored SDK's on-disk format) — so a plain
+ * run through the history mapper reproduces the same parent-linked events the live stream emits.
+ * Keyed by that parent id for splicing in after the spawn announce.
+ */
+async function readSubagentTranscripts(
+  mod: typeof import('@anthropic-ai/claude-agent-sdk'),
+  sessionId: string,
+): Promise<Map<string, AgentHistoryEvent[]>> {
+  const agentIds = await mod.listSubagents(sessionId);
+  const byParent = new Map<string, AgentHistoryEvent[]>();
+  await Promise.all(
+    agentIds.map(async (agentId) => {
+      const rows = await mod.getSubagentMessages(sessionId, agentId, { limit: 1000 });
+      const parent = rows.find((row) => row.parent_tool_use_id !== null)?.parent_tool_use_id;
+      if (!parent) return;
+      byParent.set(parent, rows.flatMap(createClaudeHistoryEventMapper(asHistoryId(sessionId))));
+    }),
+  );
+  return byParent;
 }
 
 /**

--- a/packages/agent-adapter/src/native/claude-code.ts
+++ b/packages/agent-adapter/src/native/claude-code.ts
@@ -39,6 +39,7 @@ import { invariant, nullthrow } from 'foxts/guard';
 import { BaseAgentAdapter } from '../base';
 import {
   asHistoryId,
+  asMessageId,
   boundedLimit,
   compactRecord,
   cursorFromFetched,
@@ -52,9 +53,17 @@ import {
 import { contentToText, locationsFromToolInput, toolKindFromName } from '../util';
 
 type StreamEvent = Extract<SDKMessage, { type: 'stream_event' }>['event'];
-type AssistantMessage = Extract<SDKMessage, { type: 'assistant' }>['message'];
-type UserMessage = Extract<SDKMessage, { type: 'user' }>['message'];
+type AssistantSDKMessage = Extract<SDKMessage, { type: 'assistant' }>;
+type AssistantMessage = AssistantSDKMessage['message'];
+type UserSDKMessage = Extract<SDKMessage, { type: 'user' }>;
 type ResultMessage = Extract<SDKMessage, { type: 'result' }>;
+
+/** Claude's subagent-spawning tool is literally named `Task`. Exact match on purpose: the shared
+ * name-based classifier stays untouched so other adapters (e.g. opencode's lowercase `task`) opt in
+ * deliberately rather than by regex accident. */
+function claudeToolKind(name: string): ToolCall['kind'] {
+  return name === 'Task' ? 'task' : toolKindFromName(name);
+}
 
 const PERMISSION_OPTIONS: PermissionOption[] = [
   { optionId: 'allow', name: 'Allow', kind: 'allow_once' },
@@ -354,6 +363,9 @@ export class ClaudeCodeAdapter extends BaseAgentAdapter {
         // apply through the switchable channel right after creation.
         effort: this.effort === 'max' ? 'max' : undefined,
         includePartialMessages: true,
+        // Forward subagent text/thinking (tool_use/tool_result already flow by default) so the
+        // client can render the nested transcript; all subagent frames carry parent_tool_use_id.
+        forwardSubagentText: true,
         canUseTool: this.canUseTool,
         // Resolved in onStart from settings.json `permissions.defaultMode` (see settingsDefaultMode)
         // — the SDK-driven CLI does not apply that setting itself. `undefined` only when neither the
@@ -499,7 +511,7 @@ export class ClaudeCodeAdapter extends BaseAgentAdapter {
       {
         toolCallId: options.toolUseID,
         title: options.title ?? toolName,
-        kind: toolKindFromName(toolName),
+        kind: claudeToolKind(toolName),
         rawInput: input,
       },
       PERMISSION_OPTIONS,
@@ -524,18 +536,21 @@ export class ClaudeCodeAdapter extends BaseAgentAdapter {
     if ('isReplay' in msg) return;
     switch (msg.type) {
       case 'stream_event':
-        this.handleStreamEvent(msg.event);
+        this.handleStreamEvent(msg.event, msg.parent_tool_use_id);
         break;
       case 'assistant':
-        this.handleAssistant(msg.message);
+        this.handleAssistant(msg);
         break;
       case 'user':
-        this.handleUser(msg.message);
+        this.handleUser(msg);
         break;
       case 'result':
         this.handleResult(msg);
         break;
       case 'system':
+        // task_started/task_updated/task_progress intentionally fall through: a card's state derives
+        // entirely from the Task tool_use/tool_result pair; consuming them (task_id ↔ tool_use_id
+        // correlation) only pays off once run_in_background tasks are supported.
         if (msg.subtype === 'permission_denied') this.handlePermissionDenied(msg);
         else if (msg.subtype === 'init') this.syncApprovalPolicy(msg.permissionMode);
         break;
@@ -555,7 +570,7 @@ export class ClaudeCodeAdapter extends BaseAgentAdapter {
     this.emitTool({
       toolCallId: msg.tool_use_id,
       title: msg.tool_name,
-      kind: toolKindFromName(msg.tool_name),
+      kind: claudeToolKind(msg.tool_name),
       status: 'failed',
       content: [
         ...diff,
@@ -564,14 +579,22 @@ export class ClaudeCodeAdapter extends BaseAgentAdapter {
     });
   }
 
-  private handleStreamEvent(event: StreamEvent): void {
+  private handleStreamEvent(event: StreamEvent, parentToolUseId: string | null): void {
+    // Subagent narration renders message-level from the forwarded assistant frames
+    // (handleSubagentAssistant); consuming its deltas here would render the same text twice.
+    if (parentToolUseId) return;
     if (event.type !== 'content_block_delta') return;
     const delta = event.delta;
     if (delta.type === 'text_delta') this.emitAssistantText(delta.text, this.messageId);
     else if (delta.type === 'thinking_delta') this.emitThought(delta.thinking, this.thoughtId);
   }
 
-  private handleAssistant(message: AssistantMessage): void {
+  private handleAssistant(msg: AssistantSDKMessage): void {
+    if (msg.parent_tool_use_id) {
+      this.handleSubagentAssistant(msg.message, msg.parent_tool_use_id, msg.uuid);
+      return;
+    }
+    const message = msg.message;
     let calledTool = false;
     for (const block of message.content) {
       if (block.type === 'tool_use') {
@@ -581,7 +604,7 @@ export class ClaudeCodeAdapter extends BaseAgentAdapter {
         this.emitTool({
           toolCallId: block.id,
           title: block.name,
-          kind: toolKindFromName(block.name),
+          kind: claudeToolKind(block.name),
           status: 'in_progress',
           content: diff,
           rawInput: block.input,
@@ -596,12 +619,42 @@ export class ClaudeCodeAdapter extends BaseAgentAdapter {
   }
 
   /**
+   * A subagent's assistant frame (`parent_tool_use_id` set): its tool calls carry the spawning Task's
+   * id, and its text/thinking — forwarded whole via `forwardSubagentText` — render message-level under
+   * the frame's own uuid. It never touches the main `messageId`/`thoughtId` cursors and never calls
+   * `freshSegment()`, so a subagent running mid-turn cannot break the main agent's streaming bubble.
+   * (The uuid doubles as the history mapper's id, so a live turn and a later cold-resume seed converge.)
+   */
+  private handleSubagentAssistant(message: AssistantMessage, parent: string, uuid: string): void {
+    for (const block of message.content) {
+      if (block.type === 'tool_use') {
+        const diff = editDiffContent(block.name, block.input);
+        if (diff) this.pendingEditDiffs.set(block.id, diff);
+        this.emitTool({
+          toolCallId: block.id,
+          parentToolCallId: parent,
+          title: block.name,
+          kind: claudeToolKind(block.name),
+          status: 'in_progress',
+          content: diff,
+          rawInput: block.input,
+          locations: locationsFromToolInput(block.input),
+        });
+      } else if (block.type === 'text') {
+        this.emitAssistantText(block.text, asMessageId(uuid), parent);
+      } else if (block.type === 'thinking') {
+        this.emitThought(block.thinking, asMessageId(`${uuid}:think`), parent);
+      }
+    }
+  }
+
+  /**
    * Tool results come back on the *user* message (Claude's API pairs every `tool_use` with a
    * `tool_result`). This is also where a denied permission lands: the SDK synthesizes an `is_error`
    * result with "Denied by the user", so the same branch settles success, failure, and deny alike.
    */
-  private handleUser(message: UserMessage): void {
-    const content = message.content;
+  private handleUser(msg: UserSDKMessage): void {
+    const content = msg.message.content;
     if (typeof content === 'string') return;
     for (const block of content) {
       if (block.type !== 'tool_result') continue;
@@ -609,6 +662,9 @@ export class ClaudeCodeAdapter extends BaseAgentAdapter {
       this.pendingEditDiffs.delete(block.tool_use_id);
       this.emitTool({
         toolCallId: block.tool_use_id,
+        // Re-stated on settle so the parent link survives even if the announce was never seen
+        // (e.g. it sat beyond a history read's page window). Null for main-agent results.
+        parentToolCallId: msg.parent_tool_use_id ?? undefined,
         status: block.is_error === true ? 'failed' : 'completed',
         content: [...diff, ...toolResultContent(block.content)],
         rawOutput: block.content,

--- a/packages/agent-adapter/src/native/claude-code.ts
+++ b/packages/agent-adapter/src/native/claude-code.ts
@@ -58,11 +58,12 @@ type AssistantMessage = AssistantSDKMessage['message'];
 type UserSDKMessage = Extract<SDKMessage, { type: 'user' }>;
 type ResultMessage = Extract<SDKMessage, { type: 'result' }>;
 
-/** Claude's subagent-spawning tool is literally named `Task`. Exact match on purpose: the shared
- * name-based classifier stays untouched so other adapters (e.g. opencode's lowercase `task`) opt in
- * deliberately rather than by regex accident. */
+/** Claude's subagent-spawning tool: named `Agent` in current CLIs (verified live against the
+ * vendored 0.3.x), `Task` in older transcripts — history replay still meets the old name. Exact
+ * match on purpose: the shared name-based classifier stays untouched so other adapters (e.g.
+ * opencode's lowercase `task`) opt in deliberately rather than by regex accident. */
 function claudeToolKind(name: string): ToolCall['kind'] {
-  return name === 'Task' ? 'task' : toolKindFromName(name);
+  return name === 'Task' || name === 'Agent' ? 'task' : toolKindFromName(name);
 }
 
 const PERMISSION_OPTIONS: PermissionOption[] = [

--- a/packages/client-core/src/__tests__/conversation.test.ts
+++ b/packages/client-core/src/__tests__/conversation.test.ts
@@ -147,6 +147,39 @@ describe('buildConversation', () => {
     }
   });
 
+  it('carries parentToolCallId on subagent chunks and tool snapshots', () => {
+    const c = buildConversation([
+      {
+        type: 'agent-message-chunk',
+        messageId: 'sub-m1' as MessageId,
+        parentToolCallId: 'toolu_task',
+        content: { type: 'text', text: 'nested narration' },
+      },
+      {
+        type: 'agent-thought-chunk',
+        messageId: 'sub-t1' as MessageId,
+        parentToolCallId: 'toolu_task',
+        content: { type: 'text', text: 'nested thought' },
+      },
+      {
+        type: 'tool-call',
+        toolCall: {
+          toolCallId: 'toolu_sub',
+          parentToolCallId: 'toolu_task',
+          title: 'Read',
+          kind: 'read',
+          status: 'completed',
+          content: [],
+        },
+      },
+    ]);
+    expect(c.items).toHaveLength(3);
+    const [message, reasoning, tool] = c.items;
+    if (message.kind === 'message') expect(message.parentToolCallId).toBe('toolu_task');
+    if (reasoning.kind === 'reasoning') expect(reasoning.parentToolCallId).toBe('toolu_task');
+    if (tool.kind === 'tool') expect(tool.toolCall.parentToolCallId).toBe('toolu_task');
+  });
+
   it('keeps only the latest plan per turn', () => {
     const c = buildConversation([
       userText('first'),

--- a/packages/client-core/src/conversation.ts
+++ b/packages/client-core/src/conversation.ts
@@ -32,6 +32,8 @@ export type ConversationItem = (
       role: 'user' | 'assistant';
       blocks: ContentBlock[];
       isStreaming: boolean;
+      /** Set on subagent narration: the `task`-kind tool call that spawned it (nested in the UI). */
+      parentToolCallId?: string;
     }
   | {
       kind: 'reasoning';
@@ -39,6 +41,7 @@ export type ConversationItem = (
       turnId: ConversationTurnId;
       blocks: ContentBlock[];
       isStreaming: boolean;
+      parentToolCallId?: string;
     }
   | { kind: 'tool'; id: string; turnId: ConversationTurnId; toolCall: ToolCall }
   | { kind: 'plan'; id: string; turnId: ConversationTurnId; plan: Plan }
@@ -139,6 +142,7 @@ export function createConversationBuilder(): ConversationBuilder {
     messageId: string,
     block: ContentBlock,
     receivedAt: number | undefined,
+    parentToolCallId: string | undefined,
   ): void => {
     const existing = messageIndex.get(messageId);
     if (existing !== undefined) {
@@ -160,6 +164,7 @@ export function createConversationBuilder(): ConversationBuilder {
         role: 'assistant',
         blocks: [block],
         isStreaming: false,
+        parentToolCallId,
         receivedAt,
       });
     } else {
@@ -169,6 +174,7 @@ export function createConversationBuilder(): ConversationBuilder {
         turnId: currentTurnId,
         blocks: [block],
         isStreaming: false,
+        parentToolCallId,
         receivedAt,
       });
     }
@@ -193,10 +199,22 @@ export function createConversationBuilder(): ConversationBuilder {
         break;
       }
       case 'agent-message-chunk':
-        openAgentStream('message', event.messageId, event.content, receivedAt);
+        openAgentStream(
+          'message',
+          event.messageId,
+          event.content,
+          receivedAt,
+          event.parentToolCallId,
+        );
         break;
       case 'agent-thought-chunk':
-        openAgentStream('reasoning', event.messageId, event.content, receivedAt);
+        openAgentStream(
+          'reasoning',
+          event.messageId,
+          event.content,
+          receivedAt,
+          event.parentToolCallId,
+        );
         break;
 
       case 'tool-call': {

--- a/packages/i18n/src/locales/en.ts
+++ b/packages/i18n/src/locales/en.ts
@@ -37,6 +37,9 @@ export const en = {
       label: 'Subagent',
       steps: '{count} steps',
       viewTranscript: 'View full transcript',
+      viewerTitle: 'Subagents',
+      empty: 'No subagents in this conversation yet',
+      failedBadge: 'Failed',
     },
     toolGroup: {
       explore: 'Explored',

--- a/packages/i18n/src/locales/en.ts
+++ b/packages/i18n/src/locales/en.ts
@@ -30,6 +30,7 @@ export const en = {
       kindExecute: 'Run',
       kindThink: 'Think',
       kindFetch: 'Fetch',
+      kindTask: 'Subagent',
       kindOther: 'Tool',
     },
     toolGroup: {

--- a/packages/i18n/src/locales/en.ts
+++ b/packages/i18n/src/locales/en.ts
@@ -33,6 +33,11 @@ export const en = {
       kindTask: 'Subagent',
       kindOther: 'Tool',
     },
+    subagent: {
+      label: 'Subagent',
+      steps: '{count} steps',
+      viewTranscript: 'View full transcript',
+    },
     toolGroup: {
       explore: 'Explored',
       command: 'Ran commands',

--- a/packages/i18n/src/locales/zh-cn.ts
+++ b/packages/i18n/src/locales/zh-cn.ts
@@ -31,6 +31,11 @@ export const zhCN = {
       kindTask: '子代理',
       kindOther: '工具',
     },
+    subagent: {
+      label: '子代理',
+      steps: '{count} 步',
+      viewTranscript: '查看完整转录',
+    },
     toolGroup: {
       explore: '探索',
       command: '执行命令',

--- a/packages/i18n/src/locales/zh-cn.ts
+++ b/packages/i18n/src/locales/zh-cn.ts
@@ -35,6 +35,9 @@ export const zhCN = {
       label: '子代理',
       steps: '{count} 步',
       viewTranscript: '查看完整转录',
+      viewerTitle: '子代理',
+      empty: '本会话还没有子代理',
+      failedBadge: '失败',
     },
     toolGroup: {
       explore: '探索',

--- a/packages/i18n/src/locales/zh-cn.ts
+++ b/packages/i18n/src/locales/zh-cn.ts
@@ -28,6 +28,7 @@ export const zhCN = {
       kindExecute: '执行',
       kindThink: '思考',
       kindFetch: '获取',
+      kindTask: '子代理',
       kindOther: '工具',
     },
     toolGroup: {

--- a/packages/schema/src/agent.ts
+++ b/packages/schema/src/agent.ts
@@ -103,12 +103,15 @@ export const AgentEventSchema = z.discriminatedUnion('type', [
     type: z.literal('agent-message-chunk'),
     // Required: the grouping authority (chunks with the same id form one bubble).
     messageId: MessageIdSchema,
+    // Set on subagent narration: the `task`-kind tool call that spawned the subagent.
+    parentToolCallId: z.string().min(1).optional(),
     content: ContentBlockSchema,
   }),
   z.object({
     type: z.literal('agent-thought-chunk'),
     // Required: the grouping authority (must differ from the matching message's id).
     messageId: MessageIdSchema,
+    parentToolCallId: z.string().min(1).optional(),
     content: ContentBlockSchema,
   }),
 

--- a/packages/schema/src/tool-call.ts
+++ b/packages/schema/src/tool-call.ts
@@ -16,6 +16,7 @@ export const ToolKindSchema = z.enum([
   'execute',
   'think',
   'fetch',
+  'task',
   'other',
 ]);
 export type ToolKind = z.infer<typeof ToolKindSchema>;
@@ -49,6 +50,8 @@ export const ToolCallSchema = z.object({
   title: z.string(),
   kind: ToolKindSchema,
   status: ToolCallStatusSchema,
+  /** Set on calls a subagent made: the `task`-kind tool call that spawned it. */
+  parentToolCallId: z.string().min(1).optional(),
   content: z.array(ToolCallContentSchema).default([]),
   locations: z.array(ToolCallLocationSchema).optional(),
   rawInput: z.unknown().optional(),
@@ -62,6 +65,7 @@ export const ToolCallUpdateSchema = z.object({
   title: z.string().optional(),
   kind: ToolKindSchema.optional(),
   status: ToolCallStatusSchema.optional(),
+  parentToolCallId: z.string().min(1).optional(),
   content: z.array(ToolCallContentSchema).optional(),
   locations: z.array(ToolCallLocationSchema).optional(),
   rawInput: z.unknown().optional(),

--- a/packages/ui/src/__tests__/subagents.test.ts
+++ b/packages/ui/src/__tests__/subagents.test.ts
@@ -1,0 +1,82 @@
+import type { ToolCall } from '@linkcode/schema';
+import { describe, expect, it } from 'vitest';
+import { groupTimeline } from '../chat/activity-groups';
+import { partitionSubagentItems } from '../chat/subagents';
+import type { ConversationItem } from '../chat/types';
+
+let seq = 0;
+
+function tool(
+  kind: ToolCall['kind'],
+  overrides: Partial<ToolCall> = {},
+): Extract<ConversationItem, { kind: 'tool' }> {
+  const id = `tool-${seq++}`;
+  return {
+    kind: 'tool',
+    id,
+    turnId: 'turn-0',
+    toolCall: {
+      toolCallId: id,
+      title: `${kind} ${id}`,
+      kind,
+      status: 'completed',
+      content: [],
+      ...overrides,
+    },
+  };
+}
+
+function narration(parentToolCallId?: string): ConversationItem {
+  return {
+    kind: 'message',
+    id: `msg-${seq++}`,
+    turnId: 'turn-0',
+    role: 'assistant',
+    blocks: [{ type: 'text', text: 'hi' }],
+    isStreaming: false,
+    parentToolCallId,
+  };
+}
+
+describe('partitionSubagentItems', () => {
+  it('splits children out of the timeline, grouped by parent in arrival order', () => {
+    const task = tool('task');
+    const taskId = task.toolCall.toolCallId;
+    const childText = narration(taskId);
+    const childTool = tool('read', { parentToolCallId: taskId });
+    const mainText = narration();
+    const { topLevel, childrenByParent } = partitionSubagentItems([
+      task,
+      childText,
+      mainText,
+      childTool,
+    ]);
+
+    expect(topLevel).toEqual([task, mainText]);
+    expect(childrenByParent.get(taskId)).toEqual([childText, childTool]);
+  });
+
+  it('falls back to top-level for orphans whose parent is not in the slice', () => {
+    const orphanText = narration('toolu_gone');
+    const orphanTool = tool('read', { parentToolCallId: 'toolu_gone' });
+    const { topLevel, childrenByParent } = partitionSubagentItems([orphanText, orphanTool]);
+
+    expect(topLevel).toEqual([orphanText, orphanTool]);
+    expect(childrenByParent.size).toBe(0);
+  });
+});
+
+describe('groupTimeline task entries', () => {
+  it('breaks a task tool out as its own entry, never in a streak', () => {
+    const before = tool('read');
+    const task = tool('task');
+    const after = tool('read');
+    const entries = groupTimeline([before, task, after]);
+
+    expect(entries).toEqual([
+      { type: 'single', item: before },
+      { type: 'task', item: task },
+      { type: 'single', item: after },
+    ]);
+  });
+});

--- a/packages/ui/src/__tests__/subagents.test.ts
+++ b/packages/ui/src/__tests__/subagents.test.ts
@@ -56,6 +56,20 @@ describe('partitionSubagentItems', () => {
     expect(childrenByParent.get(taskId)).toEqual([childText, childTool]);
   });
 
+  it('buckets a nested spawn under the outer task and grandchildren under the inner one', () => {
+    const outer = tool('task');
+    const outerId = outer.toolCall.toolCallId;
+    const inner = tool('task', { parentToolCallId: outerId });
+    const innerId = inner.toolCall.toolCallId;
+    const grandchild = tool('read', { parentToolCallId: innerId });
+    const { topLevel, childrenByParent } = partitionSubagentItems([outer, inner, grandchild]);
+
+    // SubagentTranscript recurses task-kind children into their own card, so nothing is dropped.
+    expect(topLevel).toEqual([outer]);
+    expect(childrenByParent.get(outerId)).toEqual([inner]);
+    expect(childrenByParent.get(innerId)).toEqual([grandchild]);
+  });
+
   it('falls back to top-level for orphans whose parent is not in the slice', () => {
     const orphanText = narration('toolu_gone');
     const orphanTool = tool('read', { parentToolCallId: 'toolu_gone' });

--- a/packages/ui/src/chat/activity-groups.ts
+++ b/packages/ui/src/chat/activity-groups.ts
@@ -15,7 +15,9 @@ export type ToolTimelineItem = Extract<ConversationItem, { kind: 'tool' }>;
 export type TimelineEntry =
   | { type: 'item'; item: ConversationItem }
   | { type: 'single'; item: ToolTimelineItem }
-  | { type: 'group'; id: string; bucket: ActivityBucket; items: ToolTimelineItem[] };
+  | { type: 'group'; id: string; bucket: ActivityBucket; items: ToolTimelineItem[] }
+  /** A subagent spawn (`task`-kind tool call); renders as its own nested card, never in a streak. */
+  | { type: 'task'; item: ToolTimelineItem };
 
 /** Buckets tool kinds by review affordance, so summaries read "Explored" / "Ran commands" / "Edited files". */
 export function activityBucket(kind: ToolCall['kind']): ActivityBucket {
@@ -33,6 +35,7 @@ export function activityBucket(kind: ToolCall['kind']): ActivityBucket {
     case 'delete':
     case 'move':
       return 'files';
+    // 'task' never reaches this default: groupTimeline breaks it out as a `task` entry first.
     default:
       return 'other';
   }
@@ -65,6 +68,11 @@ export function groupTimeline(items: readonly ConversationItem[]): TimelineEntry
     if (item.kind !== 'tool') {
       flushStreak();
       entries.push({ type: 'item', item });
+      continue;
+    }
+    if (item.toolCall.kind === 'task') {
+      flushStreak();
+      entries.push({ type: 'task', item });
       continue;
     }
     if (approvalGated.has(item.toolCall.toolCallId)) {

--- a/packages/ui/src/chat/conversation-view.tsx
+++ b/packages/ui/src/chat/conversation-view.tsx
@@ -103,6 +103,7 @@ export function ConversationView({
         <SubagentCard
           key={entry.item.id}
           awaitingApproval={awaitingApproval}
+          childrenByParent={subagentChildren}
           declined={declined}
           items={subagentChildren.get(entry.item.toolCall.toolCallId) ?? []}
           onExpand={setExpandedTaskId}

--- a/packages/ui/src/chat/conversation-view.tsx
+++ b/packages/ui/src/chat/conversation-view.tsx
@@ -1,6 +1,6 @@
 import type { AgentKind } from '@linkcode/schema';
 import { Spinner } from 'coss-ui/components/spinner';
-import { Fragment } from 'react';
+import { Fragment, useState } from 'react';
 import { useTranslations } from 'use-intl';
 import { ActivityGroup } from './activity-group';
 import type { TimelineEntry } from './activity-groups';
@@ -23,6 +23,7 @@ import { assistantTurnText, latestReceivedAt } from './conversation-text';
 import { ErrorMessage } from './error-message';
 import { Message, MessageContent } from './message';
 import { SubagentCard } from './subagent-card';
+import { SubagentViewer } from './subagent-viewer';
 import { partitionSubagentItems } from './subagents';
 import { ThoughtBlock } from './thought-block';
 import { ToolCallItem } from './tool-call-item';
@@ -55,6 +56,9 @@ export function ConversationView({
   const t = useTranslations('workbench.conversation');
   const tk = useTranslations('workbench.agentKind');
 
+  // Transient viewer state: which subagent's full transcript is open in the modal (null = closed).
+  const [expandedTaskId, setExpandedTaskId] = useState<string | null>(null);
+
   const { items } = conversation;
 
   if (items.length === 0) {
@@ -82,6 +86,13 @@ export function ConversationView({
     ),
   );
   const segments = splitTurnSegments(conversationFlowItems(items));
+  // Conversation-wide view of the same parent→children relation the per-segment partitions see
+  // (a subagent never outlives its turn), for the cross-conversation viewer rail.
+  const subagentTasks = items.filter(
+    (item): item is Extract<ConversationItem, { kind: 'tool' }> =>
+      item.kind === 'tool' && item.toolCall.kind === 'task',
+  );
+  const allSubagentChildren = partitionSubagentItems(items).childrenByParent;
 
   const renderEntry = (
     entry: TimelineEntry,
@@ -94,6 +105,7 @@ export function ConversationView({
           awaitingApproval={awaitingApproval}
           declined={declined}
           items={subagentChildren.get(entry.item.toolCall.toolCallId) ?? []}
+          onExpand={setExpandedTaskId}
           TerminalBlockComponent={TerminalBlockComponent}
           toolCall={entry.item.toolCall}
         />
@@ -222,6 +234,19 @@ export function ConversationView({
         )}
       </ConversationContent>
       <ConversationScrollButton />
+      <SubagentViewer
+        awaitingApproval={awaitingApproval}
+        childrenByParent={allSubagentChildren}
+        declined={declined}
+        onOpenChange={(open) => {
+          if (!open) setExpandedTaskId(null);
+        }}
+        onSelect={setExpandedTaskId}
+        open={expandedTaskId !== null}
+        selectedId={expandedTaskId}
+        tasks={subagentTasks}
+        TerminalBlockComponent={TerminalBlockComponent}
+      />
     </Conversation>
   );
 }

--- a/packages/ui/src/chat/conversation-view.tsx
+++ b/packages/ui/src/chat/conversation-view.tsx
@@ -22,12 +22,14 @@ import {
 import { assistantTurnText, latestReceivedAt } from './conversation-text';
 import { ErrorMessage } from './error-message';
 import { Message, MessageContent } from './message';
+import { SubagentCard } from './subagent-card';
+import { partitionSubagentItems } from './subagents';
 import { ThoughtBlock } from './thought-block';
 import { ToolCallItem } from './tool-call-item';
 import { AgentTurnActions } from './turn-actions';
 import { TurnDiffSummary } from './turn-diff-summary';
 import { splitTurnSegments, turnFileEdits } from './turn-edits';
-import type { ConversationViewModel } from './types';
+import type { ConversationItem, ConversationViewModel } from './types';
 import { UserMessage } from './user-message';
 
 export interface ConversationViewProps {
@@ -81,7 +83,22 @@ export function ConversationView({
   );
   const segments = splitTurnSegments(conversationFlowItems(items));
 
-  const renderEntry = (entry: TimelineEntry): React.ReactNode => {
+  const renderEntry = (
+    entry: TimelineEntry,
+    subagentChildren: ReadonlyMap<string, ConversationItem[]>,
+  ): React.ReactNode => {
+    if (entry.type === 'task') {
+      return (
+        <SubagentCard
+          key={entry.item.id}
+          awaitingApproval={awaitingApproval}
+          declined={declined}
+          items={subagentChildren.get(entry.item.toolCall.toolCallId) ?? []}
+          TerminalBlockComponent={TerminalBlockComponent}
+          toolCall={entry.item.toolCall}
+        />
+      );
+    }
     if (entry.type === 'group') {
       return (
         <ActivityGroup
@@ -163,9 +180,12 @@ export function ConversationView({
           // Per-turn trailers (edit rollup, reply actions) appear once the turn has settled —
           // the in-flight turn shows none.
           const ended = index < segments.length - 1 || !isThinking;
+          // Children leave the top-level timeline (they render inside their SubagentCard), but the
+          // turn's edit rollup still counts them; the copyable reply text is the main agent's only.
+          const { topLevel, childrenByParent } = partitionSubagentItems(segment.items);
           const edits = ended ? turnFileEdits(segment.items) : null;
-          const replyText = ended ? assistantTurnText(segment.items) : '';
-          const entries = groupTimeline(segment.items);
+          const replyText = ended ? assistantTurnText(topLevel) : '';
+          const entries = groupTimeline(topLevel);
           const leadingUserEntry =
             entries[0]?.type === 'item' &&
             entries[0].item.kind === 'message' &&
@@ -176,10 +196,10 @@ export function ConversationView({
           const hasAgentTurnContent = agentEntries.length > 0 || edits || replyText;
           return (
             <Fragment key={segment.turnId ?? 'lead-in'}>
-              {leadingUserEntry ? renderEntry(leadingUserEntry) : null}
+              {leadingUserEntry ? renderEntry(leadingUserEntry, childrenByParent) : null}
               {hasAgentTurnContent ? (
                 <div className="group/turn flex flex-col gap-3">
-                  {agentEntries.map((entry) => renderEntry(entry))}
+                  {agentEntries.map((entry) => renderEntry(entry, childrenByParent))}
                   {edits ? <TurnDiffSummary edits={edits} /> : null}
                   {replyText ? (
                     <AgentTurnActions

--- a/packages/ui/src/chat/subagent-card.tsx
+++ b/packages/ui/src/chat/subagent-card.tsx
@@ -35,21 +35,28 @@ interface SubagentTranscriptProps {
   toolCall: ToolCall;
   /** The subagent's items (narration / reasoning / tool calls), in arrival order. */
   items: readonly ConversationItem[];
+  /** The whole slice's parent→children buckets, so nested spawns can recurse into their own card. */
+  childrenByParent: ReadonlyMap<string, ConversationItem[]>;
   awaitingApproval: ReadonlySet<string>;
   declined: ReadonlySet<string>;
   TerminalBlockComponent?: React.ComponentType<{ terminalId: string }>;
+  onExpand?: (toolCallId: string) => void;
 }
 
 /** The nested transcript body, shared between the inline card and the full-size viewer. Children
- * render linearly (no recursive activity grouping); the Task's own rawOutput is not repeated —
+ * render linearly (no recursive activity grouping), except a nested spawn (`task`-kind child),
+ * which recurses into its own SubagentCard — partitioning buckets grandchildren under the inner
+ * task, so a plain tool row would silently drop them. The Task's own rawOutput is not repeated —
  * the transcript already ends with the subagent's report — except as the empty-transcript
  * fallback (e.g. a degraded history read), so the report is never lost. */
 export function SubagentTranscript({
   toolCall,
   items,
+  childrenByParent,
   awaitingApproval,
   declined,
   TerminalBlockComponent,
+  onExpand,
 }: SubagentTranscriptProps): React.ReactNode {
   if (items.length === 0) {
     return (
@@ -76,6 +83,20 @@ export function SubagentTranscript({
           case 'reasoning':
             return <ThoughtBlock key={item.id} blocks={item.blocks} isStreaming={false} />;
           case 'tool':
+            if (item.toolCall.kind === 'task') {
+              return (
+                <SubagentCard
+                  key={item.id}
+                  awaitingApproval={awaitingApproval}
+                  childrenByParent={childrenByParent}
+                  declined={declined}
+                  items={childrenByParent.get(item.toolCall.toolCallId) ?? []}
+                  onExpand={onExpand}
+                  TerminalBlockComponent={TerminalBlockComponent}
+                  toolCall={item.toolCall}
+                />
+              );
+            }
             return (
               <ToolCallItem
                 key={item.id}
@@ -93,10 +114,7 @@ export function SubagentTranscript({
   );
 }
 
-export interface SubagentCardProps extends SubagentTranscriptProps {
-  /** Opens the full-size transcript viewer for this subagent. */
-  onExpand?: (toolCallId: string) => void;
-}
+export type SubagentCardProps = SubagentTranscriptProps;
 
 /** Inline collapsible card for one subagent run: header shows the agent type + task description
  * and live status; the body nests the full transcript. Auto-open while running but the user's
@@ -104,6 +122,7 @@ export interface SubagentCardProps extends SubagentTranscriptProps {
 export function SubagentCard({
   toolCall,
   items,
+  childrenByParent,
   awaitingApproval,
   declined,
   TerminalBlockComponent,
@@ -169,8 +188,10 @@ export function SubagentCard({
       <CollapsibleContent className="mt-1 space-y-2 border-l-2 border-border pl-3">
         <SubagentTranscript
           awaitingApproval={awaitingApproval}
+          childrenByParent={childrenByParent}
           declined={declined}
           items={items}
+          onExpand={onExpand}
           TerminalBlockComponent={TerminalBlockComponent}
           toolCall={toolCall}
         />

--- a/packages/ui/src/chat/subagent-card.tsx
+++ b/packages/ui/src/chat/subagent-card.tsx
@@ -1,0 +1,180 @@
+import type { ToolCall } from '@linkcode/schema';
+import { Badge } from 'coss-ui/components/badge';
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from 'coss-ui/components/collapsible';
+import { Spinner } from 'coss-ui/components/spinner';
+import { BotIcon, ChevronRightIcon, Maximize2Icon } from 'lucide-react';
+import { useState } from 'react';
+import { useTranslations } from 'use-intl';
+import { ContentBlockView } from './content-block-view';
+import { Message, MessageContent } from './message';
+import { ThoughtBlock } from './thought-block';
+import { ToolCallBody, ToolCallItem } from './tool-call-item';
+import type { ConversationItem } from './types';
+
+export interface SubagentTaskInput {
+  description?: string;
+  subagentType?: string;
+}
+
+/** The Task tool's input fields the header displays (see the SDK's `AgentInput`). */
+export function subagentTaskInput(rawInput: unknown): SubagentTaskInput {
+  if (typeof rawInput !== 'object' || rawInput === null || Array.isArray(rawInput)) return {};
+  const raw = rawInput as Record<string, unknown>;
+  return {
+    description: typeof raw.description === 'string' ? raw.description : undefined,
+    subagentType: typeof raw.subagent_type === 'string' ? raw.subagent_type : undefined,
+  };
+}
+
+interface SubagentTranscriptProps {
+  /** The spawning `task`-kind tool call. */
+  toolCall: ToolCall;
+  /** The subagent's items (narration / reasoning / tool calls), in arrival order. */
+  items: readonly ConversationItem[];
+  awaitingApproval: ReadonlySet<string>;
+  declined: ReadonlySet<string>;
+  TerminalBlockComponent?: React.ComponentType<{ terminalId: string }>;
+}
+
+/** The nested transcript body, shared between the inline card and the full-size viewer. Children
+ * render linearly (no recursive activity grouping); the Task's own rawOutput is not repeated —
+ * the transcript already ends with the subagent's report — except as the empty-transcript
+ * fallback (e.g. a degraded history read), so the report is never lost. */
+export function SubagentTranscript({
+  toolCall,
+  items,
+  awaitingApproval,
+  declined,
+  TerminalBlockComponent,
+}: SubagentTranscriptProps): React.ReactNode {
+  if (items.length === 0) {
+    return (
+      <div className="space-y-2">
+        <ToolCallBody TerminalBlockComponent={TerminalBlockComponent} toolCall={toolCall} />
+      </div>
+    );
+  }
+  return (
+    <>
+      {items.map((item) => {
+        switch (item.kind) {
+          case 'message':
+            return (
+              <Message key={item.id} from="assistant">
+                <MessageContent className="space-y-1">
+                  {item.blocks.map((block, index) => (
+                    // eslint-disable-next-line @eslint-react/no-array-index-key -- append-only stream: index+type is a stable position key
+                    <ContentBlockView key={`${index}:${block.type}`} block={block} />
+                  ))}
+                </MessageContent>
+              </Message>
+            );
+          case 'reasoning':
+            return <ThoughtBlock key={item.id} blocks={item.blocks} isStreaming={false} />;
+          case 'tool':
+            return (
+              <ToolCallItem
+                key={item.id}
+                awaitingApproval={awaitingApproval.has(item.toolCall.toolCallId)}
+                declined={declined.has(item.toolCall.toolCallId)}
+                toolCall={item.toolCall}
+                TerminalBlockComponent={TerminalBlockComponent}
+              />
+            );
+          default:
+            return null;
+        }
+      })}
+    </>
+  );
+}
+
+export interface SubagentCardProps extends SubagentTranscriptProps {
+  /** Opens the full-size transcript viewer for this subagent. */
+  onExpand?: (toolCallId: string) => void;
+}
+
+/** Inline collapsible card for one subagent run: header shows the agent type + task description
+ * and live status; the body nests the full transcript. Auto-open while running but the user's
+ * toggle always wins (unlike ActivityGroup's forced-open) — a subagent can run for minutes. */
+export function SubagentCard({
+  toolCall,
+  items,
+  awaitingApproval,
+  declined,
+  TerminalBlockComponent,
+  onExpand,
+}: SubagentCardProps): React.ReactNode {
+  const t = useTranslations('workbench.subagent');
+  const tg = useTranslations('workbench.toolGroup');
+
+  const isRunning = toolCall.status === 'in_progress' || toolCall.status === 'pending';
+  const [manualOpen, setManualOpen] = useState<boolean | null>(null);
+  const open = manualOpen ?? isRunning;
+
+  const toolCount = items.reduce((count, item) => count + (item.kind === 'tool' ? 1 : 0), 0);
+  const failedCount = items.reduce(
+    (count, item) => count + (item.kind === 'tool' && item.toolCall.status === 'failed' ? 1 : 0),
+    0,
+  );
+  const input = subagentTaskInput(toolCall.rawInput);
+
+  return (
+    <Collapsible className="w-full" onOpenChange={setManualOpen} open={open}>
+      <div className="flex w-full items-center gap-2">
+        <CollapsibleTrigger className="group flex min-w-0 flex-1 items-center gap-2 py-1 text-left text-sm">
+          {isRunning ? (
+            <Spinner className="size-3.5 shrink-0 text-foreground" />
+          ) : (
+            <BotIcon
+              className={
+                toolCall.status === 'failed'
+                  ? 'size-3.5 shrink-0 text-destructive-foreground'
+                  : 'size-3.5 shrink-0 text-muted-foreground'
+              }
+            />
+          )}
+          <span className="shrink-0 text-foreground">{input.subagentType ?? t('label')}</span>
+          {toolCount > 0 ? (
+            <Badge size="sm" variant="secondary">
+              {t('steps', { count: toolCount })}
+            </Badge>
+          ) : null}
+          {failedCount > 0 ? (
+            <Badge size="sm" variant="error">
+              {tg('failed', { count: failedCount })}
+            </Badge>
+          ) : null}
+          <span className="min-w-0 flex-1 truncate text-muted-foreground/70">
+            {input.description ?? toolCall.title}
+          </span>
+          <ChevronRightIcon className="size-3.5 shrink-0 text-muted-foreground transition-transform group-data-[panel-open]:rotate-90" />
+        </CollapsibleTrigger>
+        {onExpand ? (
+          <button
+            aria-label={t('viewTranscript')}
+            className="shrink-0 rounded p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
+            onClick={() => onExpand(toolCall.toolCallId)}
+            title={t('viewTranscript')}
+            type="button"
+          >
+            <Maximize2Icon className="size-3.5" />
+          </button>
+        ) : null}
+      </div>
+      <CollapsibleContent className="mt-1 space-y-2 border-l-2 border-border pl-3">
+        <SubagentTranscript
+          awaitingApproval={awaitingApproval}
+          declined={declined}
+          items={items}
+          TerminalBlockComponent={TerminalBlockComponent}
+          toolCall={toolCall}
+        />
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}

--- a/packages/ui/src/chat/subagent-viewer.tsx
+++ b/packages/ui/src/chat/subagent-viewer.tsx
@@ -1,0 +1,126 @@
+import { Badge } from 'coss-ui/components/badge';
+import { Dialog, DialogPopup, DialogTitle } from 'coss-ui/components/dialog';
+import { Spinner } from 'coss-ui/components/spinner';
+import { BotIcon } from 'lucide-react';
+import { useTranslations } from 'use-intl';
+import { cn } from '../lib/cn';
+import type { ToolTimelineItem } from './activity-groups';
+import { SubagentTranscript, subagentTaskInput } from './subagent-card';
+import type { ConversationItem } from './types';
+
+export interface SubagentViewerProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Every subagent spawn (`task`-kind tool item) in the conversation, timeline order. */
+  tasks: readonly ToolTimelineItem[];
+  selectedId: string | null;
+  onSelect: (toolCallId: string) => void;
+  childrenByParent: ReadonlyMap<string, ConversationItem[]>;
+  awaitingApproval: ReadonlySet<string>;
+  declined: ReadonlySet<string>;
+  TerminalBlockComponent?: React.ComponentType<{ terminalId: string }>;
+}
+
+/** Full-size transcript viewer (the TUI's task view): a rail listing every subagent in the
+ * conversation, the selected one's transcript beside it at reading width. */
+export function SubagentViewer({
+  open,
+  onOpenChange,
+  tasks,
+  selectedId,
+  onSelect,
+  childrenByParent,
+  awaitingApproval,
+  declined,
+  TerminalBlockComponent,
+}: SubagentViewerProps): React.ReactNode {
+  const t = useTranslations('workbench.subagent');
+
+  // eslint-disable-next-line sukka/react-no-performance-impacting-array-find -- a conversation holds a handful of subagents at most; a lookup Map would outweigh the scan
+  const selected = tasks.find((task) => task.toolCall.toolCallId === selectedId) ?? tasks[0];
+
+  return (
+    <Dialog onOpenChange={onOpenChange} open={open}>
+      <DialogPopup className="h-[80vh] max-w-5xl">
+        <div className="flex min-h-0 flex-1">
+          <div className="flex w-60 shrink-0 flex-col gap-1 overflow-y-auto border-e border-border p-3">
+            <DialogTitle className="px-2 pt-1 pb-2 text-sm">{t('viewerTitle')}</DialogTitle>
+            {tasks.length === 0 ? (
+              <div className="px-2 text-muted-foreground text-sm">{t('empty')}</div>
+            ) : (
+              tasks.map((task) => (
+                <SubagentRailRow
+                  key={task.id}
+                  onSelect={onSelect}
+                  selected={task.toolCall.toolCallId === selected?.toolCall.toolCallId}
+                  task={task}
+                />
+              ))
+            )}
+          </div>
+          <div className="min-w-0 flex-1 space-y-2 overflow-y-auto p-4">
+            {selected ? (
+              <SubagentTranscript
+                awaitingApproval={awaitingApproval}
+                declined={declined}
+                items={childrenByParent.get(selected.toolCall.toolCallId) ?? []}
+                TerminalBlockComponent={TerminalBlockComponent}
+                toolCall={selected.toolCall}
+              />
+            ) : null}
+          </div>
+        </div>
+      </DialogPopup>
+    </Dialog>
+  );
+}
+
+function SubagentRailRow({
+  task,
+  selected,
+  onSelect,
+}: {
+  task: ToolTimelineItem;
+  selected: boolean;
+  onSelect: (toolCallId: string) => void;
+}): React.ReactNode {
+  const t = useTranslations('workbench.subagent');
+  const toolCall = task.toolCall;
+  const isRunning = toolCall.status === 'in_progress' || toolCall.status === 'pending';
+  const input = subagentTaskInput(toolCall.rawInput);
+
+  return (
+    <button
+      className={cn(
+        'flex w-full flex-col gap-0.5 rounded-lg px-2 py-1.5 text-left text-sm hover:bg-muted',
+        selected && 'bg-muted',
+      )}
+      onClick={() => onSelect(toolCall.toolCallId)}
+      type="button"
+    >
+      <span className="flex items-center gap-1.5">
+        {isRunning ? (
+          <Spinner className="size-3.5 shrink-0" />
+        ) : (
+          <BotIcon
+            className={cn(
+              'size-3.5 shrink-0',
+              toolCall.status === 'failed'
+                ? 'text-destructive-foreground'
+                : 'text-muted-foreground',
+            )}
+          />
+        )}
+        <span className="min-w-0 truncate font-medium">{input.subagentType ?? t('label')}</span>
+        {toolCall.status === 'failed' ? (
+          <Badge size="sm" variant="error">
+            {t('failedBadge')}
+          </Badge>
+        ) : null}
+      </span>
+      <span className="truncate text-muted-foreground text-xs">
+        {input.description ?? toolCall.title}
+      </span>
+    </button>
+  );
+}

--- a/packages/ui/src/chat/subagent-viewer.tsx
+++ b/packages/ui/src/chat/subagent-viewer.tsx
@@ -62,8 +62,11 @@ export function SubagentViewer({
             {selected ? (
               <SubagentTranscript
                 awaitingApproval={awaitingApproval}
+                childrenByParent={childrenByParent}
                 declined={declined}
                 items={childrenByParent.get(selected.toolCall.toolCallId) ?? []}
+                // A nested spawn's expand button re-targets the rail selection to that subagent.
+                onExpand={onSelect}
                 TerminalBlockComponent={TerminalBlockComponent}
                 toolCall={selected.toolCall}
               />

--- a/packages/ui/src/chat/subagents.ts
+++ b/packages/ui/src/chat/subagents.ts
@@ -1,0 +1,42 @@
+import type { ConversationItem } from './types';
+
+/**
+ * Splits subagent transcript items out of a timeline slice. An item belongs to a subagent when it
+ * carries a `parentToolCallId` (narration/reasoning) or its tool call does — the id of the
+ * `task`-kind tool call that spawned it. Children keep their arrival order per parent; orphans
+ * (parent not announced in this slice, e.g. a page-windowed history read) fall back to the
+ * top-level timeline so nothing silently disappears.
+ */
+export interface SubagentPartition {
+  topLevel: ConversationItem[];
+  childrenByParent: ReadonlyMap<string, ConversationItem[]>;
+}
+
+function itemParentId(item: ConversationItem): string | undefined {
+  if (item.kind === 'message' || item.kind === 'reasoning') return item.parentToolCallId;
+  if (item.kind === 'tool') return item.toolCall.parentToolCallId;
+  return undefined;
+}
+
+export function partitionSubagentItems(items: readonly ConversationItem[]): SubagentPartition {
+  const taskIds = new Set<string>();
+  for (const item of items) {
+    if (item.kind === 'tool' && item.toolCall.kind === 'task') {
+      taskIds.add(item.toolCall.toolCallId);
+    }
+  }
+
+  const topLevel: ConversationItem[] = [];
+  const childrenByParent = new Map<string, ConversationItem[]>();
+  for (const item of items) {
+    const parent = itemParentId(item);
+    if (parent === undefined || !taskIds.has(parent)) {
+      topLevel.push(item);
+      continue;
+    }
+    const children = childrenByParent.get(parent);
+    if (children) children.push(item);
+    else childrenByParent.set(parent, [item]);
+  }
+  return { topLevel, childrenByParent };
+}

--- a/packages/ui/src/chat/tool-utils.ts
+++ b/packages/ui/src/chat/tool-utils.ts
@@ -1,5 +1,6 @@
 import type { ToolCall } from '@linkcode/schema';
 import {
+  BotIcon,
   BrainIcon,
   FileOutputIcon,
   FileTextIcon,
@@ -29,5 +30,6 @@ export const TOOL_KIND_ICONS: Record<
   execute: TerminalIcon,
   think: BrainIcon,
   fetch: GlobeIcon,
+  task: BotIcon,
   other: WrenchIcon,
 };

--- a/packages/ui/src/chat/types.ts
+++ b/packages/ui/src/chat/types.ts
@@ -30,11 +30,14 @@ export type ConversationItem =
       role: 'user' | 'assistant';
       blocks: ContentBlock[];
       isStreaming: boolean;
+      /** Set on subagent narration: the `task`-kind tool call that spawned it (nested in the UI). */
+      parentToolCallId?: string;
     })
   | (ConversationItemBase & {
       kind: 'reasoning';
       blocks: ContentBlock[];
       isStreaming: boolean;
+      parentToolCallId?: string;
     })
   | (ConversationItemBase & { kind: 'tool'; toolCall: ToolCall })
   | (ConversationItemBase & { kind: 'plan'; plan: Plan })


### PR DESCRIPTION
Part of CODE-80.

## What

End-to-end subagent support for claude-code sessions: wire schema → adapter routing → client-core → UI. Before this, a subagent's tool calls and (with text forwarding) narration were flattened into the main conversation stream.

- **schema**: `task` tool kind; `parentToolCallId` on `ToolCall`/`ToolCallUpdate` and on `agent-message-chunk`/`agent-thought-chunk`
- **agent-adapter**: base emit helpers thread the parent link; claude-code enables `forwardSubagentText` and routes every frame by `parent_tool_use_id` — subagent tools carry the parent id, text/thinking render message-level under the frame uuid, subagent stream deltas are dropped (no double render), and the main agent's streaming cursor is never touched. History replay stamps the same links and skips the subagent's injected prompt.
- **client-core**: `message`/`reasoning` items carry `parentToolCallId`
- **ui**: `partitionSubagentItems` splits children out of the top-level timeline (orphans fall back); `task`-kind tools become standalone timeline entries; `SubagentCard` renders the nested transcript inline (auto-open while running, user toggle wins, auto-collapse on settle); `SubagentViewer` modal lists every subagent in the conversation with a full-size transcript pane.

The spawn tool is named `Agent` in current CLIs and `Task` in older transcripts — both classify as `task` (found live; the first run flattened everything because only `Task` was matched).

## Verified

- Unit: new adapter routing/history-mapper/client-core/UI partition tests; existing `message-grouping` regression guard still passes; full workspace vitest green.
- Live desktop (isolated daemon + real claude-code run spawning a subagent): nested card, viewer modal, main-stream isolation, cold resume without duplicates (cold resume falls back to Task input + final report by design — the SDK stores subagent transcripts under a separate `subagents/agent-{id}` subpath; follow-up tracked in CODE-80).