### PR TITLE
feat(desktop): LinkCode Cloud sign-in in the sidebar footer

### DIFF
--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -11,6 +11,14 @@ appId: com.arcboxlabs.linkcode.desktop
 productName: LinkCode
 copyright: Copyright © 2026 ArcBox Labs
 
+# `linkcode://` deep-link scheme for LinkCode Cloud OAuth callbacks. electron-builder registers it
+# in the macOS Info.plist and the Windows installer; dev shells register it at runtime via
+# setAsDefaultProtocolClient (see cloud-auth/client.ts).
+protocols:
+  - name: LinkCode
+    schemes:
+      - linkcode
+
 # electron-builder needs an exact Electron version (it downloads per-platform binaries) and
 # cannot read pnpm's `catalog:` protocol. Keep in sync with the `electron` catalog entry.
 electronVersion: 42.4.1

--- a/apps/desktop/electron.vite.config.ts
+++ b/apps/desktop/electron.vite.config.ts
@@ -24,7 +24,11 @@ export default defineConfig({
   },
   preload: {
     build: {
-      externalizeDeps: bundleWorkspace,
+      // The preload runs sandboxed and cannot `require()` external node_modules at runtime, so the
+      // better-auth electron bridge must be bundled in, not externalized (unlike in main).
+      externalizeDeps: {
+        exclude: [...bundleWorkspace.exclude, '@better-auth/electron'],
+      },
     },
   },
   renderer: {

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -18,6 +18,7 @@
   },
   "author": "ArcBox Labs <team@arcbox.dev>",
   "dependencies": {
+    "@better-auth/electron": "1.7.0-rc.1",
     "@hookform/resolvers": "^5.4.0",
     "@linkcode/common": "workspace:*",
     "@linkcode/ipc": "workspace:*",
@@ -28,6 +29,7 @@
     "@sentry/electron": "^7.14.0",
     "@sentry/react": "10.60.0",
     "allotment": "^1.20.5",
+    "better-auth": "1.7.0-rc.1",
     "coss-ui": "workspace:*",
     "electron-log": "^5.4.4",
     "electron-updater": "^6.8.9",

--- a/apps/desktop/src/main/cloud-auth/client.ts
+++ b/apps/desktop/src/main/cloud-auth/client.ts
@@ -1,0 +1,48 @@
+import { electronClient } from '@better-auth/electron/client';
+import { createAuthClient } from 'better-auth/client';
+import { BrowserWindow } from 'electron';
+import { IS_DEV_SHELL } from '../constants';
+import { createSafeStorage } from './storage';
+
+/**
+ * LinkCode Cloud (linkcodehq) endpoints. The desktop app authenticates against the Hono API
+ * (`baseURL`) but the sign-in flow itself runs in the system browser on the web origin
+ * (`signInURL`), which bounces through the central IdP and deep-links back via `linkcode://`.
+ * Env overrides let a developer point at a local/staging stack; otherwise dev shells hit
+ * localhost and released builds hit production.
+ */
+const CLOUD_API_URL =
+  process.env.LINKCODE_CLOUD_API_URL ??
+  (IS_DEV_SHELL ? 'http://localhost:3001' : 'https://api.linkcode.ai');
+
+const CLOUD_SIGN_IN_URL =
+  process.env.LINKCODE_CLOUD_SIGN_IN_URL ??
+  (IS_DEV_SHELL ? 'http://localhost:3000/sign-in' : 'https://app.linkcode.ai/sign-in');
+
+/** The custom protocol registered for OAuth deep-link callbacks; trusted by linkcodehq. */
+export const CLOUD_AUTH_SCHEME = 'linkcode';
+
+export const authClient = createAuthClient({
+  baseURL: CLOUD_API_URL,
+  plugins: [
+    electronClient({
+      signInURL: CLOUD_SIGN_IN_URL,
+      protocol: { scheme: CLOUD_AUTH_SCHEME },
+      storage: createSafeStorage(),
+    }),
+  ],
+});
+
+export type CloudAuthClient = typeof authClient;
+
+/**
+ * Wire the auth client into the main process: registers the `linkcode://` protocol, the deep-link
+ * handlers, and the IPC bridges the preload exposes. CSP is left to the renderer's own meta policy
+ * — the renderer never talks to the cloud API directly, only through these bridges.
+ */
+export function setupCloudAuth(): void {
+  authClient.setupMain({
+    csp: false,
+    getWindow: () => BrowserWindow.getAllWindows().at(0) ?? null,
+  });
+}

--- a/apps/desktop/src/main/cloud-auth/client.ts
+++ b/apps/desktop/src/main/cloud-auth/client.ts
@@ -19,6 +19,8 @@ export const CLOUD_AUTH_SCHEME = 'linkcode';
 
 export const authClient = createAuthClient({
   baseURL: CLOUD_API_URL,
+  // The API mounts better-auth at /auth, not the client default /api/auth.
+  basePath: '/auth',
   plugins: [
     electronClient({
       signInURL: CLOUD_SIGN_IN_URL,

--- a/apps/desktop/src/main/cloud-auth/client.ts
+++ b/apps/desktop/src/main/cloud-auth/client.ts
@@ -24,6 +24,9 @@ export const authClient = createAuthClient({
       signInURL: CLOUD_SIGN_IN_URL,
       protocol: { scheme: CLOUD_AUTH_SCHEME },
       storage: createSafeStorage(),
+      // The IdP does not return an avatar, so skip the user-image proxy (and its extra
+      // privileged scheme); the footer renders initials.
+      userImageProxy: { enabled: false },
     }),
   ],
 });
@@ -31,13 +34,16 @@ export const authClient = createAuthClient({
 export type CloudAuthClient = typeof authClient;
 
 /**
- * Wire the auth client into the main process: registers the `linkcode://` protocol, the deep-link
- * handlers, and the IPC bridges the preload exposes. CSP is left to the renderer's own meta policy
- * — the renderer never talks to the cloud API directly, only through these bridges.
+ * Wire the auth client into the main process. Each feature must be opted into explicitly once a
+ * config object is passed: `scheme` registers the `linkcode://` protocol + deep-link handlers,
+ * `bridges` registers the IPC handlers the preload invokes. CSP is left off — the renderer never
+ * talks to the cloud API directly, only through the bridges.
  */
 export function setupCloudAuth(): void {
   authClient.setupMain({
     csp: false,
+    scheme: true,
+    bridges: true,
     getWindow: () => BrowserWindow.getAllWindows().at(0) ?? null,
   });
 }

--- a/apps/desktop/src/main/cloud-auth/client.ts
+++ b/apps/desktop/src/main/cloud-auth/client.ts
@@ -1,23 +1,18 @@
 import { electronClient } from '@better-auth/electron/client';
 import { createAuthClient } from 'better-auth/client';
 import { BrowserWindow } from 'electron';
-import { IS_DEV_SHELL } from '../constants';
 import { createSafeStorage } from './storage';
 
 /**
  * LinkCode Cloud (linkcodehq) endpoints. The desktop app authenticates against the Hono API
  * (`baseURL`) but the sign-in flow itself runs in the system browser on the web origin
  * (`signInURL`), which bounces through the central IdP and deep-links back via `linkcode://`.
- * Env overrides let a developer point at a local/staging stack; otherwise dev shells hit
- * localhost and released builds hit production.
+ * Production is the default even for dev shells (there is no local cloud stack); the env
+ * overrides point a developer at a local/staging server when they do run one.
  */
-const CLOUD_API_URL =
-  process.env.LINKCODE_CLOUD_API_URL ??
-  (IS_DEV_SHELL ? 'http://localhost:3001' : 'https://api.linkcode.ai');
+const CLOUD_API_URL = process.env.LINKCODE_CLOUD_API_URL ?? 'https://api.linkcode.ai';
 
-const CLOUD_SIGN_IN_URL =
-  process.env.LINKCODE_CLOUD_SIGN_IN_URL ??
-  (IS_DEV_SHELL ? 'http://localhost:3000/sign-in' : 'https://app.linkcode.ai/sign-in');
+const CLOUD_SIGN_IN_URL = process.env.LINKCODE_CLOUD_SIGN_IN_URL ?? 'https://linkcode.ai/sign-in';
 
 /** The custom protocol registered for OAuth deep-link callbacks; trusted by linkcodehq. */
 export const CLOUD_AUTH_SCHEME = 'linkcode';

--- a/apps/desktop/src/main/cloud-auth/storage.ts
+++ b/apps/desktop/src/main/cloud-auth/storage.ts
@@ -1,0 +1,66 @@
+import { readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { app, safeStorage } from 'electron';
+import log from 'electron-log';
+
+/**
+ * Storage backing the better-auth electron client's session + cookie data. The plugin's
+ * `Storage` contract is a synchronous key/value store; we persist it as a single JSON map in
+ * `userData`, encrypting each value with the OS keychain (`safeStorage`).
+ *
+ * On platforms where `safeStorage` is unavailable (e.g. a Linux box with no keyring), values
+ * fall back to a base64 `plain:` encoding so login still works — logged once so it is visible.
+ */
+export interface Storage {
+  getItem: (name: string) => unknown | null;
+  setItem: (name: string, value: unknown) => void;
+}
+
+const PLAIN_PREFIX = 'plain:';
+
+function readMap(file: string): Record<string, string> {
+  try {
+    return JSON.parse(readFileSync(file, 'utf8')) as Record<string, string>;
+  } catch {
+    // Absent or unreadable store: start from empty. A corrupt file self-heals on next write.
+    return {};
+  }
+}
+
+function encode(value: unknown): string {
+  const json = JSON.stringify(value);
+  if (safeStorage.isEncryptionAvailable()) {
+    return safeStorage.encryptString(json).toString('base64');
+  }
+  log.warn('[cloud-auth] OS keychain unavailable; persisting session data unencrypted');
+  return PLAIN_PREFIX + Buffer.from(json, 'utf8').toString('base64');
+}
+
+function decode(stored: string): unknown {
+  const json = stored.startsWith(PLAIN_PREFIX)
+    ? Buffer.from(stored.slice(PLAIN_PREFIX.length), 'base64').toString('utf8')
+    : safeStorage.decryptString(Buffer.from(stored, 'base64'));
+  return JSON.parse(json);
+}
+
+export function createSafeStorage(): Storage {
+  const file = join(app.getPath('userData'), 'cloud-auth.json');
+
+  return {
+    getItem(name) {
+      const map = readMap(file);
+      if (!Object.hasOwn(map, name)) return null;
+      try {
+        return decode(map[name]);
+      } catch (err) {
+        log.warn('[cloud-auth] failed to decode stored session data:', err);
+        return null;
+      }
+    },
+    setItem(name, value) {
+      const map = readMap(file);
+      map[name] = encode(value);
+      writeFileSync(file, JSON.stringify(map), { mode: 0o600 });
+    },
+  };
+}

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -2,6 +2,7 @@ import { join } from 'node:path';
 import * as Sentry from '@sentry/electron/main';
 import { app, BrowserWindow, Menu } from 'electron';
 import { applyThemePreference } from './appearance';
+import { setupCloudAuth } from './cloud-auth/client';
 import { APP_NAME } from './constants';
 import { buildAppMenu } from './menu';
 import { getSettings } from './settings';
@@ -37,6 +38,9 @@ if (app.requestSingleInstanceLock()) {
       if (process.platform === 'darwin' && !app.isPackaged) {
         app.dock?.setIcon(join(__dirname, '../../../../assets/icon-dock.png'));
       }
+      // Register the LinkCode Cloud auth protocol + IPC bridges before the window loads so a
+      // cold-start deep-link callback is handled.
+      setupCloudAuth();
       // Apply the stored color scheme before the window exists so its chrome paints correctly first time.
       applyThemePreference(getSettings().theme);
       Menu.setApplicationMenu(buildAppMenu());

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -28,6 +28,11 @@ if (app.requestSingleInstanceLock()) {
     }
   });
 
+  // Wire the LinkCode Cloud auth protocol + IPC bridges. Must run BEFORE app is ready:
+  // the better-auth electron plugin registers a privileged scheme via
+  // protocol.registerSchemesAsPrivileged, which throws once the app is ready.
+  setupCloudAuth();
+
   app
     .whenReady()
     .then(() => {
@@ -38,9 +43,6 @@ if (app.requestSingleInstanceLock()) {
       if (process.platform === 'darwin' && !app.isPackaged) {
         app.dock?.setIcon(join(__dirname, '../../../../assets/icon-dock.png'));
       }
-      // Register the LinkCode Cloud auth protocol + IPC bridges before the window loads so a
-      // cold-start deep-link callback is handled.
-      setupCloudAuth();
       // Apply the stored color scheme before the window exists so its chrome paints correctly first time.
       applyThemePreference(getSettings().theme);
       Menu.setApplicationMenu(buildAppMenu());

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -1,3 +1,4 @@
+import { setupRenderer } from '@better-auth/electron/preload';
 import { createElectronSystemBridge } from '@linkcode/ipc/electron-renderer';
 import { contextBridge, ipcRenderer } from 'electron';
 
@@ -8,5 +9,10 @@ import { contextBridge, ipcRenderer } from 'electron';
 const systemBridge = createElectronSystemBridge(ipcRenderer);
 
 contextBridge.exposeInMainWorld('linkcodeSystem', systemBridge);
+
+// LinkCode Cloud auth bridges (window.requestAuth / onAuthenticated / signOut / …). This is the
+// better-auth electron plugin's own contextBridge surface — system-plane by nature (open browser,
+// keychain-backed session) and sandbox-safe (electron IPC only), so it coexists with the bridge above.
+setupRenderer();
 
 export type LinkcodeSystemApi = typeof systemBridge;

--- a/apps/desktop/src/renderer/index.html
+++ b/apps/desktop/src/renderer/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval'; img-src 'self' data: blob:; frame-src blob: http://*.localhost:*; connect-src 'self' http://127.0.0.1:* ws://127.0.0.1:* http://localhost:* ws://localhost:*"
+      content="default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval'; img-src 'self' data: blob: https://*.arcboxusercontent.com; frame-src blob: http://*.localhost:*; connect-src 'self' http://127.0.0.1:* ws://127.0.0.1:* http://localhost:* ws://localhost:*"
     />
     <title>Link Code · Desktop</title>
   </head>

--- a/apps/desktop/src/renderer/src/cloud-auth/bridges.ts
+++ b/apps/desktop/src/renderer/src/cloud-auth/bridges.ts
@@ -1,0 +1,39 @@
+/**
+ * Type surface for the LinkCode Cloud auth bridges the preload exposes on `window` via the
+ * better-auth electron plugin (`@better-auth/electron/preload`). Kept as an explicit contract
+ * because the bridge lives in the main process — the renderer can't import its inferred type
+ * across the process boundary, so we mirror the vendor's stable public shape here.
+ */
+
+/** The authenticated user, as normalized by the electron plugin. Extra IdP fields are preserved. */
+export interface CloudUser {
+  id: string;
+  name: string;
+  email: string;
+  image?: string | null;
+  [key: string]: unknown;
+}
+
+/** Options accepted by `requestAuth` — mirrors the plugin's request-auth schema (all optional). */
+export interface RequestAuthOptions {
+  provider?: string;
+  callbackURL?: string;
+  scopes?: string[];
+}
+
+export interface CloudAuthBridges {
+  /** Current user from the persisted session, or null when signed out. Used to seed on boot. */
+  getUser: () => Promise<CloudUser | null>;
+  /** Opens the system browser to the cloud sign-in flow. Resolves once the browser is launched. */
+  requestAuth: (options?: RequestAuthOptions) => Promise<void>;
+  signOut: () => Promise<void>;
+  /** Manual authorization-code exchange — a fallback for when the deep link cannot be delivered. */
+  authenticate: (data: { token: string }) => Promise<void>;
+  onAuthenticated: (callback: (user: CloudUser) => void) => () => void;
+  onUserUpdated: (callback: (user: CloudUser | null) => void) => () => void;
+  onAuthError: (callback: (context: unknown) => void) => () => void;
+}
+
+declare global {
+  interface Window extends CloudAuthBridges {}
+}

--- a/apps/desktop/src/renderer/src/cloud-auth/store.ts
+++ b/apps/desktop/src/renderer/src/cloud-auth/store.ts
@@ -1,0 +1,37 @@
+import { create } from 'zustand';
+import type { CloudUser } from './bridges';
+
+interface CloudAuthState {
+  /** The signed-in LinkCode Cloud user, or null when signed out / not yet loaded. */
+  user: CloudUser | null;
+  /** True from the moment sign-in is requested until the browser callback resolves or errors. */
+  authenticating: boolean;
+  signIn: () => void;
+  signOut: () => void;
+}
+
+/**
+ * Renderer-side view of the cloud auth session. The main process owns the actual session (keychain,
+ * browser flow, deep-link callback); this store seeds from `window.getUser()` on boot and stays in
+ * sync via the plugin's `onAuthenticated` / `onUserUpdated` / `onAuthError` bridges — never a
+ * `useEffect` watcher. The subscriptions are wired once when the store is created.
+ */
+export const useCloudAuthStore = create<CloudAuthState>((set) => {
+  void window.getUser().then((user) => set({ user: user ?? null }));
+  window.onAuthenticated((user) => set({ user, authenticating: false }));
+  window.onUserUpdated((user) => set({ user: user ?? null }));
+  window.onAuthError(() => set({ authenticating: false }));
+
+  return {
+    user: null,
+    authenticating: false,
+    signIn() {
+      set({ authenticating: true });
+      void window.requestAuth();
+    },
+    signOut() {
+      void window.signOut();
+      set({ user: null });
+    },
+  };
+});

--- a/apps/desktop/src/renderer/src/cloud-auth/store.ts
+++ b/apps/desktop/src/renderer/src/cloud-auth/store.ts
@@ -4,7 +4,7 @@ import type { CloudUser } from './bridges';
 interface CloudAuthState {
   /** The signed-in LinkCode Cloud user, or null when signed out / not yet loaded. */
   user: CloudUser | null;
-  /** True from the moment sign-in is requested until the browser callback resolves or errors. */
+  /** True only while the sign-in request is handing off to the system browser. */
   authenticating: boolean;
   signIn: () => void;
   signOut: () => void;
@@ -27,7 +27,11 @@ export const useCloudAuthStore = create<CloudAuthState>((set) => {
     authenticating: false,
     signIn() {
       set({ authenticating: true });
-      void window.requestAuth();
+      // requestAuth resolves once the system browser has been handed the sign-in URL; the
+      // rest of the flow happens out-of-app (deep link → onAuthenticated). Clear the flag on
+      // that handoff — otherwise abandoning the browser leaves no callback to fire and the
+      // button stays disabled until reload.
+      void window.requestAuth().finally(() => set({ authenticating: false }));
     },
     signOut() {
       void window.signOut();

--- a/apps/desktop/src/renderer/src/shell/desktop-shell.tsx
+++ b/apps/desktop/src/renderer/src/shell/desktop-shell.tsx
@@ -23,6 +23,7 @@ import { useCallback, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { useTranslations } from 'use-intl';
 import { useShallow } from 'zustand/react/shallow';
+import { useCloudAuthStore } from '../cloud-auth/store';
 import { BrowserWebviewPane } from './browser/browser-webview-pane';
 import { DesktopChrome } from './chrome/chrome';
 import { DiffStatChip } from './chrome/diff-stat-chip';
@@ -123,6 +124,14 @@ export function DesktopShell({
       resetSidebarSize: state.resetSidebarSize,
       resetRightPanelSize: state.resetRightPanelSize,
       resetBottomPanelSize: state.resetBottomPanelSize,
+    })),
+  );
+  const cloudAuth = useCloudAuthStore(
+    useShallow((state) => ({
+      user: state.user,
+      authenticating: state.authenticating,
+      signIn: state.signIn,
+      signOut: state.signOut,
     })),
   );
   const shellRootRef = useRef<HTMLDivElement | null>(null);
@@ -558,6 +567,10 @@ export function DesktopShell({
                     state={tConnection('connected')}
                     appVersion={appVersion}
                     pendingPermissionCount={conversation.pendingPermissionIds.length}
+                    account={cloudAuth.user}
+                    authPending={cloudAuth.authenticating}
+                    onSignIn={cloudAuth.signIn}
+                    onSignOut={cloudAuth.signOut}
                     onOpenSettings={onOpenSettings}
                   />
                 }

--- a/packages/i18n/src/locales/en.ts
+++ b/packages/i18n/src/locales/en.ts
@@ -200,6 +200,8 @@ export const en = {
       registerWorkspaceError: 'Failed to add workspace: {message}',
       importHistoryTitle: 'Import history',
       organization: 'Organization',
+      signInCloud: 'Sign in to LinkCode Cloud',
+      signOut: 'Sign out',
       historyEmptyTitle: 'No history to import',
       historyEmptyHint: 'This workspace has no saved conversations yet.',
       historyLoadError: 'Failed to load history. Try again later.',

--- a/packages/i18n/src/locales/zh-cn.ts
+++ b/packages/i18n/src/locales/zh-cn.ts
@@ -198,6 +198,8 @@ export const zhCN = {
       registerWorkspaceError: '添加工作区失败：{message}',
       importHistoryTitle: '导入历史记录',
       organization: '组织',
+      signInCloud: '登录 LinkCode Cloud',
+      signOut: '退出登录',
       historyEmptyTitle: '没有可导入的历史记录',
       historyEmptyHint: '该工作区还没有已保存的历史对话。',
       historyLoadError: '历史记录加载失败，请稍后重试。',

--- a/packages/ui/src/shell/session-sidebar.tsx
+++ b/packages/ui/src/shell/session-sidebar.tsx
@@ -1,20 +1,15 @@
 import type { SessionId, WorkspaceRecord } from '@linkcode/schema';
-import { Avatar, AvatarFallback } from 'coss-ui/components/avatar';
+import { Avatar, AvatarFallback, AvatarImage } from 'coss-ui/components/avatar';
 import { Badge } from 'coss-ui/components/badge';
 import { Button } from 'coss-ui/components/button';
 import { Popover, PopoverPopup, PopoverTrigger } from 'coss-ui/components/popover';
-import {
-  Select,
-  SelectItem,
-  SelectPopup,
-  SelectTrigger,
-  SelectValue,
-} from 'coss-ui/components/select';
 import { Separator } from 'coss-ui/components/separator';
 import {
   BotIcon,
   ChevronDownIcon,
+  CloudIcon,
   FilePlus2Icon,
+  LogOutIcon,
   SearchIcon,
   SettingsIcon,
   SparklesIcon,
@@ -56,7 +51,12 @@ export interface SessionSidebarProps extends ThreadGroupActions, ThreadGroupStat
   onRegisterWorkspace: (cwd: string) => Promise<WorkspaceRecord>;
 }
 
-const ORGS = [{ label: 'ArcBox Labs', value: 'arcbox' }];
+/** The signed-in LinkCode Cloud account rendered in the footer; null/undefined when signed out. */
+export interface CloudAccount {
+  name: string;
+  email: string;
+  image?: string | null;
+}
 
 export function SessionSidebar({
   threadGroups,
@@ -208,11 +208,21 @@ export function HostFooter({
   state,
   appVersion,
   pendingPermissionCount = 0,
+  account,
+  authPending = false,
+  onSignIn,
+  onSignOut,
   onOpenSettings,
 }: {
   state?: string;
   appVersion?: string;
   pendingPermissionCount?: number;
+  /** LinkCode Cloud account; null/undefined renders the signed-out sign-in button. */
+  account?: CloudAccount | null;
+  /** Sign-in in flight (browser handoff): disables the button and shows a spinner. */
+  authPending?: boolean;
+  onSignIn?: () => void;
+  onSignOut?: () => void;
   onOpenSettings?: () => void;
 }): React.ReactNode {
   const t = useTranslations('workbench.sidebar');
@@ -264,28 +274,35 @@ export function HostFooter({
         <Separator className="my-1" />
 
         <div className="flex items-center gap-2 pt-1">
-          <Select defaultValue="arcbox" items={ORGS}>
-            <SelectTrigger
-              disabled
-              aria-label={t('organization')}
-              className="min-w-0 flex-1"
-              size="sm"
-            >
-              <Avatar className="size-5 rounded-sm">
-                <AvatarFallback className="rounded-sm bg-primary text-primary-foreground">
-                  A
+          {account ? (
+            <div className="flex min-w-0 flex-1 items-center gap-2">
+              <Avatar className="size-6">
+                {account.image && <AvatarImage src={account.image} alt={account.name} />}
+                <AvatarFallback className="bg-primary text-primary-foreground text-xs">
+                  {accountInitial(account)}
                 </AvatarFallback>
               </Avatar>
-              <SelectValue />
-            </SelectTrigger>
-            <SelectPopup>
-              {ORGS.map((org) => (
-                <SelectItem key={org.value} value={org.value}>
-                  {org.label}
-                </SelectItem>
-              ))}
-            </SelectPopup>
-          </Select>
+              <div className="min-w-0 flex-1 leading-tight">
+                <div className="truncate font-medium">{account.name}</div>
+                <div className="truncate text-muted-foreground text-xs">{account.email}</div>
+              </div>
+              <Button size="icon-sm" variant="ghost" aria-label={t('signOut')} onClick={onSignOut}>
+                <LogOutIcon />
+              </Button>
+            </div>
+          ) : (
+            <Button
+              className="min-w-0 flex-1 justify-start"
+              size="sm"
+              variant="outline"
+              loading={authPending}
+              disabled={!onSignIn}
+              onClick={onSignIn}
+            >
+              <CloudIcon />
+              {t('signInCloud')}
+            </Button>
+          )}
           <Button
             disabled={!onOpenSettings}
             size="icon-sm"
@@ -299,6 +316,10 @@ export function HostFooter({
       </PopoverPopup>
     </Popover>
   );
+}
+
+function accountInitial(account: CloudAccount): string {
+  return (account.name || account.email).trim().charAt(0).toUpperCase() || '?';
 }
 
 function HostFooterRow({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -185,7 +185,7 @@ importers:
         version: 12.11.1
       drizzle-orm:
         specifier: ^0.45.2
-        version: 0.45.2(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(expo-sqlite@56.0.5(expo@56.0.13)(react-native@0.86.0(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.7))(react@19.2.7))
+        version: 0.45.2(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(expo-sqlite@56.0.5(expo@56.0.13)(react-native@0.86.0(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.7))(react@19.2.7))(kysely@0.29.2)
       foxts:
         specifier: ^5.6.0
         version: 5.6.0
@@ -211,6 +211,9 @@ importers:
 
   apps/desktop:
     dependencies:
+      '@better-auth/electron':
+        specifier: 1.7.0-rc.1
+        version: 1.7.0-rc.1(@better-auth/core@1.7.0-rc.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.7.0-rc.1(@opentelemetry/api@1.9.1)(better-sqlite3@12.11.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(expo-sqlite@56.0.5(expo@56.0.13)(react-native@0.86.0(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.7))(react@19.2.7))(kysely@0.29.2))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))))(better-call@1.3.7(zod@4.4.3))(electron@42.4.1)
       '@hookform/resolvers':
         specifier: ^5.4.0
         version: 5.4.0(react-hook-form@7.80.0(react@19.2.7))
@@ -241,6 +244,9 @@ importers:
       allotment:
         specifier: ^1.20.5
         version: 1.20.5(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      better-auth:
+        specifier: 1.7.0-rc.1
+        version: 1.7.0-rc.1(@opentelemetry/api@1.9.1)(better-sqlite3@12.11.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(expo-sqlite@56.0.5(expo@56.0.13)(react-native@0.86.0(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.7))(react@19.2.7))(kysely@0.29.2))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)))
       coss-ui:
         specifier: workspace:*
         version: link:../../packages/coss-ui
@@ -1552,6 +1558,102 @@ packages:
       '@types/react':
         optional: true
 
+  '@better-auth/core@1.7.0-rc.1':
+    resolution: {integrity: sha512-qwVJ5LBPAp8FhhRbUzJDv8cp6h6sn266PPJIXBhB2aYXee40/VGpyoTmx9+LmOotOLQ4BWSO5rCSDvS8FGVdEQ==}
+    peerDependencies:
+      '@better-auth/utils': 0.4.2
+      '@better-fetch/fetch': 1.3.1
+      '@cloudflare/workers-types': '>=4'
+      '@opentelemetry/api': ^1.9.0
+      better-call: 1.3.7
+      jose: ^6.1.0
+      kysely: ^0.28.5 || ^0.29.0
+      nanostores: ^1.0.1
+    peerDependenciesMeta:
+      '@cloudflare/workers-types':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+
+  '@better-auth/drizzle-adapter@1.7.0-rc.1':
+    resolution: {integrity: sha512-r2PjeNFZpWwkW9hvMyE+sgqzYPm3+pB7wE6+aL/iVl0SumqJns1fTFZiqTlQP67AUhJHO2Oelra+WdrtEE0v5Q==}
+    peerDependencies:
+      '@better-auth/core': ^1.7.0-rc.1
+      '@better-auth/utils': 0.4.2
+      drizzle-orm: ^0.45.2 || >=1.0.0-rc.1 <2.0.0
+    peerDependenciesMeta:
+      drizzle-orm:
+        optional: true
+
+  '@better-auth/electron@1.7.0-rc.1':
+    resolution: {integrity: sha512-jdWt/oHcDe0I4rYR2HvT0wMzekDvYB4JkTM1/xngL3Qr6HK6OJCoVTAQUbTQr/tqUsh1jB9gBVscceQAF7SJ3Q==}
+    engines: {node: '>=22.0.0'}
+    peerDependencies:
+      '@better-auth/core': ^1.7.0-rc.1
+      '@better-auth/utils': 0.4.2
+      '@better-fetch/fetch': 1.3.1
+      better-auth: ^1.7.0-rc.1
+      better-call: 1.3.7
+      conf: ^15.0.2
+      electron: '>=36.0.0'
+    peerDependenciesMeta:
+      conf:
+        optional: true
+      electron:
+        optional: true
+
+  '@better-auth/kysely-adapter@1.7.0-rc.1':
+    resolution: {integrity: sha512-8ykUlvqJERPJj3fohgc66VA091tGNiZlw0Pr4YnChr4n7bSqI6P/9bic1g6+XiGz10Li4t0qGcyqBpXKJb/iTw==}
+    peerDependencies:
+      '@better-auth/core': ^1.7.0-rc.1
+      '@better-auth/utils': 0.4.2
+      kysely: ^0.28.17 || ^0.29.0
+    peerDependenciesMeta:
+      kysely:
+        optional: true
+
+  '@better-auth/memory-adapter@1.7.0-rc.1':
+    resolution: {integrity: sha512-CyGMXZNCLQ531K4mhdSfhAjXXh+R+ybX/Xss2u9ZYs7un5XZbL+gC5rTGNPktV3KcEHPG60/om7x3bH4jMPi6g==}
+    peerDependencies:
+      '@better-auth/core': ^1.7.0-rc.1
+      '@better-auth/utils': 0.4.2
+
+  '@better-auth/mongo-adapter@1.7.0-rc.1':
+    resolution: {integrity: sha512-nJEythD9d9rsEPCb3awTSrYn+heLDAReTyBQrfxOC5HYv+m+ekElE8Fy/XuFzENw+7qyY0V7LlfGK7JYhL5XbQ==}
+    peerDependencies:
+      '@better-auth/core': ^1.7.0-rc.1
+      '@better-auth/utils': 0.4.2
+      mongodb: ^6.0.0 || ^7.0.0
+    peerDependenciesMeta:
+      mongodb:
+        optional: true
+
+  '@better-auth/prisma-adapter@1.7.0-rc.1':
+    resolution: {integrity: sha512-d7J+VO7ZGnt20agKYDfA8XRi8Tzw4fekmzQTUzfkfd9EwYvOUx1Ed6cCjG7nsEPuHn49PLVtv+iX5Cfx2XF2kw==}
+    peerDependencies:
+      '@better-auth/core': ^1.7.0-rc.1
+      '@better-auth/utils': 0.4.2
+      '@prisma/client': ^5.0.0 || ^6.0.0 || ^7.0.0
+      prisma: ^5.0.0 || ^6.0.0 || ^7.0.0
+    peerDependenciesMeta:
+      '@prisma/client':
+        optional: true
+      prisma:
+        optional: true
+
+  '@better-auth/telemetry@1.7.0-rc.1':
+    resolution: {integrity: sha512-1lpODl12kDY3jA/46odeEtfC0u/UyPWAchtqIZq/JZVJGrnK5UCLwHRcSHYlkpHfZWXm7sXZYJ1vHJHKX66HCg==}
+    peerDependencies:
+      '@better-auth/core': ^1.7.0-rc.1
+      '@better-auth/utils': 0.4.2
+      '@better-fetch/fetch': 1.3.1
+
+  '@better-auth/utils@0.4.2':
+    resolution: {integrity: sha512-AUxrvu+HaaODsUyzDxFgwd/8RZ1yZaYo42LXKSrU2oGgR38pS1ij8nqQKNgtTWoYGpNevNXtCfgTy6loHveW9A==}
+
+  '@better-fetch/fetch@1.3.1':
+    resolution: {integrity: sha512-ABkD1WhyfPZprKRQI3bhATjeiFuNWC9PXhfGWqL+sg/gKrM977oFrYkdb4msM3hgUGonr7KlOsOFT5TU2rht9g==}
+
   '@biomejs/biome@2.5.0':
     resolution: {integrity: sha512-4kURkd9hAPrdDM3C9n82ycYgx8hvQcW6MjKTEejruj8rK0N8P3OPpdy8BvI8kt3KWY4ycF5XtDOrktetEfhfuw==}
     engines: {node: '>=14.21.3'}
@@ -2716,6 +2818,10 @@ packages:
 
   '@next/eslint-plugin-next@16.2.9':
     resolution: {integrity: sha512-UZi8+YT/MLgTC9nrrn2Xd4lBYv1B7lVmtWHfPcthAI5Tt/C1LuDe6DfmtCtJ+WQod3ksY4VrKSvk3oMVAnL7qw==}
+
+  '@noble/ciphers@2.2.0':
+    resolution: {integrity: sha512-Z6pjIZ/8IJcCGzb2S/0Px5J81yij85xASuk1teLNeg75bfT07MV3a/O2Mtn1I2se43k3lkVEcFaR10N4cgQcZA==}
+    engines: {node: '>= 20.19.0'}
 
   '@noble/hashes@1.4.0':
     resolution: {integrity: sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==}
@@ -4759,6 +4865,76 @@ packages:
     resolution: {integrity: sha512-BSSLZ9/Cjjv7Gtj5B68ZzXcXUg8iOf3fme+FCuh8rC/Go+Kmh8cox7M3A8dolou16s64QjLPOSdngh7GxXvkSw==}
     engines: {node: '>=6.0.0'}
     hasBin: true
+
+  better-auth@1.7.0-rc.1:
+    resolution: {integrity: sha512-dmTImZTzxDYfNSLdv5yTwRxNMnN8xBQnG9oeeW+eSltO0R0TxOfYZTnu1JE9MSI8tlR5tFfUaoLBTal6Z28v9A==}
+    peerDependencies:
+      '@lynx-js/react': '*'
+      '@prisma/client': ^5.0.0 || ^6.0.0 || ^7.0.0
+      '@sveltejs/kit': ^2.0.0
+      '@tanstack/react-start': ^1.0.0
+      '@tanstack/solid-start': ^1.0.0
+      better-sqlite3: ^12.0.0
+      drizzle-kit: '>=0.31.4'
+      drizzle-orm: ^0.45.2
+      mongodb: ^6.0.0 || ^7.0.0
+      mysql2: ^3.0.0
+      next: ^14.0.0 || ^15.0.0 || ^16.0.0
+      pg: ^8.0.0
+      prisma: ^5.0.0 || ^6.0.0 || ^7.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+      solid-js: ^1.0.0
+      svelte: ^4.0.0 || ^5.0.0
+      vitest: ^2.0.0 || ^3.0.0 || ^4.0.0
+      vue: ^3.0.0
+    peerDependenciesMeta:
+      '@lynx-js/react':
+        optional: true
+      '@prisma/client':
+        optional: true
+      '@sveltejs/kit':
+        optional: true
+      '@tanstack/react-start':
+        optional: true
+      '@tanstack/solid-start':
+        optional: true
+      better-sqlite3:
+        optional: true
+      drizzle-kit:
+        optional: true
+      drizzle-orm:
+        optional: true
+      mongodb:
+        optional: true
+      mysql2:
+        optional: true
+      next:
+        optional: true
+      pg:
+        optional: true
+      prisma:
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+      solid-js:
+        optional: true
+      svelte:
+        optional: true
+      vitest:
+        optional: true
+      vue:
+        optional: true
+
+  better-call@1.3.7:
+    resolution: {integrity: sha512-Al51/hjp2SSp6CRTa3F2ptcx4yQVS1xWKoY6jcVXqNYOap6mHFP2jUBn5EwIL4iIed1/Sq4hlQ+Umm6EflZG+w==}
+    peerDependencies:
+      zod: ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
 
   better-sqlite3@12.11.1:
     resolution: {integrity: sha512-dq9AtApgg5PGFtBzPFSBl3HZQjHok5gaQCM6zh2Yk0aSmDCs1CbnVI8/HgASQkNKsWFpseIO9beg5xxpYhbIfA==}
@@ -6819,6 +6995,10 @@ packages:
     resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
     engines: {node: '>=6'}
 
+  kysely@0.29.2:
+    resolution: {integrity: sha512-s6WVJyEZrbm6jhBpiKHsGHyePMrVQKJ85wZCFCr9W4QHv6WTjWIrdvTmO9hDEA3bNK0xkrE2DqrHsXMLWuZpQg==}
+    engines: {node: '>=22.0.0'}
+
   lan-network@0.2.1:
     resolution: {integrity: sha512-ONPnazC96VKDntab9j9JKwIWhZ4ZUceB4A9Epu4Ssg0hYFmtHZSeQ+n15nIwTFmcBUKtExOer8WTJ4GF9MO64A==}
     hasBin: true
@@ -7504,6 +7684,10 @@ packages:
     resolution: {integrity: sha512-v+KEsUv2ps74PaSKv0gHTxTCgMXOIfBEbaqa6w6ISIGC7ZsvHN4N9oJ8d4cmf0n5oTzQz2SLmThbQWhjd/8eKg==}
     engines: {node: ^18 || >=20}
     hasBin: true
+
+  nanostores@1.4.0:
+    resolution: {integrity: sha512-i0tloweeudshAEuddpDxcg9Ik6pkPfVsHIgKyf143JrgG7/MOh0+q7BypdLXZPoOP7fOYt1eTcwGkyiVmhJFkA==}
+    engines: {node: ^20.0.0 || >=22.0.0}
 
   napi-build-utils@2.0.0:
     resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==}
@@ -8309,6 +8493,9 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  rou3@0.7.12:
+    resolution: {integrity: sha512-iFE4hLDuloSWcD7mjdCDhx2bKcIsYbtOTpfH5MHHLSKMOUyjqQXTeZVa289uuwEGEKFoE/BAPbhaU4B774nceg==}
+
   roughjs@4.6.6:
     resolution: {integrity: sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==}
 
@@ -8403,6 +8590,9 @@ packages:
 
   set-cookie-parser@2.7.2:
     resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
+
+  set-cookie-parser@3.1.1:
+    resolution: {integrity: sha512-vM9SUhjsUYs6UeJUmygc5Ofm5eQGe85riob5ju6XCgFGJI5PLV4nrDAQpQjd+LkFBpAkADn5BQQpZ9EUNkyLuA==}
 
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
@@ -10181,6 +10371,72 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.17
 
+  '@better-auth/core@1.7.0-rc.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.4.0)':
+    dependencies:
+      '@better-auth/utils': 0.4.2
+      '@better-fetch/fetch': 1.3.1
+      '@opentelemetry/semantic-conventions': 1.41.1
+      '@standard-schema/spec': 1.1.0
+      better-call: 1.3.7(zod@4.4.3)
+      jose: 6.2.3
+      kysely: 0.29.2
+      nanostores: 1.4.0
+      zod: 4.4.3
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+
+  '@better-auth/drizzle-adapter@1.7.0-rc.1(@better-auth/core@1.7.0-rc.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(expo-sqlite@56.0.5(expo@56.0.13)(react-native@0.86.0(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.7))(react@19.2.7))(kysely@0.29.2))':
+    dependencies:
+      '@better-auth/core': 1.7.0-rc.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.4.0)
+      '@better-auth/utils': 0.4.2
+    optionalDependencies:
+      drizzle-orm: 0.45.2(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(expo-sqlite@56.0.5(expo@56.0.13)(react-native@0.86.0(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.7))(react@19.2.7))(kysely@0.29.2)
+
+  '@better-auth/electron@1.7.0-rc.1(@better-auth/core@1.7.0-rc.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.7.0-rc.1(@opentelemetry/api@1.9.1)(better-sqlite3@12.11.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(expo-sqlite@56.0.5(expo@56.0.13)(react-native@0.86.0(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.7))(react@19.2.7))(kysely@0.29.2))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))))(better-call@1.3.7(zod@4.4.3))(electron@42.4.1)':
+    dependencies:
+      '@better-auth/core': 1.7.0-rc.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.4.0)
+      '@better-auth/utils': 0.4.2
+      '@better-fetch/fetch': 1.3.1
+      better-auth: 1.7.0-rc.1(@opentelemetry/api@1.9.1)(better-sqlite3@12.11.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(expo-sqlite@56.0.5(expo@56.0.13)(react-native@0.86.0(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.7))(react@19.2.7))(kysely@0.29.2))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)))
+      better-call: 1.3.7(zod@4.4.3)
+      zod: 4.4.3
+    optionalDependencies:
+      electron: 42.4.1
+
+  '@better-auth/kysely-adapter@1.7.0-rc.1(@better-auth/core@1.7.0-rc.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(kysely@0.29.2)':
+    dependencies:
+      '@better-auth/core': 1.7.0-rc.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.4.0)
+      '@better-auth/utils': 0.4.2
+    optionalDependencies:
+      kysely: 0.29.2
+
+  '@better-auth/memory-adapter@1.7.0-rc.1(@better-auth/core@1.7.0-rc.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.4.0))(@better-auth/utils@0.4.2)':
+    dependencies:
+      '@better-auth/core': 1.7.0-rc.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.4.0)
+      '@better-auth/utils': 0.4.2
+
+  '@better-auth/mongo-adapter@1.7.0-rc.1(@better-auth/core@1.7.0-rc.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.4.0))(@better-auth/utils@0.4.2)':
+    dependencies:
+      '@better-auth/core': 1.7.0-rc.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.4.0)
+      '@better-auth/utils': 0.4.2
+
+  '@better-auth/prisma-adapter@1.7.0-rc.1(@better-auth/core@1.7.0-rc.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.4.0))(@better-auth/utils@0.4.2)':
+    dependencies:
+      '@better-auth/core': 1.7.0-rc.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.4.0)
+      '@better-auth/utils': 0.4.2
+
+  '@better-auth/telemetry@1.7.0-rc.1(@better-auth/core@1.7.0-rc.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)':
+    dependencies:
+      '@better-auth/core': 1.7.0-rc.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.4.0)
+      '@better-auth/utils': 0.4.2
+      '@better-fetch/fetch': 1.3.1
+
+  '@better-auth/utils@0.4.2':
+    dependencies:
+      '@noble/hashes': 2.2.0
+
+  '@better-fetch/fetch@1.3.1': {}
+
   '@biomejs/biome@2.5.0':
     optionalDependencies:
       '@biomejs/cli-darwin-arm64': 2.5.0
@@ -11568,6 +11824,8 @@ snapshots:
   '@next/eslint-plugin-next@16.2.9':
     dependencies:
       fast-glob: 3.3.1
+
+  '@noble/ciphers@2.2.0': {}
 
   '@noble/hashes@1.4.0': {}
 
@@ -13654,6 +13912,15 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
+  '@vitest/mocker@4.1.9(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))':
+    dependencies:
+      '@vitest/spy': 4.1.9
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.5(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+    optional: true
+
   '@vitest/mocker@4.1.9(vite@7.3.5(@types/node@26.0.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.9
@@ -13981,6 +14248,45 @@ snapshots:
   base64id@2.0.0: {}
 
   baseline-browser-mapping@2.10.40: {}
+
+  better-auth@1.7.0-rc.1(@opentelemetry/api@1.9.1)(better-sqlite3@12.11.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(expo-sqlite@56.0.5(expo@56.0.13)(react-native@0.86.0(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.7))(react@19.2.7))(kysely@0.29.2))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))):
+    dependencies:
+      '@better-auth/core': 1.7.0-rc.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.4.0)
+      '@better-auth/drizzle-adapter': 1.7.0-rc.1(@better-auth/core@1.7.0-rc.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(expo-sqlite@56.0.5(expo@56.0.13)(react-native@0.86.0(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.7))(react@19.2.7))(kysely@0.29.2))
+      '@better-auth/kysely-adapter': 1.7.0-rc.1(@better-auth/core@1.7.0-rc.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(kysely@0.29.2)
+      '@better-auth/memory-adapter': 1.7.0-rc.1(@better-auth/core@1.7.0-rc.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.4.0))(@better-auth/utils@0.4.2)
+      '@better-auth/mongo-adapter': 1.7.0-rc.1(@better-auth/core@1.7.0-rc.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.4.0))(@better-auth/utils@0.4.2)
+      '@better-auth/prisma-adapter': 1.7.0-rc.1(@better-auth/core@1.7.0-rc.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.4.0))(@better-auth/utils@0.4.2)
+      '@better-auth/telemetry': 1.7.0-rc.1(@better-auth/core@1.7.0-rc.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)
+      '@better-auth/utils': 0.4.2
+      '@better-fetch/fetch': 1.3.1
+      '@noble/ciphers': 2.2.0
+      '@noble/hashes': 2.2.0
+      better-call: 1.3.7(zod@4.4.3)
+      defu: 6.1.7
+      jose: 6.2.3
+      kysely: 0.29.2
+      nanostores: 1.4.0
+      zod: 4.4.3
+    optionalDependencies:
+      better-sqlite3: 12.11.1
+      drizzle-kit: 0.31.10
+      drizzle-orm: 0.45.2(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(expo-sqlite@56.0.5(expo@56.0.13)(react-native@0.86.0(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.7))(react@19.2.7))(kysely@0.29.2)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+    transitivePeerDependencies:
+      - '@cloudflare/workers-types'
+      - '@opentelemetry/api'
+
+  better-call@1.3.7(zod@4.4.3):
+    dependencies:
+      '@better-auth/utils': 0.4.2
+      '@better-fetch/fetch': 1.3.1
+      rou3: 0.7.12
+      set-cookie-parser: 3.1.1
+    optionalDependencies:
+      zod: 4.4.3
 
   better-sqlite3@12.11.1:
     dependencies:
@@ -14715,12 +15021,13 @@ snapshots:
       esbuild: 0.25.12
       tsx: 4.22.4
 
-  drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(expo-sqlite@56.0.5(expo@56.0.13)(react-native@0.86.0(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.7))(react@19.2.7)):
+  drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(expo-sqlite@56.0.5(expo@56.0.13)(react-native@0.86.0(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.7))(react@19.2.7))(kysely@0.29.2):
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
       '@types/better-sqlite3': 7.6.13
       better-sqlite3: 12.11.1
       expo-sqlite: 56.0.5(expo@56.0.13)(react-native@0.86.0(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.7))(react@19.2.7)
+      kysely: 0.29.2
 
   dunder-proto@1.0.1:
     dependencies:
@@ -16486,6 +16793,8 @@ snapshots:
 
   kleur@3.0.3: {}
 
+  kysely@0.29.2: {}
+
   lan-network@0.2.1: {}
 
   layout-base@1.0.2: {}
@@ -17408,6 +17717,8 @@ snapshots:
   nanoid@3.3.15: {}
 
   nanoid@5.1.11: {}
+
+  nanostores@1.4.0: {}
 
   napi-build-utils@2.0.0: {}
 
@@ -18488,6 +18799,8 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.62.0
       fsevents: 2.3.3
 
+  rou3@0.7.12: {}
+
   roughjs@4.6.6:
     dependencies:
       hachure-fill: 0.5.2
@@ -18608,6 +18921,8 @@ snapshots:
   server-only@0.0.1: {}
 
   set-cookie-parser@2.7.2: {}
+
+  set-cookie-parser@3.1.1: {}
 
   setprototypeof@1.2.0: {}
 
@@ -19437,6 +19752,35 @@ snapshots:
       terser: 5.48.0
       tsx: 4.22.4
       yaml: 2.9.0
+
+  vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)):
+    dependencies:
+      '@vitest/expect': 4.1.9
+      '@vitest/mocker': 4.1.9(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.9
+      '@vitest/runner': 4.1.9
+      '@vitest/snapshot': 4.1.9
+      '@vitest/spy': 4.1.9
+      '@vitest/utils': 4.1.9
+      es-module-lexer: 2.1.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.3
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.0
+      vite: 7.3.5(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      '@types/node': 25.9.3
+    transitivePeerDependencies:
+      - msw
+    optional: true
 
   vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.1)(vite@7.3.5(@types/node@26.0.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)):
     dependencies:


### PR DESCRIPTION
Adds LinkCode Cloud (linkcodehq) authentication to the desktop app, in the sidebar footer.

## What

- **Main process** (`src/main/cloud-auth/`): a better-auth client wired via the `@better-auth/electron` plugin — registers the `linkcode://` deep-link protocol + IPC bridges (`setupMain`), with a keychain-backed session store (`safeStorage`). Defaults to the production cloud endpoints (`api.linkcode.ai` / `linkcode.ai/sign-in`); `LINKCODE_CLOUD_API_URL` / `LINKCODE_CLOUD_SIGN_IN_URL` override to a local stack.
- **Preload**: `setupRenderer()` exposes the auth bridges (`requestAuth`/`getUser`/`onAuthenticated`/`signOut`). Bundled into the sandboxed preload (it can't `require()` externals at runtime).
- **Renderer**: a zustand store seeded from `window.getUser()` and kept in sync via the plugin bridges (no `useEffect` watcher).
- **UI** (`packages/ui` `HostFooter`): the disabled org-picker placeholder becomes a cloud account area — a "Sign in to LinkCode Cloud" button when signed out; avatar + name/email + sign out when signed in. Prop-driven; desktop passes `account`/`onSignIn`/`onSignOut` down. New i18n keys.
- `electron-builder.yml`: registers the `linkcode://` scheme for packaged builds.

## Flow

`requestAuth()` → system browser opens `linkcode.ai/sign-in` → central IdP → callback → deep-links `linkcode://` back → main exchanges the code, stores the session in the keychain, emits the user → footer shows the account.

## Verification

Verified end-to-end on a real machine against production: sign-in button → browser → IdP login → deep-link back → account rendered in the footer. Typecheck + lint + format pass.

The linkcodehq counterpart (the `/sign-in` proxy page, `/auth` base-path fix, and routing the IdP OAuth back-channel through a Worker service binding to bypass the edge WAF) is already on `linkcodehq` master.