### PR TITLE
fix(desktop): packaged app crashes on launch — bundle workspace deps + pin userData

### DIFF
--- a/apps/desktop/electron.vite.config.ts
+++ b/apps/desktop/electron.vite.config.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import tailwindcss from '@tailwindcss/vite';
 import react from '@vitejs/plugin-react';
@@ -5,15 +6,16 @@ import { defineConfig } from 'electron-vite';
 import { ExternalPackageIconLoader } from 'unplugin-icons/loaders';
 import Icons from 'unplugin-icons/vite';
 
-// Workspace packages are exported as TS source, so they must be bundled into main/preload (they can't be runtime externals).
+// Workspace packages are exported as TS source, so they must be bundled into main/preload (they
+// can't be runtime externals): a require left in the bundle resolves to .ts under
+// app.asar/node_modules and crashes on launch (ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING).
+// Derive the list from package.json instead of naming packages so a new workspace import into
+// main can never be missed again.
+const { dependencies } = JSON.parse(readFileSync(resolve(__dirname, 'package.json'), 'utf8')) as {
+  dependencies: Record<string, string>;
+};
 const bundleWorkspace = {
-  exclude: [
-    '@linkcode/ipc',
-    '@linkcode/schema',
-    '@linkcode/transport',
-    '@linkcode/client-core',
-    '@linkcode/ui',
-  ],
+  exclude: Object.keys(dependencies).filter((name) => dependencies[name].startsWith('workspace:')),
 };
 
 export default defineConfig({

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@linkcode/desktop",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "description": "LinkCode desktop application",
   "homepage": "https://linkcode.ai",

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -14,6 +14,11 @@ Sentry.init({
 });
 
 app.setName(APP_NAME);
+// setName alone is not enough: Electron pins userData from package.json's productName before
+// any app code runs, and electron-builder bakes the release productName ("LinkCode") into the
+// asar even for dev-shell packages. Without this, a packaged dev shell shares the release app's
+// settings and single-instance lock — the second one to start exits silently.
+app.setPath('userData', join(app.getPath('appData'), APP_NAME));
 
 // settings.ts caches settings in memory and rewrites the whole file on save, so two instances
 // would last-write-wins clobber each other. Only one instance may run; a second launch just


### PR DESCRIPTION
Fixes #41 (CODE-101).

## Bug 1 — v0.1.0 crashes on launch on every platform

`bundleWorkspace.exclude` in `electron.vite.config.ts` was a hand-maintained allow-list; `@linkcode/common` was missing from it, so the built main bundle kept a runtime `require("@linkcode/common/node")` (introduced by 66c9ce0). Workspace packages are exported as TS source, so in the packaged app that require resolves to `app.asar/node_modules/@linkcode/common/src/node/index.ts` and Node refuses type-stripping under `node_modules`:

```
Error [ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING]
```

The main process dies before the first window. Fix: derive the exclude list from `package.json` (`workspace:*` deps), so a new workspace import into main can never be missed again.

## Bug 2 — packaged dev shell shares the release app's userData + single-instance lock

Found while verifying bug 1: the locally packaged dev shell (`pnpm package`, `APP_NAME = "LinkCode Dev"`) silently exited with code 0. Electron pins `userData` from the asar `package.json`'s `productName` ("LinkCode" — electron-builder bakes the yml value in; the `-c.productName` CLI override doesn't reach the asar) before any app code runs, so `app.setName(APP_NAME)` never moved `userData`. The dev shell therefore contended for the release app's single-instance lock — `requestSingleInstanceLock()` returned false → silent `app.quit()`, defeating the coexistence contract documented in `constants.ts`. Fix: pin `userData` explicitly to `appData/APP_NAME`. No-op for release builds (same path as today).

## Verification

- Packaged locally (`pnpm -F @linkcode/desktop run package`, unsigned arm64) and launched the artifact via playwright-core `_electron.launch`:
  - isolated `$HOME`: boots to the renderer's daemon-connection gate, no crash dialog, main process stays alive;
  - real `$HOME` with a dev daemon running: boots to the full workbench, `Local Host Connected`, thread history renders.
- Extracted `app.asar` and confirmed `out/main/index.js` has no workspace-package `require` left (all remaining externals resolve to compiled JS); sandboxed preload requires only `electron`.
- PTY sidecar checked alongside (`cargo build` up to date, `sidecar.integration.test.ts` passes). Release-build sidecar bundling remains CODE-87, packaged-app boot smoke in CI remains CODE-89.

## Release note

v0.1.0 users cannot auto-update from a build that never boots — this needs a v0.1.1 with replaced installers/feed, not just a feed bump.