### PR TITLE
refactor(desktop): JSON-import package.json in electron.vite config + typecheck the config

### DIFF
--- a/apps/desktop/electron.vite.config.ts
+++ b/apps/desktop/electron.vite.config.ts
@@ -1,21 +1,20 @@
-import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import tailwindcss from '@tailwindcss/vite';
 import react from '@vitejs/plugin-react';
 import { defineConfig } from 'electron-vite';
 import { ExternalPackageIconLoader } from 'unplugin-icons/loaders';
 import Icons from 'unplugin-icons/vite';
+import { dependencies } from './package.json';
 
 // Workspace packages are exported as TS source, so they must be bundled into main/preload (they
 // can't be runtime externals): a require left in the bundle resolves to .ts under
 // app.asar/node_modules and crashes on launch (ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING).
 // Derive the list from package.json instead of naming packages so a new workspace import into
 // main can never be missed again.
-const { dependencies } = JSON.parse(readFileSync(resolve(__dirname, 'package.json'), 'utf8')) as {
-  dependencies: Record<string, string>;
-};
 const bundleWorkspace = {
-  exclude: Object.keys(dependencies).filter((name) => dependencies[name].startsWith('workspace:')),
+  exclude: Object.entries(dependencies).flatMap(([name, version]) =>
+    version.startsWith('workspace:') ? [name] : [],
+  ),
 };
 
 export default defineConfig({

--- a/apps/desktop/tsconfig.json
+++ b/apps/desktop/tsconfig.json
@@ -8,5 +8,5 @@
     },
     "types": ["node"]
   },
-  "include": ["src"]
+  "include": ["src", "electron.vite.config.ts"]
 }

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -52,7 +52,8 @@ module.exports = require('eslint-config-sukka').sukka(
         // tsconfig (project service), and a file must not appear in both.
         'apps/*/vite.config.ts',
         'apps/*/tsup.config.ts',
-        'apps/desktop/electron.vite.config.ts',
+        // apps/desktop/electron.vite.config.ts is intentionally absent: it is included by the
+        // desktop tsconfig (project service), and a file must not appear in both.
         // agent-adapter tests are included by that package's tsconfig like every other package's;
         // listing them here too would breach typescript-eslint's 8-file default-project cap.
         'vitest.config.ts',


### PR DESCRIPTION
Follow-up to #42.

- Replace the `readFileSync` + `as` cast in `electron.vite.config.ts` with a direct `import { dependencies } from './package.json'` — `resolveJsonModule` is already on in the base tsconfig, so the literal type makes the cast unnecessary, and electron-vite's esbuild config loader inlines the JSON with identical semantics.
- Add `electron.vite.config.ts` to the desktop tsconfig `include` (it was previously not type-checked by `tsc --noEmit` at all, only linted) and drop it from eslint's `allowDefaultProject` list per the both-lists conflict rule documented in AGENTS.md.

Verified: `tsc --noEmit`, eslint, and `electron-vite build` all pass; built `out/main/index.js` still contains zero workspace requires.