### PR TITLE
fix(desktop): treat unpackaged production runs as dev shell (CODE-102)

### DIFF
--- a/apps/desktop/src/main/constants.ts
+++ b/apps/desktop/src/main/constants.ts
@@ -1,10 +1,15 @@
+import { app } from 'electron';
+
 /**
- * A dev shell is any build that is not the released app: `electron-vite dev` (MODE=development)
- * and locally packaged dev builds (`pack:dev`, MODE=devshell). It runs under a distinct app name —
- * and therefore a distinct `userData` dir and single-instance lock — so it coexists with an
- * installed release LinkCode instead of clobbering its settings or refusing to launch.
+ * A dev shell is any build that is not the released app: `electron-vite dev` (MODE=development),
+ * locally packaged dev builds (`package`, MODE=devshell), and production builds run by the dev
+ * Electron binary (`electron-vite preview` / `electron .`, where `app.isPackaged` is false). It
+ * runs under a distinct app name — and therefore a distinct `userData` dir, single-instance lock,
+ * and OS keychain entry — so it coexists with an installed release LinkCode instead of clobbering
+ * its settings, stealing its instance lock, or creating its safeStorage key under the dev
+ * binary's code signature (which makes the release app prompt for the keychain password).
  */
-export const IS_DEV_SHELL = import.meta.env.MODE !== 'production';
+export const IS_DEV_SHELL = import.meta.env.MODE !== 'production' || !app.isPackaged;
 
 export const APP_NAME = IS_DEV_SHELL ? 'LinkCode Dev' : 'LinkCode';
 

--- a/apps/desktop/src/main/updater.ts
+++ b/apps/desktop/src/main/updater.ts
@@ -1,11 +1,11 @@
 import type { UpdaterStatus } from '@linkcode/ipc';
-import { app, dialog } from 'electron';
+import { dialog } from 'electron';
 import log from 'electron-log';
 import { autoUpdater } from 'electron-updater';
 import { IS_DEV_SHELL } from './constants';
 
 /** A dev shell must never pull the production feed and replace itself with the release build. */
-const updatesDisabled = (): boolean => !app.isPackaged || IS_DEV_SHELL;
+const updatesDisabled = (): boolean => IS_DEV_SHELL;
 
 /**
  * Auto-update wiring (system plane only — never carries business data).


### PR DESCRIPTION
## Problem

Dev/prod identity separation had one remaining hole: a production-mode build executed by the **dev Electron binary** (`pnpm start` / `electron .` after `pnpm build`) ran as APP_NAME `LinkCode`, sharing with the installed release app:

- the `userData` dir (settings/Cookies pollution),
- the single-instance lock (one of the two silently exits — same failure mode as CODE-101 bug 2),
- the macOS keychain OSCrypt item `LinkCode Safe Storage`: the item gets created under the dev Electron binary's code signature (ACL pins its cdhash), so the real signed LinkCode.app later hits the "wants to use your confidential information" keychain password prompt on first launch. Observed on a dev machine after the v0.1.1 install; ACL dump showed `node_modules/electron/dist/Electron.app` as the item's only trusted app.

## Fix

`IS_DEV_SHELL` was compile-time only (`import.meta.env.MODE !== 'production'`). Add the runtime signal: `|| !app.isPackaged`. Release identity (`LinkCode`) is now reachable only by a packaged production build. `updater.ts`'s `updatesDisabled` (`!app.isPackaged || IS_DEV_SHELL`) reduces to `IS_DEV_SHELL`.

## Verification

`pnpm -F @linkcode/desktop build`, then launched `out/` with the dev Electron binary via playwright `_electron.launch` (isolated HOME, `--use-mock-keychain`):

```json
{ "name": "LinkCode Dev", "userData": ".../Application Support/LinkCode Dev", "isPackaged": false }
```

Packaged builds are unaffected: the expression only changes value when `app.isPackaged` is false.

Closes CODE-102.