### PR TITLE
fix(workbench): creating a new conversation briefly flashes the previous conversation

### DIFF
--- a/packages/workbench/src/surface/use-workbench-sessions.ts
+++ b/packages/workbench/src/surface/use-workbench-sessions.ts
@@ -95,7 +95,7 @@ export function useWorkbenchSessions(onError: (err: unknown) => void): Workbench
     setExplicitDraft({ workspaceId: workspaceId ?? null });
   }
 
-  function create(opts: {
+  async function create(opts: {
     kind: AgentKind;
     cwd: string;
     model?: string;
@@ -103,12 +103,13 @@ export function useWorkbenchSessions(onError: (err: unknown) => void): Workbench
   }): Promise<SessionId> {
     // Rejections propagate to the caller (the new-session page stays up); onError above still
     // reports them via the error banner.
-    return createMutation.trigger({ opts }).then((sessionId) => {
-      setExplicitDraft(null);
-      setSelectedId(sessionId);
-      void mutate();
-      return sessionId;
-    });
+    const sessionId = await createMutation.trigger({ opts });
+    // The list must contain the new session before selection flips: otherwise `active` falls
+    // back to the previous session for a render and its conversation flashes (CODE-103).
+    await mutate().catch(noop);
+    setExplicitDraft(null);
+    setSelectedId(sessionId);
+    return sessionId;
   }
 
   function close(id: SessionId): void {


### PR DESCRIPTION
Fixes CODE-103.

## Problem

Submitting the new-session draft briefly flashed the previously open conversation before the new (empty) one appeared: new-session page → old transcript for a frame → new conversation. Both desktop and webview were affected.

## Root cause

`create()` in `use-workbench-sessions.ts` cleared the draft and set `selectedId` synchronously, but fired the `listSessions` revalidation without awaiting it. In the window before the list refreshed, the just-created session wasn't in `sessions`, so the `active` memo fell through to `preferredActiveSession(sessions) ?? sessions.at(-1)` — the previous session. Since `ConversationSurface` is keyed by `active?.sessionId`, React mounted the old conversation's transcript, then remounted again once the list caught up.

## Fix

`create()` now awaits the list revalidation **before** clearing the draft and selecting the new id, so the draft page stays mounted until the new session is resolvable and `active` transitions directly draft → new session. The await is `.catch(noop)`-guarded: if the refresh itself fails we still select the new session (worst case degrades to the old behavior) instead of leaving the draft stuck.

The `active` memo fallback is deliberately untouched — treating an unresolved `selectedId` as pending would break the intended fallback after `close()` removes the selected session.

## Notes

- Only user-visible side effect: the draft page's pending state lasts one extra `listSessions` round-trip (local daemon, ms-level).
- Verified with typecheck, ESLint (back to the pre-existing 10-warning baseline), and Biome; not exercised in the running app — repro recording is on CODE-103.