### PR TITLE
fix(daemon): spawn the default terminal shell as a login shell on macOS

### DIFF
--- a/apps/daemon/src/pty/__tests__/sidecar.test.ts
+++ b/apps/daemon/src/pty/__tests__/sidecar.test.ts
@@ -42,6 +42,22 @@ function fakeChild(): PassThrough & {
   return child;
 }
 
+function platformed<T>(platform: NodeJS.Platform, run: () => T): T {
+  const original = Object.getOwnPropertyDescriptor(process, 'platform')!;
+  Object.defineProperty(process, 'platform', { value: platform });
+  try {
+    return run();
+  } finally {
+    Object.defineProperty(process, 'platform', original);
+  }
+}
+
+/** Decode the OPEN frame the backend just wrote to the sidecar's stdin. */
+function writtenOpenBody(child: ReturnType<typeof fakeChild>): { cmd: string; args: string[] } {
+  const written = child.stdin.read() as Buffer;
+  return JSON.parse(written.subarray(5).toString('utf8'));
+}
+
 describe('SidecarPtyBackend', () => {
   it('rejects an open with an unconfigured binary path instead of spawning it', async () => {
     const { SidecarPtyBackend } = await import('../sidecar');
@@ -97,6 +113,37 @@ describe('SidecarPtyBackend', () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it('starts the default shell as a login shell on macOS only', async () => {
+    const { SidecarPtyBackend } = await import('../sidecar');
+    const child = fakeChild();
+    mocks.spawn.mockReturnValueOnce(child);
+    const backend = new SidecarPtyBackend('/bin/linkcode-pty');
+
+    const darwinOpen = platformed('darwin', () => backend.open('term-1', { cols: 80, rows: 24 }));
+    expect(writtenOpenBody(child).args).toEqual(['-l']);
+    const linuxOpen = platformed('linux', () => backend.open('term-2', { cols: 80, rows: 24 }));
+    expect(writtenOpenBody(child).args).toEqual([]);
+
+    backend.shutdown();
+    await expect(darwinOpen).rejects.toThrow('pty backend shutdown');
+    await expect(linuxOpen).rejects.toThrow('pty backend shutdown');
+  });
+
+  it('never adds login args to an explicitly requested shell', async () => {
+    const { SidecarPtyBackend } = await import('../sidecar');
+    const child = fakeChild();
+    mocks.spawn.mockReturnValueOnce(child);
+    const backend = new SidecarPtyBackend('/bin/linkcode-pty');
+
+    const pending = platformed('darwin', () =>
+      backend.open('term-1', { cols: 80, rows: 24, shell: '/bin/sh' }),
+    );
+    expect(writtenOpenBody(child)).toMatchObject({ cmd: '/bin/sh', args: [] });
+
+    backend.shutdown();
+    await expect(pending).rejects.toThrow('pty backend shutdown');
   });
 
   it('kills the sidecar and exits live terminals after a malformed frame', async () => {

--- a/apps/daemon/src/pty/sidecar.ts
+++ b/apps/daemon/src/pty/sidecar.ts
@@ -78,7 +78,7 @@ export class SidecarPtyBackend implements PtyBackend {
         cols: opts.cols,
         rows: opts.rows,
         cmd: opts.shell ?? defaultShell(),
-        args: opts.args ?? [],
+        args: opts.args ?? (opts.shell === undefined ? defaultShellArgs() : []),
         // The daemon's own cwd is an implementation accident (wherever it was launched from) —
         // an unspecified shell belongs in the user's home, like a fresh terminal app tab.
         cwd: opts.cwd ?? homedir(),
@@ -261,4 +261,15 @@ export function binaryName(): string {
 function defaultShell(): string {
   if (process.platform === 'win32') return process.env.COMSPEC ?? 'cmd.exe';
   return process.env.SHELL ?? '/bin/bash';
+}
+
+/**
+ * macOS terminal apps (Terminal.app, iTerm, VS Code) start the default shell as a *login* shell:
+ * a Finder-launched app inherits launchd's bare PATH, and only the login files (`/etc/zprofile`
+ * path_helper, then `~/.zprofile` where Homebrew's shellenv lives) restore the user's real one.
+ * A non-login interactive shell reads `.zshrc` alone, leaving brew-installed tools unresolvable
+ * in packaged builds. Other platforms keep their convention of a plain interactive shell.
+ */
+function defaultShellArgs(): string[] {
+  return process.platform === 'darwin' ? ['-l'] : [];
 }


### PR DESCRIPTION
Fixes CODE-115.

## Problem

In the packaged desktop app, the terminal pane's shell can't resolve Homebrew-installed tools (`command not found: starship`). Dev never reproduces it because the daemon inherits the developer's terminal environment.

Two factors compound: a Finder/launchd-launched app inherits the bare `PATH=/usr/bin:/bin:/usr/sbin:/sbin`, which flows daemon → sidecar → `portable_pty::CommandBuilder` into the shell; and the shell is spawned as interactive **non-login**, so `~/.zprofile` (where `brew shellenv` lives) never runs and PATH never self-heals.

## Fix

Match Terminal.app / iTerm / VS Code: when `terminal.open` requests the default shell (no explicit `shell`/`args`), spawn it with `-l` on darwin only. Explicit shells (e.g. script-service `/bin/sh -c`) are untouched; Linux keeps the non-login convention and Windows (`COMSPEC`) is unaffected.

## Verification

- Unit tests: darwin default → `['-l']`, linux default → `[]`, explicit shell → no login arg.
- End-to-end against the real `linkcode-pty` binary: backend launched under a launchd-bare env (`env -i PATH=/usr/bin:/bin:/usr/sbin:/sbin`), opened a default terminal — the shell's PATH self-healed to include `/opt/homebrew/bin` and `command -v starship` resolved to `/opt/homebrew/bin/starship`.
- `pnpm check:ci` + full `pnpm test` green after rebase onto master.