### PR TITLE
fix(preview): open agent-produced files outside the workspace

### DIFF
--- a/apps/desktop/src/renderer/src/shell/desktop-shell.tsx
+++ b/apps/desktop/src/renderer/src/shell/desktop-shell.tsx
@@ -16,6 +16,7 @@ import {
 import type { WorkbenchShellProps } from '@linkcode/workbench';
 import {
   AttachedTerminalPanel,
+  isAbsoluteFilePath,
   locateFileArtifact,
   TerminalPanel,
   WorkspaceServicesMenu,
@@ -299,7 +300,7 @@ export function DesktopShell({
   function openFileArtifact(path: string): void {
     const cwd = active?.cwd;
     if (!cwd) {
-      if (path[0] === '/') openRightFileTab(path);
+      if (isAbsoluteFilePath(path)) openRightFileTab(path);
       return;
     }
     void locateFileArtifact(path, cwd, conversation.items).then(openRightFileTab);

--- a/apps/desktop/src/renderer/src/shell/desktop-shell.tsx
+++ b/apps/desktop/src/renderer/src/shell/desktop-shell.tsx
@@ -14,7 +14,12 @@ import {
   PanelTabContentStack,
 } from '@linkcode/ui/shell/panels';
 import type { WorkbenchShellProps } from '@linkcode/workbench';
-import { AttachedTerminalPanel, TerminalPanel, WorkspaceServicesMenu } from '@linkcode/workbench';
+import {
+  AttachedTerminalPanel,
+  locateFileArtifact,
+  TerminalPanel,
+  WorkspaceServicesMenu,
+} from '@linkcode/workbench';
 import { Allotment, LayoutPriority } from 'allotment';
 import { useEffect as useAbortableEffect } from 'foxact/use-abortable-effect';
 import { useLayoutEffect } from 'foxact/use-isomorphic-layout-effect';
@@ -288,12 +293,16 @@ export function DesktopShell({
     resetBottomPanelLayoutSize();
   }
 
-  // File-artifact clicks land in the right panel's files section; relative paths are
-  // anchored to the active session's cwd (the same root the daemon reads against).
+  // File-artifact clicks land in the right panel's files section. The clicked text may
+  // be a bare filename from agent prose whose file lives outside the session cwd, so
+  // the locator probes candidate directories from the conversation's tool calls.
   function openFileArtifact(path: string): void {
     const cwd = active?.cwd;
-    const anchored = path[0] === '/' ? path : cwd ? `${cwd}/${path}` : null;
-    if (anchored !== null) openRightFileTab(anchored);
+    if (!cwd) {
+      if (path[0] === '/') openRightFileTab(path);
+      return;
+    }
+    void locateFileArtifact(path, cwd, conversation.items).then(openRightFileTab);
   }
 
   const main = (

--- a/packages/engine/src/__tests__/file-service.test.ts
+++ b/packages/engine/src/__tests__/file-service.test.ts
@@ -1,6 +1,6 @@
 import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { join, relative } from 'node:path';
 import { afterAll, describe, expect, it } from 'vitest';
 import { readWorkspaceFile } from '../file-service';
 
@@ -75,24 +75,32 @@ describe('readWorkspaceFile', () => {
     expect(absolute.path).toBe(relative.path);
   });
 
-  it('rejects .. traversal out of the workspace', async () => {
+  it('reads files outside the workspace (agents write anywhere the user can)', async () => {
     const root = makeTempDir();
     const outside = makeTempDir();
-    writeFileSync(join(outside, 'secret.txt'), 'nope');
+    writeFileSync(join(outside, 'note.txt'), 'outside');
 
-    await expect(
-      readWorkspaceFile(join(root), join('..', outside, 'secret.txt')),
-    ).rejects.toThrow();
-    await expect(readWorkspaceFile(root, '../secret.txt')).rejects.toThrow();
+    const absolute = await readWorkspaceFile(root, join(outside, 'note.txt'));
+    expect(absolute.content).toBe('outside');
+
+    const traversal = await readWorkspaceFile(root, relative(root, join(outside, 'note.txt')));
+    expect(traversal.content).toBe('outside');
+    expect(traversal.path).toBe(join(outside, 'note.txt'));
   });
 
-  it('rejects symlinks that escape the workspace', async () => {
+  it('follows symlinks out of the workspace', async () => {
     const root = makeTempDir();
     const outside = makeTempDir();
-    writeFileSync(join(outside, 'secret.txt'), 'nope');
-    symlinkSync(join(outside, 'secret.txt'), join(root, 'innocent.md'));
+    writeFileSync(join(outside, 'target.txt'), 'linked');
+    symlinkSync(join(outside, 'target.txt'), join(root, 'link.md'));
 
-    await expect(readWorkspaceFile(root, 'innocent.md')).rejects.toThrow(/escapes/);
+    const file = await readWorkspaceFile(root, 'link.md');
+    expect(file.content).toBe('linked');
+  });
+
+  it('propagates a missing-file error with the resolved path', async () => {
+    const root = makeTempDir();
+    await expect(readWorkspaceFile(root, 'absent.pdf')).rejects.toThrow(/ENOENT/);
   });
 
   it('rejects directories', async () => {

--- a/packages/engine/src/file-service.ts
+++ b/packages/engine/src/file-service.ts
@@ -1,4 +1,4 @@
-import { open, realpath } from 'node:fs/promises';
+import { open } from 'node:fs/promises';
 import path from 'node:path';
 import type { WorkspaceFile } from '@linkcode/schema';
 
@@ -26,19 +26,15 @@ const MIME_BY_EXTENSION: Record<string, string> = {
 };
 
 /**
- * Read a file for a client, contained to the workspace directory. Containment is
- * enforced on the *realpath* of both ends, so a symlink inside the workspace cannot
- * escape it (the paseo file-explorer precedent). Throws (→ `sendFailure`) on escape,
- * oversize, or a non-file target.
+ * Read a file for a client's viewer. `requestPath` resolves against the session's
+ * workspace directory but may point anywhere the daemon user can read — agents
+ * legitimately write outside the workspace, and the daemon serves same-user loopback
+ * clients (remote access must gate reads in its own authz layer, not here). Throws
+ * (→ `sendFailure`) on a missing or non-file target or an oversized read.
  */
 export async function readWorkspaceFile(cwd: string, requestPath: string): Promise<WorkspaceFile> {
-  const root = await realpath(cwd);
-  const resolved = await realpath(path.resolve(root, requestPath));
-  if (resolved !== root && !resolved.startsWith(root + path.sep)) {
-    throw new Error(`Path escapes the workspace: ${requestPath}`);
-  }
+  const resolved = path.resolve(cwd, requestPath);
 
-  // Open first, stat the handle: no window between the containment check and the read.
   const handle = await open(resolved, 'r');
   try {
     const stat = await handle.stat();

--- a/packages/schema/src/wire/file.ts
+++ b/packages/schema/src/wire/file.ts
@@ -6,9 +6,9 @@ export const fileWireVariants = [
   z.object({
     kind: z.literal('file.read'),
     clientReqId: z.string().min(1),
-    /** Workspace root the read is anchored to; `path` must resolve inside it. */
+    /** Directory a relative `path` resolves against (the session's workspace root). */
     cwd: z.string().min(1),
-    /** Absolute, or relative to `cwd`. */
+    /** Absolute, or relative to `cwd`; may point outside the workspace. */
     path: z.string().min(1),
   }),
   z.object({

--- a/packages/ui/src/shell/files/file-viewer.tsx
+++ b/packages/ui/src/shell/files/file-viewer.tsx
@@ -1,4 +1,5 @@
 import type { WorkspaceFile } from '@linkcode/schema';
+import { extractErrorMessage } from 'foxts/extract-error-message';
 import { useTranslations } from 'use-intl';
 import { artifactKindForPath } from '../../chat/artifacts';
 import { Markdown } from '../../chat/markdown';
@@ -32,7 +33,11 @@ export function FileViewer({
 
   if (error !== undefined && error !== null && !file) {
     return (
-      <FileViewerNotice className={className} title={t('loadFailed')}>
+      <FileViewerNotice
+        className={className}
+        title={t('loadFailed')}
+        detail={extractErrorMessage(error) ?? undefined}
+      >
         {path}
       </FileViewerNotice>
     );
@@ -123,10 +128,13 @@ function PdfView({
 
 function FileViewerNotice({
   title,
+  detail,
   children,
   className,
 }: {
   title: string;
+  /** The underlying failure reason (daemon error message), shown under the path. */
+  detail?: string;
   children?: React.ReactNode;
   className?: string;
 }): React.ReactNode {
@@ -142,6 +150,9 @@ function FileViewerNotice({
         <div className="max-w-full truncate font-mono text-muted-foreground text-xs">
           {children}
         </div>
+      ) : null}
+      {detail ? (
+        <div className="max-w-full truncate text-muted-foreground/80 text-xs">{detail}</div>
       ) : null}
     </div>
   );

--- a/packages/workbench/package.json
+++ b/packages/workbench/package.json
@@ -25,6 +25,7 @@
     "coss-ui": "workspace:*",
     "foxact": "^0.3.7",
     "foxts": "^5.6.0",
+    "pathe": "^2.0.3",
     "react-hook-form": "^7.80.0",
     "swr": "catalog:",
     "tayori": "^0.3.8",

--- a/packages/workbench/src/files/__tests__/locate.test.ts
+++ b/packages/workbench/src/files/__tests__/locate.test.ts
@@ -1,0 +1,73 @@
+import type { Conversation } from '@linkcode/client-core';
+import type { ToolCall } from '@linkcode/schema';
+import { describe, expect, it } from 'vitest';
+import { fileArtifactCandidates } from '../locate';
+
+function toolItem(partial: Partial<ToolCall>): Conversation['items'][number] {
+  return {
+    kind: 'tool',
+    id: partial.toolCallId ?? 'tool-1',
+    turnId: null,
+    toolCall: {
+      toolCallId: 'tool-1',
+      title: 'Write',
+      kind: 'edit',
+      status: 'completed',
+      content: [],
+      ...partial,
+    },
+  };
+}
+
+describe('fileArtifactCandidates', () => {
+  it('returns an absolute path as the only candidate', () => {
+    expect(fileArtifactCandidates('/tmp/report.pdf', '/w', [])).toEqual(['/tmp/report.pdf']);
+  });
+
+  it('anchors a relative path to cwd when the conversation names no locations', () => {
+    expect(fileArtifactCandidates('qingjia.pdf', '/w', [])).toEqual(['/w/qingjia.pdf']);
+  });
+
+  it('puts exact basename hits from tool locations before the cwd anchor', () => {
+    const items = [toolItem({ locations: [{ path: '/docs/leave/qingjia.pdf' }] })];
+    expect(fileArtifactCandidates('qingjia.pdf', '/w', items)).toEqual([
+      '/docs/leave/qingjia.pdf',
+      '/w/qingjia.pdf',
+    ]);
+  });
+
+  it('derives sibling candidates from touched directories (Bash-produced files)', () => {
+    // The agent wrote qingjia.tex via a tool; qingjia.pdf came from a shell compile
+    // and appears in no location — its directory is still a candidate.
+    const items = [toolItem({ locations: [{ path: '/docs/leave/qingjia.tex' }] })];
+    expect(fileArtifactCandidates('qingjia.pdf', '/w', items)).toEqual([
+      '/w/qingjia.pdf',
+      '/docs/leave/qingjia.pdf',
+    ]);
+  });
+
+  it('collects paths from diff content and probes newer tool calls first', () => {
+    const items = [
+      toolItem({ toolCallId: 'old', locations: [{ path: '/a/one.md' }] }),
+      toolItem({
+        toolCallId: 'new',
+        content: [{ type: 'diff', path: '/b/two.md', newText: '' }],
+      }),
+    ];
+    expect(fileArtifactCandidates('readme.md', '/w', items)).toEqual([
+      '/w/readme.md',
+      '/b/readme.md',
+      '/a/readme.md',
+    ]);
+  });
+
+  it('ignores relative tool locations and multi-segment clicked paths still anchor everywhere', () => {
+    const items = [
+      toolItem({ locations: [{ path: 'relative/loc.md' }, { path: '/abs/dir/x.md' }] }),
+    ];
+    expect(fileArtifactCandidates('sub/report.pdf', '/w', items)).toEqual([
+      '/w/sub/report.pdf',
+      '/abs/dir/sub/report.pdf',
+    ]);
+  });
+});

--- a/packages/workbench/src/files/__tests__/locate.test.ts
+++ b/packages/workbench/src/files/__tests__/locate.test.ts
@@ -70,4 +70,21 @@ describe('fileArtifactCandidates', () => {
       '/abs/dir/sub/report.pdf',
     ]);
   });
+
+  it('recognizes Windows drive locations and joins with forward slashes', () => {
+    const items = [toolItem({ locations: [{ path: String.raw`C:\Users\me\docs\qingjia.tex` }] })];
+    expect(fileArtifactCandidates('qingjia.pdf', String.raw`C:\Users\me\proj`, items)).toEqual([
+      'C:/Users/me/proj/qingjia.pdf',
+      'C:/Users/me/docs/qingjia.pdf',
+    ]);
+  });
+
+  it('treats Windows drive and UNC clicked paths as final candidates', () => {
+    expect(fileArtifactCandidates(String.raw`C:\out\report.pdf`, '/w', [])).toEqual([
+      String.raw`C:\out\report.pdf`,
+    ]);
+    expect(fileArtifactCandidates(String.raw`\\server\share\a.md`, '/w', [])).toEqual([
+      String.raw`\\server\share\a.md`,
+    ]);
+  });
 });

--- a/packages/workbench/src/files/locate.ts
+++ b/packages/workbench/src/files/locate.ts
@@ -1,0 +1,72 @@
+import type { Conversation } from '@linkcode/client-core';
+import { readWorkspaceFile } from '@linkcode/sdk';
+
+/** Probing is bounded: candidates beyond this are dropped (dirs are deduped first). */
+const MAX_CANDIDATES = 8;
+
+/**
+ * Absolute paths a clicked file reference may resolve to, most likely first.
+ * A bare `qingjia.pdf` in agent prose carries no directory, and the agent may have
+ * worked outside the session cwd — so candidates come from the conversation's
+ * tool-call locations (exact basename hits first, then their directories), with the
+ * cwd anchor between them. Pure; exported for tests.
+ */
+export function fileArtifactCandidates(
+  requestPath: string,
+  cwd: string,
+  items: Conversation['items'],
+): string[] {
+  if (requestPath[0] === '/') return [requestPath];
+
+  const suffix = `/${requestPath}`;
+  const exactHits: string[] = [];
+  const touchedDirs: string[] = [];
+  for (const item of items) {
+    if (item.kind !== 'tool') continue;
+    const paths = (item.toolCall.locations ?? []).map((location) => location.path);
+    for (const content of item.toolCall.content) {
+      if (content.type === 'diff') paths.push(content.path);
+    }
+    for (const touched of paths) {
+      // Relative locations (adapter-dependent) have no reliable anchor; skip them.
+      if (touched[0] !== '/') continue;
+      if (touched.endsWith(suffix)) exactHits.push(touched);
+      const dir = touched.slice(0, touched.lastIndexOf('/'));
+      if (dir) touchedDirs.push(dir);
+    }
+  }
+
+  // Later tool calls are likelier to concern the clicked file — probe newest first.
+  exactHits.reverse();
+  touchedDirs.reverse();
+  const candidates = new Set<string>([
+    ...exactHits,
+    `${cwd}${suffix}`,
+    ...touchedDirs.map((dir) => `${dir}${suffix}`),
+  ]);
+  return [...candidates].slice(0, MAX_CANDIDATES);
+}
+
+/**
+ * Resolve a clicked file reference to the absolute path to open: the first candidate
+ * the daemon can actually read wins; when none reads (or there is nothing to probe),
+ * fall back to the most likely candidate so the viewer surfaces the read error.
+ */
+export async function locateFileArtifact(
+  requestPath: string,
+  cwd: string,
+  items: Conversation['items'],
+): Promise<string> {
+  const candidates = fileArtifactCandidates(requestPath, cwd, items);
+  if (candidates.length > 1) {
+    for (const candidate of candidates) {
+      try {
+        await readWorkspaceFile({ cwd, path: candidate });
+        return candidate;
+      } catch {
+        // Unreadable candidate — try the next; the viewer reports the final failure.
+      }
+    }
+  }
+  return candidates[0];
+}

--- a/packages/workbench/src/files/locate.ts
+++ b/packages/workbench/src/files/locate.ts
@@ -1,8 +1,14 @@
 import type { Conversation } from '@linkcode/client-core';
 import { readWorkspaceFile } from '@linkcode/sdk';
+import { dirname, isAbsolute, join, normalize } from 'pathe';
 
 /** Probing is bounded: candidates beyond this are dropped (dirs are deduped first). */
 const MAX_CANDIDATES = 8;
+
+/** Path predicates/joins go through `pathe`: the daemon may sit on either platform
+ * (POSIX `/`, Windows drive or UNC), and pathe recognizes all of them while
+ * normalizing output to forward slashes — which win32 Node accepts as-is. */
+export { isAbsolute as isAbsoluteFilePath } from 'pathe';
 
 /**
  * Absolute paths a clicked file reference may resolve to, most likely first.
@@ -16,9 +22,10 @@ export function fileArtifactCandidates(
   cwd: string,
   items: Conversation['items'],
 ): string[] {
-  if (requestPath[0] === '/') return [requestPath];
+  if (isAbsolute(requestPath)) return [requestPath];
 
-  const suffix = `/${requestPath}`;
+  const relative = normalize(requestPath);
+  const suffix = `/${relative}`;
   const exactHits: string[] = [];
   const touchedDirs: string[] = [];
   for (const item of items) {
@@ -29,10 +36,10 @@ export function fileArtifactCandidates(
     }
     for (const touched of paths) {
       // Relative locations (adapter-dependent) have no reliable anchor; skip them.
-      if (touched[0] !== '/') continue;
-      if (touched.endsWith(suffix)) exactHits.push(touched);
-      const dir = touched.slice(0, touched.lastIndexOf('/'));
-      if (dir) touchedDirs.push(dir);
+      if (!isAbsolute(touched)) continue;
+      const normalized = normalize(touched);
+      if (normalized.endsWith(suffix)) exactHits.push(normalized);
+      touchedDirs.push(dirname(normalized));
     }
   }
 
@@ -41,8 +48,8 @@ export function fileArtifactCandidates(
   touchedDirs.reverse();
   const candidates = new Set<string>([
     ...exactHits,
-    `${cwd}${suffix}`,
-    ...touchedDirs.map((dir) => `${dir}${suffix}`),
+    join(cwd, relative),
+    ...touchedDirs.map((dir) => join(dir, relative)),
   ]);
   return [...candidates].slice(0, MAX_CANDIDATES);
 }

--- a/packages/workbench/src/index.ts
+++ b/packages/workbench/src/index.ts
@@ -5,6 +5,7 @@ export * from './app/workbench-app';
 export * from './app/workbench-providers';
 export * from './assets/hooks';
 export * from './files/hooks';
+export * from './files/locate';
 export * from './files/panel';
 export * from './git/hooks';
 export * from './git/panel';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -972,6 +972,9 @@ importers:
       foxts:
         specifier: ^5.6.0
         version: 5.6.0
+      pathe:
+        specifier: ^2.0.3
+        version: 2.0.3
       react-hook-form:
         specifier: ^7.80.0
         version: 7.80.0(react@19.2.7)


### PR DESCRIPTION
## Problem

Clicking the inline \`qingjia.pdf\` reference in an agent reply showed "Failed to read the file /Users/Xuan/LinkCode/qingjia.pdf". The agent (session cwd \`~/LinkCode\`) had written its LaTeX output to \`~/Documents/leave-note/\`; the file itself was fine. Reproduces in dev the same way — not release-specific.

## Root cause

Three stacked issues:

1. **Wrong anchoring** — a bare filename from agent prose (\`detectInlineFilePath\`) was always resolved against the session cwd (\`openFileArtifact\`), ignoring the directories the agent actually worked in (present in the conversation's tool-call locations).
2. **Workspace containment** — even with the correct absolute path, \`readWorkspaceFile\` rejected anything outside the session cwd, so files an agent legitimately produces elsewhere could never be previewed.
3. **Swallowed errors** — \`FileViewer\` showed a generic "Failed to read the file"; the daemon's real reason (already carried by \`request.failed\` on the wire) was dropped, making ENOENT / containment / oversize indistinguishable.

## Changes

- **engine**: \`file.read\` now serves any path the daemon user can read (regular-file and 10 MB checks stay). \`file.read\` is the client viewer's fetch channel only — agents never go through it; their file access is governed by their own approval-policy axis. Wire schema comments updated; **no wire shape change, no protocol bump**.
- **workbench**: new \`locateFileArtifact\` — for a clicked relative path, build candidates (exact basename hits from tool-call locations → cwd anchor → siblings in agent-touched directories, newest first) and probe them with the existing \`file.read\`; first readable candidate opens. Absolute paths skip probing. Pure candidate builder is unit-tested.
- **ui**: \`FileViewer\` error state now shows the daemon's actual failure message under the path.

## Verification

- Unit: engine tests flipped to cover outside-workspace reads (absolute, \`../\` traversal, symlink-out) plus ENOENT propagation; 6 new locator cases. Full suite 395 tests green; \`check:ci\` green.
- Live wire: drove an isolated dev daemon over socket.io — the exact incident file (\`~/Documents/leave-note/qingjia.pdf\`, cwd \`~/LinkCode\`) reads OK (30863 bytes, application/pdf), \`../\` traversal reads OK, missing file fails with the real ENOENT message end to end.
- Not driven: the in-renderer click flow (covered by typecheck + locator unit tests).
- Compat: new client against an old (containment-enforcing) daemon degrades gracefully — outside-workspace probes fail and the locator falls back to the cwd-anchored path, i.e. today's behavior with a clearer error.

## Follow-up

When the tunnel/remote-access milestone lands, \`file.read\` must be re-gated together with the rest of the wire at the per-device authz layer — dropping containment here relies on the "loopback, same user" trust model (CODE-58's decided posture; remote credentials belong to CODE-63).