### PR TITLE
feat: wire claude-code AskUserQuestion end-to-end into the prompt dock (CODE-118)

### DIFF
--- a/apps/desktop/src/renderer/src/shell/desktop-shell.tsx
+++ b/apps/desktop/src/renderer/src/shell/desktop-shell.tsx
@@ -67,6 +67,8 @@ export function DesktopShell({
   conversation,
   permissionDecisions,
   respondingPermissions,
+  answeredQuestionIds,
+  respondingQuestions,
   errorMessage,
   pinnedSessionIds,
   onSelectSession,
@@ -86,6 +88,7 @@ export function DesktopShell({
   onSendPrompt,
   onStopTurn,
   onRespondPermission,
+  onRespondQuestion,
   onHostArtifact,
   onOpenSearch,
   TerminalBlockComponent,
@@ -333,6 +336,8 @@ export function DesktopShell({
           cwd={active?.cwd}
           permissionDecisions={permissionDecisions}
           respondingPermissions={respondingPermissions}
+          answeredQuestionIds={answeredQuestionIds}
+          respondingQuestions={respondingQuestions}
           TerminalBlockComponent={TerminalBlockComponent}
           disabled={!active || active.status === 'stopped'}
           isRunning={isRunning}
@@ -340,6 +345,7 @@ export function DesktopShell({
           onSendPrompt={onSendPrompt}
           onStopTurn={onStopTurn}
           onRespondPermission={onRespondPermission}
+          onRespondQuestion={onRespondQuestion}
           onOpenFileArtifact={openFileArtifact}
           onHostArtifact={onHostArtifact}
           onOpenPreviewUrl={openBrowserUrl}

--- a/packages/agent-adapter/package.json
+++ b/packages/agent-adapter/package.json
@@ -21,7 +21,8 @@
     "@openai/codex": "^0.140.0",
     "@opencode-ai/sdk": "^1.17.7",
     "foxts": "^5.6.0",
-    "smol-toml": "^1.7.0"
+    "smol-toml": "^1.7.0",
+    "zod": "catalog:"
   },
   "devDependencies": {
     "@types/node": "catalog:",

--- a/packages/agent-adapter/src/__tests__/base.test.ts
+++ b/packages/agent-adapter/src/__tests__/base.test.ts
@@ -27,6 +27,19 @@ class TestAdapter extends BaseAgentAdapter {
       { optionId: 'ok', name: 'Allow', kind: 'allow_once' },
     ]);
   }
+  askQuestion(): Promise<unknown> {
+    return this.requestQuestion({ toolCallId: 't1' }, [
+      {
+        questionId: 'q0',
+        prompt: 'Which one?',
+        multiSelect: false,
+        options: [
+          { optionId: 'o0', label: 'A' },
+          { optionId: 'o1', label: 'B' },
+        ],
+      },
+    ]);
+  }
 }
 
 function toolEvents(a: TestAdapter): Array<Extract<AgentEvent, { type: 'tool-call' }>> {
@@ -103,6 +116,45 @@ describe('BaseAgentAdapter teardown', () => {
     const pending = a.ask();
     expect(a.seen.some((e) => e.type === 'permission-request')).toBe(true);
 
+    await a.send({ type: 'cancel' });
+    await expect(pending).resolves.toEqual({ outcome: 'cancelled' });
+  });
+
+  it('on cancel: resolves a pending question ask with cancelled (no hang/leak)', async () => {
+    const a = new TestAdapter();
+    const pending = a.askQuestion();
+    expect(a.seen.some((e) => e.type === 'question-request')).toBe(true);
+
+    await a.send({ type: 'cancel' });
+    await expect(pending).resolves.toEqual({ outcome: 'cancelled' });
+  });
+});
+
+describe('BaseAgentAdapter question round-trip', () => {
+  it('resolves the pending ask with the answers from a question-response, by requestId', async () => {
+    const a = new TestAdapter();
+    const pending = a.askQuestion();
+    const request = a.seen.find((e) => e.type === 'question-request');
+    expect(request?.questions[0]).toMatchObject({ questionId: 'q0', prompt: 'Which one?' });
+
+    const outcome = {
+      outcome: 'answered' as const,
+      answers: [{ questionId: 'q0', selectedOptionIds: ['o1'] }],
+    };
+    await a.send({ type: 'question-response', requestId: request!.requestId, outcome });
+    await expect(pending).resolves.toEqual(outcome);
+  });
+
+  it('ignores a response for an unknown requestId', async () => {
+    const a = new TestAdapter();
+    const pending = a.askQuestion();
+    await a.send({
+      type: 'question-response',
+      requestId: 'req-unknown',
+      outcome: { outcome: 'cancelled' },
+    });
+
+    // Still pending: only teardown resolves it now.
     await a.send({ type: 'cancel' });
     await expect(pending).resolves.toEqual({ outcome: 'cancelled' });
   });

--- a/packages/agent-adapter/src/__tests__/claude-code-question.test.ts
+++ b/packages/agent-adapter/src/__tests__/claude-code-question.test.ts
@@ -1,0 +1,216 @@
+import type { SDKUserMessage } from '@anthropic-ai/claude-agent-sdk';
+import type { AgentEvent, QuestionOutcome } from '@linkcode/schema';
+import { textBlock } from '@linkcode/schema';
+import { noop } from 'foxts/noop';
+import { wait } from 'foxts/wait';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ClaudeCodeAdapter } from '../native/claude-code';
+
+const sdkMock = vi.hoisted(() => ({
+  query: null as ((opts: unknown) => unknown) | null,
+}));
+
+vi.mock('@anthropic-ai/claude-agent-sdk', () => ({
+  query(opts: unknown) {
+    if (!sdkMock.query) throw new Error('query mock not installed');
+    return sdkMock.query(opts);
+  },
+}));
+
+// Keep settingsDefaultMode away from the developer's real ~/.claude/settings.json.
+vi.mock('node:fs/promises', () => ({
+  readFile: (file: string) => Promise.reject(new Error(`ENOENT: ${file}`)),
+}));
+
+type CanUseTool = (
+  toolName: string,
+  input: Record<string, unknown>,
+  options: { signal: AbortSignal; toolUseID: string },
+) => Promise<Record<string, unknown>>;
+
+interface QueryInput {
+  prompt: AsyncIterable<SDKUserMessage>;
+  options: { canUseTool: CanUseTool };
+}
+
+/** Never-yielding Query stand-in: only the creation options matter — the tests drive the captured
+ * `canUseTool` callback directly instead of feeding SDK messages. */
+class FakeQuery {
+  readonly options: QueryInput['options'];
+
+  constructor(input: QueryInput) {
+    this.options = input.options;
+    void (async () => {
+      for await (const _ of input.prompt) void _;
+    })();
+  }
+
+  // eslint-disable-next-line require-yield -- deliberately pending: tests never consume messages
+  async *[Symbol.asyncIterator](): AsyncGenerator<never> {
+    // Park the consume loop for the test's lifetime.
+    await new Promise(noop);
+  }
+}
+
+const queries: FakeQuery[] = [];
+
+sdkMock.query = (opts) => {
+  const q = new FakeQuery(opts as QueryInput);
+  queries.push(q);
+  return q;
+};
+
+afterEach(() => {
+  queries.length = 0;
+});
+
+const QUESTION_INPUT = {
+  questions: [
+    {
+      question: 'Which library should we use?',
+      header: 'Library',
+      options: [
+        { label: 'foxts', description: 'Already adopted.' },
+        { label: 'lodash', description: 'Familiar but heavy.' },
+      ],
+    },
+    {
+      question: 'Which features do you want to enable?',
+      header: 'Features',
+      multiSelect: true,
+      options: [{ label: 'Cache' }, { label: 'Retry' }, { label: 'Tracing' }],
+    },
+  ],
+};
+
+interface Harness {
+  adapter: ClaudeCodeAdapter;
+  events: AgentEvent[];
+  canUseTool: CanUseTool;
+}
+
+async function makeHarness(): Promise<Harness> {
+  const adapter = new ClaudeCodeAdapter();
+  const events: AgentEvent[] = [];
+  adapter.onEvent((e) => events.push(e));
+  await adapter.start({ kind: 'claude-code', cwd: '/tmp/repo' });
+  await adapter.send({ type: 'prompt', content: [textBlock('hi')] });
+  return { adapter, events, canUseTool: queries[0].options.canUseTool };
+}
+
+/** Ask, wait for the emitted question-request, and answer it — the full round-trip. */
+async function askAndAnswer(
+  harness: Harness,
+  outcome: QuestionOutcome,
+): Promise<Record<string, unknown>> {
+  const result = harness.canUseTool('AskUserQuestion', QUESTION_INPUT, askOptions());
+  await wait(0);
+  const request = harness.events.findLast((e) => e.type === 'question-request');
+  expect(request).toBeDefined();
+  await harness.adapter.send({
+    type: 'question-response',
+    requestId: request!.requestId,
+    outcome,
+  });
+  return result;
+}
+
+function askOptions(): { signal: AbortSignal; toolUseID: string } {
+  return { signal: new AbortController().signal, toolUseID: 'toolu_ask1' };
+}
+
+describe('ClaudeCodeAdapter AskUserQuestion', () => {
+  it('emits a question-request mapped from the tool input', async () => {
+    const { events, canUseTool } = await makeHarness();
+    void canUseTool('AskUserQuestion', QUESTION_INPUT, askOptions());
+    await wait(0);
+
+    const request = events.findLast((e) => e.type === 'question-request');
+    expect(request).toBeDefined();
+    expect(request!.toolCall.toolCallId).toBe('toolu_ask1');
+    expect(request!.questions).toEqual([
+      {
+        questionId: 'q0',
+        prompt: 'Which library should we use?',
+        header: 'Library',
+        multiSelect: false,
+        options: [
+          { optionId: 'o0', label: 'foxts', description: 'Already adopted.' },
+          { optionId: 'o1', label: 'lodash', description: 'Familiar but heavy.' },
+        ],
+      },
+      {
+        questionId: 'q1',
+        prompt: 'Which features do you want to enable?',
+        header: 'Features',
+        multiSelect: true,
+        options: [
+          { optionId: 'o0', label: 'Cache', description: undefined },
+          { optionId: 'o1', label: 'Retry', description: undefined },
+          { optionId: 'o2', label: 'Tracing', description: undefined },
+        ],
+      },
+    ]);
+  });
+
+  it('folds answers back into updatedInput keyed by question text (multi-select comma-joined)', async () => {
+    const harness = await makeHarness();
+    const result = await askAndAnswer(harness, {
+      outcome: 'answered',
+      answers: [
+        { questionId: 'q0', selectedOptionIds: ['o0'] },
+        { questionId: 'q1', selectedOptionIds: ['o0', 'o2'] },
+      ],
+    });
+
+    expect(result).toEqual({
+      behavior: 'allow',
+      updatedInput: {
+        ...QUESTION_INPUT,
+        answers: {
+          'Which library should we use?': 'foxts',
+          'Which features do you want to enable?': 'Cache, Tracing',
+        },
+      },
+    });
+  });
+
+  it('prefers free text over selections for a question answered with customText', async () => {
+    const harness = await makeHarness();
+    const result = await askAndAnswer(harness, {
+      outcome: 'answered',
+      answers: [
+        { questionId: 'q0', selectedOptionIds: [], customText: 'use the stdlib' },
+        { questionId: 'q1', selectedOptionIds: ['o1'] },
+      ],
+    });
+
+    expect(result).toMatchObject({
+      updatedInput: {
+        answers: {
+          'Which library should we use?': 'use the stdlib',
+          'Which features do you want to enable?': 'Retry',
+        },
+      },
+    });
+  });
+
+  it('denies with the CLI-native decline message when cancelled', async () => {
+    const harness = await makeHarness();
+    const result = await askAndAnswer(harness, { outcome: 'cancelled' });
+
+    expect(result).toEqual({
+      behavior: 'deny',
+      message: 'User declined to answer questions',
+    });
+  });
+
+  it('falls back to the generic permission ask when the input shape drifted', async () => {
+    const { events, canUseTool } = await makeHarness();
+    void canUseTool('AskUserQuestion', { questions: 'not-an-array' }, askOptions());
+    await wait(0);
+
+    expect(events.some((e) => e.type === 'question-request')).toBe(false);
+    expect(events.some((e) => e.type === 'permission-request')).toBe(true);
+  });
+});

--- a/packages/agent-adapter/src/base.ts
+++ b/packages/agent-adapter/src/base.ts
@@ -15,6 +15,8 @@ import type {
   MessageId,
   PermissionOption,
   PermissionOutcome,
+  Question,
+  QuestionOutcome,
   SessionStatus,
   StartOptions,
   StopReason,
@@ -30,6 +32,7 @@ import type { AgentAdapter } from './adapter';
 import { nextMessageId, nextRequestId } from './adapter';
 
 type PermissionResolver = (outcome: PermissionOutcome) => void;
+type QuestionResolver = (outcome: QuestionOutcome) => void;
 
 /**
  * Adapter base class: consolidates event plumbing, lifecycle, tool-call normalization, and the permission
@@ -60,6 +63,8 @@ export abstract class BaseAgentAdapter implements AgentAdapter {
   private sessionRef: AgentHistoryId | null = null;
   /** Permission asks awaiting a reply, keyed by requestId. */
   private readonly pending = new Map<string, PermissionResolver>();
+  /** Question asks awaiting a reply, keyed by requestId. */
+  private readonly pendingQuestions = new Map<string, QuestionResolver>();
   /** Running tool-call snapshots, keyed by toolCallId — the source for `emitTool`'s full-snapshot emits. */
   private readonly toolCalls = new Map<string, ToolCall>();
   /** Current segment's ids, refreshed via `freshSegment()` at each turn/tool boundary so text /
@@ -112,6 +117,9 @@ export abstract class BaseAgentAdapter implements AgentAdapter {
         return;
       case 'permission-response':
         this.resolvePending(input.requestId, input.outcome);
+        break;
+      case 'question-response':
+        this.resolvePendingQuestion(input.requestId, input.outcome);
         break;
       default:
         break;
@@ -283,15 +291,36 @@ export abstract class BaseAgentAdapter implements AgentAdapter {
     }
   }
 
+  // ── Question round-trip (resolved by a `question-response` AgentInput, by id) ──
+  protected requestQuestion(
+    toolCall: ToolCallUpdate,
+    questions: Question[],
+  ): Promise<QuestionOutcome> {
+    const requestId = nextRequestId();
+    return new Promise<QuestionOutcome>((resolve) => {
+      this.pendingQuestions.set(requestId, resolve);
+      this.emit({ type: 'question-request', requestId, toolCall, questions });
+    });
+  }
+  private resolvePendingQuestion(requestId: string, outcome: QuestionOutcome): void {
+    const resolve = this.pendingQuestions.get(requestId);
+    if (resolve) {
+      this.pendingQuestions.delete(requestId);
+      resolve(outcome);
+    }
+  }
+
   /**
-   * Liveness sweep on cancel / stop / abnormal turn end: resolve every still-pending permission ask with
-   * `cancelled` (a clean deny that unblocks the agent's awaiting callback) and force every non-terminal
-   * tool call to `failed`. Together these guarantee no tool stays `in_progress` and no agent hangs awaiting
-   * a permission reply. Idempotent — a no-op on a clean turn where everything is already settled.
+   * Liveness sweep on cancel / stop / abnormal turn end: resolve every still-pending permission or
+   * question ask with `cancelled` (a clean deny that unblocks the agent's awaiting callback) and force
+   * every non-terminal tool call to `failed`. Together these guarantee no tool stays `in_progress` and
+   * no agent hangs awaiting a reply. Idempotent — a no-op on a clean turn where everything is settled.
    */
   protected teardown(): void {
     for (const resolve of this.pending.values()) resolve({ outcome: 'cancelled' });
     this.pending.clear();
+    for (const resolve of this.pendingQuestions.values()) resolve({ outcome: 'cancelled' });
+    this.pendingQuestions.clear();
     for (const toolCall of this.toolCalls.values()) {
       if (toolCall.status === 'completed' || toolCall.status === 'failed') continue;
       this.emitTool({ toolCallId: toolCall.toolCallId, status: 'failed' });

--- a/packages/agent-adapter/src/native/claude-code.ts
+++ b/packages/agent-adapter/src/native/claude-code.ts
@@ -36,6 +36,7 @@ import type {
 import { textBlock } from '@linkcode/schema';
 import { extractErrorMessage } from 'foxts/extract-error-message';
 import { invariant, nullthrow } from 'foxts/guard';
+import { z } from 'zod';
 import { BaseAgentAdapter } from '../base';
 import {
   asHistoryId,
@@ -72,6 +73,23 @@ const PERMISSION_OPTIONS: PermissionOption[] = [
   { optionId: 'allow_always', name: 'Always allow', kind: 'allow_always' },
   { optionId: 'reject', name: 'Reject', kind: 'reject_once' },
 ];
+
+/** AskUserQuestion's tool input (the CLI caps questions at 4 and options at 2–4; only what the
+ * client renders is required here, so benign vendor additions don't break the parse). */
+const ASK_USER_QUESTION_INPUT = z.object({
+  questions: z
+    .array(
+      z.object({
+        question: z.string().min(1),
+        header: z.string().optional(),
+        multiSelect: z.boolean().optional(),
+        options: z
+          .array(z.object({ label: z.string().min(1), description: z.string().optional() }))
+          .min(1),
+      }),
+    )
+    .min(1),
+});
 
 /**
  * The approval-policy axis claude-code advertises; ids map 1:1 onto the SDK's `PermissionMode` and
@@ -539,6 +557,14 @@ export class ClaudeCodeAdapter extends BaseAgentAdapter {
   }
 
   private readonly canUseTool: CanUseTool = async (toolName, input, options) => {
+    if (toolName === 'AskUserQuestion') {
+      const questions = ASK_USER_QUESTION_INPUT.safeParse(input);
+      // A parse failure means the pinned CLI's tool shape drifted; degrade to the generic
+      // allow/deny ask (allow then executes with empty answers) instead of failing the turn.
+      if (questions.success) {
+        return this.askUserQuestion(questions.data.questions, input, options.toolUseID);
+      }
+    }
     const outcome = await this.requestPermission(
       {
         toolCallId: options.toolUseID,
@@ -554,6 +580,55 @@ export class ClaudeCodeAdapter extends BaseAgentAdapter {
     if (allowed) return { behavior: 'allow', updatedInput: input } satisfies PermissionResult;
     return { behavior: 'deny', message: 'Denied by the user' } satisfies PermissionResult;
   };
+
+  /** AskUserQuestion executes with whatever answers the host writes into its input: the CLI's
+   * `checkPermissions` always asks, and an allow that carries no `answers` "succeeds" with every
+   * question reported as unanswered. So the ask surfaces as a structured question card, and the
+   * user's picks are folded back into `updatedInput.answers` keyed by the question's own text
+   * (the CLI's answer-record key; multi-select and free-text answers both ride the same record,
+   * multi-select joined with ', ' per the tool's output contract). */
+  private async askUserQuestion(
+    questions: z.infer<typeof ASK_USER_QUESTION_INPUT>['questions'],
+    input: Record<string, unknown>,
+    toolUseID: string,
+  ): Promise<PermissionResult> {
+    const outcome = await this.requestQuestion(
+      {
+        toolCallId: toolUseID,
+        title: 'AskUserQuestion',
+        kind: claudeToolKind('AskUserQuestion'),
+        rawInput: input,
+      },
+      questions.map((question, qi) => ({
+        questionId: `q${qi}`,
+        prompt: question.question,
+        header: question.header,
+        multiSelect: question.multiSelect ?? false,
+        options: question.options.map((option, oi) => ({
+          optionId: `o${oi}`,
+          label: option.label,
+          description: option.description,
+        })),
+      })),
+    );
+    if (outcome.outcome === 'cancelled') {
+      return { behavior: 'deny', message: 'User declined to answer questions' };
+    }
+    const byQuestionId = new Map(outcome.answers.map((answer) => [answer.questionId, answer]));
+    const answers: Record<string, string> = {};
+    for (const [qi, question] of questions.entries()) {
+      const answer = byQuestionId.get(`q${qi}`);
+      if (!answer) continue;
+      const selected = new Set(answer.selectedOptionIds);
+      const labels: string[] = [];
+      for (const [oi, option] of question.options.entries()) {
+        if (selected.has(`o${oi}`)) labels.push(option.label);
+      }
+      const value = answer.customText?.trim() || labels.join(', ');
+      if (value) answers[question.question] = value;
+    }
+    return { behavior: 'allow', updatedInput: { ...input, answers } };
+  }
 
   protected handleMessage(msg: SDKMessage): void {
     // Every SDK message carries the CLI's session id — the provider-local history id this live run

--- a/packages/client-core/src/__tests__/conversation.test.ts
+++ b/packages/client-core/src/__tests__/conversation.test.ts
@@ -248,6 +248,46 @@ describe('buildConversation', () => {
     expect(settled.pendingPermissionIds).toEqual([]);
   });
 
+  it('tracks a question as pending until its tool call settles', () => {
+    const question = {
+      questionId: 'q0',
+      prompt: 'Which one?',
+      multiSelect: false,
+      options: [
+        { optionId: 'o0', label: 'A' },
+        { optionId: 'o1', label: 'B' },
+      ],
+    };
+    const base: AgentEvent[] = [
+      userText('ask'),
+      {
+        type: 'question-request',
+        requestId: 'ask1',
+        toolCall: { toolCallId: 't1', title: 'AskUserQuestion' },
+        questions: [question],
+      },
+    ];
+    const open = buildConversation(base);
+    expect(open.pendingQuestionIds).toEqual(['ask1']);
+    const item = open.items.find((i) => i.kind === 'question');
+    expect(item).toMatchObject({ requestId: 'ask1', questions: [question] });
+
+    const settled = buildConversation([
+      ...base,
+      {
+        type: 'tool-call',
+        toolCall: {
+          toolCallId: 't1',
+          title: 'AskUserQuestion',
+          kind: 'other',
+          status: 'completed',
+          content: [],
+        },
+      },
+    ]);
+    expect(settled.pendingQuestionIds).toEqual([]);
+  });
+
   it('captures lifecycle state (status / usage / mode / stop / error)', () => {
     const c = buildConversation([
       { type: 'status', status: 'running' },

--- a/packages/client-core/src/client.ts
+++ b/packages/client-core/src/client.ts
@@ -16,6 +16,7 @@ import type {
   ManagedAssetStatus,
   PermissionOutcome,
   ProvidersConfig,
+  QuestionOutcome,
   SessionId,
   SessionInfo,
   SessionRecord,
@@ -243,6 +244,14 @@ export class LinkCodeClient {
     outcome: PermissionOutcome,
   ): Promise<RequestAck> {
     return this.control.respondPermission(sessionId, requestId, outcome);
+  }
+
+  respondQuestion(
+    sessionId: SessionId,
+    requestId: string,
+    outcome: QuestionOutcome,
+  ): Promise<RequestAck> {
+    return this.control.respondQuestion(sessionId, requestId, outcome);
   }
 
   /** Stop a session and drop its buffered events (its receive counter survives, see {@link EventBuffer}). */

--- a/packages/client-core/src/client/control-channel.ts
+++ b/packages/client-core/src/client/control-channel.ts
@@ -17,6 +17,7 @@ import type {
   ManagedAssetStatus,
   PermissionOutcome,
   ProvidersConfig,
+  QuestionOutcome,
   SessionId,
   SessionInfo,
   SessionRecord,
@@ -180,6 +181,15 @@ export class ControlChannel {
     outcome: PermissionOutcome,
   ): Promise<RequestAck> {
     return this.send(sessionId, { type: 'permission-response', requestId, outcome });
+  }
+
+  /** Answer a pending question-request. */
+  respondQuestion(
+    sessionId: SessionId,
+    requestId: string,
+    outcome: QuestionOutcome,
+  ): Promise<RequestAck> {
+    return this.send(sessionId, { type: 'question-response', requestId, outcome });
   }
 
   stopSession(sessionId: SessionId): Promise<RequestAck> {

--- a/packages/client-core/src/conversation-store.ts
+++ b/packages/client-core/src/conversation-store.ts
@@ -20,6 +20,7 @@ const EMPTY_CONVERSATION: Conversation = {
   approvalPolicy: null,
   stopReason: null,
   pendingPermissionIds: [],
+  pendingQuestionIds: [],
 };
 
 /**

--- a/packages/client-core/src/conversation.ts
+++ b/packages/client-core/src/conversation.ts
@@ -4,6 +4,7 @@ import type {
   ContentBlock,
   PermissionOption,
   Plan,
+  Question,
   SessionStatus,
   StopReason,
   TokenUsage,
@@ -54,6 +55,14 @@ export type ConversationItem = (
       options: PermissionOption[];
     }
   | {
+      kind: 'question';
+      id: string;
+      turnId: ConversationTurnId;
+      requestId: string;
+      toolCall: ToolCallUpdate;
+      questions: Question[];
+    }
+  | {
       kind: 'error';
       id: string;
       turnId: ConversationTurnId;
@@ -82,6 +91,8 @@ export interface ConversationViewModel {
    * terminal status. The UI additionally hides ones the user already answered in this client.
    */
   pendingPermissionIds: string[];
+  /** requestIds of question asks that are still open, tracked the same way as permission asks. */
+  pendingQuestionIds: string[];
 }
 
 export type Conversation = ConversationViewModel;
@@ -125,6 +136,7 @@ export function createConversationBuilder(): ConversationBuilder {
   const planIndexByTurn = new Map<ConversationTurnId, number>();
   /** Asks in arrival order; each stays "pending" until its tool call reaches a terminal status. */
   const approvals: Array<{ requestId: string; toolCallId: string }> = [];
+  const questionAsks: Array<{ requestId: string; toolCallId: string }> = [];
   let currentTurnId: ConversationTurnId = null;
   let gen = 0;
   let status: SessionStatus | null = null;
@@ -306,6 +318,18 @@ export function createConversationBuilder(): ConversationBuilder {
         });
         approvals.push({ requestId: event.requestId, toolCallId: event.toolCall.toolCallId });
         break;
+      case 'question-request':
+        items.push({
+          kind: 'question',
+          id: event.requestId,
+          turnId: currentTurnId,
+          requestId: event.requestId,
+          toolCall: event.toolCall,
+          questions: event.questions,
+          receivedAt,
+        });
+        questionAsks.push({ requestId: event.requestId, toolCallId: event.toolCall.toolCallId });
+        break;
       default:
         break;
     }
@@ -323,16 +347,21 @@ export function createConversationBuilder(): ConversationBuilder {
       }
     }
 
-    // A permission ask is "pending" until its referenced tool call reaches a terminal status.
-    const pendingPermissionIds: string[] = [];
-    for (const approval of approvals) {
-      const toolItemIndex = toolIndex.get(approval.toolCallId);
-      const toolItem = toolItemIndex === undefined ? undefined : items[toolItemIndex];
-      const settled =
-        toolItem?.kind === 'tool' &&
-        (toolItem.toolCall.status === 'completed' || toolItem.toolCall.status === 'failed');
-      if (!settled) pendingPermissionIds.push(approval.requestId);
-    }
+    // An ask (permission or question) is "pending" until its tool call reaches a terminal status.
+    const pendingIds = (
+      asks: ReadonlyArray<{ requestId: string; toolCallId: string }>,
+    ): string[] => {
+      const pending: string[] = [];
+      for (const ask of asks) {
+        const toolItemIndex = toolIndex.get(ask.toolCallId);
+        const toolItem = toolItemIndex === undefined ? undefined : items[toolItemIndex];
+        const settled =
+          toolItem?.kind === 'tool' &&
+          (toolItem.toolCall.status === 'completed' || toolItem.toolCall.status === 'failed');
+        if (!settled) pending.push(ask.requestId);
+      }
+      return pending;
+    };
 
     cached = {
       items: out,
@@ -341,7 +370,8 @@ export function createConversationBuilder(): ConversationBuilder {
       currentModeId,
       approvalPolicy,
       stopReason,
-      pendingPermissionIds,
+      pendingPermissionIds: pendingIds(approvals),
+      pendingQuestionIds: pendingIds(questionAsks),
     };
     return cached;
   };

--- a/packages/i18n/src/locales/en.ts
+++ b/packages/i18n/src/locales/en.ts
@@ -91,6 +91,12 @@ export const en = {
       next: 'Next prompt',
       customPlaceholder: 'Tell Codex what to do differently',
     },
+    question: {
+      badge: 'Question',
+      progress: '{current}/{total}',
+      next: 'Next',
+      customPlaceholder: 'Type a custom answer',
+    },
     composer: {
       placeholderDisconnected: 'Create or pick a thread first',
       send: 'Send',

--- a/packages/i18n/src/locales/zh-cn.ts
+++ b/packages/i18n/src/locales/zh-cn.ts
@@ -89,6 +89,12 @@ export const zhCN = {
       next: '下一个提示',
       customPlaceholder: '告诉 Codex 要如何调整',
     },
+    question: {
+      badge: '提问',
+      progress: '{current}/{total}',
+      next: '下一题',
+      customPlaceholder: '输入自定义回答',
+    },
     composer: {
       placeholderDisconnected: '请先创建或选择线程',
       send: '发送',

--- a/packages/schema/src/agent.ts
+++ b/packages/schema/src/agent.ts
@@ -9,6 +9,7 @@ import {
 import { ContentBlockSchema } from './content';
 import { PermissionOutcomeSchema, PermissionRequestSchema } from './permission';
 import { PlanSchema } from './plan';
+import { QuestionOutcomeSchema, QuestionRequestSchema } from './question';
 import {
   ApprovalPolicyIdSchema,
   ApprovalPolicyStateSchema,
@@ -78,6 +79,12 @@ export const AgentInputSchema = z.discriminatedUnion('type', [
     requestId: z.string().min(1),
     outcome: PermissionOutcomeSchema,
   }),
+  /** The user's answers for a pending question-request (correlated by requestId). */
+  z.object({
+    type: z.literal('question-response'),
+    requestId: z.string().min(1),
+    outcome: QuestionOutcomeSchema,
+  }),
 ]);
 export type AgentInput = z.infer<typeof AgentInputSchema>;
 
@@ -139,9 +146,13 @@ export const AgentEventSchema = z.discriminatedUnion('type', [
     recoverable: z.boolean().default(true),
   }),
 
-  // ── Agent → client request (awaits a reply via AgentInput, correlated by requestId) ──
+  // ── Agent → client requests (await a reply via AgentInput, correlated by requestId) ──
   PermissionRequestSchema.extend({
     type: z.literal('permission-request'),
+    requestId: z.string().min(1),
+  }),
+  QuestionRequestSchema.extend({
+    type: z.literal('question-request'),
     requestId: z.string().min(1),
   }),
 ]);

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -21,6 +21,7 @@ export * from './managed-asset';
 export * from './permission';
 export * from './plan';
 export * from './provider-config';
+export * from './question';
 export * from './script';
 export * from './session';
 export * from './terminal';

--- a/packages/schema/src/question.ts
+++ b/packages/schema/src/question.ts
@@ -1,0 +1,53 @@
+import { z } from 'zod';
+import { ToolCallUpdateSchema } from './tool-call';
+
+/**
+ * Structured question flow — the agent asks the user to choose among options (claude-code's
+ * AskUserQuestion tool). Distinct from the permission flow: a permission ask is allow/deny over a
+ * tool's execution, while a question ask collects answers that become the tool's own result.
+ */
+
+export const QuestionOptionSchema = z.object({
+  optionId: z.string().min(1),
+  label: z.string().min(1),
+  /** What choosing this option means (trade-offs, implications). */
+  description: z.string().optional(),
+});
+export type QuestionOption = z.infer<typeof QuestionOptionSchema>;
+
+export const QuestionSchema = z.object({
+  questionId: z.string().min(1),
+  /** The full question text. */
+  prompt: z.string().min(1),
+  /** Very short chip/tag label (vendor-capped; claude-code caps it at 12 chars). */
+  header: z.string().optional(),
+  /** Whether multiple options may be selected. */
+  multiSelect: z.boolean(),
+  options: z.array(QuestionOptionSchema).min(1),
+});
+export type Question = z.infer<typeof QuestionSchema>;
+
+/** The agent's question ask: which tool call is waiting, and the questions to answer. */
+export const QuestionRequestSchema = z.object({
+  /** The asking tool call — pending-tracking joins on `toolCallId`, like the permission flow. */
+  toolCall: ToolCallUpdateSchema,
+  questions: z.array(QuestionSchema).min(1),
+});
+export type QuestionRequest = z.infer<typeof QuestionRequestSchema>;
+
+/** One question's answer: selected options, or free text typed instead of selecting. */
+export const QuestionAnswerSchema = z.object({
+  questionId: z.string().min(1),
+  /** Chosen options; a single-select answer carries exactly one entry. */
+  selectedOptionIds: z.array(z.string().min(1)),
+  /** Freeform answer typed instead of picking a structured option. */
+  customText: z.string().optional(),
+});
+export type QuestionAnswer = z.infer<typeof QuestionAnswerSchema>;
+
+/** The user's reply to a question request: answers for every question, or a decline. */
+export const QuestionOutcomeSchema = z.discriminatedUnion('outcome', [
+  z.object({ outcome: z.literal('answered'), answers: z.array(QuestionAnswerSchema).min(1) }),
+  z.object({ outcome: z.literal('cancelled') }),
+]);
+export type QuestionOutcome = z.infer<typeof QuestionOutcomeSchema>;

--- a/packages/schema/src/wire/index.ts
+++ b/packages/schema/src/wire/index.ts
@@ -37,7 +37,7 @@ export {
  * originating client can pair the reply despite the broadcast.
  */
 
-export const WIRE_PROTOCOL_VERSION = 15 as const;
+export const WIRE_PROTOCOL_VERSION = 16 as const;
 
 /** Envelope payload: a discriminated union keyed by `kind`. */
 export const WirePayloadSchema = z.discriminatedUnion('kind', [

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -16,6 +16,7 @@ import type {
   ManagedAssetStatus,
   PermissionOutcome,
   ProvidersConfig,
+  QuestionOutcome,
   SessionId,
   SessionInfo,
   SessionRecord,
@@ -150,6 +151,14 @@ export class LinkCodeSdkClient {
     outcome: PermissionOutcome,
   ): RequestResult<{ ok: true }> {
     return toResult(this.raw.respondPermission(sessionId, requestId, outcome));
+  }
+
+  respondQuestion(
+    sessionId: SessionId,
+    requestId: string,
+    outcome: QuestionOutcome,
+  ): RequestResult<{ ok: true }> {
+    return toResult(this.raw.respondQuestion(sessionId, requestId, outcome));
   }
 
   /** Read the daemon-owned provider config (data plane). */

--- a/packages/sdk/src/operations.ts
+++ b/packages/sdk/src/operations.ts
@@ -15,6 +15,7 @@ import type {
   ManagedAssetStatus,
   PermissionOutcome,
   ProvidersConfig,
+  QuestionOutcome,
   SessionId,
   SessionInfo,
   SessionRecord,
@@ -116,6 +117,16 @@ export function respondPermission(
   options: Options<{ sessionId: SessionId; requestId: string; outcome: PermissionOutcome }>,
 ): RequestResult<{ ok: true }> {
   return resolveClient(options).respondPermission(
+    options.sessionId,
+    options.requestId,
+    options.outcome,
+  );
+}
+
+export function respondQuestion(
+  options: Options<{ sessionId: SessionId; requestId: string; outcome: QuestionOutcome }>,
+): RequestResult<{ ok: true }> {
+  return resolveClient(options).respondQuestion(
     options.sessionId,
     options.requestId,
     options.outcome,

--- a/packages/ui/src/__tests__/conversation-prompts.test.ts
+++ b/packages/ui/src/__tests__/conversation-prompts.test.ts
@@ -36,6 +36,7 @@ function conversation(
     approvalPolicy: null,
     stopReason: null,
     pendingPermissionIds: [],
+    pendingQuestionIds: [],
     ...overrides,
   };
 }

--- a/packages/ui/src/__tests__/conversation-prompts.test.ts
+++ b/packages/ui/src/__tests__/conversation-prompts.test.ts
@@ -2,7 +2,6 @@ import type { PermissionOption, Plan } from '@linkcode/schema';
 import { describe, expect, it } from 'vitest';
 import {
   isConversationPromptResponseSubmittable,
-  STUB_AGENT_QUESTION_PROMPTS,
   STUB_PLAN_REVIEW_PROMPTS,
 } from '../chat/conversation-prompt';
 import type { PermissionConversationItem, PermissionDecision } from '../chat/conversation-prompts';
@@ -14,6 +13,7 @@ import {
   resolvePromptPageIndex,
   selectCurrentPlan,
   selectPendingPermissionItems,
+  selectPendingQuestionItems,
 } from '../chat/conversation-prompts';
 import type { ConversationItem, ConversationViewModel } from '../chat/types';
 
@@ -237,7 +237,38 @@ describe('conversation prompt selectors', () => {
   });
 
   it('leaves future prompt stubs empty until the backend schema exists', () => {
-    expect(STUB_AGENT_QUESTION_PROMPTS).toEqual([]);
     expect(STUB_PLAN_REVIEW_PROMPTS).toEqual([]);
+  });
+
+  it('selects pending question items only while the turn is live', () => {
+    const question: ConversationItem = {
+      kind: 'question',
+      id: 'ask1',
+      turnId: 'turn-1',
+      requestId: 'ask1',
+      toolCall: { toolCallId: 't1', title: 'AskUserQuestion' },
+      questions: [
+        {
+          questionId: 'q0',
+          prompt: 'Which one?',
+          multiSelect: false,
+          options: [
+            { optionId: 'o0', label: 'A' },
+            { optionId: 'o1', label: 'B' },
+          ],
+        },
+      ],
+    };
+    const live = conversation([question], { pendingQuestionIds: ['ask1'] });
+    expect(selectPendingQuestionItems(live)).toHaveLength(1);
+
+    const settled = conversation([question], { pendingQuestionIds: [] });
+    expect(selectPendingQuestionItems(settled)).toHaveLength(0);
+
+    const ended = conversation([question], {
+      pendingQuestionIds: ['ask1'],
+      status: 'idle',
+    });
+    expect(selectPendingQuestionItems(ended)).toHaveLength(0);
   });
 });

--- a/packages/ui/src/chat/conversation-prompt.ts
+++ b/packages/ui/src/chat/conversation-prompt.ts
@@ -33,10 +33,6 @@ export function isConversationPromptResponseSubmittable(
   return selected.length === 1;
 }
 
-// TODO(backend): replace with prompts emitted by an agent-question event once the schema carries
-// question text, answer mode, choices, and reply correlation.
-export const STUB_AGENT_QUESTION_PROMPTS: ConversationPromptDefinition[] = [];
-
 // TODO(backend): replace with prompts emitted by a plan-review permission event once plans can ask
 // for explicit user approval before execution.
 export const STUB_PLAN_REVIEW_PROMPTS: ConversationPromptDefinition[] = [];

--- a/packages/ui/src/chat/conversation-prompts.ts
+++ b/packages/ui/src/chat/conversation-prompts.ts
@@ -3,6 +3,7 @@ import type { ConversationItem, ConversationViewModel } from './types';
 
 export type PlanConversationItem = Extract<ConversationItem, { kind: 'plan' }>;
 export type PermissionConversationItem = Extract<ConversationItem, { kind: 'approval' }>;
+export type QuestionConversationItem = Extract<ConversationItem, { kind: 'question' }>;
 
 export type PermissionDecision =
   | {
@@ -68,6 +69,21 @@ export function selectPendingPermissionItems(
   return conversation.items.filter(
     (item): item is PermissionConversationItem =>
       item.kind === 'approval' && pending.has(item.requestId),
+  );
+}
+
+/**
+ * Question asks that still need answers — same live-turn gating as permission asks: once the turn
+ * ends, the agent is no longer awaiting, so a stale ask must not present an actionable card.
+ */
+export function selectPendingQuestionItems(
+  conversation: Pick<ConversationViewModel, 'items' | 'pendingQuestionIds' | 'status'>,
+): QuestionConversationItem[] {
+  if (conversation.status !== 'running' && conversation.status !== 'starting') return [];
+  const pending = new Set(conversation.pendingQuestionIds);
+  return conversation.items.filter(
+    (item): item is QuestionConversationItem =>
+      item.kind === 'question' && pending.has(item.requestId),
   );
 }
 

--- a/packages/ui/src/chat/types.ts
+++ b/packages/ui/src/chat/types.ts
@@ -3,6 +3,7 @@ import type {
   ContentBlock,
   PermissionOption,
   Plan,
+  Question,
   SessionStatus,
   StopReason,
   TokenUsage,
@@ -48,6 +49,12 @@ export type ConversationItem =
       options: PermissionOption[];
     })
   | (ConversationItemBase & {
+      kind: 'question';
+      requestId: string;
+      toolCall: ToolCallUpdate;
+      questions: Question[];
+    })
+  | (ConversationItemBase & {
       kind: 'error';
       message: string;
       code?: string;
@@ -70,4 +77,6 @@ export interface ConversationViewModel {
   stopReason: StopReason | null;
   /** Permission requests still awaiting a decision. */
   pendingPermissionIds: string[];
+  /** Question requests still awaiting answers. */
+  pendingQuestionIds: string[];
 }

--- a/packages/ui/src/shell/conversation-prompt-dock.tsx
+++ b/packages/ui/src/shell/conversation-prompt-dock.tsx
@@ -1,4 +1,4 @@
-import type { PermissionOption, ToolCallUpdate } from '@linkcode/schema';
+import type { PermissionOption, QuestionOutcome, ToolCallUpdate } from '@linkcode/schema';
 import {
   Pagination,
   PaginationContent,
@@ -20,15 +20,18 @@ import type {
   PermissionConversationItem,
   PermissionDecision,
   PromptPageCursor,
+  QuestionConversationItem,
 } from '../chat/conversation-prompts';
 import {
   resolvePromptPageIndex,
   selectCurrentPlan,
   selectPendingPermissionItems,
+  selectPendingQuestionItems,
 } from '../chat/conversation-prompts';
 import { Step, StepContent, StepHeader, StepItem } from '../chat/step';
 import type { ConversationViewModel } from '../chat/types';
 import { cn } from '../lib/cn';
+import { QuestionPrompt } from './question-prompt';
 
 interface MockConversationPrompt {
   promptId: string;
@@ -42,6 +45,7 @@ interface MockConversationPrompt {
 
 type PromptQueueItem =
   | { kind: 'permission'; promptId: string; item: PermissionConversationItem }
+  | { kind: 'question'; promptId: string; item: QuestionConversationItem }
   | { kind: 'mock'; promptId: string; prompt: MockConversationPrompt };
 
 const EMPTY_MOCK_PROMPTS: MockConversationPrompt[] = [];
@@ -78,21 +82,30 @@ const MOCK_SHOWCASE_PROMPTS: MockConversationPrompt[] = [
   },
 ];
 
-/** Actionable prompts pinned above the composer: the current plan and pending permission asks. */
+/** Actionable prompts pinned above the composer: the current plan and pending permission/question asks. */
 export function ConversationPromptDock({
   conversation,
   permissionDecisions,
   respondingPermissions,
+  answeredQuestionIds,
+  respondingQuestions,
   onRespondPermission,
+  onRespondQuestion,
 }: {
   conversation: ConversationViewModel;
   permissionDecisions: ReadonlyMap<string, PermissionDecision>;
   respondingPermissions: ReadonlySet<string>;
+  answeredQuestionIds: ReadonlySet<string>;
+  respondingQuestions: ReadonlySet<string>;
   onRespondPermission: (requestId: string, decision: PermissionDecision) => void;
+  onRespondQuestion: (requestId: string, outcome: QuestionOutcome) => void;
 }): React.ReactNode {
   const plan = selectCurrentPlan(conversation);
   const pendingPermissions = selectPendingPermissionItems(conversation).filter(
     (item) => !permissionDecisions.has(item.requestId),
+  );
+  const pendingQuestions = selectPendingQuestionItems(conversation).filter(
+    (item) => !answeredQuestionIds.has(item.requestId),
   );
   const [dismissedMockPromptIds, setDismissedMockPromptIds] = useState<string[]>([]);
   const [promptCursor, setPromptCursor] = useState<PromptPageCursor>({
@@ -109,6 +122,13 @@ export function ConversationPromptDock({
       (item): PromptQueueItem => ({
         kind: 'permission',
         promptId: `permission:${item.requestId}`,
+        item,
+      }),
+    ),
+    ...pendingQuestions.map(
+      (item): PromptQueueItem => ({
+        kind: 'question',
+        promptId: `question:${item.requestId}`,
         item,
       }),
     ),
@@ -159,6 +179,14 @@ export function ConversationPromptDock({
             item={currentPrompt.item}
             respondingPermissions={respondingPermissions}
             onRespondPermission={onRespondPermission}
+          />
+        ) : currentPrompt?.kind === 'question' ? (
+          <QuestionPrompt
+            key={currentPrompt.promptId}
+            action={pager}
+            item={currentPrompt.item}
+            responding={respondingQuestions.has(currentPrompt.item.requestId)}
+            onRespond={onRespondQuestion}
           />
         ) : currentPrompt ? (
           <ConversationPromptAlert

--- a/packages/ui/src/shell/conversation-surface.tsx
+++ b/packages/ui/src/shell/conversation-surface.tsx
@@ -1,4 +1,4 @@
-import type { AgentKind, EffortLevel } from '@linkcode/schema';
+import type { AgentKind, EffortLevel, QuestionOutcome } from '@linkcode/schema';
 import { useRef } from 'react';
 import { ArtifactHostActionsProvider } from '../chat/artifacts';
 import type { PermissionDecision } from '../chat/conversation-prompts';
@@ -18,6 +18,8 @@ export interface ConversationSurfaceProps {
   modelName?: string;
   permissionDecisions: ReadonlyMap<string, PermissionDecision>;
   respondingPermissions: ReadonlySet<string>;
+  answeredQuestionIds: ReadonlySet<string>;
+  respondingQuestions: ReadonlySet<string>;
   disabled?: boolean;
   isRunning: boolean;
   topContent?: React.ReactNode;
@@ -27,6 +29,7 @@ export interface ConversationSurfaceProps {
   onSendPrompt: (text: string) => void;
   onStopTurn: () => void;
   onRespondPermission: (requestId: string, decision: PermissionDecision) => void;
+  onRespondQuestion: (requestId: string, outcome: QuestionOutcome) => void;
   /** Opens a produced-file artifact in the shell's viewer (desktop right panel). Absent
    * when the shell has no viewer — file cards then render without the open affordance. */
   onOpenFileArtifact?: (path: string) => void;
@@ -48,6 +51,8 @@ export function ConversationSurface({
   modelName,
   permissionDecisions,
   respondingPermissions,
+  answeredQuestionIds,
+  respondingQuestions,
   disabled = false,
   isRunning,
   topContent,
@@ -57,6 +62,7 @@ export function ConversationSurface({
   onSendPrompt,
   onStopTurn,
   onRespondPermission,
+  onRespondQuestion,
   onOpenFileArtifact,
   onHostArtifact,
   onOpenPreviewUrl,
@@ -94,7 +100,10 @@ export function ConversationSurface({
         conversation={conversation}
         permissionDecisions={permissionDecisions}
         respondingPermissions={respondingPermissions}
+        answeredQuestionIds={answeredQuestionIds}
+        respondingQuestions={respondingQuestions}
         onRespondPermission={onRespondPermission}
+        onRespondQuestion={onRespondQuestion}
       />
       {/* TODO(backend): pass the agent-advertised mode list (session-modes.ts) once the daemon
           emits it; the composer stubs the workflow-mode list today. */}

--- a/packages/ui/src/shell/question-prompt.tsx
+++ b/packages/ui/src/shell/question-prompt.tsx
@@ -1,0 +1,66 @@
+import type { QuestionAnswer, QuestionOutcome } from '@linkcode/schema';
+import { useState } from 'react';
+import { useTranslations } from 'use-intl';
+import { ConversationPromptAlert } from '../chat/conversation-prompt-alert';
+import type { QuestionConversationItem } from '../chat/conversation-prompts';
+
+/**
+ * One agent question ask (1–4 questions), stepped through one question per card. Answers accumulate
+ * locally and submit as ONE reply on the last step — the agent awaits a single response for the
+ * whole ask. Skip declines the whole ask (the agent hears "declined", not partial answers).
+ */
+export function QuestionPrompt({
+  action,
+  item,
+  responding,
+  onRespond,
+}: {
+  action?: React.ReactNode;
+  item: QuestionConversationItem;
+  responding: boolean;
+  onRespond: (requestId: string, outcome: QuestionOutcome) => void;
+}): React.ReactNode {
+  const t = useTranslations('workbench.question');
+  const [answers, setAnswers] = useState<QuestionAnswer[]>([]);
+  const index = Math.min(answers.length, item.questions.length - 1);
+  const question = item.questions[index];
+  const isLast = index === item.questions.length - 1;
+  const header = question.header ?? t('badge');
+  const badge =
+    item.questions.length > 1
+      ? `${header} · ${t('progress', { current: index + 1, total: item.questions.length })}`
+      : header;
+
+  return (
+    <ConversationPromptAlert
+      // Remount per question so the alert's selection state starts fresh on each step.
+      key={question.questionId}
+      className="my-0"
+      action={action}
+      badge={badge}
+      choices={question.options.map((option) => ({
+        id: option.optionId,
+        label: option.label,
+        description: option.description,
+      }))}
+      customInputPlaceholder={t('customPlaceholder')}
+      mode={question.multiSelect ? 'multiple' : 'single'}
+      submitting={responding}
+      submitLabel={isLast ? undefined : t('next')}
+      title={question.prompt}
+      onSkip={() => onRespond(item.requestId, { outcome: 'cancelled' })}
+      onSubmit={(response) => {
+        const answer: QuestionAnswer = {
+          questionId: question.questionId,
+          selectedOptionIds: response.selectedIds,
+          customText: response.customText,
+        };
+        if (isLast) {
+          onRespond(item.requestId, { outcome: 'answered', answers: [...answers, answer] });
+        } else {
+          setAnswers((current) => [...current, answer]);
+        }
+      }}
+    />
+  );
+}

--- a/packages/ui/src/shell/shell-frame.tsx
+++ b/packages/ui/src/shell/shell-frame.tsx
@@ -1,4 +1,10 @@
-import type { EffortLevel, SessionId, SessionInfo, WorkspaceRecord } from '@linkcode/schema';
+import type {
+  EffortLevel,
+  QuestionOutcome,
+  SessionId,
+  SessionInfo,
+  WorkspaceRecord,
+} from '@linkcode/schema';
 import type { ConversationViewModel } from '../chat';
 import type { PermissionDecision } from '../chat/conversation-prompts';
 import { ConversationSurface } from './conversation-surface';
@@ -29,6 +35,8 @@ export interface ShellFrameProps
   conversation: ConversationViewModel;
   permissionDecisions: ReadonlyMap<string, PermissionDecision>;
   respondingPermissions: ReadonlySet<string>;
+  answeredQuestionIds: ReadonlySet<string>;
+  respondingQuestions: ReadonlySet<string>;
   header?: React.ReactNode;
   errorMessage?: string | null;
   onSelectSession: (id: SessionId) => void;
@@ -50,6 +58,7 @@ export interface ShellFrameProps
   onSendPrompt: (text: string) => void;
   onStopTurn: () => void;
   onRespondPermission: (requestId: string, decision: PermissionDecision) => void;
+  onRespondQuestion: (requestId: string, outcome: QuestionOutcome) => void;
   /** Hosts inline artifact content on the daemon (sandboxed html previews, CODE-62). */
   onHostArtifact?: (content: string, mimeType: string) => Promise<{ url: string }>;
   /** Opens the command palette — the sidebar Search entry stays disabled without it. */
@@ -75,6 +84,8 @@ export function ShellFrame({
   conversation,
   permissionDecisions,
   respondingPermissions,
+  answeredQuestionIds,
+  respondingQuestions,
   header,
   errorMessage,
   pinnedSessionIds,
@@ -95,6 +106,7 @@ export function ShellFrame({
   onSendPrompt,
   onStopTurn,
   onRespondPermission,
+  onRespondQuestion,
   onHostArtifact,
   onOpenSearch,
   searchShortcut,
@@ -166,10 +178,13 @@ export function ShellFrame({
             cwd={active?.cwd}
             permissionDecisions={permissionDecisions}
             respondingPermissions={respondingPermissions}
+            answeredQuestionIds={answeredQuestionIds}
+            respondingQuestions={respondingQuestions}
             TerminalBlockComponent={TerminalBlockComponent}
             onSendPrompt={onSendPrompt}
             onStopTurn={onStopTurn}
             onRespondPermission={onRespondPermission}
+            onRespondQuestion={onRespondQuestion}
             onHostArtifact={onHostArtifact}
             onModeChange={onModeChange}
             onApprovalPolicyChange={onApprovalPolicyChange}

--- a/packages/workbench/src/surface/workbench.tsx
+++ b/packages/workbench/src/surface/workbench.tsx
@@ -1,5 +1,11 @@
 import type { Conversation } from '@linkcode/client-core';
-import type { EffortLevel, SessionId, WorkspaceId, WorkspaceRecord } from '@linkcode/schema';
+import type {
+  EffortLevel,
+  QuestionOutcome,
+  SessionId,
+  WorkspaceId,
+  WorkspaceRecord,
+} from '@linkcode/schema';
 import { workspaceKind } from '@linkcode/schema';
 import {
   archiveWorkspace,
@@ -8,6 +14,7 @@ import {
   promptText,
   registerWorkspace,
   respondPermission,
+  respondQuestion,
   sendInput,
   setEffort,
   setModel,
@@ -115,6 +122,7 @@ function WorkbenchSessionSurface({
   const promptMutation = useMutation(promptText, { onError });
   const cancelMutation = useMutation(cancelTurn, { onError });
   const permissionMutation = useMutation(respondPermission, { onError });
+  const questionMutation = useMutation(respondQuestion, { onError });
   const modelMutation = useMutation(setModel, { onError });
   const effortMutation = useMutation(setEffort, { onError });
   // Workflow-mode and approval-policy switches ride the generic input op; each reflects back via
@@ -124,6 +132,8 @@ function WorkbenchSessionSurface({
     () => new Map<string, PermissionDecision>(),
   );
   const [responding, addResponding, removeResponding] = useSet<string>();
+  const [answeredQuestions, addAnsweredQuestion] = useSet<string>();
+  const [respondingQuestions, addRespondingQuestion, removeRespondingQuestion] = useSet<string>();
   const active = sessions.active;
   const sdkClient = useWorkbenchSdkClient();
   const activeSessionId = sessions.activeId;
@@ -366,6 +376,21 @@ function WorkbenchSessionSurface({
       });
   }
 
+  function handleRespondQuestion(requestId: string, outcome: QuestionOutcome): void {
+    if (!sessions.activeId) return;
+    onClearError();
+    addRespondingQuestion(requestId);
+    void questionMutation
+      .trigger({ sessionId: sessions.activeId, requestId, outcome })
+      .then(() => {
+        addAnsweredQuestion(requestId);
+      })
+      .catch(noop)
+      .finally(() => {
+        removeRespondingQuestion(requestId);
+      });
+  }
+
   return (
     <ShellComponent
       threadGroups={threadGroups}
@@ -378,6 +403,8 @@ function WorkbenchSessionSurface({
       conversation={conversation}
       permissionDecisions={permissionDecisions}
       respondingPermissions={responding}
+      answeredQuestionIds={answeredQuestions}
+      respondingQuestions={respondingQuestions}
       header={{
         title: active ? (active.title ?? tk(active.kind)) : 'Link Code',
         subtitle: active?.cwd,
@@ -402,6 +429,7 @@ function WorkbenchSessionSurface({
       onSendPrompt={handleSend}
       onStopTurn={handleStopTurn}
       onRespondPermission={handleRespond}
+      onRespondQuestion={handleRespondQuestion}
       onHostArtifact={handleHostArtifact}
       onOpenSearch={openCommandPalette}
       searchShortcut={paletteShortcut}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -604,6 +604,9 @@ importers:
       smol-toml:
         specifier: ^1.7.0
         version: 1.7.0
+      zod:
+        specifier: 'catalog:'
+        version: 4.4.3
     devDependencies:
       '@types/node':
         specifier: 'catalog:'


### PR DESCRIPTION
## Summary

claude-code's AskUserQuestion tool was previously treated as a generic permission ask: the user saw a bare Allow/Reject card (questions never rendered), and allowing executed the tool with empty answers — the model received `(no option selected)` for every question. This wires the structured question flow end-to-end.

- **schema**: new `question.ts` contract (`Question`/`QuestionOption`/`QuestionAnswer`/`QuestionOutcome`) + `question-request`/`question-response` variants on `AgentEvent`/`AgentInput`; `WIRE_PROTOCOL_VERSION` 15 → **16**
- **agent-adapter**: `BaseAgentAdapter.requestQuestion` pending pipeline (teardown sweeps it like permission asks); claude-code `canUseTool` special-cases `AskUserQuestion` — parses the tool input, raises a structured ask, and folds the reply back into `updatedInput.answers` keyed by question text (multi-select comma-joined, free text preferred), matching the vendored CLI's own answer contract; decline denies with the CLI-native `User declined to answer questions`; input-shape drift falls back to the generic permission ask
- **client-core/sdk**: conversation folds `kind:'question'` items + `pendingQuestionIds` (pending until the tool call settles); `respondQuestion` through control-channel/client/sdk
- **workbench/ui/desktop**: `QuestionPrompt` stepper card in the conversation dock — 1–4 questions aggregate into ONE reply, `multiSelect` → multiple mode, free-text answers enabled, Skip declines the whole ask; i18n (zh-CN/en); removes the `STUB_AGENT_QUESTION_PROMPTS` scaffolding

## Verification

Real-machine E2E against a dev daemon driving the vendored CLI (0.3.179 pair), real model turns:

- **Answer path**: model called AskUserQuestion → `question-request` mapped correctly → answered Blue over the wire → tool result `"Which color do you prefer?"="Blue"` → model replied "You picked Blue."
- **Decline path**: cancelled → tool failed `User declined to answer questions` → model continued gracefully
- Unit tests: adapter mapping (5), base round-trip/teardown (3), conversation fold, UI selector; `pnpm check:ci` + full `pnpm test` (454) green

## Known pre-existing gap (not introduced here)

A client that connects/reloads **after** the ask fired never receives `question-request` (engine attach replays only approval-policy; `history.read` carries no ephemeral events) — same limitation permission asks already have. Suggested follow-up: replay pending asks on `session.attach` for both kinds.

Closes CODE-118.