### PR TITLE
feat: reflect the session's actual model/effort in the composer

### DIFF
--- a/packages/agent-adapter/src/__tests__/claude-code-effort.test.ts
+++ b/packages/agent-adapter/src/__tests__/claude-code-effort.test.ts
@@ -235,3 +235,55 @@ describe('ClaudeCodeAdapter effort switching', () => {
     expect(q2.applyFlagSettings).toHaveBeenCalledWith({ ultracode: null, effortLevel: 'high' });
   });
 });
+
+/** The read-only Stop hook the adapter registers to learn the resolved effort level. */
+function stopHookOf(q: FakeQuery): (input: unknown) => Promise<unknown> {
+  const hooks = q.options.hooks as {
+    Stop: Array<{ hooks: Array<(input: unknown) => Promise<unknown>> }>;
+  };
+  return hooks.Stop[0].hooks[0];
+}
+
+describe('ClaudeCodeAdapter model/effort reflection', () => {
+  it('reflects an explicit effort pick as an effort-update event', async () => {
+    const { adapter, events } = await makeAdapter();
+    await setEffort(adapter, 'high');
+    expect(events).toContainEqual({ type: 'effort-update', effort: 'high' });
+  });
+
+  it('reflects an explicit model pick as a model-update event', async () => {
+    const { adapter, events } = await makeAdapter();
+    await adapter.send({ type: 'set-model', model: 'claude-opus-4-8' });
+    expect(events).toContainEqual({ type: 'model-update', model: 'claude-opus-4-8' });
+  });
+
+  it('reflects the served model the CLI reports on its init frame', async () => {
+    const { adapter, events } = await makeAdapter();
+    await prompt(adapter);
+    queries[0].push({
+      type: 'system',
+      subtype: 'init',
+      permissionMode: 'default',
+      model: 'claude-sonnet-5',
+    });
+    await vi.waitFor(() => {
+      expect(events).toContainEqual({ type: 'model-update', model: 'claude-sonnet-5' });
+    });
+  });
+
+  it("learns the resolved default effort from the Stop hook only when the user hasn't picked one", async () => {
+    const { adapter, events } = await makeAdapter();
+    await prompt(adapter);
+    const stopHook = stopHookOf(queries[0]);
+
+    // Effort unset: the hook reflects the CLI's resolved level.
+    await stopHook({ effort: { level: 'medium' } });
+    expect(events).toContainEqual({ type: 'effort-update', effort: 'medium' });
+
+    // After an explicit pick, the hook must not overwrite the authoritative choice.
+    await setEffort(adapter, 'high');
+    events.length = 0;
+    await stopHook({ effort: { level: 'medium' } });
+    expect(events.some((e) => e.type === 'effort-update')).toBe(false);
+  });
+});

--- a/packages/agent-adapter/src/base.ts
+++ b/packages/agent-adapter/src/base.ts
@@ -61,6 +61,9 @@ export abstract class BaseAgentAdapter implements AgentAdapter {
   protected opts: StartOptions | null = null;
   /** Last announced provider-local id — `emitSessionRef` dedupes against it. */
   private sessionRef: AgentHistoryId | null = null;
+  /** Last announced model / effort — `emitModel` / `emitEffort` dedupe against these. */
+  private reflectedModel: string | null = null;
+  private reflectedEffort: EffortLevel | null = null;
   /** Permission asks awaiting a reply, keyed by requestId. */
   private readonly pending = new Map<string, PermissionResolver>();
   /** Question asks awaiting a reply, keyed by requestId. */
@@ -264,6 +267,18 @@ export abstract class BaseAgentAdapter implements AgentAdapter {
   }
   protected emitApprovalPolicy(state: ApprovalPolicyState): void {
     this.emit({ type: 'approval-policy-update', state });
+  }
+  /** Announce the model the session is running on; re-emits only when it changes. */
+  protected emitModel(model: string): void {
+    if (this.reflectedModel === model) return;
+    this.reflectedModel = model;
+    this.emit({ type: 'model-update', model });
+  }
+  /** Announce the reasoning-effort level the session is running at; re-emits only when it changes. */
+  protected emitEffort(effort: EffortLevel): void {
+    if (this.reflectedEffort === effort) return;
+    this.reflectedEffort = effort;
+    this.emit({ type: 'effort-update', effort });
   }
   protected emitStop(stopReason: StopReason): void {
     this.emit({ type: 'stop', stopReason });

--- a/packages/agent-adapter/src/native/claude-code.ts
+++ b/packages/agent-adapter/src/native/claude-code.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 import { env } from 'node:process';
 import type {
   CanUseTool,
+  HookCallback,
   PermissionMode,
   PermissionResult,
   Query,
@@ -33,7 +34,7 @@ import type {
   ToolCall,
   ToolCallContent,
 } from '@linkcode/schema';
-import { textBlock } from '@linkcode/schema';
+import { EffortLevelSchema, textBlock } from '@linkcode/schema';
 import { extractErrorMessage } from 'foxts/extract-error-message';
 import { invariant, nullthrow } from 'foxts/guard';
 import { z } from 'zod';
@@ -298,6 +299,26 @@ export class ClaudeCodeAdapter extends BaseAgentAdapter {
     this.emitApprovalPolicy(this.approvalPolicyState());
   }
 
+  /** Reflect the served model the CLI reports — the init message and every assistant frame carry it,
+   * so the client shows the true model even when the session started without a requested one. Dedup
+   * lives in `emitModel`. */
+  private syncModel(model: string | undefined): void {
+    if (model) this.emitModel(model);
+  }
+
+  /** Read-only `Stop` hook that learns the CLI's *resolved* effort (after any per-model downgrade)
+   * so a session the user never set an effort on still reflects a real value instead of a
+   * placeholder. Skipped once the user picks explicitly: that pick — including `ultracode`/`max`,
+   * which this hook's base-level field can't express — is authoritative and emitted by `onSetEffort`.
+   * The `effort` field is absent on models without effort support, in which case nothing is emitted. */
+  private readonly reflectEffortHook: HookCallback = (input) => {
+    if (this.effort === undefined && input.effort?.level) {
+      const parsed = EffortLevelSchema.safeParse(input.effort.level);
+      if (parsed.success) this.emitEffort(parsed.data);
+    }
+    return Promise.resolve({ continue: true });
+  };
+
   override async resumeHistory(
     opts: AgentHistoryResumeOptions,
     startOpts: StartOptions,
@@ -416,6 +437,9 @@ export class ClaudeCodeAdapter extends BaseAgentAdapter {
         // Forward subagent text/thinking (tool_use/tool_result already flow by default) so the
         // client can render the nested transcript; all subagent frames carry parent_tool_use_id.
         forwardSubagentText: true,
+        // Read-only Stop hook: learns the resolved effort level so a session the user never set an
+        // effort on reflects a real value instead of a placeholder (see `reflectEffortHook`).
+        hooks: { Stop: [{ hooks: [this.reflectEffortHook] }] },
         canUseTool: this.canUseTool,
         // Resolved in onStart from settings.json `permissions.defaultMode` (see settingsDefaultMode)
         // — the SDK-driven CLI does not apply that setting itself. `undefined` only when neither the
@@ -497,9 +521,12 @@ export class ClaudeCodeAdapter extends BaseAgentAdapter {
     if (!this.q) {
       invariant(this.opts, 'claude-code: session not started');
       this.opts.model = model;
-      return;
+    } else {
+      await this.q.setModel(model);
     }
-    await this.q.setModel(model);
+    // Reflect the pick immediately (the CLI accepted it, or it will apply at the next Query
+    // creation); the served id off the next assistant frame reconciles it via `syncModel`.
+    this.emitModel(model);
   }
 
   /** Live switch rides the streaming-input control request `Query#setPermissionMode`; before the
@@ -527,6 +554,7 @@ export class ClaudeCodeAdapter extends BaseAgentAdapter {
     if (effort === previous) return;
     if (!this.q) {
       this.effort = effort; // No process yet; onPrompt's Query creation applies it.
+      this.emitEffort(effort);
       return;
     }
     if (effort !== 'max' && previous !== 'max') {
@@ -534,9 +562,11 @@ export class ClaudeCodeAdapter extends BaseAgentAdapter {
       // Committed only after the CLI accepted the switch: a rejected one (ultracode without
       // dynamic workflows enabled) must not linger and get replayed onto a later rebuilt Query.
       this.effort = effort;
+      this.emitEffort(effort);
       return;
     }
     this.effort = effort;
+    this.emitEffort(effort);
     // Detach before closing so a prompt racing the async consume() unwind creates the new Query
     // instead of pushing into the closed queue; consume()'s self-guard then skips its own cleanup.
     const q = this.q;
@@ -659,7 +689,10 @@ export class ClaudeCodeAdapter extends BaseAgentAdapter {
         // entirely from the Task tool_use/tool_result pair; consuming them (task_id ↔ tool_use_id
         // correlation) only pays off once run_in_background tasks are supported.
         if (msg.subtype === 'permission_denied') this.handlePermissionDenied(msg);
-        else if (msg.subtype === 'init') this.syncApprovalPolicy(msg.permissionMode);
+        else if (msg.subtype === 'init') {
+          this.syncApprovalPolicy(msg.permissionMode);
+          this.syncModel(msg.model);
+        }
         break;
       default:
         break;
@@ -702,6 +735,9 @@ export class ClaudeCodeAdapter extends BaseAgentAdapter {
       return;
     }
     const message = msg.message;
+    // Every assistant frame carries the served model — the source of truth for a mid-session switch
+    // (`init` fires only at Query creation, so it can't catch a live `setModel`).
+    this.syncModel(message.model);
     let calledTool = false;
     for (const block of message.content) {
       if (block.type === 'tool_use') {

--- a/packages/agent-adapter/src/native/codex/adapter.ts
+++ b/packages/agent-adapter/src/native/codex/adapter.ts
@@ -222,6 +222,9 @@ export class CodexAdapter extends BaseAgentAdapter {
 
   protected async onStart(opts: StartOptions): Promise<void> {
     this.model = opts.model;
+    // Reflect a model chosen at new-session time; codex has no live channel to observe the
+    // config.toml default when none was picked, so a fresh unset session shows a placeholder.
+    if (this.model) this.emitModel(this.model);
     await this.ensureThread();
   }
 
@@ -332,6 +335,8 @@ export class CodexAdapter extends BaseAgentAdapter {
     invariant(this.opts, 'codex: session not started');
     this.opts.model = model;
     this.model = model;
+    // Reflect the pick now; it applies from the next turn/start.
+    this.emitModel(model);
     return Promise.resolve();
   }
 
@@ -344,6 +349,8 @@ export class CodexAdapter extends BaseAgentAdapter {
       );
     }
     this.effort = effort;
+    // Reflect the pick now; it applies from the next turn/start.
+    this.emitEffort(effort);
     return Promise.resolve();
   }
 

--- a/packages/client-core/src/__tests__/conversation.test.ts
+++ b/packages/client-core/src/__tests__/conversation.test.ts
@@ -324,6 +324,21 @@ describe('buildConversation', () => {
     expect(c.approvalPolicy).toEqual({ availablePolicies: policies, currentPolicyId: 'auto' });
     expect(c.items).toHaveLength(0);
   });
+
+  it('reflects the latest model/effort without adding timeline items', () => {
+    const empty = buildConversation([]);
+    expect(empty.currentModel).toBeNull();
+    expect(empty.currentEffort).toBeNull();
+    const c = buildConversation([
+      { type: 'model-update', model: 'claude-opus-4-8' },
+      { type: 'effort-update', effort: 'high' },
+      { type: 'model-update', model: 'claude-sonnet-5' },
+      { type: 'effort-update', effort: 'xhigh' },
+    ]);
+    expect(c.currentModel).toBe('claude-sonnet-5');
+    expect(c.currentEffort).toBe('xhigh');
+    expect(c.items).toHaveLength(0);
+  });
 });
 
 describe('createConversationBuilder', () => {

--- a/packages/client-core/src/conversation-store.ts
+++ b/packages/client-core/src/conversation-store.ts
@@ -18,6 +18,8 @@ const EMPTY_CONVERSATION: Conversation = {
   usage: null,
   currentModeId: null,
   approvalPolicy: null,
+  currentModel: null,
+  currentEffort: null,
   stopReason: null,
   pendingPermissionIds: [],
   pendingQuestionIds: [],

--- a/packages/client-core/src/conversation.ts
+++ b/packages/client-core/src/conversation.ts
@@ -2,6 +2,7 @@ import type {
   AgentEvent,
   ApprovalPolicyState,
   ContentBlock,
+  EffortLevel,
   PermissionOption,
   Plan,
   Question,
@@ -84,6 +85,13 @@ export interface ConversationViewModel {
   /** Advertised approval-policy state (the permission axis), from `approval-policy-update`;
    * null (or an empty list) means the agent has no switchable policies and the UI hides the menu. */
   approvalPolicy: ApprovalPolicyState | null;
+  /** The model the session is actually running on, from `model-update`. `null` until the adapter
+   * reports it (before the first turn, or for adapters that can't observe their model) — the composer
+   * then shows a placeholder rather than a guess. */
+  currentModel: string | null;
+  /** The reasoning-effort level the session is running at, from `effort-update`. `null` until the
+   * adapter reports it — same placeholder rule as `currentModel`. */
+  currentEffort: EffortLevel | null;
   /** Why the last turn ended (if it did). */
   stopReason: StopReason | null;
   /**
@@ -143,6 +151,8 @@ export function createConversationBuilder(): ConversationBuilder {
   let usage: TokenUsage | null = null;
   let currentModeId: string | null = null;
   let approvalPolicy: ApprovalPolicyState | null = null;
+  let currentModel: string | null = null;
+  let currentEffort: EffortLevel | null = null;
   let stopReason: StopReason | null = null;
   let cached: Conversation | null = null;
 
@@ -284,6 +294,12 @@ export function createConversationBuilder(): ConversationBuilder {
       case 'approval-policy-update':
         approvalPolicy = event.state;
         break;
+      case 'model-update':
+        currentModel = event.model;
+        break;
+      case 'effort-update':
+        currentEffort = event.effort;
+        break;
       case 'status':
         status = event.status;
         break;
@@ -369,6 +385,8 @@ export function createConversationBuilder(): ConversationBuilder {
       usage,
       currentModeId,
       approvalPolicy,
+      currentModel,
+      currentEffort,
       stopReason,
       pendingPermissionIds: pendingIds(approvals),
       pendingQuestionIds: pendingIds(questionAsks),

--- a/packages/engine/src/engine.ts
+++ b/packages/engine/src/engine.ts
@@ -6,6 +6,7 @@ import type {
   ApprovalPolicyState,
   AssetInstallEvent,
   ContentBlock,
+  EffortLevel,
   InstalledAsset,
   ManagedAssetId,
   ManagedAssetStatus,
@@ -43,6 +44,11 @@ interface Session {
   /** Latest advertised approval-policy state, replayed to freshly-attached clients — the event is
    * emitted at adapter start / on switches, which a client that (re)connects later has missed. */
   approvalPolicy?: ApprovalPolicyState;
+  /** Latest model/effort the adapter reported, replayed to freshly-attached clients for the same
+   * reason as `approvalPolicy` — a reconnecting client missed the emit and would otherwise show a
+   * placeholder instead of the value the session is actually running on. */
+  currentModel?: string;
+  currentEffort?: EffortLevel;
 }
 
 /** Optional collaborators the daemon injects; each defaults to an in-memory/no-op implementation. */
@@ -550,6 +556,24 @@ export class Engine {
             }),
           );
         }
+        if (attached?.currentModel) {
+          this.transport.send(
+            createWireMessage({
+              kind: 'agent.event',
+              sessionId: p.sessionId,
+              event: { type: 'model-update', model: attached.currentModel },
+            }),
+          );
+        }
+        if (attached?.currentEffort) {
+          this.transport.send(
+            createWireMessage({
+              kind: 'agent.event',
+              sessionId: p.sessionId,
+              event: { type: 'effort-update', effort: attached.currentEffort },
+            }),
+          );
+        }
         break;
       }
       case 'session.detach': {
@@ -638,6 +662,12 @@ export class Engine {
             break;
           case 'approval-policy-update':
             session.approvalPolicy = event.state;
+            break;
+          case 'model-update':
+            session.currentModel = event.model;
+            break;
+          case 'effort-update':
+            session.currentEffort = event.effort;
             break;
           default:
             break;

--- a/packages/schema/src/agent.ts
+++ b/packages/schema/src/agent.ts
@@ -130,6 +130,17 @@ export const AgentEventSchema = z.discriminatedUnion('type', [
   z.object({ type: z.literal('current-mode-update'), currentModeId: SessionModeIdSchema }),
   /** Full approval-policy state (advertised list + current), at session start and after switches. */
   z.object({ type: z.literal('approval-policy-update'), state: ApprovalPolicyStateSchema }),
+  /** The model the session is actually running on, so clients reflect the true value instead of a
+   * placeholder. The available list is the static UI catalog (not adapter-advertised, unlike
+   * approval policies), so only the current id travels. Emitted once the adapter learns the served
+   * model (claude-code's init/assistant frames report it even when no model was requested) and on
+   * every switch. Adapters that can't observe their model never emit it. */
+  z.object({ type: z.literal('model-update'), model: z.string().min(1) }),
+  /** The reasoning-effort level the session is actually running at. Same rationale as `model-update`.
+   * Emitted on every switch and, for adapters that can observe the resolved default (claude-code via
+   * a Stop hook's `effort.level`), once the default is learned. `undefined`/never-emitted keeps the
+   * client showing a placeholder rather than a guessed value. */
+  z.object({ type: z.literal('effort-update'), effort: EffortLevelSchema }),
 
   // ── Lifecycle ──
   z.object({ type: z.literal('status'), status: SessionStatusSchema }),

--- a/packages/schema/src/wire/index.ts
+++ b/packages/schema/src/wire/index.ts
@@ -37,7 +37,7 @@ export {
  * originating client can pair the reply despite the broadcast.
  */
 
-export const WIRE_PROTOCOL_VERSION = 17 as const;
+export const WIRE_PROTOCOL_VERSION = 18 as const;
 
 /** Envelope payload: a discriminated union keyed by `kind`. */
 export const WirePayloadSchema = z.discriminatedUnion('kind', [

--- a/packages/ui/src/__tests__/agent-models.test.ts
+++ b/packages/ui/src/__tests__/agent-models.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { AGENT_MODEL_OPTIONS, resolveModel } from '../shell/agent-models';
+
+const claude = AGENT_MODEL_OPTIONS['claude-code'];
+const codex = AGENT_MODEL_OPTIONS.codex;
+
+describe('resolveModel', () => {
+  it('resolves an exact catalog id', () => {
+    expect(resolveModel(claude, 'claude-opus-4-8')?.label).toBe('Opus 4.8');
+  });
+
+  it('resolves a served snapshot id back to its alias by prefix', () => {
+    // claude-haiku-4-5 is served as the pinned snapshot claude-haiku-4-5-20251001.
+    expect(resolveModel(claude, 'claude-haiku-4-5-20251001')?.id).toBe('claude-haiku-4-5');
+  });
+
+  it('prefers an exact match over a prefix so gpt-5.4-mini is not read as gpt-5.4', () => {
+    expect(resolveModel(codex, 'gpt-5.4-mini')?.id).toBe('gpt-5.4-mini');
+  });
+
+  it('returns undefined for null, unknown, or absent options', () => {
+    expect(resolveModel(claude, null)).toBeUndefined();
+    expect(resolveModel(claude, 'not-a-model')).toBeUndefined();
+    expect(resolveModel(undefined, 'claude-opus-4-8')).toBeUndefined();
+  });
+});

--- a/packages/ui/src/__tests__/conversation-prompts.test.ts
+++ b/packages/ui/src/__tests__/conversation-prompts.test.ts
@@ -34,6 +34,8 @@ function conversation(
     usage: null,
     currentModeId: null,
     approvalPolicy: null,
+    currentModel: null,
+    currentEffort: null,
     stopReason: null,
     pendingPermissionIds: [],
     pendingQuestionIds: [],

--- a/packages/ui/src/chat/types.ts
+++ b/packages/ui/src/chat/types.ts
@@ -1,6 +1,7 @@
 import type {
   ApprovalPolicyState,
   ContentBlock,
+  EffortLevel,
   PermissionOption,
   Plan,
   Question,
@@ -73,6 +74,10 @@ export interface ConversationViewModel {
   /** Advertised approval-policy state (the permission axis), from `approval-policy-update`;
    * null (or an empty list) hides the composer's policy menu. */
   approvalPolicy: ApprovalPolicyState | null;
+  /** The model the session is running on, from `model-update`; null until the adapter reports it. */
+  currentModel: string | null;
+  /** The reasoning-effort level the session is running at, from `effort-update`; null until reported. */
+  currentEffort: EffortLevel | null;
   /** Why the last turn ended (if it did). */
   stopReason: StopReason | null;
   /** Permission requests still awaiting a decision. */

--- a/packages/ui/src/shell/agent-models.ts
+++ b/packages/ui/src/shell/agent-models.ts
@@ -6,6 +6,24 @@ export interface ModelOption {
 }
 
 /**
+ * Resolve a reflected model id (from `model-update`) to its catalog entry. The daemon emits the
+ * *served* id, which for some aliases is a pinned snapshot — e.g. `claude-haiku-4-5` is served as
+ * `claude-haiku-4-5-20251001` — so an exact lookup would miss and the picker would fall back to the
+ * placeholder. Match a snapshot back to its alias by prefix, but only after an exact match fails, so
+ * an id that is itself a prefix of another (`gpt-5.4` vs `gpt-5.4-mini`) never mis-resolves.
+ */
+export function resolveModel(
+  options: readonly ModelOption[] | undefined,
+  id: string | null,
+): ModelOption | undefined {
+  if (id === null) return undefined;
+  return (
+    options?.find((option) => option.id === id) ??
+    options?.find((option) => id.startsWith(`${option.id}-`))
+  );
+}
+
+/**
  * Curated model choices, keyed by adapter — only for adapters with a *verified* live model switch
  * (`BaseAgentAdapter#onSetModel` actually changing the vendor's behavior end-to-end against a real
  * session, not just read from source — claude-code's first attempt looked live-switchable from its

--- a/packages/ui/src/shell/composer-controls.tsx
+++ b/packages/ui/src/shell/composer-controls.tsx
@@ -26,9 +26,10 @@ import { useTranslations } from 'use-intl';
 import { AGENT_LABELS, AgentIcon } from '../chat/agent-icon';
 import type { EffortOption } from './agent-efforts';
 import type { ModelOption } from './agent-models';
+import { resolveModel } from './agent-models';
 import type { AgentRuntimeCue, AgentRuntimeCues } from './agent-onboarding-card';
 
-// Linear lookup: the policy/model/effort lists are a handful of entries at most.
+// Linear lookup: the policy/effort lists are a handful of entries at most.
 function optionById<T extends { id: string }>(
   options: readonly T[] | undefined,
   id: string | null,
@@ -204,7 +205,7 @@ export function ModelSelectorMenu({
   onSelectProvider?: (provider: AgentKind) => void;
 }): React.ReactNode {
   const t = useTranslations('workbench.composer');
-  const selectedModel = optionById(modelOptions, selectedModelId);
+  const selectedModel = resolveModel(modelOptions, selectedModelId);
   const selectedEffort = optionById(effortOptions, selectedEffortId);
   const providers = selectableProviders ?? [];
   const hasEfforts = Boolean(effortOptions?.length);
@@ -252,7 +253,7 @@ export function ModelSelectorMenu({
               <MenuSubTrigger>{selectedModel?.label ?? t('modelDefault')}</MenuSubTrigger>
               <MenuSubPopup className="w-56">
                 <MenuRadioGroup
-                  value={selectedModelId ?? ''}
+                  value={selectedModel?.id ?? selectedModelId ?? ''}
                   onValueChange={(value) => onSelectModel(String(value))}
                 >
                   {modelOptions?.map((option) => (

--- a/packages/ui/src/shell/composer.tsx
+++ b/packages/ui/src/shell/composer.tsx
@@ -70,6 +70,12 @@ export interface ComposerProps {
   /** The agent-advertised approval-policy state (the permission/safety axis), reflected from the
    * session's `approval-policy-update` event. Absent or empty hides the policy menu. */
   approvalPolicy?: ApprovalPolicyState | null;
+  /** The model the session is actually running on, reflected from the session's `model-update`
+   * event. `null` until the adapter reports it — the picker then shows a placeholder. */
+  currentModel?: string | null;
+  /** The reasoning-effort level the session is running at, reflected from `effort-update`; same
+   * placeholder rule as `currentModel`. */
+  currentEffort?: EffortLevel | null;
   onSend: (text: string) => void;
   onStop: () => void;
   /** Sends the workflow-mode switch (`set-mode`); the active mode is reflected from the session's
@@ -78,10 +84,10 @@ export interface ComposerProps {
   /** Sends the approval-policy switch (`set-approval-policy`); like `onModeChange`, the pick is
    * reflected back via `approval-policy-update` — a rejected switch keeps the previous policy. */
   onApprovalPolicyChange?: (policyId: string) => Promise<void>;
-  /** Called when the user picks a model from the (adapter-specific) list. The picker only reflects
-   * the pick once this resolves — it stays on the previous model if the switch is rejected. */
+  /** Sends the model switch (`set-model`); the active model is reflected from `model-update`, not
+   * locally — a rejected switch keeps the previous model. */
   onModelChange?: (model: string) => Promise<void>;
-  /** Called when the user picks a reasoning-effort level; same confirm-then-reflect contract. */
+  /** Sends the reasoning-effort switch (`set-effort`); reflected from `effort-update`, same contract. */
   onEffortChange?: (effort: EffortLevel) => Promise<void>;
   /** Providers offered for selection (the new-session composer). Absent or empty means the
    * provider is fixed — the trigger then hides the provider glyph and submenu. */
@@ -108,6 +114,8 @@ export function Composer({
   currentModeId,
   availableModes = STUB_SESSION_MODES,
   approvalPolicy,
+  currentModel,
+  currentEffort,
   onSend,
   onStop,
   onModeChange,
@@ -121,8 +129,6 @@ export function Composer({
 }: ComposerProps): React.ReactNode {
   const t = useTranslations('workbench.composer');
   const [value, setValue] = useState('');
-  const [selectedModelId, setSelectedModelId] = useState<string | null>(null);
-  const [selectedEffortId, setSelectedEffortId] = useState<EffortLevel | null>(null);
   const [caret, setCaret] = useState(0);
   // The start offset of a trigger the user dismissed with Escape, so the menu stays closed for that token only.
   const [dismissedStart, setDismissedStart] = useState<number | null>(null);
@@ -352,25 +358,16 @@ export function Composer({
   // No deps: the handle re-binds every render so insertText always sees the current draft.
   useImperativeHandle(handleRef, () => ({ insertText }));
 
-  async function selectModel(modelId: string): Promise<void> {
-    try {
-      await onModelChange?.(modelId);
-      // Only reflect the pick once the switch is confirmed — otherwise the picker would show a
-      // model that isn't actually the one the session is running.
-      setSelectedModelId(modelId);
-    } catch {
-      // The workbench's error banner already reports the failure; nothing else to do here.
-    }
+  // Server-reflected like the workflow mode and approval policy: the pick shows once the session's
+  // `model-update` / `effort-update` echoes it back (the adapter emits optimistically on accept, so
+  // the round-trip is fast), and a rejected switch simply leaves the previous value — the failure
+  // lands in the error banner.
+  function selectModel(modelId: string): void {
+    void onModelChange?.(modelId).catch(noop);
   }
 
-  async function selectEffort(effort: EffortLevel): Promise<void> {
-    try {
-      await onEffortChange?.(effort);
-      // Confirm-then-reflect, same as selectModel.
-      setSelectedEffortId(effort);
-    } catch {
-      // The workbench's error banner already reports the failure; nothing else to do here.
-    }
+  function selectEffort(effort: EffortLevel): void {
+    void onEffortChange?.(effort).catch(noop);
   }
 
   const emptyCommandLabel = commandSource === 'mention' ? t('noMentions') : t('noCommands');
@@ -445,14 +442,10 @@ export function Composer({
                   provider={agentKind}
                   runtimeCues={runtimeCues}
                   selectableProviders={selectableProviders}
-                  selectedEffortId={selectedEffortId}
-                  selectedModelId={selectedModelId}
-                  onSelectEffort={(effort) => {
-                    void selectEffort(effort);
-                  }}
-                  onSelectModel={(model) => {
-                    void selectModel(model);
-                  }}
+                  selectedEffortId={currentEffort ?? null}
+                  selectedModelId={currentModel ?? null}
+                  onSelectEffort={selectEffort}
+                  onSelectModel={selectModel}
                   onSelectProvider={
                     onProviderChange
                       ? (provider) => {

--- a/packages/ui/src/shell/conversation-surface.tsx
+++ b/packages/ui/src/shell/conversation-surface.tsx
@@ -115,6 +115,8 @@ export function ConversationSurface({
         isRunning={isRunning}
         currentModeId={conversation.currentModeId}
         approvalPolicy={conversation.approvalPolicy}
+        currentModel={conversation.currentModel}
+        currentEffort={conversation.currentEffort}
         onSend={onSendPrompt}
         onStop={onStopTurn}
         onModeChange={onModeChange}

--- a/packages/ui/src/shell/new-session-surface.tsx
+++ b/packages/ui/src/shell/new-session-surface.tsx
@@ -170,6 +170,7 @@ export function NewSessionSurface({
             runtimeCues={runtimeCues}
             sendBlocked={cue !== undefined}
             currentModeId={modeId}
+            currentModel={model}
             selectableProviders={SELECTABLE_PROVIDERS}
             onSend={handleSend}
             onStop={noop}

--- a/packages/ui/src/styles.css
+++ b/packages/ui/src/styles.css
@@ -39,6 +39,15 @@
     margin: 0;
   }
 
+  /* Native scrollbars: transparent track (the default opaque one clashes with the
+     translucent desktop shell) and a thin thumb matching coss-ui's ScrollArea
+     (`bg-foreground/20`). base-ui's own scrollbar-hiding style is unlayered, so it
+     still wins over this layered rule. */
+  * {
+    scrollbar-width: thin;
+    scrollbar-color: color-mix(in oklab, var(--foreground) 20%, transparent) transparent;
+  }
+
   body {
     @apply bg-background text-foreground;
     font-family: var(--font-sans, system-ui, -apple-system, "Segoe UI", sans-serif);

--- a/packages/workbench/src/mock/dev-mock-host.ts
+++ b/packages/workbench/src/mock/dev-mock-host.ts
@@ -483,6 +483,12 @@ export class DevMockHost {
     const { sessionId } = session;
     this.emit(sessionId, { type: 'status', status: 'starting' });
     this.emit(sessionId, { type: 'current-mode-update', currentModeId: 'mock' });
+    // Reflect a concrete model/effort like a real adapter, so the composer shows them not placeholders.
+    this.emit(sessionId, {
+      type: 'model-update',
+      model: model ?? (kind === 'codex' ? 'gpt-5.5' : 'claude-opus-4-8'),
+    });
+    this.emit(sessionId, { type: 'effort-update', effort: 'high' });
     this.emit(sessionId, { type: 'status', status: 'idle' });
     this.send({ kind: 'session.started', replyTo, sessionId });
   }
@@ -603,9 +609,11 @@ export class DevMockHost {
         break;
       case 'set-model':
         session.model = input.model;
+        this.emit(sessionId, { type: 'model-update', model: input.model });
         this.sendSuccess(replyTo);
         break;
       case 'set-effort':
+        this.emit(sessionId, { type: 'effort-update', effort: input.effort });
         this.sendSuccess(replyTo);
         break;
       case 'set-mode':


### PR DESCRIPTION
## Why

The composer's model/Effort picker showed placeholders (`Default` / `Effort`) instead of the real values. The root cause isn't cosmetic: the picker held **write-only optimistic local state** (initially null), and the data plane **never told the client which model/effort the session is actually running on** — unlike the mode and approval-policy axes, which already have downstream `current-*-update` reflection + engine caching/replay. Model and effort were **upstream-only** in the wire contract.

## What

Mirror the approval-policy reflection end-to-end so the composer shows the true value:

- **schema/wire**: add `model-update` / `effort-update` agent events; **bump `WIRE_PROTOCOL_VERSION` 17 → 18** (Invariant 1 — rebuild/restart daemon + all clients).
- **client-core**: `buildConversation` folds them into `currentModel` / `currentEffort`.
- **engine**: cache both per session and replay on `session.attach` (so a reconnecting client doesn't fall back to a placeholder).
- **agent-adapter**:
  - claude-code reflects the **served model** from the `system:init` frame and every assistant frame (`syncModel`), and emits on `set-model`. Effort has no message-stream carrier, so it learns the **resolved** level (after any per-model downgrade) from a read-only `Stop` hook (`input.effort.level`) — only when the user hasn't explicitly picked one; an explicit pick (incl. `ultracode`/`max`) stays authoritative via `set-effort`.
  - codex reflects model/effort on pick and at start (no live channel for the config default, so a never-set fresh session still shows a placeholder).
- **composer**: drop the local optimistic state; read the server-reflected `currentModel` / `currentEffort`, unifying with how mode / approval-policy already work. Picks are fire-and-forget and reflect back via the session events. Placeholders now appear only before the first turn (genuinely unknown).
- **dev mock**: emits both events so mock mode shows real values too.

## Verification

- Full vitest suite passes (474 passed, 2 skipped) + typecheck across all touched packages.
- New unit tests: `set-model`/`set-effort` emit reflection events; the `init` frame reflects the served model; the `Stop` hook learns the default only when effort is unset.
- ⚠️ Real-app visual verification (observe in the running app) not yet done — mock mode can be used to eyeball the composer showing concrete values.

## Notes

- Wire bump to v18 — check no other in-flight branch also bumps it (parallel bumps merge silently).
- new-session composer's effort picker remains cosmetic (never entered `StartOptions`); only its model is wired to local reflection. Wiring new-session effort is out of scope (needs a `StartOptions.effort`).