### PR TITLE
chore(desktop): bump version to 0.3.0

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@linkcode/desktop",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "private": true,
   "description": "LinkCode desktop application",
   "homepage": "https://linkcode.ai",


### PR DESCRIPTION
Release 0.3.0. Ships the CODE-107 packaging fixes merged in #62: the Windows daemon-crash root cause (better-sqlite3 rebuilt for both arches via the single-importer staging deploy), the daemon single-file bundle fix, the native-binding tripwire, and standalone daemon packaging.

Version-only bump. Tag `v0.3.0` follows once this lands on master (`release-desktop.yml` asserts `v${version}` == tag).