### PR TITLE
fix(ui): collapse right-panel section tabs to icons when narrow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,4 +66,4 @@ devenv.local.yaml
 .pre-commit-config.yaml
 
 # Claude Code local state (plans, worktrees) — never tracked or linted
-.claude/
+.claude/worktrees/

--- a/apps/desktop/src/renderer/src/shell/chrome/chrome.tsx
+++ b/apps/desktop/src/renderer/src/shell/chrome/chrome.tsx
@@ -296,8 +296,13 @@ function ChromeSegment({
   setPortalTarget: SetChromePortalTarget;
 }): React.ReactNode {
   return (
+    // Size container so portaled panel chrome (e.g. the section tab strip) can collapse
+    // its labels to icons when its host segment gets narrow (`@max-*/chrome-segment`).
     <div
-      className={cn('relative min-w-0 overflow-hidden backdrop-blur-xl', className)}
+      className={cn(
+        '@container/chrome-segment relative min-w-0 overflow-hidden backdrop-blur-xl',
+        className,
+      )}
       data-chrome-divider={divider}
     >
       <div

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "Xuan Zhang <dev@aprilnea.me>",
     "Yifei Zhang <yidadaa@qq.com>",
     "SukkaW <github@skk.moe>",
-    "Zerlight <me@zerlight.cc>"
+    "Zerlight <me@zerlight.cc>",
+    "Chenyu Lu <chenyu@arcbox.dev>"
   ],
   "homepage": "https://github.com/arcboxlabs/linkcode#readme",
   "repository": {

--- a/packages/ui/src/shell/panels/section-panel.tsx
+++ b/packages/ui/src/shell/panels/section-panel.tsx
@@ -146,21 +146,28 @@ function SectionTabStrip({
 
   return (
     <div className="flex h-full min-w-0 items-center gap-1">
-      {PANEL_SECTIONS.map((section) => (
-        <button
-          key={section}
-          type="button"
-          aria-pressed={section === activeSection}
-          className={cn(
-            'flex h-7 shrink-0 items-center gap-1.5 rounded-md border px-2.5 text-xs outline-none [-webkit-app-region:no-drag] focus-visible:ring-2 focus-visible:ring-ring',
-            section === activeSection ? PANEL_TAB_ACTIVE_CLASSNAME : PANEL_TAB_INACTIVE_CLASSNAME,
-          )}
-          onClick={() => onSelectSection(section)}
-        >
-          <span className="shrink-0 [&_svg]:size-3.5">{PANEL_WINDOW_ICONS[section]}</span>
-          <span>{tWindow(section)}</span>
-        </button>
-      ))}
+      {PANEL_SECTIONS.map((section) => {
+        const label = tWindow(section);
+        return (
+          <button
+            key={section}
+            type="button"
+            aria-label={label}
+            title={label}
+            aria-pressed={section === activeSection}
+            className={cn(
+              'flex h-7 shrink-0 items-center gap-1.5 rounded-md border px-2.5 text-xs outline-none [-webkit-app-region:no-drag] focus-visible:ring-2 focus-visible:ring-ring',
+              section === activeSection ? PANEL_TAB_ACTIVE_CLASSNAME : PANEL_TAB_INACTIVE_CLASSNAME,
+            )}
+            onClick={() => onSelectSection(section)}
+          >
+            <span className="shrink-0 [&_svg]:size-3.5">{PANEL_WINDOW_ICONS[section]}</span>
+            {/* Collapse to icon-only when the host chrome segment is too narrow to fit
+                labels without overlapping the panel's maximize control. */}
+            <span className="@max-[480px]/chrome-segment:hidden">{label}</span>
+          </button>
+        );
+      })}
     </div>
   );
 }


### PR DESCRIPTION
## Problem

The right panel's section tab strip (Diff / Terminal / Browser / Files) is portaled into a fixed chrome segment whose width tracks the right panel (`--lc-right-w`, range 320–820, default **440**). The tab buttons are `shrink-0` and the segment is `overflow-hidden`, so once the four full-label tabs (~460px) no longer fit, they overflow and overlap the panel's maximize control. At the default width this already happens — see the reported screenshot.

## Fix

- `chrome.tsx`: make each `ChromeSegment` a named size container (`@container/chrome-segment`).
- `section-panel.tsx`: hide the tab label under `@max-[480px]/chrome-segment` so the strip degrades to icon-only when its host segment is too narrow. Add `aria-label` + `title` to each tab so the icon-only state keeps an accessible name and a hover tooltip.

Pure CSS container query — works across the portal boundary, no JS measurement or prop threading. When maximized the tabs move to the wide `main` segment, so labels stay visible there.

## Notes / open questions

- **480px threshold** is estimated from font metrics (full tabs ~460px + margin), **not yet eyeballed on a running build** (the panel needs a connected session). May want tuning.
- At the default panel width (440) tabs now render icon-only — that is the cost of removing the overlap. If we'd rather keep labels at the default, a follow-up could tighten tab padding/gap instead.

## Verification

`@linkcode/ui` typecheck ✓ · ESLint (both files) ✓ · Biome format ✓ · `shell-state.test.ts` 15/15 ✓. (Desktop typecheck's pre-existing `cross-spawn` types error is unrelated — confirmed via stash.)