### PR TITLE
fix(desktop): Windows/Linux window controls + taskbar icon identity

### DIFF
--- a/apps/desktop/src/main/constants.ts
+++ b/apps/desktop/src/main/constants.ts
@@ -13,5 +13,15 @@ export const IS_DEV_SHELL = import.meta.env.MODE !== 'production' || !app.isPack
 
 export const APP_NAME = IS_DEV_SHELL ? 'LinkCode Dev' : 'LinkCode';
 
+/**
+ * Windows AppUserModelID — mirrors the electron-builder `appId`. Windows keys the taskbar icon,
+ * pinning, and notification identity off this; without setting it at runtime the taskbar shows a
+ * blank/default icon. A dev shell gets a distinct id so it neither steals the installed release's
+ * taskbar slot nor its notifications (same isolation rationale as `APP_NAME`).
+ */
+export const APP_ID = IS_DEV_SHELL
+  ? 'com.arcboxlabs.linkcode.desktop.dev'
+  : 'com.arcboxlabs.linkcode.desktop';
+
 /** `~/LinkCode` holds user workspaces — shared between dev and release shells on purpose. */
 export const DEFAULT_WORKSPACES_DIRNAME = 'LinkCode';

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -4,7 +4,7 @@ import { app, BrowserWindow, Menu } from 'electron';
 import { applyThemePreference } from './appearance';
 import { setupCloudAuth } from './cloud-auth/client';
 import { registerCloudTunnelBridge } from './cloud-auth/tunnel';
-import { APP_NAME } from './constants';
+import { APP_ID, APP_NAME } from './constants';
 import { startDaemonSupervisor } from './daemon-supervisor';
 import { buildAppMenu } from './menu';
 import { getSettings } from './settings';
@@ -21,6 +21,10 @@ app.setName(APP_NAME);
 // asar even for dev-shell packages. Without this, a packaged dev shell shares the release app's
 // settings and single-instance lock — the second one to start exits silently.
 app.setPath('userData', join(app.getPath('appData'), APP_NAME));
+
+// Windows keys the taskbar icon, pinning, and notification identity off the AppUserModelID; without
+// this the taskbar shows a blank/default icon. No-op on macOS/Linux.
+if (process.platform === 'win32') app.setAppUserModelId(APP_ID);
 
 // settings.ts caches settings in memory and rewrites the whole file on save, so two instances
 // would last-write-wins clobber each other. Only one instance may run; a second launch just

--- a/apps/desktop/src/renderer/src/app.tsx
+++ b/apps/desktop/src/renderer/src/app.tsx
@@ -14,6 +14,7 @@ import { useState } from 'react';
 import { systemBridge } from './ipc';
 import { SettingsView } from './settings/settings-view';
 import { useDesktopSettingsStore } from './settings/store';
+import { DesktopWindowControls } from './shell/chrome/window-controls';
 import { ConnectionSkeleton } from './shell/connection-skeleton';
 import { DesktopWorkbenchShell } from './shell/desktop-workbench-shell';
 
@@ -38,6 +39,9 @@ export function DesktopApp(): React.ReactNode {
           </DaemonConnection>
         </div>
         {settingsOpen ? <SettingsView /> : null}
+        {/* Window controls live above the connection gate and the settings overlay so Windows/Linux
+            can always minimize/maximize/close — including while the daemon is connecting or down. */}
+        <DesktopWindowControls />
       </CloudHostsProvider>
     </WorkbenchAppProviders>
   );

--- a/apps/desktop/src/renderer/src/settings/settings-view.tsx
+++ b/apps/desktop/src/renderer/src/settings/settings-view.tsx
@@ -35,6 +35,7 @@ export function SettingsView(): React.ReactNode {
   const [desktopPlatform, setDesktopPlatform] = useState<NodeJS.Platform | null>(null);
   const hasNativeTrafficLights = desktopPlatform === 'darwin';
   const hasNativeBackdrop = desktopPlatform === 'darwin' || desktopPlatform === 'win32';
+  const showWindowControls = desktopPlatform !== null && desktopPlatform !== 'darwin';
 
   useAbortableEffect((signal) => {
     void systemBridge.app.platform().then((platform) => {
@@ -63,6 +64,7 @@ export function SettingsView(): React.ReactNode {
         expandedPanel={null}
         hasNativeBackdrop={hasNativeBackdrop}
         hasNativeTrafficLights={hasNativeTrafficLights}
+        showWindowControls={showWindowControls}
         // Back lives in the settings sidebar, so suppress the workbench navigation controls.
         leftControls={null}
         rightControls={null}

--- a/apps/desktop/src/renderer/src/shell/chrome/chrome.tsx
+++ b/apps/desktop/src/renderer/src/shell/chrome/chrome.tsx
@@ -13,6 +13,7 @@ import {
 import { createContext, use, useCallback, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { useChromeRailInsets } from './use-chrome-rail-insets';
+import { WindowControls } from './window-controls';
 
 type DesktopPanelSide = 'right' | 'bottom';
 
@@ -27,6 +28,8 @@ export interface DesktopChromeProps {
   expandedPanel: DesktopPanelSide | null;
   hasNativeBackdrop: boolean;
   hasNativeTrafficLights: boolean;
+  /** Draw renderer window controls (minimize/maximize/close) — non-macOS, once the platform is known. */
+  showWindowControls: boolean;
   onShowSidebar: () => void;
   onHideSidebar: () => void;
   onToggleRight: () => void;
@@ -139,6 +142,7 @@ export function DesktopChrome({
   expandedPanel,
   hasNativeBackdrop,
   hasNativeTrafficLights,
+  showWindowControls,
   onShowSidebar,
   onHideSidebar,
   onToggleRight,
@@ -199,7 +203,7 @@ export function DesktopChrome({
             leftControls
           )}
         </StableLeftChrome>
-        <StableRightChrome contentRef={rightRailContentRef}>
+        <StableRightChrome contentRef={rightRailContentRef} showWindowControls={showWindowControls}>
           {rightControls === undefined ? (
             <DefaultRightChromeControls
               rightPanelOpen={rightPanelOpen}
@@ -437,9 +441,11 @@ function MainChromeTitle({
 
 function StableRightChrome({
   contentRef,
+  showWindowControls,
   children,
 }: {
   contentRef: React.Ref<HTMLDivElement>;
+  showWindowControls: boolean;
   children: React.ReactNode;
 }): React.ReactNode {
   return (
@@ -449,6 +455,7 @@ function StableRightChrome({
         className="pointer-events-none flex h-full items-center gap-(--lc-chrome-control-gap)"
       >
         {children}
+        {showWindowControls ? <WindowControls /> : null}
       </div>
     </div>
   );

--- a/apps/desktop/src/renderer/src/shell/chrome/chrome.tsx
+++ b/apps/desktop/src/renderer/src/shell/chrome/chrome.tsx
@@ -13,7 +13,6 @@ import {
 import { createContext, use, useCallback, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { useChromeRailInsets } from './use-chrome-rail-insets';
-import { WindowControls } from './window-controls';
 
 type DesktopPanelSide = 'right' | 'bottom';
 
@@ -455,7 +454,9 @@ function StableRightChrome({
         className="pointer-events-none flex h-full items-center gap-(--lc-chrome-control-gap)"
       >
         {children}
-        {showWindowControls ? <WindowControls /> : null}
+        {/* Reserve the space the persistent window-controls layer (DesktopWindowControls, mounted at
+            the app root) floats over, so the panel toggles never sit under it. */}
+        {showWindowControls ? <WindowControlsInset /> : null}
       </div>
     </div>
   );
@@ -504,6 +505,10 @@ function DefaultRightChromeControls({
 
 function NativeTrafficLightInset(): React.ReactNode {
   return <div aria-hidden className="w-(--lc-chrome-traffic-inset) shrink-0" />;
+}
+
+function WindowControlsInset(): React.ReactNode {
+  return <div aria-hidden className="w-(--lc-chrome-window-controls-inset) shrink-0" />;
 }
 
 function createChromeSlotKey(

--- a/apps/desktop/src/renderer/src/shell/chrome/metrics.ts
+++ b/apps/desktop/src/renderer/src/shell/chrome/metrics.ts
@@ -4,6 +4,9 @@ export const DESKTOP_CHROME_METRICS = {
   controlGap: 4,
   sectionGap: 8,
   nativeTrafficInset: 80,
+  // Right-edge space the persistent Windows/Linux window controls occupy (3 icon-xs buttons +
+  // gaps); the chrome reserves it so the panel toggles never sit under the floating controls.
+  windowControlsInset: 88,
   leftRailWidth: 188,
   rightRailWidth: 92,
   sidebarEdgePadding: 8,
@@ -18,6 +21,7 @@ export type DesktopChromeMetricsStyle = React.CSSProperties & {
   '--lc-chrome-control-gap': string;
   '--lc-chrome-section-gap': string;
   '--lc-chrome-traffic-inset': string;
+  '--lc-chrome-window-controls-inset': string;
   '--lc-chrome-left-rail-w': string;
   '--lc-chrome-right-rail-w': string;
   '--lc-chrome-left-local-inset': string;
@@ -32,6 +36,7 @@ export const DESKTOP_CHROME_METRICS_STYLE = {
   '--lc-chrome-control-gap': `${DESKTOP_CHROME_METRICS.controlGap}px`,
   '--lc-chrome-section-gap': `${DESKTOP_CHROME_METRICS.sectionGap}px`,
   '--lc-chrome-traffic-inset': `${DESKTOP_CHROME_METRICS.nativeTrafficInset}px`,
+  '--lc-chrome-window-controls-inset': `${DESKTOP_CHROME_METRICS.windowControlsInset}px`,
   '--lc-chrome-left-rail-w': `${DESKTOP_CHROME_METRICS.leftRailWidth}px`,
   '--lc-chrome-right-rail-w': `${DESKTOP_CHROME_METRICS.rightRailWidth}px`,
   '--lc-chrome-left-local-inset': `${DESKTOP_CHROME_METRICS.edgePadding}px`,

--- a/apps/desktop/src/renderer/src/shell/chrome/window-controls.tsx
+++ b/apps/desktop/src/renderer/src/shell/chrome/window-controls.tsx
@@ -3,14 +3,46 @@ import { systemBridge } from '@renderer/ipc';
 import { useEffect as useAbortableEffect } from 'foxact/use-abortable-effect';
 import { CopyIcon, MinusIcon, SquareIcon, XIcon } from 'lucide-react';
 import { useState } from 'react';
+import type { DesktopChromeMetricsStyle } from './metrics';
+import { DESKTOP_CHROME_METRICS_STYLE } from './metrics';
+
+// The layer mounts at the app root, outside any `.linkcode-desktop-shell`, so it carries the chrome
+// CSS vars itself (height / edge padding / control gap) for its own sizing.
+const WINDOW_CONTROLS_LAYER_STYLE: DesktopChromeMetricsStyle = DESKTOP_CHROME_METRICS_STYLE;
 
 /**
- * Minimize / maximize-restore / close buttons for platforms without native traffic lights
- * (Windows, Linux). `titleBarStyle: 'hidden'` strips the OS caption buttons there, so the renderer
- * draws them and drives the already-wired `systemBridge.window` IPC; macOS keeps its native traffic
- * lights and never renders these. Maximize state comes from the main-pushed `onMaximizedChange`.
+ * Persistent minimize / maximize-restore / close controls for platforms without native traffic
+ * lights (Windows, Linux). `titleBarStyle: 'hidden'` strips the OS caption buttons there, so the
+ * renderer draws them. Mounted at the app root ABOVE the connection gate and the settings overlay,
+ * so they stay reachable while the daemon is connecting/unreachable and never shift as the app moves
+ * between the connection fallback, the shell, and settings. macOS keeps its native traffic lights;
+ * gated on a resolved non-macOS platform so nothing flashes there before `app.platform()` returns.
  */
-export function WindowControls(): React.ReactNode {
+export function DesktopWindowControls(): React.ReactNode {
+  const [platform, setPlatform] = useState<NodeJS.Platform | null>(null);
+  useAbortableEffect((signal) => {
+    void systemBridge.app.platform().then((value) => {
+      if (!signal.aborted) setPlatform(value);
+    });
+  }, []);
+
+  if (platform === null || platform === 'darwin') return null;
+
+  return (
+    <div
+      className="pointer-events-none fixed top-0 right-0 z-[60] flex h-(--lc-chrome-h) items-center px-(--lc-chrome-edge)"
+      style={WINDOW_CONTROLS_LAYER_STYLE}
+    >
+      <WindowControls />
+    </div>
+  );
+}
+
+/**
+ * The button row; positioned by {@link DesktopWindowControls}. Drives the already-wired
+ * `systemBridge.window` IPC; maximize state comes from the main-pushed `onMaximizedChange`.
+ */
+function WindowControls(): React.ReactNode {
   const [maximized, setMaximized] = useState(false);
   useAbortableEffect((signal) => {
     void systemBridge.window.isMaximized().then((value) => {
@@ -20,7 +52,7 @@ export function WindowControls(): React.ReactNode {
   }, []);
 
   return (
-    <div className="pointer-events-auto ms-1 flex h-full items-center gap-(--lc-chrome-control-gap)">
+    <div className="pointer-events-auto flex h-full items-center gap-(--lc-chrome-control-gap)">
       <ShellIconButton
         label="Minimize"
         onClick={() => {

--- a/apps/desktop/src/renderer/src/shell/chrome/window-controls.tsx
+++ b/apps/desktop/src/renderer/src/shell/chrome/window-controls.tsx
@@ -1,0 +1,51 @@
+import { ShellIconButton } from '@linkcode/ui';
+import { systemBridge } from '@renderer/ipc';
+import { useEffect as useAbortableEffect } from 'foxact/use-abortable-effect';
+import { CopyIcon, MinusIcon, SquareIcon, XIcon } from 'lucide-react';
+import { useState } from 'react';
+
+/**
+ * Minimize / maximize-restore / close buttons for platforms without native traffic lights
+ * (Windows, Linux). `titleBarStyle: 'hidden'` strips the OS caption buttons there, so the renderer
+ * draws them and drives the already-wired `systemBridge.window` IPC; macOS keeps its native traffic
+ * lights and never renders these. Maximize state comes from the main-pushed `onMaximizedChange`.
+ */
+export function WindowControls(): React.ReactNode {
+  const [maximized, setMaximized] = useState(false);
+  useAbortableEffect((signal) => {
+    void systemBridge.window.isMaximized().then((value) => {
+      if (!signal.aborted) setMaximized(value);
+    });
+    signal.addEventListener('abort', systemBridge.window.onMaximizedChange(setMaximized));
+  }, []);
+
+  return (
+    <div className="pointer-events-auto ms-1 flex h-full items-center gap-(--lc-chrome-control-gap)">
+      <ShellIconButton
+        label="Minimize"
+        onClick={() => {
+          void systemBridge.window.minimize();
+        }}
+      >
+        <MinusIcon className="size-4" />
+      </ShellIconButton>
+      <ShellIconButton
+        label={maximized ? 'Restore' : 'Maximize'}
+        onClick={() => {
+          void systemBridge.window.toggleMaximize();
+        }}
+      >
+        {maximized ? <CopyIcon className="size-4" /> : <SquareIcon className="size-4" />}
+      </ShellIconButton>
+      <ShellIconButton
+        label="Close"
+        className="hover:bg-destructive hover:text-white"
+        onClick={() => {
+          void systemBridge.window.close();
+        }}
+      >
+        <XIcon className="size-4" />
+      </ShellIconButton>
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/src/shell/desktop-shell.tsx
+++ b/apps/desktop/src/renderer/src/shell/desktop-shell.tsx
@@ -215,6 +215,9 @@ export function DesktopShell({
 
   const hasNativeTrafficLights = desktopPlatform === 'darwin';
   const hasNativeBackdrop = desktopPlatform === 'darwin' || desktopPlatform === 'win32';
+  // Non-macOS gets renderer-drawn window controls; gate on a known platform so macOS never flashes
+  // them before `app.platform()` resolves.
+  const showWindowControls = desktopPlatform !== null && desktopPlatform !== 'darwin';
   // Hints mirror the window keydown bindings below; hidden until the platform is known.
   const panelShortcuts = getPanelToggleShortcuts(desktopPlatform);
   const sidebarClassName = hasNativeBackdrop ? 'bg-sidebar/25' : 'bg-sidebar';
@@ -525,6 +528,7 @@ export function DesktopShell({
         expandedPanel={expandedPanel}
         hasNativeBackdrop={hasNativeBackdrop}
         hasNativeTrafficLights={hasNativeTrafficLights}
+        showWindowControls={showWindowControls}
         sidebarShortcut={panelShortcuts.sidebar}
         rightPanelShortcut={panelShortcuts.right}
         bottomPanelShortcut={panelShortcuts.bottom}

--- a/packages/ipc/src/bridge.ts
+++ b/packages/ipc/src/bridge.ts
@@ -16,7 +16,8 @@ export interface SystemBridge {
     toggleMaximize(): Promise<void>;
     close(): Promise<void>;
     isMaximized(): Promise<boolean>;
-    onMaximizedChange?(cb: (value: boolean) => void): () => void;
+    /** Subscribe to maximize/restore/full-screen changes pushed from main — drives the restore icon. */
+    onMaximizedChange(cb: (value: boolean) => void): () => void;
   };
   fs: {
     pickFile(opts?: PickFileOptions): Promise<string | null>;


### PR DESCRIPTION
Two Windows-desktop chrome fixes reported on a Windows (Parallels) build.

## Problem 2 — no minimize/maximize/close buttons on Windows/Linux
`titleBarStyle: 'hidden'` keeps macOS's native traffic lights but strips the OS caption buttons on Windows/Linux, and the renderer never drew replacements. The window IPC bridge (`systemBridge.window.minimize/toggleMaximize/close/isMaximized/onMaximizedChange`, plus the `WINDOW_MAXIMIZED_CHANGED_CHANNEL` push) was already wired end-to-end with **zero consumers** — the original design clearly intended renderer-drawn buttons.

- New `window-controls.tsx`: minimize / maximize-restore / close as ghost `ShellIconButton`s; close hovers red; the restore icon toggles off the existing `onMaximizedChange` push.
- Rendered in the chrome right rail (left of the panel toggles, counted in the rail-inset measurement so it never underlaps the title).
- `showWindowControls = platform known && !== 'darwin'` — gated on a resolved platform so macOS never flashes them before `app.platform()` returns. Both the main shell and the Settings overlay get them.
- `packages/ipc` `bridge.ts`: `onMaximizedChange` promoted from optional to required, matching its sibling subscriptions and its sole implementation.

## Problem 1 — blank taskbar icon on Windows
Added the missing `app.setAppUserModelId(APP_ID)` (win32 only) — Windows keys the taskbar icon, pinning, and notification identity off it. Packaged builds still get their icon from electron-builder (`icon.png` → ICO); a dev-shell blank in a VM may also be a Parallels icon-cache artifact.

## Verify on Windows (couldn't run Windows locally)
- [ ] ⊟ ▢ ✕ appear top-right; minimize/close work; maximize toggles to the restore glyph and back
- [ ] close hovers red; drag-region moves the window; double-click maximizes/restores
- [ ] macOS shows **no** right-side controls (still left traffic lights), no flash on launch
- [ ] taskbar icon no longer blank (if a **packaged** build still blanks, ship a dedicated multi-size `.ico`)

Verified: typecheck / eslint (0 errors) / biome / 486 tests all pass.