### PR TITLE
fix(desktop): center macOS traffic lights on Tahoe

### DIFF
--- a/apps/desktop/src/main/window.ts
+++ b/apps/desktop/src/main/window.ts
@@ -1,3 +1,4 @@
+import { release } from 'node:os';
 import { join } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { DAEMON_RUNTIME_CHANGED_CHANNEL, UPDATER_STATUS_CHANNEL } from '@linkcode/ipc';
@@ -48,7 +49,13 @@ function createWindow(): BrowserWindow {
     icon,
     title: APP_NAME,
     titleBarStyle: 'hidden',
-    ...(process.platform === 'darwin' && { trafficLightPosition: { x: 16, y: 16 } }),
+    // macOS 26 Tahoe (Darwin ≥ 25) shrank the traffic-light frame height used for
+    // vertical centering from 16pt to 14pt (same fix as microsoft/vscode#279769).
+    // y = floor((48 − frameHeight) / 2) centers the buttons on the midline of the
+    // 48px chrome bar (renderer DESKTOP_CHROME_METRICS.height).
+    ...(process.platform === 'darwin' && {
+      trafficLightPosition: { x: 16, y: Number.parseFloat(release()) >= 25 ? 17 : 16 },
+    }),
     ...desktopBackdropOptions(),
     webPreferences: {
       preload: join(__dirname, '../preload/index.js'),


### PR DESCRIPTION
This pull request updates the positioning of the window control (traffic light) buttons on macOS in the Electron desktop app to account for changes in macOS 26 Tahoe (Darwin 25+), ensuring the buttons remain visually centered in the chrome bar. Additionally, it adds an import for the `release` function from the Node.js `os` module.

**macOS window controls adjustment:**
* Updated the `trafficLightPosition` in the `createWindow` function to set the y-coordinate to 17 instead of 16 when running on macOS 26 Tahoe (Darwin 25+) to keep the traffic light buttons vertically centered, matching recent platform changes.

**Dependency import:**
* Added an import for the `release` function from the `node:os` module in `window.ts` to enable platform version checking.