### PR TITLE
feat(ui): improve cmdk UI

### DIFF
--- a/apps/desktop/src/renderer/src/main.tsx
+++ b/apps/desktop/src/renderer/src/main.tsx
@@ -1,10 +1,10 @@
-import { useNavigationHistoryStore } from '@linkcode/workbench';
 import { init as sentryInit } from '@sentry/electron/renderer';
 import { init as reactInit } from '@sentry/react';
 import { createRoot } from 'react-dom/client';
 import { DesktopApp } from './app';
 import { systemBridge } from './ipc';
 import { installNotificationClickThrough } from './notifications';
+import { openDesktopSettings } from './settings/store';
 import { installAdaptiveTheme } from './theme';
 import 'allotment/dist/style.css';
 import './index.css';
@@ -21,7 +21,7 @@ if (import.meta.hot) import.meta.hot.dispose(uninstallAdaptiveTheme);
 
 // Menubar / Cmd+, opens Settings even while the daemon is unreachable.
 const unsubscribeOpenSettings = systemBridge.app.onOpenSettings(() => {
-  useNavigationHistoryStore.getState().openOverlay('settings');
+  openDesktopSettings();
 });
 if (import.meta.hot) import.meta.hot.dispose(unsubscribeOpenSettings);
 

--- a/apps/desktop/src/renderer/src/settings/store.ts
+++ b/apps/desktop/src/renderer/src/settings/store.ts
@@ -1,5 +1,6 @@
 import type { ThemePreference } from '@linkcode/ipc';
 import type { AgentKind } from '@linkcode/schema';
+import { useNavigationHistoryStore } from '@linkcode/workbench';
 import { create } from 'zustand';
 import { systemBridge } from '../ipc';
 
@@ -79,3 +80,14 @@ export const useDesktopSettingsStore = create<DesktopSettingsState>()((set) => (
   setSettingsCategory: (category) => set({ settingsCategory: category }),
   setHistoryImportProvider: (provider) => set({ historyImportProvider: provider }),
 }));
+
+/**
+ * Open the Settings overlay at a category. Every entry point routes through here: generic ones
+ * (sidebar button, palette "Open settings", the native menu) take the `general` default so a
+ * previous deep link doesn't leak into the next open — the category is store-held and would
+ * otherwise stick across close/reopen.
+ */
+export function openDesktopSettings(category: SettingsCategory = 'general'): void {
+  useDesktopSettingsStore.getState().setSettingsCategory(category);
+  useNavigationHistoryStore.getState().openOverlay('settings');
+}

--- a/apps/desktop/src/renderer/src/shell/desktop-workbench-shell.tsx
+++ b/apps/desktop/src/renderer/src/shell/desktop-workbench-shell.tsx
@@ -1,17 +1,15 @@
 import type { WorkbenchShellProps } from '@linkcode/workbench';
-import { useNavigationHistoryStore } from '@linkcode/workbench';
 import { systemBridge } from '@renderer/ipc';
-import { useDesktopSettingsStore } from '../settings/store';
+import { openDesktopSettings, useDesktopSettingsStore } from '../settings/store';
 import { DesktopShell } from './desktop-shell';
 
 export function DesktopWorkbenchShell({ header, ...props }: WorkbenchShellProps): React.ReactNode {
-  const openOverlay = useNavigationHistoryStore((state) => state.openOverlay);
   const theme = useDesktopSettingsStore((state) => state.theme);
   return (
     <DesktopShell
       systemBridge={systemBridge}
       header={header}
-      onOpenSettings={() => openOverlay('settings')}
+      onOpenSettings={() => openDesktopSettings()}
       themeType={theme}
       {...props}
     />

--- a/apps/desktop/src/renderer/src/shell/use-desktop-palette-commands.ts
+++ b/apps/desktop/src/renderer/src/shell/use-desktop-palette-commands.ts
@@ -4,6 +4,7 @@ import { useCommandPaletteStore } from '@linkcode/workbench';
 import { noop } from 'foxact/noop';
 import { useAbortableEffect } from 'foxact/use-abortable-effect';
 import { useTranslations } from 'use-intl';
+import { useDesktopSettingsStore } from '../settings/store';
 import { getPanelToggleShortcuts } from './use-desktop-shell-shortcuts';
 
 interface UseDesktopPaletteCommandsOptions {
@@ -16,9 +17,10 @@ interface UseDesktopPaletteCommandsOptions {
 }
 
 /**
- * Desktop-owned palette entries: native folder pick, the Settings overlay, and the panel
- * toggles. Registered into the shared palette store so the workbench-rendered palette lists
- * them without desktop threading props through the surface.
+ * Desktop-owned palette entries: native folder pick, the Settings overlay (plus a deep link to
+ * its Import-chat-history pane), and the panel toggles. Registered into the shared palette store
+ * so the workbench-rendered palette lists them without desktop threading props through the
+ * surface.
  */
 export function useDesktopPaletteCommands({
   desktopPlatform,
@@ -71,12 +73,27 @@ export function useDesktopPaletteCommands({
       },
     ];
     if (onOpenSettings) {
-      commands.splice(1, 0, {
-        id: 'desktop.settings',
-        label: tPalette('openSettings'),
-        shortcut: shortcuts.settings,
-        run: onOpenSettings,
-      });
+      commands.splice(
+        1,
+        0,
+        {
+          id: 'desktop.settings',
+          label: tPalette('openSettings'),
+          shortcut: shortcuts.settings,
+          run: onOpenSettings,
+        },
+        {
+          id: 'desktop.import-history',
+          label: tPalette('importHistory'),
+          keywords: ['history', 'import', 'chat'],
+          run() {
+            // Deep-link the Settings overlay to the Import-chat-history pane; the category is
+            // store-held, so it survives until SettingsView mounts.
+            useDesktopSettingsStore.getState().setSettingsCategory('history-import');
+            onOpenSettings();
+          },
+        },
+      );
     }
     const { registerCommands, unregisterCommands } = useCommandPaletteStore.getState();
     registerCommands('desktop', commands);

--- a/apps/desktop/src/renderer/src/shell/use-desktop-palette-commands.ts
+++ b/apps/desktop/src/renderer/src/shell/use-desktop-palette-commands.ts
@@ -4,7 +4,7 @@ import { useCommandPaletteStore } from '@linkcode/workbench';
 import { noop } from 'foxact/noop';
 import { useAbortableEffect } from 'foxact/use-abortable-effect';
 import { useTranslations } from 'use-intl';
-import { useDesktopSettingsStore } from '../settings/store';
+import { openDesktopSettings } from '../settings/store';
 import { getPanelToggleShortcuts } from './use-desktop-shell-shortcuts';
 
 interface UseDesktopPaletteCommandsOptions {
@@ -87,10 +87,7 @@ export function useDesktopPaletteCommands({
           label: tPalette('importHistory'),
           keywords: ['history', 'import', 'chat'],
           run() {
-            // Deep-link the Settings overlay to the Import-chat-history pane; the category is
-            // store-held, so it survives until SettingsView mounts.
-            useDesktopSettingsStore.getState().setSettingsCategory('history-import');
-            onOpenSettings();
+            openDesktopSettings('history-import');
           },
         },
       );

--- a/packages/i18n/src/locales/en.ts
+++ b/packages/i18n/src/locales/en.ts
@@ -288,6 +288,7 @@ export const en = {
       goForward: 'Go forward',
       openFolder: 'Open folder…',
       openSettings: 'Open settings',
+      importHistory: 'Import chat history',
       toggleSidebar: 'Toggle sidebar',
       toggleBottomPanel: 'Toggle bottom panel',
       toggleRightPanel: 'Toggle right panel',

--- a/packages/i18n/src/locales/en.ts
+++ b/packages/i18n/src/locales/en.ts
@@ -291,6 +291,9 @@ export const en = {
       toggleSidebar: 'Toggle sidebar',
       toggleBottomPanel: 'Toggle bottom panel',
       toggleRightPanel: 'Toggle right panel',
+      footerNavigate: 'Navigate',
+      footerOpen: 'Open',
+      footerClose: 'Close',
     },
     content: {
       audio: '[audio]',

--- a/packages/i18n/src/locales/zh-cn.ts
+++ b/packages/i18n/src/locales/zh-cn.ts
@@ -282,6 +282,7 @@ export const zhCN = {
       goForward: '前进',
       openFolder: '打开文件夹…',
       openSettings: '打开设置',
+      importHistory: '导入聊天历史',
       toggleSidebar: '切换侧边栏',
       toggleBottomPanel: '切换底部面板',
       toggleRightPanel: '切换右侧面板',

--- a/packages/i18n/src/locales/zh-cn.ts
+++ b/packages/i18n/src/locales/zh-cn.ts
@@ -285,6 +285,9 @@ export const zhCN = {
       toggleSidebar: '切换侧边栏',
       toggleBottomPanel: '切换底部面板',
       toggleRightPanel: '切换右侧面板',
+      footerNavigate: '导航',
+      footerOpen: '打开',
+      footerClose: '关闭',
     },
     content: {
       audio: '[音频]',

--- a/packages/ui/src/lib/base-ui.ts
+++ b/packages/ui/src/lib/base-ui.ts
@@ -1,0 +1,9 @@
+import type * as React from 'react';
+
+/**
+ * Suppress Base UI's own handler for this event — e.g. stop an Autocomplete item press from
+ * writing the item's value into the input when the row's `onClick` fully owns the action.
+ */
+export function preventBaseUIHandler(event: React.SyntheticEvent): void {
+  (event as React.SyntheticEvent & { preventBaseUIHandler?: () => void }).preventBaseUIHandler?.();
+}

--- a/packages/ui/src/shell/command-palette.tsx
+++ b/packages/ui/src/shell/command-palette.tsx
@@ -3,7 +3,9 @@ import {
   Command,
   CommandCollection,
   CommandDialog,
-  CommandDialogPopup,
+  CommandDialogPortal,
+  CommandDialogPrimitive,
+  CommandDialogViewport,
   CommandEmpty,
   CommandFooter,
   CommandGroup,
@@ -17,6 +19,7 @@ import {
 } from 'coss-ui/components/command';
 import { Kbd, KbdGroup } from 'coss-ui/components/kbd';
 import { ArrowDownIcon, ArrowUpIcon, CornerDownLeftIcon } from 'lucide-react';
+import type { Transition } from 'motion/react';
 import { motion, useReducedMotion } from 'motion/react';
 import { Fragment, useState } from 'react';
 import { useTranslations } from 'use-intl';
@@ -76,6 +79,17 @@ function paletteEntryToString(item: unknown): string {
   return entry.kind === 'thread' ? entry.thread.title : entry.command.label;
 }
 
+/**
+ * Dialog chrome forked from coss-ui's `CommandDialogBackdrop`/`CommandDialogPopup`: motion owns
+ * enter/exit here (the workbench container defers unmount via `AnimatePresence`), so the CSS
+ * `data-starting/ending-style` transition classes are dropped, and the backdrop loses
+ * `backdrop-blur-sm` — backdrop-filter cannot blur the native vibrancy behind the desktop's
+ * translucent sidebar, where it reads as a milky seam instead.
+ */
+const BACKDROP_CLASS = 'fixed inset-0 z-50 bg-black/32';
+const POPUP_CLASS =
+  'relative flex max-h-105 min-h-0 w-full min-w-0 max-w-xl flex-col rounded-2xl border bg-popover not-dark:bg-clip-padding text-popover-foreground shadow-lg/5 outline-none before:pointer-events-none before:absolute before:inset-0 before:rounded-[calc(var(--radius-2xl)-1px)] before:bg-muted/72 before:shadow-[0_1px_--theme(--color-black/4%)] **:data-[slot=scroll-area-viewport]:data-has-overflow-y:pe-1 dark:before:shadow-[0_-1px_--theme(--color-white/6%)]';
+
 /** Intrinsic height of an element, observed so the list wrapper can animate to it. */
 function useMeasuredHeight(): [React.RefCallback<HTMLElement>, number | null] {
   const [height, setHeight] = useState<number | null>(null);
@@ -124,81 +138,112 @@ export function CommandPalette({
     });
   }
 
+  const dialogTransition: Transition = reducedMotion
+    ? { duration: 0 }
+    : { duration: 0.2, ease: 'easeInOut' };
+
   return (
     <CommandDialog open={open} onOpenChange={onOpenChange}>
-      <CommandDialogPopup>
-        <Command
-          mode="none"
-          items={groups}
-          itemToStringValue={paletteEntryToString}
-          value={query}
-          onValueChange={onQueryChange}
-        >
-          <CommandInput placeholder={t('placeholder')} />
-          <CommandPanel className="flex flex-col">
-            <CommandEmpty>{t('empty')}</CommandEmpty>
+      <CommandDialogPortal>
+        <CommandDialogPrimitive.Backdrop
+          className={BACKDROP_CLASS}
+          data-slot="command-dialog-backdrop"
+          render={
             <motion.div
-              className="min-h-0"
-              initial={false}
-              animate={listHeight === null ? undefined : { height: listHeight }}
-              transition={reducedMotion ? { duration: 0 } : { duration: 0.15, ease: 'easeOut' }}
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              transition={dialogTransition}
+            />
+          }
+        />
+        <CommandDialogViewport>
+          <CommandDialogPrimitive.Popup
+            className={POPUP_CLASS}
+            data-slot="command-dialog-popup"
+            render={
+              <motion.div
+                initial={{ opacity: 0, scale: 0.98 }}
+                animate={{ opacity: 1, scale: 1 }}
+                exit={{ opacity: 0, scale: 0.98 }}
+                transition={dialogTransition}
+              />
+            }
+          >
+            <Command
+              mode="none"
+              items={groups}
+              itemToStringValue={paletteEntryToString}
+              value={query}
+              onValueChange={onQueryChange}
             >
-              <CommandList ref={listRef}>
-                {(group: PaletteGroup) => (
-                  <Fragment key={group.value}>
-                    <CommandGroup items={group.items}>
-                      <CommandGroupLabel>{group.label}</CommandGroupLabel>
-                      <CommandCollection>
-                        {(entry: PaletteEntry) =>
-                          entry.kind === 'thread' ? (
-                            <PaletteThreadRow
-                              key={entry.thread.sessionId}
-                              entry={entry}
-                              onSelect={onSelectThread}
-                            />
-                          ) : (
-                            <PaletteCommandRow
-                              key={entry.command.id}
-                              entry={entry}
-                              onRun={onRunCommand}
-                            />
-                          )
-                        }
-                      </CommandCollection>
-                    </CommandGroup>
-                    <CommandSeparator />
-                  </Fragment>
-                )}
-              </CommandList>
-            </motion.div>
-          </CommandPanel>
-          <CommandFooter>
-            <div className="flex items-center gap-4">
-              <div className="flex items-center gap-2">
-                <KbdGroup>
-                  <Kbd>
-                    <ArrowUpIcon />
-                  </Kbd>
-                  <Kbd>
-                    <ArrowDownIcon />
-                  </Kbd>
-                </KbdGroup>
-                <span>{t('footerNavigate')}</span>
-              </div>
-              <div className="flex items-center gap-2">
-                <Kbd>
-                  <CornerDownLeftIcon />
-                </Kbd>
-                <span>{t('footerOpen')}</span>
-              </div>
-            </div>
-            <div className="flex items-center gap-2">
-              <Kbd>Esc</Kbd>
-              <span>{t('footerClose')}</span>
-            </div>
-          </CommandFooter>
-        </Command>
-      </CommandDialogPopup>
+              <CommandInput placeholder={t('placeholder')} />
+              <CommandPanel className="flex flex-col">
+                <CommandEmpty>{t('empty')}</CommandEmpty>
+                <motion.div
+                  className="min-h-0"
+                  initial={false}
+                  animate={listHeight === null ? undefined : { height: listHeight }}
+                  transition={reducedMotion ? { duration: 0 } : { duration: 0.15, ease: 'easeOut' }}
+                >
+                  <CommandList ref={listRef}>
+                    {(group: PaletteGroup) => (
+                      <Fragment key={group.value}>
+                        <CommandGroup items={group.items}>
+                          <CommandGroupLabel>{group.label}</CommandGroupLabel>
+                          <CommandCollection>
+                            {(entry: PaletteEntry) =>
+                              entry.kind === 'thread' ? (
+                                <PaletteThreadRow
+                                  key={entry.thread.sessionId}
+                                  entry={entry}
+                                  onSelect={onSelectThread}
+                                />
+                              ) : (
+                                <PaletteCommandRow
+                                  key={entry.command.id}
+                                  entry={entry}
+                                  onRun={onRunCommand}
+                                />
+                              )
+                            }
+                          </CommandCollection>
+                        </CommandGroup>
+                        <CommandSeparator />
+                      </Fragment>
+                    )}
+                  </CommandList>
+                </motion.div>
+              </CommandPanel>
+              <CommandFooter>
+                <div className="flex items-center gap-4">
+                  <div className="flex items-center gap-2">
+                    <KbdGroup>
+                      <Kbd>
+                        <ArrowUpIcon />
+                      </Kbd>
+                      <Kbd>
+                        <ArrowDownIcon />
+                      </Kbd>
+                    </KbdGroup>
+                    <span>{t('footerNavigate')}</span>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <Kbd>
+                      <CornerDownLeftIcon />
+                    </Kbd>
+                    <span>{t('footerOpen')}</span>
+                  </div>
+                </div>
+                <div className="flex items-center gap-2">
+                  <Kbd>Esc</Kbd>
+                  <span>{t('footerClose')}</span>
+                </div>
+              </CommandFooter>
+            </Command>
+          </CommandDialogPrimitive.Popup>
+        </CommandDialogViewport>
+      </CommandDialogPortal>
     </CommandDialog>
   );
 }

--- a/packages/ui/src/shell/command-palette.tsx
+++ b/packages/ui/src/shell/command-palette.tsx
@@ -24,8 +24,8 @@ import { motion, useReducedMotion } from 'motion/react';
 import { Fragment, useState } from 'react';
 import { useTranslations } from 'use-intl';
 import { AgentIcon } from '../chat/agent-icon';
+import { preventBaseUIHandler } from '../lib/base-ui';
 import { cn } from '../lib/cn';
-import { preventBaseUIHandler } from './composer-command';
 import { SESSION_STATUS_DOT_CLASS } from './sidebar/thread-row';
 
 export interface PaletteThreadViewModel {
@@ -45,7 +45,7 @@ export interface PaletteCommandViewModel {
 }
 
 export interface CommandPaletteProps {
-  open: boolean;
+  /** Fires with `false` on Escape/backdrop dismissal; closing happens by unmounting (the caller's `AnimatePresence` plays the exit). */
   onOpenChange: (open: boolean) => void;
   /** Controlled query — filtering/ranking happens upstream, never inside the dialog. */
   query: string;
@@ -109,7 +109,6 @@ function useMeasuredHeight(): [React.RefCallback<HTMLElement>, number | null] {
  * highlighted-item, so rows only need `onClick`.
  */
 export function CommandPalette({
-  open,
   onOpenChange,
   query,
   onQueryChange,
@@ -143,7 +142,7 @@ export function CommandPalette({
     : { duration: 0.2, ease: 'easeInOut' };
 
   return (
-    <CommandDialog open={open} onOpenChange={onOpenChange}>
+    <CommandDialog open onOpenChange={onOpenChange}>
       <CommandDialogPortal>
         <CommandDialogPrimitive.Backdrop
           className={BACKDROP_CLASS}

--- a/packages/ui/src/shell/command-palette.tsx
+++ b/packages/ui/src/shell/command-palette.tsx
@@ -1,9 +1,11 @@
 import type { AgentKind, SessionId, SessionStatus } from '@linkcode/schema';
 import {
   Command,
+  CommandCollection,
   CommandDialog,
   CommandDialogPopup,
   CommandEmpty,
+  CommandFooter,
   CommandGroup,
   CommandGroupLabel,
   CommandInput,
@@ -13,9 +15,14 @@ import {
   CommandSeparator,
   CommandShortcut,
 } from 'coss-ui/components/command';
+import { Kbd, KbdGroup } from 'coss-ui/components/kbd';
+import { ArrowDownIcon, ArrowUpIcon, CornerDownLeftIcon } from 'lucide-react';
+import { motion, useReducedMotion } from 'motion/react';
+import { Fragment, useState } from 'react';
 import { useTranslations } from 'use-intl';
 import { AgentIcon } from '../chat/agent-icon';
 import { cn } from '../lib/cn';
+import { preventBaseUIHandler } from './composer-command';
 import { SESSION_STATUS_DOT_CLASS } from './sidebar/thread-row';
 
 export interface PaletteThreadViewModel {
@@ -46,10 +53,46 @@ export interface CommandPaletteProps {
   onRunCommand: (id: string) => void;
 }
 
+interface ThreadPaletteEntry {
+  kind: 'thread';
+  thread: PaletteThreadViewModel;
+}
+
+interface CommandPaletteEntry {
+  kind: 'command';
+  command: PaletteCommandViewModel;
+}
+
+type PaletteEntry = ThreadPaletteEntry | CommandPaletteEntry;
+
+interface PaletteGroup {
+  value: string;
+  label: string;
+  items: PaletteEntry[];
+}
+
+function paletteEntryToString(item: unknown): string {
+  const entry = item as PaletteEntry;
+  return entry.kind === 'thread' ? entry.thread.title : entry.command.label;
+}
+
+/** Intrinsic height of an element, observed so the list wrapper can animate to it. */
+function useMeasuredHeight(): [React.RefCallback<HTMLElement>, number | null] {
+  const [height, setHeight] = useState<number | null>(null);
+  const measureRef = (element: HTMLElement | null): (() => void) | undefined => {
+    if (!element) return undefined;
+    const observer = new ResizeObserver(() => setHeight(element.offsetHeight));
+    observer.observe(element);
+    return () => observer.disconnect();
+  };
+  return [measureRef, height];
+}
+
 /**
- * The ⌘K palette dialog: one input, a Threads group and a command group, pre-ranked by the
- * caller. Built on coss-ui's Command (Base UI Dialog + Autocomplete); Base UI owns keyboard
- * navigation and Enter-activates-the-highlighted-item, so rows only need `onClick`.
+ * The ⌘K palette dialog: the canonical coss-ui command sandwich — input on the popup's muted
+ * surface, a raised panel holding the grouped results, a Kbd-hint footer. Items are pre-ranked
+ * by the caller (`mode="none"`); Base UI owns keyboard navigation and Enter-activates-the-
+ * highlighted-item, so rows only need `onClick`.
  */
 export function CommandPalette({
   open,
@@ -62,58 +105,98 @@ export function CommandPalette({
   onRunCommand,
 }: CommandPaletteProps): React.ReactNode {
   const t = useTranslations('workbench.palette');
-  const hasResults = threads.length > 0 || commands.length > 0;
+  const reducedMotion = useReducedMotion();
+  const [listRef, listHeight] = useMeasuredHeight();
+
+  const groups: PaletteGroup[] = [];
+  if (threads.length > 0) {
+    groups.push({
+      value: 'threads',
+      label: query ? t('threadsGroup') : t('recentGroup'),
+      items: threads.map((thread) => ({ kind: 'thread', thread })),
+    });
+  }
+  if (commands.length > 0) {
+    groups.push({
+      value: 'commands',
+      label: query ? t('commandsGroup') : t('suggestedGroup'),
+      items: commands.map((command) => ({ kind: 'command', command })),
+    });
+  }
 
   return (
     <CommandDialog open={open} onOpenChange={onOpenChange}>
       <CommandDialogPopup>
-        <Command mode="none">
-          <CommandPanel>
-            <CommandInput
-              placeholder={t('placeholder')}
-              value={query}
-              onChange={(event) => onQueryChange(event.currentTarget.value)}
-            />
-            <CommandList>
-              {threads.length > 0 && (
-                <CommandGroup>
-                  <CommandGroupLabel>
-                    {query ? t('threadsGroup') : t('recentGroup')}
-                  </CommandGroupLabel>
-                  {threads.map((thread) => (
-                    <PaletteThreadRow
-                      key={thread.sessionId}
-                      thread={thread}
-                      onSelect={() => onSelectThread(thread.sessionId)}
-                    />
-                  ))}
-                </CommandGroup>
-              )}
-              {threads.length > 0 && commands.length > 0 && <CommandSeparator />}
-              {commands.length > 0 && (
-                <CommandGroup>
-                  <CommandGroupLabel>
-                    {query ? t('commandsGroup') : t('suggestedGroup')}
-                  </CommandGroupLabel>
-                  {commands.map((command) => (
-                    <CommandItem
-                      key={command.id}
-                      value={`command:${command.id}`}
-                      className="cursor-pointer gap-2"
-                      onMouseDown={(event) => {
-                        event.preventDefault();
-                      }}
-                      onClick={() => onRunCommand(command.id)}
-                    >
-                      <span className="min-w-0 flex-1 truncate">{command.label}</span>
-                      {command.shortcut && <CommandShortcut>{command.shortcut}</CommandShortcut>}
-                    </CommandItem>
-                  ))}
-                </CommandGroup>
-              )}
-              {!hasResults && <CommandEmpty>{t('empty')}</CommandEmpty>}
-            </CommandList>
+        <Command
+          mode="none"
+          items={groups}
+          itemToStringValue={paletteEntryToString}
+          value={query}
+          onValueChange={onQueryChange}
+        >
+          <CommandInput placeholder={t('placeholder')} />
+          <CommandPanel className="flex flex-col">
+            <CommandEmpty>{t('empty')}</CommandEmpty>
+            <motion.div
+              className="min-h-0"
+              initial={false}
+              animate={listHeight === null ? undefined : { height: listHeight }}
+              transition={reducedMotion ? { duration: 0 } : { duration: 0.15, ease: 'easeOut' }}
+            >
+              <CommandList ref={listRef}>
+                {(group: PaletteGroup) => (
+                  <Fragment key={group.value}>
+                    <CommandGroup items={group.items}>
+                      <CommandGroupLabel>{group.label}</CommandGroupLabel>
+                      <CommandCollection>
+                        {(entry: PaletteEntry) =>
+                          entry.kind === 'thread' ? (
+                            <PaletteThreadRow
+                              key={entry.thread.sessionId}
+                              entry={entry}
+                              onSelect={onSelectThread}
+                            />
+                          ) : (
+                            <PaletteCommandRow
+                              key={entry.command.id}
+                              entry={entry}
+                              onRun={onRunCommand}
+                            />
+                          )
+                        }
+                      </CommandCollection>
+                    </CommandGroup>
+                    <CommandSeparator />
+                  </Fragment>
+                )}
+              </CommandList>
+            </motion.div>
           </CommandPanel>
+          <CommandFooter>
+            <div className="flex items-center gap-4">
+              <div className="flex items-center gap-2">
+                <KbdGroup>
+                  <Kbd>
+                    <ArrowUpIcon />
+                  </Kbd>
+                  <Kbd>
+                    <ArrowDownIcon />
+                  </Kbd>
+                </KbdGroup>
+                <span>{t('footerNavigate')}</span>
+              </div>
+              <div className="flex items-center gap-2">
+                <Kbd>
+                  <CornerDownLeftIcon />
+                </Kbd>
+                <span>{t('footerOpen')}</span>
+              </div>
+            </div>
+            <div className="flex items-center gap-2">
+              <Kbd>Esc</Kbd>
+              <span>{t('footerClose')}</span>
+            </div>
+          </CommandFooter>
         </Command>
       </CommandDialogPopup>
     </CommandDialog>
@@ -121,20 +204,21 @@ export function CommandPalette({
 }
 
 function PaletteThreadRow({
-  thread,
+  entry,
   onSelect,
 }: {
-  thread: PaletteThreadViewModel;
-  onSelect: () => void;
+  entry: ThreadPaletteEntry;
+  onSelect: (id: SessionId) => void;
 }): React.ReactNode {
+  const { thread } = entry;
   return (
     <CommandItem
-      value={`thread:${thread.sessionId}`}
-      className="cursor-pointer gap-2"
-      onMouseDown={(event) => {
-        event.preventDefault();
+      value={entry}
+      className="gap-2"
+      onClick={(event) => {
+        preventBaseUIHandler(event);
+        onSelect(thread.sessionId);
       }}
-      onClick={onSelect}
     >
       <span className="relative shrink-0">
         <AgentIcon kind={thread.kind} variant="ghost" className="text-muted-foreground" />
@@ -150,6 +234,29 @@ function PaletteThreadRow({
       {thread.workspaceLabel && (
         <span className="shrink-0 text-muted-foreground text-xs">{thread.workspaceLabel}</span>
       )}
+    </CommandItem>
+  );
+}
+
+function PaletteCommandRow({
+  entry,
+  onRun,
+}: {
+  entry: CommandPaletteEntry;
+  onRun: (id: string) => void;
+}): React.ReactNode {
+  const { command } = entry;
+  return (
+    <CommandItem
+      value={entry}
+      className="gap-2"
+      onClick={(event) => {
+        preventBaseUIHandler(event);
+        onRun(command.id);
+      }}
+    >
+      <span className="min-w-0 flex-1 truncate">{command.label}</span>
+      {command.shortcut && <CommandShortcut>{command.shortcut}</CommandShortcut>}
     </CommandItem>
   );
 }

--- a/packages/ui/src/shell/composer-command.tsx
+++ b/packages/ui/src/shell/composer-command.tsx
@@ -88,10 +88,6 @@ export function computeTextTrigger(value: string, caret: number): TextTriggerSta
   return null;
 }
 
-export function preventBaseUIHandler(event: React.SyntheticEvent): void {
-  (event as React.SyntheticEvent & { preventBaseUIHandler?: () => void }).preventBaseUIHandler?.();
-}
-
 export function textControlFromEvent(event: Event): HTMLInputElement | HTMLTextAreaElement | null {
   return event.target instanceof HTMLInputElement || event.target instanceof HTMLTextAreaElement
     ? event.target

--- a/packages/ui/src/shell/composer.tsx
+++ b/packages/ui/src/shell/composer.tsx
@@ -12,6 +12,7 @@ import {
   PromptInputTextarea,
   PromptInputTools,
 } from '../chat/prompt-input';
+import { preventBaseUIHandler } from '../lib/base-ui';
 import { AGENT_EFFORT_OPTIONS } from './agent-efforts';
 import { AGENT_MODEL_OPTIONS } from './agent-models';
 import type { AgentRuntimeCues } from './agent-onboarding-card';
@@ -26,7 +27,6 @@ import {
   ComposerCommandMenu,
   commandEntryToString,
   computeTextTrigger,
-  preventBaseUIHandler,
   textControlFromEvent,
 } from './composer-command';
 import {

--- a/packages/workbench/package.json
+++ b/packages/workbench/package.json
@@ -25,6 +25,7 @@
     "coss-ui": "workspace:*",
     "foxact": "^0.3.7",
     "foxts": "^5.6.0",
+    "motion": "^12.40.0",
     "pathe": "^2.0.3",
     "react-hook-form": "^7.80.0",
     "swr": "catalog:",

--- a/packages/workbench/src/palette/command-palette.tsx
+++ b/packages/workbench/src/palette/command-palette.tsx
@@ -2,6 +2,7 @@ import type { SessionId, WorkspaceRecord } from '@linkcode/schema';
 import { normalizeCwdKey, workspaceKind } from '@linkcode/schema';
 import type { PaletteThreadViewModel } from '@linkcode/ui';
 import { AGENT_LABELS, CommandPalette, repositoryLabel } from '@linkcode/ui';
+import { AnimatePresence } from 'motion/react';
 import { useState } from 'react';
 import { useTranslations } from 'use-intl';
 import type { WorkbenchSessions } from '../surface/use-workbench-sessions';
@@ -17,14 +18,18 @@ export interface WorkbenchCommandPaletteProps {
 /**
  * The palette container: mounted permanently by `Workbench`, but everything below — data
  * assembly, matching, the dialog — exists only while open, so the closed palette costs nothing
- * and the query resets on close for free.
+ * and the query resets on close for free. `AnimatePresence` defers the unmount until the
+ * dialog's motion exit transition finishes.
  */
 export function WorkbenchCommandPalette({
   sessions,
 }: WorkbenchCommandPaletteProps): React.ReactNode {
   const open = useCommandPaletteStore((state) => state.open);
-  if (!open) return null;
-  return <OpenCommandPalette sessions={sessions} />;
+  return (
+    <AnimatePresence>
+      {open && <OpenCommandPalette key="palette" sessions={sessions} />}
+    </AnimatePresence>
+  );
 }
 
 function OpenCommandPalette({ sessions }: WorkbenchCommandPaletteProps): React.ReactNode {

--- a/packages/workbench/src/palette/command-palette.tsx
+++ b/packages/workbench/src/palette/command-palette.tsx
@@ -130,7 +130,6 @@ function OpenCommandPalette({ sessions }: WorkbenchCommandPaletteProps): React.R
 
   return (
     <CommandPalette
-      open
       onOpenChange={setOpen}
       query={query}
       onQueryChange={setQuery}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -990,6 +990,9 @@ importers:
       foxts:
         specifier: ^5.6.0
         version: 5.6.0
+      motion:
+        specifier: ^12.40.0
+        version: 12.40.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       pathe:
         specifier: ^2.0.3
         version: 2.0.3


### PR DESCRIPTION
This pull request refactors and enhances the desktop command palette and settings overlay handling. It centralizes the logic for opening the settings overlay, improves the command palette UI with better grouping and keyboard hints, and adds a deep link for importing chat history. There are also improvements to i18n and code organization.

**Settings Overlay Handling:**
- Introduced a new `openDesktopSettings` function in `settings/store.ts` to centralize and standardize how the settings overlay is opened, ensuring the category resets to `'general'` unless specified. All entry points (menu, palette, sidebar) now use this function. [[1]](diffhunk://#diff-0b0ebd286e4ed983544c8976dc3350800bfdb6a1506d97572f22f8dbb3bed519R83-R93) [[2]](diffhunk://#diff-f59bc2814586b1d03a6782483a235801f6d6bf227a043704ce70a080adf4df62L24-R24) [[3]](diffhunk://#diff-788d945f2b5d6a3c87afb87f926b49adf29dcbc89d3818cb1cda573027896554L2-R12) [[4]](diffhunk://#diff-db9d45f1ad33427f16b5b88cecfed6e10006f9d4f0aeb936ebd197812540c201R7) [[5]](diffhunk://#diff-db9d45f1ad33427f16b5b88cecfed6e10006f9d4f0aeb936ebd197812540c201L74-R93)

**Command Palette UI/UX Improvements:**
- Refactored `CommandPalette` in `command-palette.tsx` to use grouped items for threads and commands, added animated transitions, and included a footer with keyboard navigation hints. [[1]](diffhunk://#diff-bfe6a0cae93b1cac97863cddcfdf7df6e5e0b04f954bd897b74e57f4c4f51ecdR59-L55) [[2]](diffhunk://#diff-bfe6a0cae93b1cac97863cddcfdf7df6e5e0b04f954bd897b74e57f4c4f51ecdL65-L137)
- Added a new command to the palette for directly opening the "Import chat history" settings pane, with appropriate i18n entries. [[1]](diffhunk://#diff-db9d45f1ad33427f16b5b88cecfed6e10006f9d4f0aeb936ebd197812540c201L74-R93) [[2]](diffhunk://#diff-04dac7c6e4aafa6039f9217d461c4a630c1ecfe63a45f5e03f4c06c12b381df1R291-R297) [[3]](diffhunk://#diff-946cf09ed5be989adcc9a67919b03675f1521e8c1273c90929d7287372b0de69R285-R291)

**Code Organization and Reuse:**
- Moved the `preventBaseUIHandler` utility to a shared location in `lib/base-ui.ts` for use across components, and updated relevant imports. [[1]](diffhunk://#diff-3aea12620e314f51089cd2e18ba0c42818cfa4fd678eac1feaea8984141fec97R1-R9) [[2]](diffhunk://#diff-7c09b5b2f1b1bd178b3ee020478ad807008a82aae8a7eb78a1f95026f6405059L91-L94) [[3]](diffhunk://#diff-be55c01c195c5db967d43b27b29b742555b7e1bbc243c9a8dbb313ab1993a706R15)

**Internationalization:**
- Added new English and Chinese translations for palette commands and footer hints, improving accessibility and clarity. [[1]](diffhunk://#diff-04dac7c6e4aafa6039f9217d461c4a630c1ecfe63a45f5e03f4c06c12b381df1R291-R297) [[2]](diffhunk://#diff-946cf09ed5be989adcc9a67919b03675f1521e8c1273c90929d7287372b0de69R285-R291)

**Component Cleanup:**
- Removed unused direct imports of navigation store in favor of the new centralized settings opening logic. [[1]](diffhunk://#diff-f59bc2814586b1d03a6782483a235801f6d6bf227a043704ce70a080adf4df62L1-R7) [[2]](diffhunk://#diff-0b0ebd286e4ed983544c8976dc3350800bfdb6a1506d97572f22f8dbb3bed519R3) [[3]](diffhunk://#diff-788d945f2b5d6a3c87afb87f926b49adf29dcbc89d3818cb1cda573027896554L2-R12)

These changes collectively improve maintainability, user experience, and code clarity.