### PR TITLE
chore(deps): bump agent SDKs — claude 0.3.206, codex 0.144.1, opencode 1.17.18, pi 0.80.6

### DIFF
--- a/packages/agent-adapter/AGENTS.md
+++ b/packages/agent-adapter/AGENTS.md
@@ -1,6 +1,6 @@
 # packages/agent-adapter — vendor coding-agent adapters
 
-`@linkcode/agent-adapter` drives four coding agents through one normalized `AgentAdapter`. It is the deepest vendor-specific layer in the repo: the agent SDKs are fast-moving (claude/pi are 0.x; opencode is 1.x), so read the installed `.d.ts` under `node_modules`, not vendor docs, and verify behavior against the installed SDK — never re-derive it from memory. codex has no JS SDK since the app-server rewrite — its protocol facts must be verified against a live `codex app-server` (the adapter's comments record what codex-cli 0.140.0 actually does).
+`@linkcode/agent-adapter` drives four coding agents through one normalized `AgentAdapter`. It is the deepest vendor-specific layer in the repo: the agent SDKs are fast-moving (claude/pi are 0.x; opencode is 1.x), so read the installed `.d.ts` under `node_modules`, not vendor docs, and verify behavior against the installed SDK — never re-derive it from memory. codex has no JS SDK since the app-server rewrite — its protocol facts must be verified against a live `codex app-server` (the adapter's comments record what codex-cli 0.144.1 actually does).
 
 ## Layout
 
@@ -20,10 +20,10 @@ Pins as of 2026-07 (package.json ranges are caret; the lockfile is the real pin)
 
 | agent | JS package | version |
 | --- | --- | --- |
-| claude-code | `@anthropic-ai/claude-agent-sdk` | 0.3.179 |
-| codex | `@openai/codex` (CLI carrier — no JS SDK) | 0.140.0 |
-| opencode | `@opencode-ai/sdk` | 1.17.7 |
-| pi | `@earendil-works/pi-coding-agent` | 0.79.6 |
+| claude-code | `@anthropic-ai/claude-agent-sdk` | 0.3.206 |
+| codex | `@openai/codex` (CLI carrier — no JS SDK) | 0.144.1 |
+| opencode | `@opencode-ai/sdk` | 1.17.18 |
+| pi | `@earendil-works/pi-coding-agent` | 0.80.6 |
 
 - **Bumping a JS package** moves the exact pair self-resolved in dev; detected user installs are unaffected (their drift is the compat manifest's problem, CODE-77/113). Nothing is staged at package time anymore (CODE-114).
 - Quirk: `@openai/codex-<arch>` is an npm alias for `@openai/codex@<ver>-<arch>`, so querying the registry by the alias name 404s — resolve via the `@openai/codex` version.
@@ -50,7 +50,7 @@ Every new adapter MUST honor these (`base.ts`); downstream relies on them, they 
 
 ## codex (CODE-97: app-server)
 
-- **Driven over `codex app-server`** — line-delimited JSON-RPC on stdio, the protocol behind the official VS Code extension; framing carries no `jsonrpc` field (verified against codex-cli 0.140.0). `@openai/codex-sdk` was dropped: its one-shot `codex exec` wrapper had no approval callback, no mid-turn input, no structured diffs, no per-turn overrides. One persistent process per session: prompts are `turn/start` on a single thread; prompts during a running turn QUEUE and drain one per `turn/completed`; `turn/completed` status maps failed→error event, interrupted→`stop:cancelled`, else `stop:end_turn`.
+- **Driven over `codex app-server`** — line-delimited JSON-RPC on stdio, the protocol behind the official VS Code extension; framing carries no `jsonrpc` field (verified against codex-cli 0.144.1). `@openai/codex-sdk` was dropped: its one-shot `codex exec` wrapper had no approval callback, no mid-turn input, no structured diffs, no per-turn overrides. One persistent process per session: prompts are `turn/start` on a single thread; prompts during a running turn QUEUE and drain one per `turn/completed`; `turn/completed` status maps failed→error event, interrupted→`stop:cancelled`, else `stop:end_turn`.
 - **Spawn resolution**: `agentRuntimeProber.resolveBinary('codex')` (managed dir → detected user install) with `resolveCodexBinaryPath()` — the node_modules vendor of `@openai/codex` — as the dev/standalone fallback; packaged apps ship no codex binary (CODE-114). Both live behind the `startAppServer` test seam; `readConfiguredSandbox` is the other seam.
 - **Approvals**: server→client requests `item/commandExecution|fileChange/requestApproval` answer through the shared `requestPermission` round-trip — Allow→`accept`, Always allow→`acceptForSession` (real session-scoped grant), Reject→`decline`, teardown/cancel→`cancel`. The `declined` item status folds into `failed`, like claude-code's denied tool_result.
 - **Approval-policy axis** (three tiers; claude-only ids like `plan`/`auto` reject): `default`→untrusted + workspace-write, `acceptEdits` (initial)→on-request + workspace-write, `bypassPermissions`→never + danger-full-access. Applied per `turn/start` — next-turn semantics, same channel as model/effort; nothing can alter an in-flight turn.

--- a/packages/agent-adapter/package.json
+++ b/packages/agent-adapter/package.json
@@ -13,13 +13,13 @@
     "lint": "eslint --format=sukka ."
   },
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "^0.3.179",
-    "@anthropic-ai/sdk": "^0.104.2",
-    "@earendil-works/pi-coding-agent": "^0.79.6",
+    "@anthropic-ai/claude-agent-sdk": "^0.3.206",
+    "@anthropic-ai/sdk": "^0.110.0",
+    "@earendil-works/pi-coding-agent": "^0.80.6",
     "@linkcode/schema": "workspace:*",
     "@linkcode/transport": "workspace:*",
-    "@openai/codex": "^0.140.0",
-    "@opencode-ai/sdk": "^1.17.7",
+    "@openai/codex": "^0.144.1",
+    "@opencode-ai/sdk": "^1.17.18",
     "foxts": "^5.6.0",
     "smol-toml": "^1.7.0",
     "zod": "catalog:"

--- a/packages/agent-adapter/src/__tests__/claude-code-compaction.test.ts
+++ b/packages/agent-adapter/src/__tests__/claude-code-compaction.test.ts
@@ -221,7 +221,14 @@ describe('ClaudeCodeAdapter readHistory compaction', () => {
   const SESSION = 'session-compact';
 
   function row(type: 'user' | 'assistant', uuid: string, content: unknown): SessionMessage {
-    return { type, uuid, session_id: SESSION, parent_tool_use_id: null, message: { content } };
+    return {
+      type,
+      uuid,
+      session_id: SESSION,
+      parent_tool_use_id: null,
+      parent_agent_id: null,
+      message: { content },
+    };
   }
 
   class HistoryClaude extends ClaudeCodeAdapter {

--- a/packages/agent-adapter/src/__tests__/claude-code-subagent.test.ts
+++ b/packages/agent-adapter/src/__tests__/claude-code-subagent.test.ts
@@ -200,7 +200,14 @@ describe('ClaudeCodeAdapter readHistory subagent splice', () => {
   const SESSION = 'session-1';
 
   function mainRow(type: 'user' | 'assistant', uuid: string, content: unknown[]): SessionMessage {
-    return { type, uuid, session_id: SESSION, parent_tool_use_id: null, message: { content } };
+    return {
+      type,
+      uuid,
+      session_id: SESSION,
+      parent_tool_use_id: null,
+      parent_agent_id: null,
+      message: { content },
+    };
   }
 
   function subRow(
@@ -208,7 +215,14 @@ describe('ClaudeCodeAdapter readHistory subagent splice', () => {
     uuid: string,
     content: string | unknown[],
   ): SessionMessage {
-    return { type, uuid, session_id: SESSION, parent_tool_use_id: TASK_ID, message: { content } };
+    return {
+      type,
+      uuid,
+      session_id: SESSION,
+      parent_tool_use_id: TASK_ID,
+      parent_agent_id: null,
+      message: { content },
+    };
   }
 
   /** The trimmed slice of the SDK module surface readHistory touches. */
@@ -303,6 +317,7 @@ describe('ClaudeCodeAdapter readHistory subagent splice', () => {
       uuid,
       session_id: SESSION,
       parent_tool_use_id: INNER_ID,
+      parent_agent_id: null,
       message: { content },
     });
     const adapter = new HistoryClaude(

--- a/packages/agent-adapter/src/__tests__/normalize.test.ts
+++ b/packages/agent-adapter/src/__tests__/normalize.test.ts
@@ -56,6 +56,7 @@ function row(
     uuid,
     session_id: 'h1',
     parent_tool_use_id: parentToolUseId,
+    parent_agent_id: null,
     message: { content },
   };
 }

--- a/packages/agent-adapter/src/native/claude-code.ts
+++ b/packages/agent-adapter/src/native/claude-code.ts
@@ -1072,6 +1072,7 @@ export function buildClaudeCompactionSupplement(
         session_id: typeof row.sessionId === 'string' ? row.sessionId : '',
         message: row.message,
         parent_tool_use_id: null,
+        parent_agent_id: null,
       },
       boundariesBefore: boundaries,
     });

--- a/packages/agent-adapter/src/native/codex/app-server.ts
+++ b/packages/agent-adapter/src/native/codex/app-server.ts
@@ -17,7 +17,7 @@ import { isRecord } from '../../history-util';
  * with claude-code.
  *
  * Framing follows the server's own dialect: requests/responses carry `{id, method?, params?}`
- * with no `jsonrpc` envelope field (verified against codex-cli 0.140.0, which accepts both but
+ * with no `jsonrpc` envelope field (verified against codex-cli 0.144.1, which accepts both but
  * replies without it).
  */
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -593,14 +593,14 @@ importers:
   packages/agent-adapter:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.3.179
-        version: 0.3.179(@anthropic-ai/sdk@0.104.2(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(zod@4.4.3)
+        specifier: ^0.3.206
+        version: 0.3.206(@anthropic-ai/sdk@0.110.0(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(zod@4.4.3)
       '@anthropic-ai/sdk':
-        specifier: ^0.104.2
-        version: 0.104.2(zod@4.4.3)
+        specifier: ^0.110.0
+        version: 0.110.0(zod@4.4.3)
       '@earendil-works/pi-coding-agent':
-        specifier: ^0.79.6
-        version: 0.79.6(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
+        specifier: ^0.80.6
+        version: 0.80.6(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
       '@linkcode/schema':
         specifier: workspace:*
         version: link:../schema
@@ -608,11 +608,11 @@ importers:
         specifier: workspace:*
         version: link:../transport
       '@openai/codex':
-        specifier: ^0.140.0
-        version: 0.140.0
+        specifier: ^0.144.1
+        version: 0.144.1
       '@opencode-ai/sdk':
-        specifier: ^1.17.7
-        version: 1.17.7
+        specifier: ^1.17.18
+        version: 1.17.18
       foxts:
         specifier: ^5.6.0
         version: 5.6.0
@@ -1045,60 +1045,60 @@ packages:
   '@antfu/install-pkg@1.1.0':
     resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==}
 
-  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.179':
-    resolution: {integrity: sha512-2QoEl7p+RTkF4ARZ40N9OWWi+at8Iy9ZZg3UeP6sWoGrM0GL6NJSv8pbYUdoSRySbNeZshqWar5DF41265J5Sg==}
+  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.206':
+    resolution: {integrity: sha512-FL2+NKcMMN47vcnCW2Fkt3AOgeRRlQxrisbPNaxrxqPJFzhUKs17x5j0XzLefd0xRbDAr74hd0PK/tnp6PHM6w==}
     cpu: [arm64]
     os: [darwin]
 
-  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.179':
-    resolution: {integrity: sha512-U5683Hi4uP5Wkg9IhHayqx8co9rgeZaAJcutLAgJiAN9ZnL128+WT0K4DKaBVuMbeeoORodVs9IJgM38lBxUxg==}
+  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.206':
+    resolution: {integrity: sha512-mRW8PPMfQN15EunLwpdmcVzk3XuM4DXQUM8DOzaeA1Hr1yxYPaVVBLr9hkdBKOqr8XTl3ueoTR6RZAy6a/n7OA==}
     cpu: [x64]
     os: [darwin]
 
-  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.179':
-    resolution: {integrity: sha512-ehqWR9bV0dJONkoKleKg/LJIGDVevLGLPVIQpol+Bqrgyv05DE1hx68g6mBnfp9IEKo2BMZCba3aHKhkHlZvnQ==}
+  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.206':
+    resolution: {integrity: sha512-aMZe1Kl+kYv5QlA15W9Ae25MAzBsA9FA40f5TOtJebA+M/xliF0r2LLb2NdyBviiZCDllcE31l0zgYE0rQqFQw==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.179':
-    resolution: {integrity: sha512-Io9X2xF5J3cHR20b0oflLe0sLHyT/KFMCA7sVJhwuSvcqeCHqXTxn6sG+4lArD9wNf+RtLVKgSvOt5Oz4j7mew==}
+  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.206':
+    resolution: {integrity: sha512-Id6H8l6EsGb7849EAZDOB4Ic+FQpbzt4D5HGOwp59CTW3o/1c4etjQA/Kl1K+DSEWn3FGo6D5UMVgc/rwhBj8g==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.179':
-    resolution: {integrity: sha512-Q+clijh01m+Gg/tSNjHQWfPFRvXSVMIQJZqu6v28vFduaucL7ZL+p6o6VOSdlgLjhqtIFFjOO37aL+VkvEu9MQ==}
+  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.206':
+    resolution: {integrity: sha512-xQBOBhlcmTNc7YeYT5qLZOikpSq3WHlsJ/t6i7kJqUWrcXlOPaAoSMdKp5xO/V0CjAdzdJoWB88I55UAh8mclQ==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.179':
-    resolution: {integrity: sha512-Ck2pLG2GJ5lYULK0Rb6FvAUhkLSvIFgJ77MsbVhvBJHG3C31Fuk6FnkXEL614WSZZdI1ST0Y7s7wc9yLI2kmiQ==}
+  '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.206':
+    resolution: {integrity: sha512-egZhOC1RlEVhZyq6Oa1b04AF7hh4hO+8oCsJCZ3gOifJQuHih1oW3lZ8fOUxU85jlT2ytAnt5kRp4uQr6PJgbg==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.179':
-    resolution: {integrity: sha512-7wc4j3vDE/TiuiCEPV024U/TDNKXUJ89V0N9WteYJ57YrIUm0RA51WiKCrEmSxSqstQ7Slq26e0gWGHRf7ljDQ==}
+  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.206':
+    resolution: {integrity: sha512-oRQk23bFXSz4QRhOxqnnvlLWq/KiF2PtSBYXrMg1AQrCOHJd2k66aOAS7AJ4ZSzejiyV4N6sS6UThfmF6ipHBQ==}
     cpu: [arm64]
     os: [win32]
 
-  '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.179':
-    resolution: {integrity: sha512-gFad1AVUZOXbEyS9lf3Pr0LDXrLuO6limZoZoUZQmjhjy0LnudnTU8P/VbCY0AHmT46YMZ/ieisFzeq8X5jTcg==}
+  '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.206':
+    resolution: {integrity: sha512-BdjKmDojZjc5RjN+8Q6K7Yqf1WYhel6I3DkMXc9zdxS/xIuN42sx7zgQpdMGY73pm7ROPLqo3LieOeMhVH161w==}
     cpu: [x64]
     os: [win32]
 
-  '@anthropic-ai/claude-agent-sdk@0.3.179':
-    resolution: {integrity: sha512-BlZULVW61ZCcho6mb026QoOQbGZnfxbsEtcoNaW5lF0sIEu7D+/nnQjHSMK8buS/h7HVmIx2RtGbHVX1y4V0uQ==}
+  '@anthropic-ai/claude-agent-sdk@0.3.206':
+    resolution: {integrity: sha512-KljDh9Pg4YCYpoXS8dnWoVSsOHtU4yLCW268K2iOruSxFXE8/Tay6DPvmJzYuqjP5YLNYfj05ZGykwZSUn6GXA==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       '@anthropic-ai/sdk': '>=0.93.0'
       '@modelcontextprotocol/sdk': ^1.29.0
       zod: ^4.0.0
 
-  '@anthropic-ai/sdk@0.104.2':
-    resolution: {integrity: sha512-s1wEVDAtEwkS7Ajgep6PZKJLFqybRkmD3Byz+iVVsSpbDY0gjROXE9aOft6V3PMqynn3NTcycV5whga9tCzmKA==}
+  '@anthropic-ai/sdk@0.110.0':
+    resolution: {integrity: sha512-hOP4bNYXDFHDxxiEgzlILXrxZIYCDnhe8sry0RDRKD/QnsEpvZcQpablCdm9X/WuD/YgOiSIkkqsL1mLLlTqJw==}
     hasBin: true
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
@@ -1832,22 +1832,22 @@ packages:
   '@drizzle-team/brocli@0.10.2':
     resolution: {integrity: sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==}
 
-  '@earendil-works/pi-agent-core@0.79.6':
-    resolution: {integrity: sha512-SXZc4rQI+3zgUmAJDbU0GzFEHCPHbhItjN7QLsahj3TKfQAon4guwCqsrwZBLH5lPcub2+evTojPNrPItL62tA==}
+  '@earendil-works/pi-agent-core@0.80.6':
+    resolution: {integrity: sha512-Lvn89ko42h5ETUb6Z0Ku6ldskEqXaTdQBYvSa0+7bdG9V6rUEpXptv5e0OVZ1HDcvi8s6/2lGCQWsxKX+DFHNw==}
     engines: {node: '>=22.19.0'}
 
-  '@earendil-works/pi-ai@0.79.6':
-    resolution: {integrity: sha512-KGepEdgEeWDs7Imwlp96tBsO8TjSIpcDBvazsCDtHRa81+uwJI/YGetTegI52pMlKhVpJFLIGajRi4PCGC5MUg==}
-    engines: {node: '>=22.19.0'}
-    hasBin: true
-
-  '@earendil-works/pi-coding-agent@0.79.6':
-    resolution: {integrity: sha512-xPQDoA3+4Q8UsInST8OGFHPHyi7JQIbx51ku5kf2VuhXrrTv/npjVTXYD3A3D5xs6QRebV0B2mQqHfXaxQAplw==}
+  '@earendil-works/pi-ai@0.80.6':
+    resolution: {integrity: sha512-7xfLk8sANBp+bpPEbjoOZTbPxsa+++b1JXAoSJsNa3vbs9AHHEclmvg54XLQcxH+fuwaeti/g2jeIfJ+mVYLpA==}
     engines: {node: '>=22.19.0'}
     hasBin: true
 
-  '@earendil-works/pi-tui@0.79.6':
-    resolution: {integrity: sha512-6JCq780X0UuqvJsUDSJmi4V54ObB8qSwFQiBOI1jhPpC+Ydusd8SEXn2HtyIqve/utMgwcZT9aOyZM72m26A0w==}
+  '@earendil-works/pi-coding-agent@0.80.6':
+    resolution: {integrity: sha512-vcfD6tOk402isLl3Cm/qbn2O10TvgroMp1+/fEGM24ZdvETFCdOYv5VZ7m59EI5fPsjfSJh+CpQ5bhBrhfOg7g==}
+    engines: {node: '>=22.19.0'}
+    hasBin: true
+
+  '@earendil-works/pi-tui@0.80.6':
+    resolution: {integrity: sha512-bSuzS4EVSqEPj/Qr/p9eqCESfKsGuDNbl77EGci8Iaqqt/C/XCBZL1MjXaxSWW1NsT5afjp/Cb0NTPzOLv/aPA==}
     engines: {node: '>=22.19.0'}
 
   '@egjs/hammerjs@2.0.17':
@@ -2870,8 +2870,13 @@ packages:
   '@mermaid-js/parser@1.2.0':
     resolution: {integrity: sha512-oYPyv8A4As1yH5Bx+04iQEQxXuIQDe0GKCNSRgao6z8AM9jixXIfP0vsppRLvGf+nKIOb9/LdpWA4YuJiVvESA==}
 
-  '@mistralai/mistralai@2.2.1':
-    resolution: {integrity: sha512-uKU8CZmL2RzYKmplsU01hii4p3pe4HqJefpWNRWXm1Tcm0Sm4xXfwSLIy4k7ZCPlbETCGcp69E7hZs+WOJ5itQ==}
+  '@mistralai/mistralai@2.2.6':
+    resolution: {integrity: sha512-W8pX7zHxjJvMIpw8JMxeJEleapXX0Q9NPszdNzqkM3MIEoIGPObdodujj+WHteXEvGfaP/AMwlNyRfEzSY6dQQ==}
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
 
   '@modelcontextprotocol/sdk@1.29.0':
     resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
@@ -2979,52 +2984,56 @@ packages:
     resolution: {integrity: sha512-3zcN5Q3yEmeyxXBzqB6fXPQFzYa2ROsGFSr69W0ArXIAGJqxl/aFECOVPD2kbkYPm0U/EHxFKgclK3UA9WQg5A==}
     engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
 
-  '@openai/codex@0.140.0':
-    resolution: {integrity: sha512-FMnN12kJzVPljMTYRydLCNgd0cXXmVasNSfq2PtS42RMEIxoQ3dHtMvmno35hu2tfwrKNAAPCm4s+2PaFTEBGg==}
+  '@openai/codex@0.144.1':
+    resolution: {integrity: sha512-Xir1zqPfpenhdoAoshN53uonzbBXj18COyzRkFlVZpSNyEl5XtkuYu9oddELePFN7K/0sXUcSO34Ad5IeCXPbw==}
     engines: {node: '>=16'}
     hasBin: true
 
-  '@openai/codex@0.140.0-darwin-arm64':
-    resolution: {integrity: sha512-KDyQHsxdc8FHZKziSBXs82ABgben/8lLPdhi2Nu+wj6qs2RAp4k/IvE8foafVnp3OeGqhtEFbhlZp0H4Dg/Slg==}
+  '@openai/codex@0.144.1-darwin-arm64':
+    resolution: {integrity: sha512-dABeDK+ATqMG54MGBd3VjpKfh5EOoqx9PKVQB2QYDaEXx3F6CdUCXue5QIMfr4OxziUj8pUcLAQyd+KFqiTUFw==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [darwin]
 
-  '@openai/codex@0.140.0-darwin-x64':
-    resolution: {integrity: sha512-xA77AcKbP8BKxKqaJz8bqXtU1dUtanEKpWCMJ68LuYU054EC31BD7NftFe5/vpLUQR95fhRr7V9a91SLtCuLAg==}
+  '@openai/codex@0.144.1-darwin-x64':
+    resolution: {integrity: sha512-K2g3Q3tNxzFhV0SuzO6HcsYK7EQrp/o4HyeReyhkwVrwwUPoYwyIbB0IRjHIiDzRhbKriDccid2iyF5aPqdTcg==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [darwin]
 
-  '@openai/codex@0.140.0-linux-arm64':
-    resolution: {integrity: sha512-rGOgWEONilm+pQoQgcGpPRzvnou1CawyBOe8gvtuS32PQ00Pn+9nZF4O7iKBVlNh6Jeun8kpdJSjFdULm2wr4A==}
+  '@openai/codex@0.144.1-linux-arm64':
+    resolution: {integrity: sha512-451o15+XtaXCCb35t/KCyyPqXHnTPxPxtdqEYOnE3e4sH5AfnI/uVJwfdjOksMG6vRLy6R+fLvSDOMguRFLmQw==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [linux]
 
-  '@openai/codex@0.140.0-linux-x64':
-    resolution: {integrity: sha512-7+N/cHB74nsDkOoL+VQVFVFRlfGj6GFSIAQHgs9DQIsvG+UdzWgUeeDE3l926taJqmzcP9NH8bysptKlZ2Ff6g==}
+  '@openai/codex@0.144.1-linux-x64':
+    resolution: {integrity: sha512-HNGVI+BulrOaC/0IzBvd6EL62j7LrlbFKibrhw6hZjjCjAeUYzRB2jB4qDzXN1NfqDi6Xrvniof3kwbwab24lg==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [linux]
 
-  '@openai/codex@0.140.0-win32-arm64':
-    resolution: {integrity: sha512-vs5Ed5OF+4671SZoO0MN5WoHl/K9aOSNzLgzbyyDyM7Jwm/PZYvF6OmIPRWf5AGatYqEOWt8Ovp5+df5PFPM7A==}
+  '@openai/codex@0.144.1-win32-arm64':
+    resolution: {integrity: sha512-L4aDVEh9o1u7WYoxpSyv3un9Bz26YZYocOFqE2oHdEQDL2s6/LdtutLQc3oUZruLlEbkNsjSU0HI1OKsP0+Ctg==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [win32]
 
-  '@openai/codex@0.140.0-win32-x64':
-    resolution: {integrity: sha512-dP+nzd8UQ3Gdby+F5x0Sxd0hu6V9s6/cZYFsGtmmA6eCpU+IIu5tCOnUfgSu5HDw4BvXg046yd8Ihy5bOhwO4A==}
+  '@openai/codex@0.144.1-win32-x64':
+    resolution: {integrity: sha512-qv2HOp6v/nVP31p5I5GxYyL0wa79PMzim1+W9CKSV0UldjFV9AMbualA8PeXcYhbvvh9Y1UASXxwjuQdlyfAvw==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]
 
-  '@opencode-ai/sdk@1.17.7':
-    resolution: {integrity: sha512-7q7StGM+N0OwUgRsmDc8Gyz3hMIH1XGig+qZ4lzWUpmSgFEjLx8U7R14GXY7KiMJVdbVf6FeaYloRz2Rcsma4A==}
+  '@opencode-ai/sdk@1.17.18':
+    resolution: {integrity: sha512-c/C9PhY8PrbcxDY+JIYtOZsrmMD0KzoVvxq+RGUrZ6LQp57SuVBbT4lfwA2G8Se5RNC1N5JtYjiuaXeECnF2SQ==}
 
   '@opentelemetry/api-logs@0.214.0':
     resolution: {integrity: sha512-40lSJeqYO8Uz2Yj7u94/SJWE/wONa7rmMKjI1ZcIjgf3MHNHv1OZUCrCETGuaRF62d5pQD1wKIW+L4lmSMTzZA==}
+    engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/api@1.9.0':
+    resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
     engines: {node: '>=8.0.0'}
 
   '@opentelemetry/api@1.9.1':
@@ -9658,46 +9667,46 @@ snapshots:
       package-manager-detector: 1.6.0
       tinyexec: 1.2.4
 
-  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.179':
+  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.206':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.179':
+  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.206':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.179':
+  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.206':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.179':
+  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.206':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.179':
+  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.206':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.179':
+  '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.206':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.179':
+  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.206':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.179':
+  '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.206':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk@0.3.179(@anthropic-ai/sdk@0.104.2(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(zod@4.4.3)':
+  '@anthropic-ai/claude-agent-sdk@0.3.206(@anthropic-ai/sdk@0.110.0(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(zod@4.4.3)':
     dependencies:
-      '@anthropic-ai/sdk': 0.104.2(zod@4.4.3)
+      '@anthropic-ai/sdk': 0.110.0(zod@4.4.3)
       '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
       zod: 4.4.3
     optionalDependencies:
-      '@anthropic-ai/claude-agent-sdk-darwin-arm64': 0.3.179
-      '@anthropic-ai/claude-agent-sdk-darwin-x64': 0.3.179
-      '@anthropic-ai/claude-agent-sdk-linux-arm64': 0.3.179
-      '@anthropic-ai/claude-agent-sdk-linux-arm64-musl': 0.3.179
-      '@anthropic-ai/claude-agent-sdk-linux-x64': 0.3.179
-      '@anthropic-ai/claude-agent-sdk-linux-x64-musl': 0.3.179
-      '@anthropic-ai/claude-agent-sdk-win32-arm64': 0.3.179
-      '@anthropic-ai/claude-agent-sdk-win32-x64': 0.3.179
+      '@anthropic-ai/claude-agent-sdk-darwin-arm64': 0.3.206
+      '@anthropic-ai/claude-agent-sdk-darwin-x64': 0.3.206
+      '@anthropic-ai/claude-agent-sdk-linux-arm64': 0.3.206
+      '@anthropic-ai/claude-agent-sdk-linux-arm64-musl': 0.3.206
+      '@anthropic-ai/claude-agent-sdk-linux-x64': 0.3.206
+      '@anthropic-ai/claude-agent-sdk-linux-x64-musl': 0.3.206
+      '@anthropic-ai/claude-agent-sdk-win32-arm64': 0.3.206
+      '@anthropic-ai/claude-agent-sdk-win32-x64': 0.3.206
 
-  '@anthropic-ai/sdk@0.104.2(zod@4.4.3)':
+  '@anthropic-ai/sdk@0.110.0(zod@4.4.3)':
     dependencies:
       json-schema-to-ts: 3.1.1
       standardwebhooks: 1.0.0
@@ -10621,9 +10630,9 @@ snapshots:
 
   '@drizzle-team/brocli@0.10.2': {}
 
-  '@earendil-works/pi-agent-core@0.79.6(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)':
+  '@earendil-works/pi-agent-core@0.80.6(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)':
     dependencies:
-      '@earendil-works/pi-ai': 0.79.6(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
+      '@earendil-works/pi-ai': 0.80.6(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
       ignore: 7.0.5
       typebox: 1.1.38
       yaml: 2.9.0
@@ -10635,12 +10644,13 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-ai@0.79.6(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)':
+  '@earendil-works/pi-ai@0.80.6(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)':
     dependencies:
       '@anthropic-ai/sdk': 0.91.1(zod@4.4.3)
       '@aws-sdk/client-bedrock-runtime': 3.1048.0
       '@google/genai': 1.52.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))
-      '@mistralai/mistralai': 2.2.1
+      '@mistralai/mistralai': 2.2.6(@opentelemetry/api@1.9.0)
+      '@opentelemetry/api': 1.9.0
       '@smithy/node-http-handler': 4.7.3
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
@@ -10655,11 +10665,11 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-coding-agent@0.79.6(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)':
+  '@earendil-works/pi-coding-agent@0.80.6(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)':
     dependencies:
-      '@earendil-works/pi-agent-core': 0.79.6(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
-      '@earendil-works/pi-ai': 0.79.6(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
-      '@earendil-works/pi-tui': 0.79.6
+      '@earendil-works/pi-agent-core': 0.80.6(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
+      '@earendil-works/pi-ai': 0.80.6(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
+      '@earendil-works/pi-tui': 0.80.6
       '@silvia-odwyer/photon-node': 0.3.4
       chalk: 5.6.2
       cross-spawn: 7.0.6
@@ -10685,7 +10695,7 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-tui@0.79.6':
+  '@earendil-works/pi-tui@0.80.6':
     dependencies:
       get-east-asian-width: 1.6.0
       marked: 18.0.5
@@ -11730,11 +11740,14 @@ snapshots:
     dependencies:
       '@chevrotain/types': 11.1.2
 
-  '@mistralai/mistralai@2.2.1':
+  '@mistralai/mistralai@2.2.6(@opentelemetry/api@1.9.0)':
     dependencies:
+      '@opentelemetry/semantic-conventions': 1.41.1
       ws: 8.21.0
       zod: 4.4.3
       zod-to-json-schema: 3.25.2(zod@4.4.3)
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -11845,40 +11858,42 @@ snapshots:
 
   '@npmcli/redact@5.0.0': {}
 
-  '@openai/codex@0.140.0':
+  '@openai/codex@0.144.1':
     optionalDependencies:
-      '@openai/codex-darwin-arm64': '@openai/codex@0.140.0-darwin-arm64'
-      '@openai/codex-darwin-x64': '@openai/codex@0.140.0-darwin-x64'
-      '@openai/codex-linux-arm64': '@openai/codex@0.140.0-linux-arm64'
-      '@openai/codex-linux-x64': '@openai/codex@0.140.0-linux-x64'
-      '@openai/codex-win32-arm64': '@openai/codex@0.140.0-win32-arm64'
-      '@openai/codex-win32-x64': '@openai/codex@0.140.0-win32-x64'
+      '@openai/codex-darwin-arm64': '@openai/codex@0.144.1-darwin-arm64'
+      '@openai/codex-darwin-x64': '@openai/codex@0.144.1-darwin-x64'
+      '@openai/codex-linux-arm64': '@openai/codex@0.144.1-linux-arm64'
+      '@openai/codex-linux-x64': '@openai/codex@0.144.1-linux-x64'
+      '@openai/codex-win32-arm64': '@openai/codex@0.144.1-win32-arm64'
+      '@openai/codex-win32-x64': '@openai/codex@0.144.1-win32-x64'
 
-  '@openai/codex@0.140.0-darwin-arm64':
+  '@openai/codex@0.144.1-darwin-arm64':
     optional: true
 
-  '@openai/codex@0.140.0-darwin-x64':
+  '@openai/codex@0.144.1-darwin-x64':
     optional: true
 
-  '@openai/codex@0.140.0-linux-arm64':
+  '@openai/codex@0.144.1-linux-arm64':
     optional: true
 
-  '@openai/codex@0.140.0-linux-x64':
+  '@openai/codex@0.144.1-linux-x64':
     optional: true
 
-  '@openai/codex@0.140.0-win32-arm64':
+  '@openai/codex@0.144.1-win32-arm64':
     optional: true
 
-  '@openai/codex@0.140.0-win32-x64':
+  '@openai/codex@0.144.1-win32-x64':
     optional: true
 
-  '@opencode-ai/sdk@1.17.7':
+  '@opencode-ai/sdk@1.17.18':
     dependencies:
       cross-spawn: 7.0.6
 
   '@opentelemetry/api-logs@0.214.0':
     dependencies:
       '@opentelemetry/api': 1.9.1
+
+  '@opentelemetry/api@1.9.0': {}
 
   '@opentelemetry/api@1.9.1': {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -99,19 +99,18 @@ catalog:
   '@proj-airi/lobe-icons': ^1.0.19
 
 minimumReleaseAgeExclude:
-  - '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.179'
-  - '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.179'
-  - '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.179'
-  - '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.179'
-  - '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.179'
-  - '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.179'
-  - '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.179'
-  - '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.179'
-  - '@anthropic-ai/claude-agent-sdk@0.3.179'
-  - '@earendil-works/pi-agent-core@0.79.6'
-  - '@earendil-works/pi-ai@0.79.6'
-  - '@earendil-works/pi-coding-agent@0.79.6'
-  - '@earendil-works/pi-tui@0.79.6'
+  # codex platform artifacts are versions of @openai/codex keyed <ver>-<platform>-<arch>.
+  - '@openai/codex@0.144.1'
+  - '@openai/codex@0.144.1-darwin-arm64'
+  - '@openai/codex@0.144.1-darwin-x64'
+  - '@openai/codex@0.144.1-linux-arm64'
+  - '@openai/codex@0.144.1-linux-x64'
+  - '@openai/codex@0.144.1-win32-arm64'
+  - '@openai/codex@0.144.1-win32-x64'
+  - '@earendil-works/pi-agent-core@0.80.6'
+  - '@earendil-works/pi-ai@0.80.6'
+  - '@earendil-works/pi-coding-agent@0.80.6'
+  - '@earendil-works/pi-tui@0.80.6'
   - electron@42.4.1
   - react-router@7.18.0
   - '@shikijs/core@4.3.0'


### PR DESCRIPTION
Closes CODE-156. Analysis: per-package changelog review + .d.ts diff of the consumed surface + live pre-auth smoke of codex app-server 0.144.1.

## Bumps

| Package | From | To |
|---|---|---|
| `@anthropic-ai/claude-agent-sdk` | 0.3.179 | 0.3.206 |
| `@openai/codex` | 0.140.0 | 0.144.1 |
| `@opencode-ai/sdk` | 1.17.7 | 1.17.18 |
| `@earendil-works/pi-coding-agent` | 0.79.6 | 0.80.6 |
| `@anthropic-ai/sdk` (peer-only, no direct imports) | 0.104.2 | 0.110.0 (0.111.0 is still inside pnpm's 1-day release-age floor; `^0.110.0` picks it up later) |

## Code changes

- `SessionMessage` gained a required `parent_agent_id` in SDK 0.3.202 — added `parent_agent_id: null` at the 5 construction sites (claude-code.ts compaction supplement + normalize/subagent/compaction tests).
- `minimumReleaseAgeExclude`: pruned 13 stale entries (claude@0.3.179 ×9, pi@0.79.6 ×4), added the reviewed fresh pins (codex@0.144.1 + its 6 platform version keys, pi@0.80.6 ×4) — both were younger than pnpm 11's 1-day floor at install time.
- Docs: agent-adapter AGENTS.md pin table; codex framing comments re-stamped to 0.144.1 (framing + thread/turn/interrupt surface re-verified against a live 0.144.1 app-server). claude-side "verified against 0.3.179" behavior notes intentionally left until live re-verification.
- `packages/assets` needs no changes: managed CLI pins auto-follow the carrier versions; claude 8 platform packages and codex/opencode artifacts verified on the registry, tarball member paths match the catalog. Codex note: 0.144.1 (not 0.144.0) is required — it restores the embedded code-mode fallback our single-member managed extraction relies on.

## Verified

- `pnpm check:ci` green, full vitest suite green locally (87 files / 633 tests) under devenv.
- Not yet observed live (checklist on CODE-156): claude compaction summary capture, background-agent approval asks now reaching `canUseTool` (user-visible new cards), `setModel` rejecting unknown ids; codex/opencode/pi one real session each (pi: runtime-key/gateway injection path).