### PR TITLE
fix(assets): keep boot garbage collection best-effort on directory errors

### DIFF
--- a/packages/assets/src/__tests__/manager.test.ts
+++ b/packages/assets/src/__tests__/manager.test.ts
@@ -1,6 +1,6 @@
 import { existsSync, mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { AssetDescriptor } from '../catalog';
 import type { AssetInstallEvent } from '../manager';
@@ -72,6 +72,24 @@ describe('AssetManager', () => {
     const report = manager.gcAtBoot();
     expect(report.removed.sort()).toEqual([join(dir, '.tmp-orphan'), join(dir, '1.0.0')]);
     expect(existsSync(join(dir, '2.0.0'))).toBe(true);
+  });
+
+  it('gcAtBoot skips an uninspectable asset path and continues with later assets', () => {
+    freshStore();
+    const catalog = (['agent:claude-code', 'agent:opencode', 'agent:codex'] as const).map((id) => ({
+      id,
+      binaryBase: 'tool',
+      version: { kind: 'pinned' as const, version: '2.0.0' },
+      artifacts: {},
+    }));
+    const manager = new AssetManager({ catalog });
+    const blocked = assetDir('agent:claude-code');
+    mkdirSync(dirname(blocked), { recursive: true });
+    writeFileSync(blocked, 'not a directory');
+    const stale = join(assetDir('agent:codex'), '1.0.0');
+    mkdirSync(stale, { recursive: true });
+
+    expect(manager.gcAtBoot()).toEqual({ removed: [stale], skipped: [blocked] });
   });
 
   it('leaves unpinnable assets alone: ensure() is undefined and GC does not touch their dirs', async () => {

--- a/packages/assets/src/gc.ts
+++ b/packages/assets/src/gc.ts
@@ -1,5 +1,5 @@
 /// <reference types="node" />
-import { existsSync, readdirSync, rmSync } from 'node:fs';
+import { readdirSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import type { ManagedAssetId } from '@linkcode/schema';
 import { assetDir } from './paths';
@@ -7,7 +7,7 @@ import { assetDir } from './paths';
 export interface GcReport {
   /** Absolute paths removed (superseded versions and `.tmp-*` orphans). */
   removed: string[];
-  /** Absolute paths that could not be removed (win file locks) — retried next boot. */
+  /** Absolute paths that could not be inspected or removed — retried next boot. */
   skipped: string[];
 }
 
@@ -24,8 +24,14 @@ export function collectGarbage(wanted: ReadonlyMap<ManagedAssetId, string | unde
   for (const [id, version] of wanted) {
     if (!version) continue;
     const dir = assetDir(id);
-    if (!existsSync(dir)) continue;
-    for (const entry of readdirSync(dir)) {
+    let entries: string[];
+    try {
+      entries = readdirSync(dir);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') report.skipped.push(dir);
+      continue;
+    }
+    for (const entry of entries) {
       if (entry === version) continue;
       const target = join(dir, entry);
       try {


### PR DESCRIPTION
## Summary

- keep boot-time managed-asset GC best-effort when an asset directory cannot be inspected
- remove the `existsSync` precheck and handle `readdirSync` failures per asset
- add a regression covering a file at the asset path, a missing directory, and continued cleanup

## Root cause

`collectGarbage()` only caught per-entry removal errors. `readdirSync()` ran outside that boundary, so `ENOTDIR`, `EACCES`, or other inspection failures escaped through daemon boot and terminated the daemon.

## Validation

- `pnpm check:ci`
- `pnpm test --reporter=dot` — 95 files, 663 tests
- focused `manager.test.ts` regression

Linear: CODE-152