### PR TITLE
chore(desktop): bump version to 0.4.1

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@linkcode/desktop",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "private": true,
   "description": "LinkCode desktop application",
   "homepage": "https://linkcode.ai",


### PR DESCRIPTION
Release v0.4.1 — first release carrying the agent SDK bumps (#84: claude-agent-sdk 0.3.206, codex 0.144.1, opencode 1.17.18, pi 0.80.6) and the daemon connection-recovery work.

After merge, the annotated tag `v0.4.1` goes on this bump commit to trigger `release-desktop.yml`.