### PR TITLE
fix(ui): cap composer input height

### DIFF
--- a/packages/ui/src/chat/prompt-input.tsx
+++ b/packages/ui/src/chat/prompt-input.tsx
@@ -47,7 +47,10 @@ export function PromptInputTextarea({
 }: PromptInputTextareaProps): React.ReactNode {
   return (
     <InputGroupTextarea
-      className={cn('max-h-48 px-3.5 pt-3 pb-1.5', className)}
+      className={cn(
+        'px-3.5 pt-3 pb-1.5 **:[textarea]:max-h-48 **:[textarea]:overflow-y-auto',
+        className,
+      )}
       name={name}
       rows={rows}
       {...props}


### PR DESCRIPTION
This pull request makes a small change to the styling of the `PromptInputTextarea` component to improve how the textarea's maximum height and overflow are handled.

- Updated the `className` for `InputGroupTextarea` to apply `max-h-48` and `overflow-y-auto` directly to the textarea element, ensuring better scrolling behavior when the content exceeds the maximum height.