### PR TITLE
fix(daemon): self-heal drizzle migration ledger on timestamp drift

### DIFF
--- a/apps/daemon/src/__tests__/session-store.test.ts
+++ b/apps/daemon/src/__tests__/session-store.test.ts
@@ -1,6 +1,10 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import type { SessionRecord } from '@linkcode/schema';
 import { SessionRecordSchema } from '@linkcode/schema';
-import { describe, expect, it } from 'vitest';
+import Sqlite from 'better-sqlite3';
+import { afterEach, describe, expect, it } from 'vitest';
 import { createSessionStore } from '../session-store';
 
 function makeRecord(value: Record<string, unknown>): SessionRecord {
@@ -17,6 +21,11 @@ function makeRecord(value: Record<string, unknown>): SessionRecord {
 }
 
 describe('daemon sqlite session store', () => {
+  const tmpDirs: string[] = [];
+  afterEach(() => {
+    while (tmpDirs.length > 0) rmSync(tmpDirs.pop()!, { recursive: true, force: true });
+  });
+
   it('round-trips created and imported records', async () => {
     const store = createSessionStore(':memory:');
     const created = makeRecord({
@@ -51,6 +60,31 @@ describe('daemon sqlite session store', () => {
 
     const loaded = await store.load();
     expect(loaded).toEqual([next]);
+  });
+
+  it('reboots without re-running an already-applied migration whose journal timestamp drifted', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'linkcode-session-store-'));
+    tmpDirs.push(dir);
+    const dbPath = join(dir, 'daemon.db');
+
+    const first = createSessionStore(dbPath);
+    const record = makeRecord({ runs: [{ startedAt: 1 }] });
+    await first.save(record);
+
+    // Simulate a dev DB migrated under an older journal: the newest migration is applied, but its
+    // recorded created_at predates the current journal's `when`, which without reconciliation makes
+    // the migrator re-run it and crash on the duplicate column.
+    const raw = new Sqlite(dbPath);
+    raw
+      .prepare(
+        'UPDATE __drizzle_migrations SET created_at = created_at - 1000 ' +
+          'WHERE created_at = (SELECT MAX(created_at) FROM __drizzle_migrations)',
+      )
+      .run();
+    raw.close();
+
+    const second = createSessionStore(dbPath);
+    expect(await second.load()).toEqual([record]);
   });
 
   it('deletes a record together with its runs', async () => {

--- a/apps/daemon/src/session-store.ts
+++ b/apps/daemon/src/session-store.ts
@@ -8,10 +8,36 @@ import Sqlite from 'better-sqlite3';
 import { asc, eq } from 'drizzle-orm';
 import { drizzle } from 'drizzle-orm/better-sqlite3';
 import { migrate } from 'drizzle-orm/better-sqlite3/migrator';
+import { readMigrationFiles } from 'drizzle-orm/migrator';
 import { sessionRuns, sessions } from './db/schema';
 
 type SessionRow = typeof sessions.$inferSelect;
 type RunRow = typeof sessionRuns.$inferSelect;
+
+/**
+ * drizzle's migrator decides "already applied?" by comparing each migration's journal `when`
+ * (`folderMillis`) against the newest recorded `created_at` — it never looks at the content hash.
+ * A migration regenerated during development keeps identical SQL but gets a fresh, larger `when`,
+ * so the migrator re-runs it; the resulting non-idempotent DDL (`ALTER TABLE … ADD COLUMN`) then
+ * crashes the daemon at boot on a DB that recorded the older timestamp. Since the stored hash is
+ * the sha256 of the migration SQL, a recorded hash proves that exact migration already ran — so we
+ * realign its `created_at` to the current journal before migrating. Steady state writes nothing;
+ * genuinely new migrations (unrecorded hash) still run and still fail loudly on real errors.
+ */
+function reconcileMigrationLedger(sqlite: Sqlite.Database, migrationsFolder: string): void {
+  const hasLedger = sqlite
+    .prepare("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = '__drizzle_migrations'")
+    .get();
+  if (!hasLedger) return; // First boot — nothing has been applied yet.
+  const realign = sqlite.prepare(
+    'UPDATE __drizzle_migrations SET created_at = ? WHERE hash = ? AND created_at <> ?',
+  );
+  sqlite.transaction(() => {
+    for (const migration of readMigrationFiles({ migrationsFolder })) {
+      realign.run(migration.folderMillis, migration.hash, migration.folderMillis);
+    }
+  })();
+}
 
 /**
  * SQLite-backed `SessionStore` (drizzle over better-sqlite3), owning the session registry at
@@ -24,7 +50,9 @@ export function createSessionStore(dbPath: string): SessionStore {
   sqlite.pragma('journal_mode = WAL');
   sqlite.pragma('foreign_keys = ON');
   const db = drizzle(sqlite);
-  migrate(db, { migrationsFolder: fileURLToPath(new URL('../drizzle', import.meta.url)) });
+  const migrationsFolder = fileURLToPath(new URL('../drizzle', import.meta.url));
+  reconcileMigrationLedger(sqlite, migrationsFolder);
+  migrate(db, { migrationsFolder });
 
   return {
     load(): Promise<SessionRecord[]> {


### PR DESCRIPTION
## Problem

The daemon crashes at boot with a fatal `DrizzleError` when a local `daemon.db` has a migration-ledger timestamp drift:

```
[linkcode/daemon] fatal: DrizzleError: Failed to run the query 'ALTER TABLE `sessions` ADD `created_via` text;'
  cause: SqliteError: duplicate column name: created_via
```

## Root cause

drizzle's migrator decides "already applied?" by comparing each migration's journal `when` (`folderMillis`) against the newest recorded `created_at` in `__drizzle_migrations` — it **never looks at the content hash** (`sqlite-core/dialect.js:660`).

When a migration is regenerated during development the SQL stays identical (same sha256 hash) but gets a fresh, larger `when`. The migrator then re-runs it, and the non-idempotent `ALTER TABLE … ADD COLUMN` hard-fails on the already-present column, killing the daemon at boot. Fresh clones are unaffected (empty ledger → clean apply); only a dev DB that recorded the older timestamp breaks.

## Fix

Add `reconcileMigrationLedger()`, run just before `migrate()`. For every migration whose hash is already recorded (same hash ⇒ that exact SQL provably ran), realign its `created_at` to the current journal `folderMillis`. This eliminates the drift-driven re-run entirely.

- **Not a silent fallback:** it doesn't swallow migration errors. Genuinely new migrations (unrecorded hash) still run and still fail loudly on real errors.
- **Steady state writes nothing** (the `created_at <> ?` guard).
- **No data loss** — the session/workspace registry is preserved.

## Verification

- New regression test drives the real `createSessionStore` through the exact drift scenario. Confirmed it reproduces the original `duplicate column name: created_via` crash when the fix is disabled, and passes with it.
- Full suite: **747 passed / 102 files**. daemon typecheck, lint (0 errors), biome format all clean.
- End-to-end: booted the real daemon against an isolated fake-`$HOME` DB with an injected timestamp drift — crashed before the fix, boots cleanly after, and the ledger timestamp is realigned to the journal value.