### PR TITLE
fix(desktop): resolve cloud-auth storage path lazily and prune undecryptable entries

### DIFF
--- a/apps/desktop/src/main/__tests__/cloud-auth-storage.test.ts
+++ b/apps/desktop/src/main/__tests__/cloud-auth-storage.test.ts
@@ -74,21 +74,26 @@ describe('cloud-auth safe storage', () => {
     expect(storage.getItem('session')).toEqual({ token: 't' });
   });
 
-  it('discards an undecryptable entry and keeps the rest', async () => {
+  it('keeps an undecryptable entry on disk and warns once', async () => {
     const storage = await createStorage();
     storage.setItem('good', 'kept');
     mocks.keychainKey = 'B';
-    storage.setItem('foreign', 'poison');
+    storage.setItem('stuck', 'recoverable');
     mocks.keychainKey = 'A';
 
-    expect(storage.getItem('foreign')).toBeNull();
-    expect(mocks.warn).toHaveBeenCalledTimes(1);
-    expect(Object.keys(JSON.parse(readFileSync(storeFile(), 'utf8')))).toEqual(['good']);
-
-    // The pruned entry is gone from the store, so later reads stay silent.
-    expect(storage.getItem('foreign')).toBeNull();
+    expect(storage.getItem('stuck')).toBeNull();
+    expect(storage.getItem('stuck')).toBeNull();
     expect(mocks.warn).toHaveBeenCalledTimes(1);
     expect(storage.getItem('good')).toBe('kept');
+
+    // The entry survives on disk, so a transient keychain failure (e.g. a declined ACL
+    // prompt) does not destroy the session: once decryption works again, the value is back.
+    expect(Object.keys(JSON.parse(readFileSync(storeFile(), 'utf8'))).sort()).toEqual([
+      'good',
+      'stuck',
+    ]);
+    mocks.keychainKey = 'B';
+    expect(storage.getItem('stuck')).toBe('recoverable');
   });
 
   it('round-trips through the plain fallback when the keychain is unavailable', async () => {

--- a/apps/desktop/src/main/__tests__/cloud-auth-storage.test.ts
+++ b/apps/desktop/src/main/__tests__/cloud-auth-storage.test.ts
@@ -1,0 +1,102 @@
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  userData: '',
+  encryptionAvailable: true,
+  // Stands in for the OS keychain's per-app-identity key: ciphertext written under one
+  // key value fails to decrypt under another, like a foreign safeStorage identity.
+  keychainKey: 'A',
+  warn: vi.fn(),
+}));
+
+vi.mock('electron', () => ({
+  app: { getPath: () => mocks.userData },
+  safeStorage: {
+    isEncryptionAvailable: () => mocks.encryptionAvailable,
+    encryptString: (json: string) => Buffer.from(`${mocks.keychainKey}:${json}`, 'utf8'),
+    decryptString(buf: Buffer) {
+      const text = buf.toString('utf8');
+      if (!text.startsWith(`${mocks.keychainKey}:`)) {
+        throw new Error(
+          'Error while decrypting the ciphertext provided to safeStorage.decryptString.',
+        );
+      }
+      return text.slice(mocks.keychainKey.length + 1);
+    },
+  },
+}));
+
+vi.mock('electron-log', () => ({ default: { warn: mocks.warn } }));
+
+let root: string;
+
+function storeFile(): string {
+  return join(mocks.userData, 'cloud-auth.json');
+}
+
+beforeEach(() => {
+  vi.resetModules();
+  mocks.warn.mockReset();
+  mocks.encryptionAvailable = true;
+  mocks.keychainKey = 'A';
+  root = mkdtempSync(join(tmpdir(), 'linkcode-cloud-auth-'));
+  mocks.userData = join(root, 'user-data');
+  mkdirSync(mocks.userData, { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(root, { force: true, recursive: true });
+});
+
+async function createStorage() {
+  const { createSafeStorage } = await import('../cloud-auth/storage');
+  return createSafeStorage();
+}
+
+describe('cloud-auth safe storage', () => {
+  it('resolves the store path at call time, not at construction', async () => {
+    // Regression: the storage is constructed at module scope, before main re-points
+    // userData to the app identity's directory. An eagerly captured path leaks the
+    // store into the productName-derived profile.
+    const wrongDir = mocks.userData;
+    const storage = await createStorage();
+
+    mocks.userData = join(root, 'identity-user-data');
+    mkdirSync(mocks.userData, { recursive: true });
+
+    storage.setItem('session', { token: 't' });
+
+    expect(existsSync(storeFile())).toBe(true);
+    expect(existsSync(join(wrongDir, 'cloud-auth.json'))).toBe(false);
+    expect(storage.getItem('session')).toEqual({ token: 't' });
+  });
+
+  it('discards an undecryptable entry and keeps the rest', async () => {
+    const storage = await createStorage();
+    storage.setItem('good', 'kept');
+    mocks.keychainKey = 'B';
+    storage.setItem('foreign', 'poison');
+    mocks.keychainKey = 'A';
+
+    expect(storage.getItem('foreign')).toBeNull();
+    expect(mocks.warn).toHaveBeenCalledTimes(1);
+    expect(Object.keys(JSON.parse(readFileSync(storeFile(), 'utf8')))).toEqual(['good']);
+
+    // The pruned entry is gone from the store, so later reads stay silent.
+    expect(storage.getItem('foreign')).toBeNull();
+    expect(mocks.warn).toHaveBeenCalledTimes(1);
+    expect(storage.getItem('good')).toBe('kept');
+  });
+
+  it('round-trips through the plain fallback when the keychain is unavailable', async () => {
+    mocks.encryptionAvailable = false;
+    const storage = await createStorage();
+    storage.setItem('session', { token: 't' });
+
+    expect(readFileSync(storeFile(), 'utf8')).toContain('plain:');
+    expect(storage.getItem('session')).toEqual({ token: 't' });
+  });
+});

--- a/apps/desktop/src/main/cloud-auth/storage.ts
+++ b/apps/desktop/src/main/cloud-auth/storage.ts
@@ -2,6 +2,7 @@ import { readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { app, safeStorage } from 'electron';
 import log from 'electron-log';
+import { extractErrorMessage } from 'foxts/extract-error-message';
 
 /**
  * Storage backing the better-auth electron client's session + cookie data. The plugin's
@@ -27,6 +28,10 @@ function readMap(file: string): Record<string, string> {
   }
 }
 
+function writeMap(file: string, map: Record<string, string>): void {
+  writeFileSync(file, JSON.stringify(map), { mode: 0o600 });
+}
+
 function encode(value: unknown): string {
   const json = JSON.stringify(value);
   if (safeStorage.isEncryptionAvailable()) {
@@ -43,24 +48,38 @@ function decode(stored: string): unknown {
   return JSON.parse(json);
 }
 
-export function createSafeStorage(): Storage {
-  const file = join(app.getPath('userData'), 'cloud-auth.json');
+// Resolved per call, never at module scope: this module is imported (via the auth client)
+// before main sets the app name and userData path, so an eager join would pin the store to
+// the productName-derived directory and leak dev-shell data into the release profile.
+function storageFile(): string {
+  return join(app.getPath('userData'), 'cloud-auth.json');
+}
 
+export function createSafeStorage(): Storage {
   return {
     getItem(name) {
+      const file = storageFile();
       const map = readMap(file);
       if (!Object.hasOwn(map, name)) return null;
       try {
         return decode(map[name]);
       } catch (err) {
-        log.warn('[cloud-auth] failed to decode stored session data:', err);
+        // Undecryptable ciphertext (e.g. written under another app identity's safeStorage
+        // key) can never heal on its own — drop the entry so the failure logs once instead
+        // of on every session refresh.
+        log.warn(
+          `[cloud-auth] failed to decode stored session data; discarding entry: ${extractErrorMessage(err)}`,
+        );
+        const { [name]: _dropped, ...rest } = map;
+        writeMap(file, rest);
         return null;
       }
     },
     setItem(name, value) {
+      const file = storageFile();
       const map = readMap(file);
       map[name] = encode(value);
-      writeFileSync(file, JSON.stringify(map), { mode: 0o600 });
+      writeMap(file, map);
     },
   };
 }

--- a/apps/desktop/src/main/cloud-auth/storage.ts
+++ b/apps/desktop/src/main/cloud-auth/storage.ts
@@ -55,23 +55,28 @@ function storageFile(): string {
   return join(app.getPath('userData'), 'cloud-auth.json');
 }
 
+// A decode failure is indistinguishable from a transient keychain failure (locked keychain,
+// declined ACL prompt after a binary change), so the entry must survive for the next attempt;
+// a truly foreign entry is overwritten by the next successful sign-in anyway. Deduping the
+// warning is what keeps a permanent failure from logging on every session refresh.
+const warnedKeys = new Set<string>();
+
 export function createSafeStorage(): Storage {
   return {
     getItem(name) {
-      const file = storageFile();
-      const map = readMap(file);
+      const map = readMap(storageFile());
       if (!Object.hasOwn(map, name)) return null;
       try {
-        return decode(map[name]);
+        const value = decode(map[name]);
+        warnedKeys.delete(name);
+        return value;
       } catch (err) {
-        // Undecryptable ciphertext (e.g. written under another app identity's safeStorage
-        // key) can never heal on its own — drop the entry so the failure logs once instead
-        // of on every session refresh.
-        log.warn(
-          `[cloud-auth] failed to decode stored session data; discarding entry: ${extractErrorMessage(err)}`,
-        );
-        const { [name]: _dropped, ...rest } = map;
-        writeMap(file, rest);
+        if (!warnedKeys.has(name)) {
+          warnedKeys.add(name);
+          log.warn(
+            `[cloud-auth] failed to decode stored session data for "${name}": ${extractErrorMessage(err)}`,
+          );
+        }
         return null;
       }
     },

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -1,6 +1,7 @@
 import { join } from 'node:path';
 import * as Sentry from '@sentry/electron/main';
 import { app, BrowserWindow, Menu } from 'electron';
+import log from 'electron-log';
 import { applyThemePreference } from './appearance';
 import { setupCloudAuth } from './cloud-auth/client';
 import { registerCloudImBridge } from './cloud-auth/im';
@@ -22,6 +23,9 @@ app.setName(APP_NAME);
 // asar even for dev-shell packages. Without this, a packaged dev shell shares the release app's
 // settings and single-instance lock — the second one to start exits silently.
 app.setPath('userData', join(app.getPath('appData'), APP_NAME));
+// Self-evidence for identity drift: any module that resolves a path before the lines above
+// lands in the wrong profile, and this line makes that visible on day one.
+log.info(`userData: ${app.getPath('userData')}`);
 
 // Windows keys the taskbar icon, pinning, and notification identity off the AppUserModelID; without
 // this the taskbar shows a blank/default icon. No-op on macOS/Linux.


### PR DESCRIPTION
Fixes CODE-166.

## Problem

The dev shell and the packaged release share one `cloud-auth.json`: `createSafeStorage()` captures `app.getPath('userData')` at module scope (via the auth client's top-level plugin construction), which runs **before** `index.ts` re-points userData to the app identity's directory. The store is therefore pinned to the productName-derived **release** directory even in dev shells. Each side writes entries under its own per-binary safeStorage keychain key, so both apps spam `[cloud-auth] failed to decode stored session data` on every better-auth session refresh (338 hits in the dev log, 218 in the release log since 07-07).

## Fix

- Resolve the store path at call time (`storageFile()`), never at construction — `getItem`/`setItem` only run after identity setup.
- Prune an undecryptable entry instead of returning `null` forever: foreign ciphertext can never heal on its own, so drop it and log once.
- Log `userData: <path>` at boot right after identity setup so this class of drift is visible immediately.

## Verification

- New unit tests (`cloud-auth-storage.test.ts`, following the `settings.test.ts` electron-mock pattern): lazy-resolution regression test (construct → re-point userData → assert the store lands in the new dir), prune-keeps-siblings semantics, plain fallback round-trip.
- Full suite: 102 files / 747 tests pass; scoped biome + eslint + `tsc --build` pass.
- Isolated real launch confirms the boot line prints the post-`setPath` directory.

Cleanup for already-poisoned machines: delete `~/Library/Application Support/LinkCode/cloud-auth.json` and sign in again (both identities re-encrypt under their own keys from then on).