### PR TITLE
fix(ui): remove truncate and add tooltip to prompt

### DIFF
--- a/packages/ui/src/chat/__tests__/conversation-prompt-alert.test.tsx
+++ b/packages/ui/src/chat/__tests__/conversation-prompt-alert.test.tsx
@@ -23,6 +23,8 @@ const CHOICES = [
   { id: 'second', label: 'Second' },
 ] as const;
 const FIRST_CHOICE_NAME = /First$/;
+const FIRST_CHOICE_WITH_DESCRIPTION_NAME = /First.*Full choice description$/;
+const FULL_CHOICE_DESCRIPTION = 'Full choice description';
 const SECOND_CHOICE_NAME = /Second$/;
 
 afterEach(cleanup);
@@ -46,6 +48,22 @@ function renderPrompt(overrides: Partial<ConversationPromptAlertProps> = {}) {
 }
 
 describe('ConversationPromptAlert keyboard behavior', () => {
+  it('shows a choice description when its row receives keyboard focus', async () => {
+    const user = userEvent.setup();
+    renderPrompt({
+      choices: [{ id: 'first', label: 'First', description: FULL_CHOICE_DESCRIPTION }],
+    });
+    const choice = screen.getByRole('button', { name: FIRST_CHOICE_WITH_DESCRIPTION_NAME });
+
+    await user.tab();
+
+    expect(document.activeElement).toBe(choice);
+    expect(Object.hasOwn(choice.dataset, 'popupOpen')).toBe(true);
+    expect(document.querySelector('[data-slot="tooltip-popup"][data-open]')?.textContent).toBe(
+      FULL_CHOICE_DESCRIPTION,
+    );
+  });
+
   it('submits a single choice directly when clicked', async () => {
     const user = userEvent.setup();
     const { onSubmit } = renderPrompt();

--- a/packages/ui/src/chat/conversation-prompt-alert.tsx
+++ b/packages/ui/src/chat/conversation-prompt-alert.tsx
@@ -10,6 +10,7 @@ import {
   FrameTitle,
 } from 'coss-ui/components/frame';
 import { InputPrimitive } from 'coss-ui/components/input';
+import { Tooltip, TooltipContent, TooltipTrigger } from 'coss-ui/components/tooltip';
 import { ArrowDownIcon, ArrowUpIcon, CornerDownLeftIcon, PencilIcon } from 'lucide-react';
 import { useId, useState } from 'react';
 import { useTranslations } from 'use-intl';
@@ -401,19 +402,24 @@ function PromptChoiceRow({
         <span className="min-w-0 flex-1 flex items-center gap-2 text-left">
           <span
             className={cn(
-              'block truncate font-medium text-foreground text-sm',
+              'block font-medium text-foreground text-sm',
               choice.tone === 'danger' && 'text-destructive-foreground',
             )}
           >
             {choice.label}
           </span>
           {choice.description ? (
-            <span
-              className="block truncate text-muted-foreground text-xs"
-              title={choice.description}
-            >
-              {choice.description}
-            </span>
+            <Tooltip>
+              <TooltipTrigger
+                delay={300}
+                render={
+                  <span className="block truncate text-muted-foreground text-xs">
+                    {choice.description}
+                  </span>
+                }
+              />
+              <TooltipContent className="max-w-xl">{choice.description}</TooltipContent>
+            </Tooltip>
           ) : null}
         </span>
         {checked ? (

--- a/packages/ui/src/chat/conversation-prompt-alert.tsx
+++ b/packages/ui/src/chat/conversation-prompt-alert.tsx
@@ -373,6 +373,47 @@ function PromptChoiceRow({
   multiple: boolean;
   onSelect: () => void;
 }) {
+  const button = (
+    <Button
+      className="h-auto w-full justify-start whitespace-normal px-2 py-1.5 text-left"
+      data-prompt-choice=""
+      aria-pressed={multiple || checked ? checked : undefined}
+      autoFocus={autoFocus}
+      disabled={disabled}
+      type="button"
+      variant="ghost"
+      onClick={onSelect}
+    >
+      <span
+        className={cn(
+          'flex size-5 shrink-0 items-center justify-center rounded-full border border-input bg-background text-muted-foreground',
+          checked && 'border-foreground bg-foreground text-background',
+        )}
+      >
+        <span className="text-xs tabular-nums">{index + 1}</span>
+      </span>
+      <span className="min-w-0 flex-1 flex items-center gap-2 text-left">
+        <span
+          className={cn(
+            'block font-medium text-foreground text-sm',
+            choice.tone === 'danger' && 'text-destructive-foreground',
+          )}
+        >
+          {choice.label}
+        </span>
+        {choice.description ? (
+          <span className="block truncate text-muted-foreground text-xs">{choice.description}</span>
+        ) : null}
+      </span>
+      {checked ? (
+        <span className="ms-auto flex shrink-0 items-center gap-1 text-muted-foreground">
+          <ArrowUpIcon className="size-3.5" />
+          <ArrowDownIcon className="size-3.5" />
+        </span>
+      ) : null}
+    </Button>
+  );
+
   return (
     <div
       className={cn(
@@ -381,54 +422,14 @@ function PromptChoiceRow({
         choice.tone === 'danger' && checked && 'bg-destructive/8',
       )}
     >
-      <Button
-        className="h-auto w-full justify-start whitespace-normal px-2 py-1.5 text-left"
-        data-prompt-choice=""
-        aria-pressed={multiple || checked ? checked : undefined}
-        autoFocus={autoFocus}
-        disabled={disabled}
-        type="button"
-        variant="ghost"
-        onClick={onSelect}
-      >
-        <span
-          className={cn(
-            'flex size-5 shrink-0 items-center justify-center rounded-full border border-input bg-background text-muted-foreground',
-            checked && 'border-foreground bg-foreground text-background',
-          )}
-        >
-          <span className="text-xs tabular-nums">{index + 1}</span>
-        </span>
-        <span className="min-w-0 flex-1 flex items-center gap-2 text-left">
-          <span
-            className={cn(
-              'block font-medium text-foreground text-sm',
-              choice.tone === 'danger' && 'text-destructive-foreground',
-            )}
-          >
-            {choice.label}
-          </span>
-          {choice.description ? (
-            <Tooltip>
-              <TooltipTrigger
-                delay={300}
-                render={
-                  <span className="block truncate text-muted-foreground text-xs">
-                    {choice.description}
-                  </span>
-                }
-              />
-              <TooltipContent className="max-w-xl">{choice.description}</TooltipContent>
-            </Tooltip>
-          ) : null}
-        </span>
-        {checked ? (
-          <span className="ms-auto flex shrink-0 items-center gap-1 text-muted-foreground">
-            <ArrowUpIcon className="size-3.5" />
-            <ArrowDownIcon className="size-3.5" />
-          </span>
-        ) : null}
-      </Button>
+      {choice.description ? (
+        <Tooltip>
+          <TooltipTrigger delay={300} render={button} />
+          <TooltipContent className="max-w-xl">{choice.description}</TooltipContent>
+        </Tooltip>
+      ) : (
+        button
+      )}
     </div>
   );
 }


### PR DESCRIPTION
This pull request improves the user interface for displaying prompt choices in the chat conversation alert component. The main enhancement is the addition of a tooltip for prompt descriptions, which provides better accessibility and readability for long or truncated descriptions.

**UI/UX Improvements:**

* Added the `Tooltip`, `TooltipContent`, and `TooltipTrigger` components from `coss-ui/components/tooltip` to enable tooltips for prompt descriptions.
* Replaced the static `title` attribute with a tooltip for the `choice.description`, ensuring that long descriptions are easily viewable on hover and improving the overall user experience.
* Removed the `truncate` class from the prompt label to avoid unnecessary truncation and improve label readability.