### PR TITLE
feat(daemon,schema,common): profile-scoped state dirs and profile-aware daemon discovery

### DIFF
--- a/apps/daemon/src/__tests__/config.test.ts
+++ b/apps/daemon/src/__tests__/config.test.ts
@@ -123,6 +123,12 @@ describe('profile-scoped state paths', () => {
     expect(() => daemonProfile()).toThrow(TypeError);
     expect(() => databasePath()).toThrow(TypeError);
   });
+
+  it('rejects a path-traversal profile instead of resolving outside the home sibling', () => {
+    process.env.LINKCODE_PROFILE = '../evil';
+    expect(() => runtimeFilePath()).toThrow(TypeError);
+    expect(() => databasePath()).toThrow(TypeError);
+  });
 });
 
 describe('loadConfig accounts', () => {

--- a/apps/daemon/src/__tests__/config.test.ts
+++ b/apps/daemon/src/__tests__/config.test.ts
@@ -3,7 +3,13 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { noop } from 'foxts/noop';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { loadConfig } from '../config';
+import {
+  daemonProfile,
+  databasePath,
+  hqCredentialsPath,
+  loadConfig,
+  runtimeFilePath,
+} from '../config';
 
 let savedHome: string | undefined;
 
@@ -15,6 +21,7 @@ beforeEach(() => {
 
 afterEach(() => {
   process.env.HOME = savedHome;
+  delete process.env.LINKCODE_PROFILE;
   vi.restoreAllMocks();
 });
 
@@ -87,6 +94,34 @@ describe('loadConfig providers', () => {
 
     expect(config.providers).toEqual({});
     expect(errorSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('profile-scoped state paths', () => {
+  it('resolves under ~/.linkcode for the default profile', () => {
+    expect(daemonProfile()).toBeUndefined();
+    expect(databasePath()).toBe(join(process.env.HOME ?? '', '.linkcode', 'daemon.db'));
+  });
+
+  it('forks every state path into the profile sibling directory', () => {
+    process.env.LINKCODE_PROFILE = 'alpha';
+    const root = join(process.env.HOME ?? '', '.linkcode-alpha');
+    expect(daemonProfile()).toBe('alpha');
+    expect(databasePath()).toBe(join(root, 'daemon.db'));
+    expect(runtimeFilePath()).toBe(join(root, 'runtime.json'));
+    expect(hqCredentialsPath()).toBe(join(root, 'hq.json'));
+  });
+
+  it('treats an empty LINKCODE_PROFILE as the default profile', () => {
+    process.env.LINKCODE_PROFILE = '';
+    expect(daemonProfile()).toBeUndefined();
+    expect(databasePath()).toBe(join(process.env.HOME ?? '', '.linkcode', 'daemon.db'));
+  });
+
+  it('aborts on an invalid profile name instead of using the default universe', () => {
+    process.env.LINKCODE_PROFILE = 'Not_Valid!';
+    expect(() => daemonProfile()).toThrow(TypeError);
+    expect(() => databasePath()).toThrow(TypeError);
   });
 });
 

--- a/apps/daemon/src/__tests__/runtime.test.ts
+++ b/apps/daemon/src/__tests__/runtime.test.ts
@@ -120,6 +120,26 @@ describe('listenWithPortHunt', () => {
     expect(url).toBe(`ws://127.0.0.1:${port + 1}`);
     await server.close();
   });
+
+  it('hunts past a live daemon of another profile', async () => {
+    const port = await serveIdentity({ ...identity(4242), profile: 'alpha' });
+    const { server, url } = await listenWithPortHunt(
+      { type: 'ws', port, host: '127.0.0.1' },
+      identity(process.pid),
+    );
+    expect(url).toBe(`ws://127.0.0.1:${port + 1}`);
+    await server.close();
+  });
+
+  it('refuses to hunt past a live daemon of the same profile', async () => {
+    const port = await serveIdentity({ ...identity(4242), profile: 'alpha' });
+    await expect(
+      listenWithPortHunt(
+        { type: 'ws', port, host: '127.0.0.1' },
+        { ...identity(process.pid), profile: 'alpha' },
+      ),
+    ).rejects.toBeInstanceOf(DaemonAlreadyRunningError);
+  });
 });
 
 describe('findRunningDaemon', () => {

--- a/apps/daemon/src/config.ts
+++ b/apps/daemon/src/config.ts
@@ -7,14 +7,17 @@ import {
   AccountSchema,
   AgentKindSchema,
   DAEMON_DEFAULT_PORT,
+  linkcodeStateDirName,
   ProviderConfigSchema,
+  parseProfileName,
 } from '@linkcode/schema';
 import type { TransportServerOptions } from '@linkcode/transport/server';
 
 /**
- * Daemon configuration, loaded from `~/.linkcode/config.json` (optional) with env overrides.
- * Per-provider settings (API keys / default model) are typed by `ProvidersConfigSchema` (data plane)
- * and applied to a session's StartOptions by the Engine; the daemon reads/writes them here.
+ * Daemon configuration, loaded from `config.json` in the profile's state dir (optional) with env
+ * overrides. Per-provider settings (API keys / default model) are typed by `ProvidersConfigSchema`
+ * (data plane) and applied to a session's StartOptions by the Engine; the daemon reads/writes them
+ * here.
  */
 export type DaemonListenerConfig = TransportServerOptions;
 
@@ -37,33 +40,48 @@ interface ConfigFile {
   accounts?: unknown;
 }
 
+/**
+ * The daemon's profile, from `LINKCODE_PROFILE`; `undefined` is the default profile. Each profile
+ * is a fully isolated state universe — every path below (and therefore the device identity HQ
+ * sees) forks with it. Resolved per call so tests can vary the env like they vary `$HOME`; an
+ * invalid name throws and aborts boot rather than silently landing in the default universe.
+ */
+export function daemonProfile(): string | undefined {
+  return parseProfileName(process.env.LINKCODE_PROFILE);
+}
+
+/** The daemon's state directory: `~/.linkcode`, or the profile sibling `~/.linkcode-<name>`. */
+function stateDir(): string {
+  return join(homedir(), linkcodeStateDirName(daemonProfile()));
+}
+
 function configPath(): string {
-  return join(homedir(), '.linkcode', 'config.json');
+  return join(stateDir(), 'config.json');
 }
 
 /** The daemon's SQLite database (session registry), next to config.json. */
 export function databasePath(): string {
-  return join(homedir(), '.linkcode', 'daemon.db');
+  return join(stateDir(), 'daemon.db');
 }
 
 /** Runtime discovery file advertising the running daemon's bound endpoints, next to config.json. */
 export function runtimeFilePath(): string {
-  return daemonRuntimeFilePath();
+  return daemonRuntimeFilePath(daemonProfile());
 }
 
 /** HQ sign-in state (session token + registered device id), next to config.json; written 0600. */
 export function hqCredentialsPath(): string {
-  return join(homedir(), '.linkcode', 'hq.json');
+  return join(stateDir(), 'hq.json');
 }
 
 /** The device's Ed25519 private key (PKCS#8 PEM), next to config.json; written 0600. */
 export function deviceKeyPath(): string {
-  return join(homedir(), '.linkcode', 'device-key.pem');
+  return join(stateDir(), 'device-key.pem');
 }
 
 /** Hardware-wrapped device-key handles (@arcboxlabs/deviceid), next to config.json. */
 export function deviceKeysDir(): string {
-  return join(homedir(), '.linkcode', 'keys');
+  return join(stateDir(), 'keys');
 }
 
 /**

--- a/apps/daemon/src/index.ts
+++ b/apps/daemon/src/index.ts
@@ -51,6 +51,11 @@ process.on('unhandledRejection', (reason) => {
  * they spawn CLI subprocesses and hold credentials, so they cannot run inside a browser tab.
  */
 async function main(): Promise<void> {
+  // Resolved before anything touches state paths — including the subcommands below, which read
+  // hq.json/device-key from the profile's state dir: an invalid LINKCODE_PROFILE must abort here,
+  // not surface mid-command or as a half-initialized default-profile daemon.
+  const profile = daemonProfile();
+
   // Subcommands run and exit instead of booting the host (a running daemon
   // picks the new sign-in state up on its next restart).
   const command = process.argv[2];
@@ -61,9 +66,6 @@ async function main(): Promise<void> {
   // desktop app's asar (no-op outside Electron — see asar-spawn.ts).
   installAsarSpawnFix();
 
-  // Resolved before anything touches state paths: an invalid LINKCODE_PROFILE must abort boot
-  // here, not surface as a half-initialized default-profile daemon.
-  const profile = daemonProfile();
   const config = loadConfig();
 
   // One daemon per profile — a second instance would share this profile's daemon.db and split

--- a/apps/daemon/src/index.ts
+++ b/apps/daemon/src/index.ts
@@ -10,7 +10,7 @@ import { noop } from 'foxts/noop';
 import { once } from 'foxts/once';
 import { createAiGatewaySidecar } from './ai-gateway';
 import { installAsarSpawnFix } from './asar-spawn';
-import { chatWorkspaceRoot, databasePath, loadConfig } from './config';
+import { chatWorkspaceRoot, daemonProfile, databasePath, loadConfig } from './config';
 import { runLoginCommand, runLogoutCommand } from './hq/login';
 import { startHqUplink } from './hq/uplink';
 import { createProviderConfigStore } from './provider-store';
@@ -61,9 +61,13 @@ async function main(): Promise<void> {
   // desktop app's asar (no-op outside Electron — see asar-spawn.ts).
   installAsarSpawnFix();
 
+  // Resolved before anything touches state paths: an invalid LINKCODE_PROFILE must abort boot
+  // here, not surface as a half-initialized default-profile daemon.
+  const profile = daemonProfile();
   const config = loadConfig();
 
-  // One daemon per machine — a second instance would share ~/.linkcode/daemon.db and split sessions.
+  // One daemon per profile — a second instance would share this profile's daemon.db and split
+  // sessions. Daemons of other profiles live in sibling state dirs and are not visible here.
   const running = await findRunningDaemon();
   if (running) {
     const urls = running.listeners.map((listener) => listener.url).join(', ');
@@ -77,6 +81,7 @@ async function main(): Promise<void> {
     name: 'linkcode-daemon',
     pid: process.pid,
     startedAt: Date.now(),
+    ...(profile !== undefined && { profile }),
   };
   const hub = new Hub();
   const store = createProviderConfigStore(config.providers ?? {}, config.accounts ?? []);

--- a/apps/daemon/src/runtime.ts
+++ b/apps/daemon/src/runtime.ts
@@ -16,8 +16,9 @@ import { runtimeFilePath } from './config';
 
 /**
  * Daemon runtime discovery: bind listeners with port hunting, refuse to double-start
- * (one daemon per machine — they would share `~/.linkcode/daemon.db`), and advertise the
+ * (one daemon per profile — they would share that profile's `daemon.db`), and advertise the
  * actually-bound endpoints in the runtime file for local clients (desktop main, cli) to read.
+ * Daemons of other profiles are just port neighbors: the hunt skips past them.
  */
 
 const PORT_HUNT_ATTEMPTS = 10;
@@ -80,7 +81,9 @@ async function huntFrom(
     const probeUrl = httpUrl(listener.host, port);
     const occupant = await probeDaemonIdentity(probeUrl);
     // Our own pid means another of this daemon's listeners hunted onto the port — keep going.
-    if (occupant && occupant.pid !== identity.pid) {
+    // A daemon of another profile (absent field = default profile) is not a double-start
+    // either: profiles are isolated universes, so hunt past it like any foreign process.
+    if (occupant && occupant.pid !== identity.pid && occupant.profile === identity.profile) {
       throw new DaemonAlreadyRunningError(occupant, probeUrl);
     }
     if (attempt + 1 >= PORT_HUNT_ATTEMPTS) {

--- a/packages/common/src/node/index.ts
+++ b/packages/common/src/node/index.ts
@@ -2,7 +2,7 @@
 import { readFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
-import { DAEMON_RUNTIME_FILE_SEGMENTS } from '@linkcode/schema/daemon-runtime-constants';
+import { daemonRuntimeFileSegments } from '@linkcode/schema/daemon-runtime-constants';
 
 /**
  * Node-only utilities, exposed via the `@linkcode/common/node` subpath so they never
@@ -31,6 +31,6 @@ export function isPidAlive(pid: number): boolean {
 }
 
 /** Path of the daemon's runtime discovery file under the user's home directory. */
-export function daemonRuntimeFilePath(): string {
-  return join(homedir(), ...DAEMON_RUNTIME_FILE_SEGMENTS);
+export function daemonRuntimeFilePath(profile?: string): string {
+  return join(homedir(), ...daemonRuntimeFileSegments(profile));
 }

--- a/packages/schema/src/daemon-runtime-constants.ts
+++ b/packages/schema/src/daemon-runtime-constants.ts
@@ -8,12 +8,42 @@
 export const DAEMON_DEFAULT_PORT = 19523;
 export const DAEMON_DEFAULT_URL = `http://127.0.0.1:${DAEMON_DEFAULT_PORT}`;
 
-/** Runtime discovery file the daemon writes after binding, as path segments under the user's home directory. */
-export const DAEMON_RUNTIME_FILE_SEGMENTS = ['.linkcode', 'runtime.json'] as const;
+/**
+ * Shape of a profile name. A profile is an isolated state universe on one machine — its own
+ * daemon state directory, discovery file, and device identity — activated via `LINKCODE_PROFILE`
+ * (daemon) or `--profile` (desktop). No profile means the default universe, which is what every
+ * install before profiles used.
+ */
+export const PROFILE_NAME_PATTERN = /^[a-z0-9][a-z0-9-]{0,31}$/;
 
 /**
- * Exit code of a daemon that stood down because a live daemon already serves this machine
- * (one daemon per machine — see apps/daemon/src/runtime.ts). Supervisors treat it as
+ * Normalize a raw profile value: absent/empty means the default profile (`undefined`); anything
+ * else must match {@link PROFILE_NAME_PATTERN}. Throws so an invalid name aborts boot instead of
+ * silently landing in the default universe.
+ */
+export function parseProfileName(raw: string | undefined): string | undefined {
+  if (raw === undefined || raw === '') return undefined;
+  if (!PROFILE_NAME_PATTERN.test(raw)) {
+    throw new TypeError(
+      `invalid profile name ${JSON.stringify(raw)}: expected ${PROFILE_NAME_PATTERN.source}`,
+    );
+  }
+  return raw;
+}
+
+/** The daemon state directory name under the user's home: `.linkcode`, or a profile sibling. */
+export function linkcodeStateDirName(profile?: string): string {
+  return profile === undefined ? '.linkcode' : `.linkcode-${profile}`;
+}
+
+/** Runtime discovery file the daemon writes after binding, as path segments under the user's home directory. */
+export function daemonRuntimeFileSegments(profile?: string): readonly [string, string] {
+  return [linkcodeStateDirName(profile), 'runtime.json'];
+}
+
+/**
+ * Exit code of a daemon that stood down because a live daemon already serves this profile
+ * (one daemon per profile — see apps/daemon/src/runtime.ts). Supervisors treat it as
  * "someone else is serving", not as a crash to restart.
  */
 export const DAEMON_EXIT_ALREADY_RUNNING = 3;

--- a/packages/schema/src/daemon-runtime-constants.ts
+++ b/packages/schema/src/daemon-runtime-constants.ts
@@ -31,9 +31,14 @@ export function parseProfileName(raw: string | undefined): string | undefined {
   return raw;
 }
 
-/** The daemon state directory name under the user's home: `.linkcode`, or a profile sibling. */
+/**
+ * The daemon state directory name under the user's home: `.linkcode`, or a profile sibling.
+ * Validates its input so no caller can interpolate a traversal (`../x`) or separator into a
+ * path segment — safety lives in the helper, not in caller discipline.
+ */
 export function linkcodeStateDirName(profile?: string): string {
-  return profile === undefined ? '.linkcode' : `.linkcode-${profile}`;
+  const parsed = parseProfileName(profile);
+  return parsed === undefined ? '.linkcode' : `.linkcode-${parsed}`;
 }
 
 /** Runtime discovery file the daemon writes after binding, as path segments under the user's home directory. */

--- a/packages/schema/src/daemon-runtime.ts
+++ b/packages/schema/src/daemon-runtime.ts
@@ -12,8 +12,13 @@ export {
   DAEMON_DEFAULT_PORT,
   DAEMON_DEFAULT_URL,
   DAEMON_EXIT_ALREADY_RUNNING,
-  DAEMON_RUNTIME_FILE_SEGMENTS,
+  daemonRuntimeFileSegments,
+  linkcodeStateDirName,
+  PROFILE_NAME_PATTERN,
+  parseProfileName,
 } from './daemon-runtime-constants';
+
+import { PROFILE_NAME_PATTERN } from './daemon-runtime-constants';
 
 /** HTTP path every daemon listener answers with its `DaemonIdentity`. */
 export const DAEMON_IDENTITY_PATH = '/linkcode';
@@ -23,6 +28,8 @@ export const DaemonIdentitySchema = z.object({
   name: z.literal('linkcode-daemon'),
   pid: z.number().int().positive(),
   startedAt: TimestampSchema,
+  /** The daemon's profile; absent means the default profile (pre-profile daemons included). */
+  profile: z.string().regex(PROFILE_NAME_PATTERN).optional(),
 });
 export type DaemonIdentity = z.infer<typeof DaemonIdentitySchema>;
 


### PR DESCRIPTION
Part 1 of CODE-167 (daemon/schema/common side; the desktop `--profile` identity wiring is the follow-up PR).

## What

A **profile** is an isolated state universe on one machine, activated via `LINKCODE_PROFILE`. No profile = the default universe — behavior is byte-identical to before, zero migration.

- `packages/schema` (zero-dep constants): `PROFILE_NAME_PATTERN` (`/^[a-z0-9][a-z0-9-]{0,31}$/`), `parseProfileName` (empty → default; invalid → throw, aborting boot), `linkcodeStateDirName`, and `DAEMON_RUNTIME_FILE_SEGMENTS` → `daemonRuntimeFileSegments(profile?)`. `DaemonIdentitySchema`/`DaemonRuntimeInfoSchema` gain an optional `profile` field (absent = default, so pre-profile daemons parse unchanged). HTTP/file layer only — **no wire-protocol bump**.
- `packages/common`: `daemonRuntimeFilePath(profile?)`.
- `apps/daemon`: all five state paths (`config.json`, `daemon.db`, `hq.json`, `device-key.pem`, `keys/`) resolve under `~/.linkcode-<profile>`; `runtime.json` and `GET /linkcode` advertise the profile; the port hunt treats a live daemon of **another** profile as a port neighbor to hunt past, while a **same-profile** daemon still triggers `DAEMON_EXIT_ALREADY_RUNNING` — single-instance semantics go from per-machine to per-profile. Device identity forks with the state dir, which is what lets two profiles hold concurrent HQ uplinks (the relay evicts same-device-id peers).

Deliberately **not** profile-scoped: `~/LinkCode` workspaces, the managed asset store (content-addressed cache), and the `linkcode://` scheme.

## Verification

- Unit: profile path resolution (default/sibling/empty/invalid-throws), hunt past other-profile vs refuse same-profile (6 new tests; suite 103 files / 756 pass).
- Live, against a real pre-profile daemon holding 19523: an `alpha` daemon hunted to 19524, wrote `~/.linkcode-alpha/runtime.json` with `"profile": "alpha"`, served it at `GET /linkcode`; a second default-profile daemon correctly stood down against the pre-profile occupant (absent field = default); SIGTERM removed the runtime file and freed the port.
- Whole-repo typecheck + lint + format pass.