### PR TITLE
feat(ui): icon-based sidebar host footer

### DIFF
--- a/packages/i18n/src/locales/en.ts
+++ b/packages/i18n/src/locales/en.ts
@@ -261,6 +261,7 @@ export const en = {
       registerWorkspaceError: 'Failed to add workspace: {message}',
       organization: 'Organization',
       signInCloud: 'Sign in to LinkCode Cloud',
+      account: 'Account',
       manageAccount: 'Manage account',
       signOut: 'Sign out',
       remoteSignedOut: 'Sign in to connect',

--- a/packages/i18n/src/locales/zh-cn.ts
+++ b/packages/i18n/src/locales/zh-cn.ts
@@ -256,6 +256,7 @@ export const zhCN = {
       registerWorkspaceError: '添加工作区失败：{message}',
       organization: '组织',
       signInCloud: '登录 LinkCode Cloud',
+      account: '账户',
       manageAccount: '管理账户',
       signOut: '退出登录',
       remoteSignedOut: '登录后可连接远程主机',

--- a/packages/ui/src/shell/session-sidebar.tsx
+++ b/packages/ui/src/shell/session-sidebar.tsx
@@ -12,7 +12,6 @@ import {
   SidebarMenu,
   SidebarMenuButton,
   SidebarMenuItem,
-  SidebarSeparator,
 } from 'coss-ui/components/sidebar';
 import {
   BotIcon,
@@ -23,6 +22,7 @@ import {
   FilePlus2Icon,
   LogOutIcon,
   SearchIcon,
+  ServerIcon,
   SettingsIcon,
   SparklesIcon,
 } from 'lucide-react';
@@ -186,18 +186,15 @@ export function DefaultHostFooter({
   if (!latency) return <HostFooter state={state} />;
 
   return (
-    <>
-      <SidebarSeparator className="mx-0 self-center data-[orientation=horizontal]:w-[calc(100%-1rem)]" />
-      <SidebarFooter className="shrink-0 px-2 py-1">
-        <div className="flex h-8 items-center gap-2 px-2 text-sm">
-          <span className="size-2 rounded-full bg-success" />
-          <span>Local Host</span>
-          {state && <span className="text-muted-foreground">{state}</span>}
-          <span className="text-muted-foreground">{latency}</span>
-          <ChevronUpIcon className="ml-auto size-4 text-muted-foreground" />
-        </div>
-      </SidebarFooter>
-    </>
+    <SidebarFooter className="shrink-0 px-2 py-1">
+      <div className="flex h-8 items-center gap-2 px-2 text-sm">
+        <span className="size-2 rounded-full bg-success" />
+        <span>Local Host</span>
+        {state && <span className="text-muted-foreground">{state}</span>}
+        <span className="text-muted-foreground">{latency}</span>
+        <ChevronUpIcon className="ml-auto size-4 text-muted-foreground" />
+      </div>
+    </SidebarFooter>
   );
 }
 
@@ -240,37 +237,69 @@ export function HostFooter({
   const tPalette = useTranslations('workbench.palette');
   const pendingPermissionLabel =
     pendingPermissionCount === 1 ? '1 pending' : `${pendingPermissionCount} pending`;
-  const openingSettingsRef = useRef(false);
+  const footerRef = useRef<HTMLDivElement>(null);
 
   return (
     <Popover>
-      <SidebarSeparator className="mx-0 self-center data-[orientation=horizontal]:w-[calc(100%-1rem)]" />
       <SidebarFooter className="shrink-0 px-2 py-1">
-        <SidebarMenu>
-          <SidebarMenuItem>
-            <PopoverTrigger
-              render={
-                <SidebarMenuButton className="hover:bg-transparent focus-visible:ring-1 focus-visible:ring-inset">
-                  <span className="size-2 rounded-full bg-success" />
-                  <span>Local Host</span>
-                  {state && <span className="text-muted-foreground">{state}</span>}
-                  <ChevronUpIcon className="ml-auto text-muted-foreground" />
-                </SidebarMenuButton>
-              }
-            />
-          </SidebarMenuItem>
-        </SidebarMenu>
+        <div ref={footerRef} className="flex items-center gap-1">
+          <PopoverTrigger
+            render={
+              <Button
+                size="icon-sm"
+                variant="ghost"
+                className="relative"
+                aria-label={state ? `Local Host · ${state}` : 'Local Host'}
+              >
+                <ServerIcon />
+                <span className="absolute right-1 bottom-1 size-2 rounded-full bg-success ring-2 ring-sidebar" />
+              </Button>
+            }
+          />
+          <div className="ml-auto flex items-center gap-1">
+            {account ? (
+              <PopoverTrigger
+                render={
+                  <Button size="icon-sm" variant="ghost" aria-label={t('account')}>
+                    <Avatar className="size-6">
+                      {account.image && <AvatarImage src={account.image} alt={account.name} />}
+                      <AvatarFallback className="bg-primary text-primary-foreground text-[10px]">
+                        {accountInitial(account)}
+                      </AvatarFallback>
+                    </Avatar>
+                  </Button>
+                }
+              />
+            ) : (
+              <Button
+                size="icon-sm"
+                variant="ghost"
+                aria-label={t('signInCloud')}
+                loading={authPending}
+                disabled={!onSignIn}
+                onClick={onSignIn}
+              >
+                <CloudIcon />
+              </Button>
+            )}
+            <Button
+              size="icon-sm"
+              variant="ghost"
+              aria-label={tPalette('openSettings')}
+              disabled={!onOpenSettings}
+              onClick={onOpenSettings}
+            >
+              <SettingsIcon />
+            </Button>
+          </div>
+        </div>
       </SidebarFooter>
       <PopoverPopup
         side="top"
         align="start"
         sideOffset={8}
+        anchor={footerRef}
         className="w-80 text-sm"
-        finalFocus={(closeType) => {
-          const restoreFocus = closeType === 'keyboard' && !openingSettingsRef.current;
-          openingSettingsRef.current = false;
-          return restoreFocus;
-        }}
       >
         <div className="flex items-center gap-2 py-1.5">
           <span className="size-2 rounded-full bg-success" />
@@ -374,22 +403,6 @@ export function HostFooter({
               }
             />
           )}
-          <PopoverClose
-            render={
-              <Button
-                disabled={!onOpenSettings}
-                size="icon-sm"
-                variant="outline"
-                aria-label={tPalette('openSettings')}
-                onClick={() => {
-                  openingSettingsRef.current = true;
-                  onOpenSettings?.();
-                }}
-              >
-                <SettingsIcon />
-              </Button>
-            }
-          />
         </div>
       </PopoverPopup>
     </Popover>
@@ -474,14 +487,11 @@ function HostFooterRow({
 
 export function EmptyHostFooter(): React.ReactNode {
   return (
-    <>
-      <SidebarSeparator className="mx-0 self-center data-[orientation=horizontal]:w-[calc(100%-1rem)]" />
-      <SidebarFooter className="shrink-0 px-2 py-1">
-        <div className="flex h-8 items-center gap-2 px-2 text-muted-foreground text-sm">
-          <BotIcon className="size-4" />
-          Local Host
-        </div>
-      </SidebarFooter>
-    </>
+    <SidebarFooter className="shrink-0 px-2 py-1">
+      <div className="flex h-8 items-center gap-2 px-2 text-muted-foreground text-sm">
+        <BotIcon className="size-4" />
+        Local Host
+      </div>
+    </SidebarFooter>
   );
 }

--- a/packages/ui/src/shell/session-sidebar.tsx
+++ b/packages/ui/src/shell/session-sidebar.tsx
@@ -272,26 +272,34 @@ export function HostFooter({
                 }
               />
             ) : (
-              <Button
-                size="icon-sm"
-                variant="ghost"
-                aria-label={t('signInCloud')}
-                loading={authPending}
-                disabled={!onSignIn}
-                onClick={onSignIn}
-              >
-                <CloudIcon />
-              </Button>
+              <PopoverClose
+                render={
+                  <Button
+                    size="icon-sm"
+                    variant="ghost"
+                    aria-label={t('signInCloud')}
+                    loading={authPending}
+                    disabled={!onSignIn}
+                    onClick={onSignIn}
+                  >
+                    <CloudIcon />
+                  </Button>
+                }
+              />
             )}
-            <Button
-              size="icon-sm"
-              variant="ghost"
-              aria-label={tPalette('openSettings')}
-              disabled={!onOpenSettings}
-              onClick={onOpenSettings}
-            >
-              <SettingsIcon />
-            </Button>
+            <PopoverClose
+              render={
+                <Button
+                  size="icon-sm"
+                  variant="ghost"
+                  aria-label={tPalette('openSettings')}
+                  disabled={!onOpenSettings}
+                  onClick={onOpenSettings}
+                >
+                  <SettingsIcon />
+                </Button>
+              }
+            />
           </div>
         </div>
       </SidebarFooter>

--- a/packages/ui/src/shell/session-sidebar.tsx
+++ b/packages/ui/src/shell/session-sidebar.tsx
@@ -13,6 +13,7 @@ import {
   SidebarMenuButton,
   SidebarMenuItem,
 } from 'coss-ui/components/sidebar';
+import type { LucideIcon } from 'lucide-react';
 import {
   BotIcon,
   CheckIcon,
@@ -20,10 +21,12 @@ import {
   CloudIcon,
   ExternalLinkIcon,
   FilePlus2Icon,
+  GlobeIcon,
   LogOutIcon,
   SearchIcon,
   ServerIcon,
   SettingsIcon,
+  ShieldIcon,
   SparklesIcon,
 } from 'lucide-react';
 import { useRef } from 'react';
@@ -235,8 +238,6 @@ export function HostFooter({
 }): React.ReactNode {
   const t = useTranslations('workbench.sidebar');
   const tPalette = useTranslations('workbench.palette');
-  const pendingPermissionLabel =
-    pendingPermissionCount === 1 ? '1 pending' : `${pendingPermissionCount} pending`;
   const footerRef = useRef<HTMLDivElement>(null);
 
   return (
@@ -302,47 +303,49 @@ export function HostFooter({
         className="w-80 text-sm"
       >
         <div className="flex items-center gap-2 py-1.5">
-          <span className="size-2 rounded-full bg-success" />
+          <ServerIcon className="size-4 shrink-0 text-muted-foreground" />
           <span className="font-semibold">Local Host</span>
-          {state && (
-            <Badge size="sm" variant="success">
-              {state}
-            </Badge>
-          )}
-          {appVersion && (
-            <span className="ml-auto font-mono text-muted-foreground text-xs">{appVersion}</span>
-          )}
+          <div className="ml-auto flex items-center gap-1.5">
+            {state && (
+              <Badge size="sm" variant="success">
+                {state}
+              </Badge>
+            )}
+            {appVersion && (
+              <span className="font-mono text-muted-foreground text-xs">{appVersion}</span>
+            )}
+          </div>
         </div>
 
         <Separator className="my-1" />
 
-        <div className="py-1">
-          <div className="flex h-8 items-center gap-2">
-            <span className="min-w-0 flex-1 truncate">Remote access</span>
+        <div className="py-0.5">
+          <HostRow icon={GlobeIcon} label="Remote access">
             {!account && (
               <span className="text-muted-foreground text-xs">{t('remoteSignedOut')}</span>
             )}
-          </div>
+          </HostRow>
           {account && (
-            <RemoteHostList
-              hosts={remoteHosts}
-              loading={remoteHostsLoading}
-              selectedHostId={selectedHostId}
-              onSelectHost={onSelectHost}
-              loadingLabel={t('remoteHostsLoading')}
-              emptyLabel={t('remoteHostsEmpty')}
-            />
+            <div className="pl-6">
+              <RemoteHostList
+                hosts={remoteHosts}
+                loading={remoteHostsLoading}
+                selectedHostId={selectedHostId}
+                onSelectHost={onSelectHost}
+                loadingLabel={t('remoteHostsLoading')}
+                emptyLabel={t('remoteHostsEmpty')}
+              />
+            </div>
           )}
         </div>
-        <HostFooterRow label="Permission requests">
-          <span className="text-muted-foreground text-xs">{pendingPermissionLabel}</span>
-        </HostFooterRow>
-
-        <Separator className="my-1" />
-
-        <HostFooterRow label="Agent availability">
+        <HostRow icon={ShieldIcon} label="Permission requests">
+          <Badge size="sm" variant={pendingPermissionCount > 0 ? 'warning' : 'secondary'}>
+            {pendingPermissionCount}
+          </Badge>
+        </HostRow>
+        <HostRow icon={BotIcon} label="Agent availability">
           <span className="text-muted-foreground text-xs">Not reported</span>
-        </HostFooterRow>
+        </HostRow>
 
         <Separator className="my-1" />
 
@@ -470,15 +473,18 @@ function RemoteHostList({
   );
 }
 
-function HostFooterRow({
+function HostRow({
+  icon: Icon,
   label,
   children,
 }: {
+  icon: LucideIcon;
   label: string;
   children?: React.ReactNode;
 }): React.ReactNode {
   return (
     <div className="flex h-8 items-center gap-2">
+      <Icon className="size-4 shrink-0 text-muted-foreground" />
       <span className="min-w-0 flex-1 truncate">{label}</span>
       {children}
     </div>


### PR DESCRIPTION
把左下角侧边栏 footer 及其 daemon/host Popover 一起重做为图标化 UI。

## Footer（图标条）
- 主机行由 `🟢 Local Host [state] ⌃` 文字行改为图标：`ServerIcon` + 右下角在线圆点，点击打开主机 Popover。
- 右侧两枚直接图标：账号头像（已登录，点击开同一 Popover）/ `CloudIcon` 登录（未登录），以及 `SettingsIcon` 齿轮——设置从 Popover 内提到 footer 一键直达。
- 去掉 footer 上方多余分割线（三个变体 `HostFooter`/`DefaultHostFooter`/`EmptyHostFooter` 一并去除，收掉随之多余的单子节点 fragment）。
- 两个触发器（主机图标 + 头像）共用同一 Popover（base-ui 多 trigger），`anchor={footerRef}` 锚定整条 footer 保证位置稳定。

## Daemon host dropdown（重构）
- Header：`ServerIcon` + `Local Host` + 状态 Badge + 版本（替换裸圆点）。
- 每行加 leading 图标：`🌐 Remote access` / `🛡 Permission requests` / `🤖 Agent availability`（新增可复用 `HostRow`，取代纯文字 `HostFooterRow`）。
- 权限请求由「N pending」整句改为数字 Badge——有待批=amber(`warning`)，为 0=静默(`secondary`)。
- 远程主机列表缩进到「Remote access」标签之下，形成层级。
- 分割线由 3 条减到 2 条（header 后 / account 前），中间三行成组。
- 账号块（头像 + 名称/邮箱 + 管理/退出，或登录按钮）保持不变。

新增 i18n `workbench.sidebar.account`（头像触发器 aria-label）。

## Verify
- `tsc` / ESLint(0 error) / Biome ✅
- `pnpm test` 757 passed ✅
- jsdom 渲染冒烟（一次性、已删）：footer 两态渲染无崩；点开 Popover 后 `Remote access`/`Permission requests`/`Agent availability` 图标行、权限数字 Badge、版本、账号邮箱均正确渲染。
- 真机桌面视觉待确认（webview 用 `DefaultHostFooter`，不经此图标条/新 dropdown）。