### PR TITLE
feat(settings): Codex-style grouped settings nav + General/Appearance split

### DIFF
--- a/apps/desktop/src/renderer/src/settings/appearance-tab.tsx
+++ b/apps/desktop/src/renderer/src/settings/appearance-tab.tsx
@@ -1,0 +1,9 @@
+import { AppearanceSettingsPanel } from '@linkcode/ui';
+import { useDesktopSettingsStore } from './store';
+
+export function AppearanceTab(): React.ReactNode {
+  const theme = useDesktopSettingsStore((state) => state.theme);
+  const setTheme = useDesktopSettingsStore((state) => state.setTheme);
+
+  return <AppearanceSettingsPanel theme={theme} onThemeChange={setTheme} />;
+}

--- a/apps/desktop/src/renderer/src/settings/general-tab.tsx
+++ b/apps/desktop/src/renderer/src/settings/general-tab.tsx
@@ -2,17 +2,8 @@ import { GeneralSettingsPanel } from '@linkcode/ui';
 import { useDesktopSettingsStore } from './store';
 
 export function GeneralTab(): React.ReactNode {
-  const theme = useDesktopSettingsStore((state) => state.theme);
-  const setTheme = useDesktopSettingsStore((state) => state.setTheme);
   const localeOverride = useDesktopSettingsStore((state) => state.localeOverride);
   const setLocaleOverride = useDesktopSettingsStore((state) => state.setLocaleOverride);
 
-  return (
-    <GeneralSettingsPanel
-      theme={theme}
-      onThemeChange={setTheme}
-      locale={localeOverride}
-      onLocaleChange={setLocaleOverride}
-    />
-  );
+  return <GeneralSettingsPanel locale={localeOverride} onLocaleChange={setLocaleOverride} />;
 }

--- a/apps/desktop/src/renderer/src/settings/settings-view.tsx
+++ b/apps/desktop/src/renderer/src/settings/settings-view.tsx
@@ -17,6 +17,7 @@ import {
   KeyRoundIcon,
   SendIcon,
   SettingsIcon,
+  SunMoonIcon,
   WifiIcon,
 } from 'lucide-react';
 import { useRef } from 'react';
@@ -28,6 +29,7 @@ import type { DesktopShellStyle } from '../shell/layout/shell-style';
 import { DEFAULT_LAYOUT } from '../shell/store/model';
 import { AboutTab } from './about-tab';
 import { AgentsTab } from './agents-tab';
+import { AppearanceTab } from './appearance-tab';
 import { ConnectionTab } from './connection-tab';
 import { GeneralTab } from './general-tab';
 import { HistoryImportTab } from './history-import-tab';
@@ -123,77 +125,102 @@ export function SettingsView(): React.ReactNode {
                 backAutoFocus
                 onBack={backFromOverlay}
                 searchPlaceholder={t('searchPlaceholder')}
-                items={[
+                groups={[
                   {
-                    key: 'general',
-                    icon: <SettingsIcon className="size-4" />,
-                    label: t('tabs.general'),
-                    active: category === 'general',
-                    onClick: () => setCategory('general'),
-                  },
-                  {
-                    key: 'connection',
-                    icon: <WifiIcon className="size-4" />,
-                    label: t('tabs.connection'),
-                    active: category === 'connection',
-                    onClick: () => setCategory('connection'),
-                  },
-                  {
-                    key: 'notifications',
-                    icon: <BellIcon className="size-4" />,
-                    label: t('tabs.notifications'),
-                    active: category === 'notifications',
-                    onClick: () => setCategory('notifications'),
-                  },
-                  {
-                    key: 'about',
-                    icon: <InfoIcon className="size-4" />,
-                    label: t('tabs.about'),
-                    active: category === 'about',
-                    onClick: () => setCategory('about'),
-                  },
-                  {
-                    key: 'providers',
-                    icon: <KeyRoundIcon className="size-4" />,
-                    label: t('tabs.providers'),
-                    active: category === 'providers',
-                    onClick: () => setCategory('providers'),
-                  },
-                  {
-                    key: 'agents',
-                    icon: <BotIcon className="size-4" />,
-                    label: t('tabs.agents'),
-                    active: category === 'agents',
-                    onClick: () => setCategory('agents'),
-                  },
-                  {
-                    key: 'imChannel',
-                    icon: <SendIcon className="size-4" />,
-                    label: t('tabs.imChannel'),
-                    active: category === 'imChannel',
-                    onClick: () => setCategory('imChannel'),
-                  },
-                  {
-                    key: 'history-import',
-                    icon: <HistoryIcon className="size-4" />,
-                    label: t('historyImport.portalLabel'),
-                    active: category === 'history-import',
-                    // The disclosure row selects the section's first provider (the accordion
-                    // opens via `active`); it is never highlighted itself.
-                    onClick() {
-                      setCategory('history-import');
-                      setHistoryProvider(DEFAULT_HISTORY_PROVIDER);
-                    },
-                    children: AGENT_KINDS.map((agentKind) => ({
-                      key: agentKind,
-                      icon: <AgentIcon kind={agentKind} variant="ghost" />,
-                      label: AGENT_LABELS[agentKind],
-                      active: category === 'history-import' && historyProvider === agentKind,
-                      onClick() {
-                        setCategory('history-import');
-                        setHistoryProvider(agentKind);
+                    key: 'personal',
+                    label: t('groups.personal'),
+                    items: [
+                      {
+                        key: 'general',
+                        icon: <SettingsIcon className="size-4" />,
+                        label: t('tabs.general'),
+                        active: category === 'general',
+                        onClick: () => setCategory('general'),
                       },
-                    })),
+                      {
+                        key: 'appearance',
+                        icon: <SunMoonIcon className="size-4" />,
+                        label: t('tabs.appearance'),
+                        active: category === 'appearance',
+                        onClick: () => setCategory('appearance'),
+                      },
+                      {
+                        key: 'notifications',
+                        icon: <BellIcon className="size-4" />,
+                        label: t('tabs.notifications'),
+                        active: category === 'notifications',
+                        onClick: () => setCategory('notifications'),
+                      },
+                    ],
+                  },
+                  {
+                    key: 'integrations',
+                    label: t('groups.integrations'),
+                    items: [
+                      {
+                        key: 'agents',
+                        icon: <BotIcon className="size-4" />,
+                        label: t('tabs.agents'),
+                        active: category === 'agents',
+                        onClick: () => setCategory('agents'),
+                      },
+                      {
+                        key: 'providers',
+                        icon: <KeyRoundIcon className="size-4" />,
+                        label: t('tabs.providers'),
+                        active: category === 'providers',
+                        onClick: () => setCategory('providers'),
+                      },
+                      {
+                        key: 'imChannel',
+                        icon: <SendIcon className="size-4" />,
+                        label: t('tabs.imChannel'),
+                        active: category === 'imChannel',
+                        onClick: () => setCategory('imChannel'),
+                      },
+                      {
+                        key: 'history-import',
+                        icon: <HistoryIcon className="size-4" />,
+                        label: t('historyImport.portalLabel'),
+                        active: category === 'history-import',
+                        // The disclosure row selects the section's first provider (the accordion
+                        // opens via `active`); it is never highlighted itself.
+                        onClick() {
+                          setCategory('history-import');
+                          setHistoryProvider(DEFAULT_HISTORY_PROVIDER);
+                        },
+                        children: AGENT_KINDS.map((agentKind) => ({
+                          key: agentKind,
+                          icon: <AgentIcon kind={agentKind} variant="ghost" />,
+                          label: AGENT_LABELS[agentKind],
+                          active: category === 'history-import' && historyProvider === agentKind,
+                          onClick() {
+                            setCategory('history-import');
+                            setHistoryProvider(agentKind);
+                          },
+                        })),
+                      },
+                    ],
+                  },
+                  {
+                    key: 'system',
+                    label: t('groups.system'),
+                    items: [
+                      {
+                        key: 'connection',
+                        icon: <WifiIcon className="size-4" />,
+                        label: t('tabs.connection'),
+                        active: category === 'connection',
+                        onClick: () => setCategory('connection'),
+                      },
+                      {
+                        key: 'about',
+                        icon: <InfoIcon className="size-4" />,
+                        label: t('tabs.about'),
+                        active: category === 'about',
+                        onClick: () => setCategory('about'),
+                      },
+                    ],
                   },
                 ]}
               />
@@ -222,6 +249,8 @@ function renderSettingsPanel(
   switch (category) {
     case 'general':
       return <GeneralTab />;
+    case 'appearance':
+      return <AppearanceTab />;
     case 'connection':
       return <ConnectionTab />;
     case 'notifications':

--- a/apps/desktop/src/renderer/src/settings/store.ts
+++ b/apps/desktop/src/renderer/src/settings/store.ts
@@ -6,6 +6,7 @@ import { systemBridge } from '../ipc';
 
 export type SettingsCategory =
   | 'general'
+  | 'appearance'
   | 'connection'
   | 'notifications'
   | 'about'

--- a/apps/webview/src/router.tsx
+++ b/apps/webview/src/router.tsx
@@ -1,5 +1,6 @@
 import { RootLayout } from '@webview/routes/root-layout';
 import { AgentsSettings } from '@webview/routes/settings/agents';
+import { AppearanceSettings } from '@webview/routes/settings/appearance';
 import { ConnectionSettings } from '@webview/routes/settings/connection';
 import { GeneralSettings } from '@webview/routes/settings/general';
 import { MessagingSettings } from '@webview/routes/settings/messaging';
@@ -19,6 +20,7 @@ export const router = createBrowserRouter([
         element: <SettingsLayout />,
         children: [
           { index: true, element: <GeneralSettings /> },
+          { path: 'appearance', element: <AppearanceSettings /> },
           { path: 'connection', element: <ConnectionSettings /> },
           { path: 'notifications', element: <NotificationsSettings /> },
           { path: 'providers', element: <ProvidersSettings /> },

--- a/apps/webview/src/routes/settings/appearance.tsx
+++ b/apps/webview/src/routes/settings/appearance.tsx
@@ -1,0 +1,13 @@
+import { AppearanceSettingsPanel } from '@linkcode/ui';
+import { usePageTitle } from '@webview/hooks/use-page-title';
+import { useSettingsStore } from '@webview/settings/store';
+import { useTranslations } from 'use-intl';
+
+export function AppearanceSettings(): React.ReactNode {
+  const tTabs = useTranslations('settings.tabs');
+  usePageTitle(tTabs('appearance'));
+  const theme = useSettingsStore((state) => state.theme);
+  const setTheme = useSettingsStore((state) => state.setTheme);
+
+  return <AppearanceSettingsPanel theme={theme} onThemeChange={setTheme} />;
+}

--- a/apps/webview/src/routes/settings/general.tsx
+++ b/apps/webview/src/routes/settings/general.tsx
@@ -6,17 +6,8 @@ import { useTranslations } from 'use-intl';
 export function GeneralSettings(): React.ReactNode {
   const tTabs = useTranslations('settings.tabs');
   usePageTitle(tTabs('general'));
-  const theme = useSettingsStore((state) => state.theme);
-  const setTheme = useSettingsStore((state) => state.setTheme);
   const locale = useSettingsStore((state) => state.locale);
   const setLocale = useSettingsStore((state) => state.setLocale);
 
-  return (
-    <GeneralSettingsPanel
-      theme={theme}
-      onThemeChange={setTheme}
-      locale={locale}
-      onLocaleChange={setLocale}
-    />
-  );
+  return <GeneralSettingsPanel locale={locale} onLocaleChange={setLocale} />;
 }

--- a/apps/webview/src/routes/settings/settings-layout.tsx
+++ b/apps/webview/src/routes/settings/settings-layout.tsx
@@ -1,5 +1,13 @@
 import { SettingsSidebarNav, ShellSidebar, TitleStrip } from '@linkcode/ui';
-import { BellIcon, BotIcon, KeyRoundIcon, SendIcon, SettingsIcon, WifiIcon } from 'lucide-react';
+import {
+  BellIcon,
+  BotIcon,
+  KeyRoundIcon,
+  SendIcon,
+  SettingsIcon,
+  SunMoonIcon,
+  WifiIcon,
+} from 'lucide-react';
 import { Link, Outlet, useLocation } from 'react-router';
 import { useTranslations } from 'use-intl';
 
@@ -15,48 +23,73 @@ export function SettingsLayout(): React.ReactNode {
             backLabel={t('back')}
             backRender={<Link to="/" />}
             searchPlaceholder={t('searchPlaceholder')}
-            items={[
+            groups={[
               {
-                key: 'general',
-                icon: <SettingsIcon className="size-4" />,
-                label: t('tabs.general'),
-                active: isActive(pathname, ''),
-                render: <Link to="/settings" />,
+                key: 'personal',
+                label: t('groups.personal'),
+                items: [
+                  {
+                    key: 'general',
+                    icon: <SettingsIcon className="size-4" />,
+                    label: t('tabs.general'),
+                    active: isActive(pathname, ''),
+                    render: <Link to="/settings" />,
+                  },
+                  {
+                    key: 'appearance',
+                    icon: <SunMoonIcon className="size-4" />,
+                    label: t('tabs.appearance'),
+                    active: isActive(pathname, 'appearance'),
+                    render: <Link to="/settings/appearance" />,
+                  },
+                  {
+                    key: 'notifications',
+                    icon: <BellIcon className="size-4" />,
+                    label: t('tabs.notifications'),
+                    active: isActive(pathname, 'notifications'),
+                    render: <Link to="/settings/notifications" />,
+                  },
+                ],
               },
               {
-                key: 'connection',
-                icon: <WifiIcon className="size-4" />,
-                label: t('tabs.connection'),
-                active: isActive(pathname, 'connection'),
-                render: <Link to="/settings/connection" />,
+                key: 'integrations',
+                label: t('groups.integrations'),
+                items: [
+                  {
+                    key: 'agents',
+                    icon: <BotIcon className="size-4" />,
+                    label: t('tabs.agents'),
+                    active: isActive(pathname, 'agents'),
+                    render: <Link to="/settings/agents" />,
+                  },
+                  {
+                    key: 'providers',
+                    icon: <KeyRoundIcon className="size-4" />,
+                    label: t('tabs.providers'),
+                    active: isActive(pathname, 'providers'),
+                    render: <Link to="/settings/providers" />,
+                  },
+                  {
+                    key: 'messaging',
+                    icon: <SendIcon className="size-4" />,
+                    label: t('tabs.imChannel'),
+                    active: isActive(pathname, 'messaging'),
+                    render: <Link to="/settings/messaging" />,
+                  },
+                ],
               },
               {
-                key: 'notifications',
-                icon: <BellIcon className="size-4" />,
-                label: t('tabs.notifications'),
-                active: isActive(pathname, 'notifications'),
-                render: <Link to="/settings/notifications" />,
-              },
-              {
-                key: 'providers',
-                icon: <KeyRoundIcon className="size-4" />,
-                label: t('tabs.providers'),
-                active: isActive(pathname, 'providers'),
-                render: <Link to="/settings/providers" />,
-              },
-              {
-                key: 'agents',
-                icon: <BotIcon className="size-4" />,
-                label: t('tabs.agents'),
-                active: isActive(pathname, 'agents'),
-                render: <Link to="/settings/agents" />,
-              },
-              {
-                key: 'messaging',
-                icon: <SendIcon className="size-4" />,
-                label: t('tabs.imChannel'),
-                active: isActive(pathname, 'messaging'),
-                render: <Link to="/settings/messaging" />,
+                key: 'system',
+                label: t('groups.system'),
+                items: [
+                  {
+                    key: 'connection',
+                    icon: <WifiIcon className="size-4" />,
+                    label: t('tabs.connection'),
+                    active: isActive(pathname, 'connection'),
+                    render: <Link to="/settings/connection" />,
+                  },
+                ],
               },
             ]}
           />
@@ -81,7 +114,14 @@ export function SettingsLayout(): React.ReactNode {
 
 function isActive(
   pathname: string,
-  section: '' | 'connection' | 'notifications' | 'providers' | 'agents' | 'messaging',
+  section:
+    | ''
+    | 'appearance'
+    | 'connection'
+    | 'notifications'
+    | 'providers'
+    | 'agents'
+    | 'messaging',
 ): boolean {
   return pathname.replace(/\/$/, '') === `/settings${section ? `/${section}` : ''}`;
 }

--- a/packages/i18n/src/locales/en.ts
+++ b/packages/i18n/src/locales/en.ts
@@ -371,8 +371,14 @@ export const en = {
     title: 'Settings',
     back: 'Back',
     searchPlaceholder: 'Search settings...',
+    groups: {
+      personal: 'Personal',
+      integrations: 'Integrations',
+      system: 'System',
+    },
     tabs: {
       general: 'General',
+      appearance: 'Appearance',
       connection: 'Connection',
       notifications: 'Notifications',
       about: 'About',
@@ -403,15 +409,15 @@ export const en = {
       messageCount: '{count, plural, one {# message} other {# messages}}',
     },
     general: {
-      appearance: 'Appearance',
-      appearanceHint: 'How LinkCode looks on this device.',
+      language: 'Language',
+      languageHint: 'Interface language. Auto follows your system.',
+      languageAuto: 'Auto',
+    },
+    appearance: {
       theme: 'Theme',
       themeSystem: 'System',
       themeLight: 'Light',
       themeDark: 'Dark',
-      language: 'Language',
-      languageHint: 'Interface language. Auto follows your system.',
-      languageAuto: 'Auto',
     },
     connection: {
       title: 'Daemon',

--- a/packages/i18n/src/locales/zh-cn.ts
+++ b/packages/i18n/src/locales/zh-cn.ts
@@ -365,8 +365,14 @@ export const zhCN = {
     title: '设置',
     back: '返回',
     searchPlaceholder: '搜索设置...',
+    groups: {
+      personal: '个人',
+      integrations: '集成',
+      system: '系统',
+    },
     tabs: {
       general: '通用',
+      appearance: '外观',
       connection: '连接',
       notifications: '通知',
       about: '关于',
@@ -396,15 +402,15 @@ export const zhCN = {
       messageCount: '{count} 条消息',
     },
     general: {
-      appearance: '外观',
-      appearanceHint: 'LinkCode 在此设备上的外观。',
+      language: '语言',
+      languageHint: '界面语言。「自动」跟随系统。',
+      languageAuto: '自动',
+    },
+    appearance: {
       theme: '主题',
       themeSystem: '跟随系统',
       themeLight: '浅色',
       themeDark: '深色',
-      language: '语言',
-      languageHint: '界面语言。「自动」跟随系统。',
-      languageAuto: '自动',
     },
     connection: {
       title: 'Daemon',

--- a/packages/ui/src/shell/appearance-settings-panel.tsx
+++ b/packages/ui/src/shell/appearance-settings-panel.tsx
@@ -1,0 +1,106 @@
+import { useTranslations } from 'use-intl';
+import { cn } from '../lib/cn';
+import { SettingsSection } from './settings-page';
+
+/** Display-layer theme union — apps map their own store's theme type onto this. */
+export type ThemePreference = 'system' | 'light' | 'dark';
+
+const THEME_PREFERENCES: readonly ThemePreference[] = ['system', 'light', 'dark'];
+
+const THEME_LABEL_KEYS = {
+  system: 'themeSystem',
+  light: 'themeLight',
+  dark: 'themeDark',
+} as const;
+
+export interface AppearanceSettingsPanelProps {
+  theme: ThemePreference;
+  onThemeChange: (theme: ThemePreference) => void;
+}
+
+export function AppearanceSettingsPanel({
+  theme,
+  onThemeChange,
+}: AppearanceSettingsPanelProps): React.ReactNode {
+  const t = useTranslations('settings.appearance');
+
+  return (
+    <div className="flex flex-col gap-8">
+      <SettingsSection title={t('theme')}>
+        <div className="flex flex-wrap gap-6">
+          {THEME_PREFERENCES.map((value) => (
+            <ThemePreviewOption
+              key={value}
+              label={t(THEME_LABEL_KEYS[value])}
+              preference={value}
+              selected={theme === value}
+              onSelect={() => onThemeChange(value)}
+            />
+          ))}
+        </div>
+      </SettingsSection>
+    </div>
+  );
+}
+
+function ThemePreviewOption({
+  label,
+  preference,
+  selected,
+  onSelect,
+}: {
+  label: string;
+  preference: ThemePreference;
+  selected: boolean;
+  onSelect: () => void;
+}): React.ReactNode {
+  return (
+    <button
+      type="button"
+      aria-pressed={selected}
+      onClick={onSelect}
+      className="group flex flex-col items-center gap-2 outline-none"
+    >
+      <span
+        className={cn(
+          'relative block h-20 w-32 overflow-hidden rounded-lg border transition-[border-color,box-shadow]',
+          selected
+            ? 'border-primary ring-2 ring-primary/50'
+            : 'border-border group-hover:border-muted-foreground/40 group-focus-visible:ring-2 group-focus-visible:ring-ring',
+        )}
+      >
+        <PreviewPane dark={preference === 'dark'} />
+        {/* System splits one window down the middle: a dark copy clipped to the right half. */}
+        {preference === 'system' && (
+          <span className="absolute inset-0 [clip-path:inset(0_0_0_50%)]">
+            <PreviewPane dark />
+          </span>
+        )}
+      </span>
+      <span className={cn('text-sm', !selected && 'text-muted-foreground')}>{label}</span>
+    </button>
+  );
+}
+
+/** Fixed-palette window mock — a "light" preview must look light even in dark mode. */
+function PreviewPane({ dark = false }: { dark?: boolean }): React.ReactNode {
+  return (
+    <span
+      className={cn(
+        'flex h-full w-full flex-col gap-1.5 p-2.5',
+        dark ? 'bg-zinc-800' : 'bg-zinc-100',
+      )}
+    >
+      <span className={cn('h-1.5 w-10 rounded-full', dark ? 'bg-zinc-500' : 'bg-zinc-400')} />
+      <span
+        className={cn(
+          'flex flex-1 flex-col gap-1 rounded-md p-1.5',
+          dark ? 'bg-zinc-700' : 'bg-white',
+        )}
+      >
+        <span className={cn('h-1 w-3/4 rounded-full', dark ? 'bg-zinc-500' : 'bg-zinc-300')} />
+        <span className={cn('h-1 w-1/2 rounded-full', dark ? 'bg-zinc-500' : 'bg-zinc-300')} />
+      </span>
+    </span>
+  );
+}

--- a/packages/ui/src/shell/general-settings-panel.tsx
+++ b/packages/ui/src/shell/general-settings-panel.tsx
@@ -1,5 +1,3 @@
-import { Field, FieldDescription, FieldLabel } from 'coss-ui/components/field';
-import { RadioGroup, RadioGroupItem } from 'coss-ui/components/radio-group';
 import {
   Select,
   SelectItem,
@@ -8,27 +6,15 @@ import {
   SelectValue,
 } from 'coss-ui/components/select';
 import { useTranslations } from 'use-intl';
-
-/** Display-layer theme union — apps map their own store's theme type onto this. */
-export type ThemePreference = 'system' | 'light' | 'dark';
-
-const THEME_PREFERENCES = new Set<ThemePreference>(['system', 'light', 'dark']);
-
-function isThemePreference(value: unknown): value is ThemePreference {
-  return typeof value === 'string' && THEME_PREFERENCES.has(value as ThemePreference);
-}
+import { SettingsCard, SettingsRow } from './settings-page';
 
 export interface GeneralSettingsPanelProps {
-  theme: ThemePreference;
-  onThemeChange: (theme: ThemePreference) => void;
   /** Locale override, or null to follow the platform default. */
   locale: string | null;
   onLocaleChange: (locale: string | null) => void;
 }
 
 export function GeneralSettingsPanel({
-  theme,
-  onThemeChange,
   locale,
   onLocaleChange,
 }: GeneralSettingsPanelProps): React.ReactNode {
@@ -42,51 +28,26 @@ export function GeneralSettingsPanel({
 
   return (
     <div className="flex flex-col gap-8">
-      <Field>
-        <FieldLabel>{t('theme')}</FieldLabel>
-        <FieldDescription>{t('appearanceHint')}</FieldDescription>
-        <RadioGroup
-          className="mt-1 flex-row gap-5"
-          value={theme}
-          onValueChange={(value) => {
-            if (isThemePreference(value)) onThemeChange(value);
-          }}
-        >
-          <ThemeOption value="system" label={t('themeSystem')} />
-          <ThemeOption value="light" label={t('themeLight')} />
-          <ThemeOption value="dark" label={t('themeDark')} />
-        </RadioGroup>
-      </Field>
-
-      <Field>
-        <FieldLabel>{t('language')}</FieldLabel>
-        <FieldDescription>{t('languageHint')}</FieldDescription>
-        <Select
-          items={languageItems}
-          value={locale ?? 'auto'}
-          onValueChange={(value) => onLocaleChange(value === 'auto' ? null : String(value))}
-        >
-          <SelectTrigger className="mt-1 w-56">
-            <SelectValue />
-          </SelectTrigger>
-          <SelectPopup>
-            {languageItems.map((item) => (
-              <SelectItem key={item.value} value={item.value}>
-                {item.label}
-              </SelectItem>
-            ))}
-          </SelectPopup>
-        </Select>
-      </Field>
+      <SettingsCard>
+        <SettingsRow title={t('language')} description={t('languageHint')}>
+          <Select
+            items={languageItems}
+            value={locale ?? 'auto'}
+            onValueChange={(value) => onLocaleChange(value === 'auto' ? null : String(value))}
+          >
+            <SelectTrigger className="w-40">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectPopup>
+              {languageItems.map((item) => (
+                <SelectItem key={item.value} value={item.value}>
+                  {item.label}
+                </SelectItem>
+              ))}
+            </SelectPopup>
+          </Select>
+        </SettingsRow>
+      </SettingsCard>
     </div>
-  );
-}
-
-function ThemeOption({ value, label }: { value: string; label: string }): React.ReactNode {
-  return (
-    <label className="flex cursor-pointer items-center gap-2 text-sm">
-      <RadioGroupItem value={value} />
-      {label}
-    </label>
   );
 }

--- a/packages/ui/src/shell/index.ts
+++ b/packages/ui/src/shell/index.ts
@@ -1,6 +1,7 @@
 export * from './agent-efforts';
 export * from './agent-models';
 export * from './agent-onboarding-card';
+export * from './appearance-settings-panel';
 export * from './command-palette';
 export * from './composer';
 export * from './conversation-surface';
@@ -14,6 +15,7 @@ export * from './new-session-surface';
 export * from './notifications-settings-panel';
 export * from './service-icon';
 export * from './session-sidebar';
+export * from './settings-page';
 export * from './settings-sidebar-nav';
 export * from './shell-control';
 export * from './shell-frame';

--- a/packages/ui/src/shell/settings-page.tsx
+++ b/packages/ui/src/shell/settings-page.tsx
@@ -1,0 +1,52 @@
+import { Card } from 'coss-ui/components/card';
+import { cn } from '../lib/cn';
+
+/** A titled settings section: small heading floating above its content (Codex-style). */
+export function SettingsSection({
+  title,
+  children,
+}: {
+  title: React.ReactNode;
+  children: React.ReactNode;
+}): React.ReactNode {
+  return (
+    <section className="flex flex-col gap-3">
+      <h3 className="px-1 font-medium text-sm">{title}</h3>
+      {children}
+    </section>
+  );
+}
+
+/** Card container that stacks {@link SettingsRow} children with hairline dividers. */
+export function SettingsCard({
+  className,
+  children,
+}: {
+  className?: string;
+  children: React.ReactNode;
+}): React.ReactNode {
+  return <Card className={cn('divide-y divide-border', className)}>{children}</Card>;
+}
+
+/** One settings row: title + description on the left, the control on the right. */
+export function SettingsRow({
+  title,
+  description,
+  children,
+}: {
+  title: React.ReactNode;
+  description?: React.ReactNode;
+  children: React.ReactNode;
+}): React.ReactNode {
+  return (
+    <div className="flex items-center justify-between gap-6 px-4 py-3.5">
+      <div className="flex min-w-0 flex-col gap-0.5">
+        <span className="font-medium text-sm">{title}</span>
+        {description === undefined ? null : (
+          <span className="text-muted-foreground text-xs">{description}</span>
+        )}
+      </div>
+      <div className="flex shrink-0 items-center">{children}</div>
+    </div>
+  );
+}

--- a/packages/ui/src/shell/settings-sidebar-nav.tsx
+++ b/packages/ui/src/shell/settings-sidebar-nav.tsx
@@ -1,5 +1,8 @@
 import { Collapsible, CollapsiblePanel } from 'coss-ui/components/collapsible';
 import {
+  SidebarGroup,
+  SidebarGroupContent,
+  SidebarGroupLabel,
   SidebarInput,
   SidebarMenu,
   SidebarMenuButton,
@@ -36,6 +39,12 @@ export interface SettingsSidebarNavItem {
   children?: SettingsSidebarNavSubItem[];
 }
 
+export interface SettingsSidebarNavGroup {
+  key: string;
+  label: React.ReactNode;
+  items: SettingsSidebarNavItem[];
+}
+
 export interface SettingsSidebarNavProps {
   backLabel: React.ReactNode;
   onBack?: () => void;
@@ -44,17 +53,17 @@ export interface SettingsSidebarNavProps {
   /** Focuses the back control when a non-routed settings overlay opens. */
   backAutoFocus?: boolean;
   searchPlaceholder: string;
-  items: SettingsSidebarNavItem[];
+  groups: SettingsSidebarNavGroup[];
 }
 
-/** The settings sidebar's inner nav: back row, search placeholder, and category items. */
+/** The settings sidebar's inner nav: back row, search placeholder, and grouped category items. */
 export function SettingsSidebarNav({
   backLabel,
   onBack,
   backRender,
   backAutoFocus,
   searchPlaceholder,
-  items,
+  groups,
 }: SettingsSidebarNavProps): React.ReactNode {
   return (
     <div className="px-2">
@@ -81,58 +90,68 @@ export function SettingsSidebarNav({
       </div>
 
       <nav>
-        <SidebarMenu>
-          {items.map((item) =>
-            item.children === undefined ? (
-              <SidebarMenuItem key={item.key}>
-                <SidebarMenuButton
-                  isActive={Boolean(item.active)}
-                  aria-current={item.active ? 'page' : undefined}
-                  onClick={item.onClick}
-                  render={item.render}
-                >
-                  {item.icon}
-                  {item.label}
-                </SidebarMenuButton>
-              </SidebarMenuItem>
-            ) : (
-              // Accordion category: a disclosure row (never the selected pill) whose expansion +
-              // single highlighted sub-item carry the selection signal.
-              <SidebarMenuItem key={item.key}>
-                <Collapsible open={Boolean(item.active)}>
-                  <SidebarMenuButton onClick={item.onClick} render={item.render}>
-                    {item.icon}
-                    <span className="min-w-0 flex-1 truncate text-left">{item.label}</span>
-                    <ChevronDownIcon
-                      className={cn(
-                        'size-3.5 shrink-0 text-muted-foreground transition-transform',
-                        !item.active && '-rotate-90',
-                      )}
-                    />
-                  </SidebarMenuButton>
-                  <CollapsiblePanel>
-                    <SidebarMenuSub className="my-1">
-                      {item.children.map((child) => (
-                        <SidebarMenuSubItem key={child.key}>
-                          <SidebarMenuButton
-                            className="h-7"
-                            isActive={Boolean(child.active)}
-                            aria-current={child.active ? 'page' : undefined}
-                            onClick={child.onClick}
-                          >
-                            {child.icon}
-                            {child.label}
-                          </SidebarMenuButton>
-                        </SidebarMenuSubItem>
-                      ))}
-                    </SidebarMenuSub>
-                  </CollapsiblePanel>
-                </Collapsible>
-              </SidebarMenuItem>
-            ),
-          )}
-        </SidebarMenu>
+        {groups.map((group) => (
+          <SidebarGroup key={group.key} className="p-0 pb-3">
+            <SidebarGroupLabel className="text-muted-foreground">{group.label}</SidebarGroupLabel>
+            <SidebarGroupContent>
+              <SidebarMenu>{group.items.map(renderNavItem)}</SidebarMenu>
+            </SidebarGroupContent>
+          </SidebarGroup>
+        ))}
       </nav>
     </div>
+  );
+}
+
+function renderNavItem(item: SettingsSidebarNavItem): React.ReactNode {
+  if (item.children === undefined) {
+    return (
+      <SidebarMenuItem key={item.key}>
+        <SidebarMenuButton
+          isActive={Boolean(item.active)}
+          aria-current={item.active ? 'page' : undefined}
+          onClick={item.onClick}
+          render={item.render}
+        >
+          {item.icon}
+          {item.label}
+        </SidebarMenuButton>
+      </SidebarMenuItem>
+    );
+  }
+  // Accordion category: a disclosure row (never the selected pill) whose expansion +
+  // single highlighted sub-item carry the selection signal.
+  return (
+    <SidebarMenuItem key={item.key}>
+      <Collapsible open={Boolean(item.active)}>
+        <SidebarMenuButton onClick={item.onClick} render={item.render}>
+          {item.icon}
+          <span className="min-w-0 flex-1 truncate text-left">{item.label}</span>
+          <ChevronDownIcon
+            className={cn(
+              'size-3.5 shrink-0 text-muted-foreground transition-transform',
+              !item.active && '-rotate-90',
+            )}
+          />
+        </SidebarMenuButton>
+        <CollapsiblePanel>
+          <SidebarMenuSub className="my-1">
+            {item.children.map((child) => (
+              <SidebarMenuSubItem key={child.key}>
+                <SidebarMenuButton
+                  className="h-7"
+                  isActive={Boolean(child.active)}
+                  aria-current={child.active ? 'page' : undefined}
+                  onClick={child.onClick}
+                >
+                  {child.icon}
+                  {child.label}
+                </SidebarMenuButton>
+              </SidebarMenuSubItem>
+            ))}
+          </SidebarMenuSub>
+        </CollapsiblePanel>
+      </Collapsible>
+    </SidebarMenuItem>
   );
 }


### PR DESCRIPTION
Closes CODE-169.

Restructures the Settings surface after Codex.app's information architecture, on both desktop (overlay) and webview (routes):

- **Grouped sidebar**: `SettingsSidebarNav` now takes `groups` (section label + items) instead of a flat item list — **Personal** (General, Appearance, Notifications) / **Integrations** (Agents, Providers, Messaging, Import chat history) / **System** (Connection, About).
- **New Appearance tab**: theme moves out of General into `AppearanceSettingsPanel`, rendered as Codex-style System/Light/Dark mini-window preview cards (pure CSS, fixed palette so a "light" card stays light in dark mode). Persistence unchanged per plane: desktop `settings.json` over IPC, webview localStorage.
- **General reshaped**: Codex-style card rows via new `packages/ui` primitives `SettingsSection` / `SettingsCard` / `SettingsRow` (title + description left, control right, hairline dividers); General keeps Language.
- i18n: `settings.groups.*`, `settings.tabs.appearance`, `settings.appearance.*` (zh-CN + en); theme keys moved out of `settings.general`.

Verified running: webview via Playwright (grouped labels, 3 preview cards, dark applies + persists across reload) and the built desktop app via `_electron.launch` with a fresh `LINKCODE_PROFILE` universe (Settings… menu with daemon down → grouped nav → Appearance → Dark: `nativeTheme` flips, `.dark` applied, `settings.json` persists `"theme": "dark"`). `pnpm check:ci` + `pnpm test` (757) pass.