### PR TITLE
feat(settings): live settings search over the grouped sidebar nav

### DIFF
--- a/apps/desktop/src/renderer/src/settings/settings-view.tsx
+++ b/apps/desktop/src/renderer/src/settings/settings-view.tsx
@@ -246,7 +246,15 @@ export function SettingsView(): React.ReactNode {
                 searchValue={searchQuery}
                 onSearchChange={setSearchQuery}
                 onSearchSubmit={() => {
-                  visibleGroups.flatMap((group) => group.items)[0]?.onClick?.();
+                  const first = visibleGroups.flatMap((group) => group.items)[0];
+                  if (first === undefined) return;
+                  // A query that matched an accordion child by name lands on that child, not
+                  // the parent's default selection ("codex" → History import → Codex).
+                  const query = searchQuery.trim().toLowerCase();
+                  const child = first.children?.find((item) =>
+                    item.label.toLowerCase().includes(query),
+                  );
+                  (child ?? first).onClick?.();
                 }}
                 searchEmptyLabel={t('searchNoResults')}
                 groups={visibleGroups}

--- a/apps/desktop/src/renderer/src/settings/settings-view.tsx
+++ b/apps/desktop/src/renderer/src/settings/settings-view.tsx
@@ -7,7 +7,11 @@ import {
   ShellSidebar,
   useKeyboardShortcut,
 } from '@linkcode/ui';
-import { useNavigationHistoryStore } from '@linkcode/workbench';
+import {
+  filterSettingsNavGroups,
+  useNavigationHistoryStore,
+  useSettingsSearchKeywords,
+} from '@linkcode/workbench';
 import { noop } from 'foxact/noop';
 import {
   BellIcon,
@@ -20,7 +24,7 @@ import {
   SunMoonIcon,
   WifiIcon,
 } from 'lucide-react';
-import { useRef } from 'react';
+import { useRef, useState } from 'react';
 import { useTranslations } from 'use-intl';
 import { systemBridge } from '../ipc';
 import { DesktopChrome } from '../shell/chrome/chrome';
@@ -63,6 +67,8 @@ export function SettingsView(): React.ReactNode {
   const setCategory = useDesktopSettingsStore((state) => state.setSettingsCategory);
   const historyProvider = useDesktopSettingsStore((state) => state.historyImportProvider);
   const setHistoryProvider = useDesktopSettingsStore((state) => state.setHistoryImportProvider);
+  const [searchQuery, setSearchQuery] = useState('');
+  const searchKeywords = useSettingsSearchKeywords();
   const settingsRootRef = useRef<HTMLDivElement>(null);
   const desktopPlatform = systemBridge.app.platform;
   const hasNativeTrafficLights = desktopPlatform === 'darwin';
@@ -78,6 +84,118 @@ export function SettingsView(): React.ReactNode {
       return true;
     },
   });
+
+  const navGroups = [
+    {
+      key: 'personal',
+      label: t('groups.personal'),
+      items: [
+        {
+          key: 'general',
+          icon: <SettingsIcon className="size-4" />,
+          label: t('tabs.general'),
+          keywords: searchKeywords.general,
+          active: category === 'general',
+          onClick: () => setCategory('general'),
+        },
+        {
+          key: 'appearance',
+          icon: <SunMoonIcon className="size-4" />,
+          label: t('tabs.appearance'),
+          keywords: searchKeywords.appearance,
+          active: category === 'appearance',
+          onClick: () => setCategory('appearance'),
+        },
+        {
+          key: 'notifications',
+          icon: <BellIcon className="size-4" />,
+          label: t('tabs.notifications'),
+          keywords: searchKeywords.notifications,
+          active: category === 'notifications',
+          onClick: () => setCategory('notifications'),
+        },
+      ],
+    },
+    {
+      key: 'integrations',
+      label: t('groups.integrations'),
+      items: [
+        {
+          key: 'agents',
+          icon: <BotIcon className="size-4" />,
+          label: t('tabs.agents'),
+          keywords: searchKeywords.agents,
+          active: category === 'agents',
+          onClick: () => setCategory('agents'),
+        },
+        {
+          key: 'providers',
+          icon: <KeyRoundIcon className="size-4" />,
+          label: t('tabs.providers'),
+          keywords: searchKeywords.providers,
+          active: category === 'providers',
+          onClick: () => setCategory('providers'),
+        },
+        {
+          key: 'imChannel',
+          icon: <SendIcon className="size-4" />,
+          label: t('tabs.imChannel'),
+          keywords: searchKeywords.imChannel,
+          active: category === 'imChannel',
+          onClick: () => setCategory('imChannel'),
+        },
+        {
+          key: 'history-import',
+          icon: <HistoryIcon className="size-4" />,
+          label: t('historyImport.portalLabel'),
+          keywords: [
+            ...searchKeywords.historyImport,
+            ...AGENT_KINDS.map((agentKind) => AGENT_LABELS[agentKind]),
+          ],
+          active: category === 'history-import',
+          // The disclosure row selects the section's first provider (the accordion
+          // opens via `active`); it is never highlighted itself.
+          onClick() {
+            setCategory('history-import');
+            setHistoryProvider(DEFAULT_HISTORY_PROVIDER);
+          },
+          children: AGENT_KINDS.map((agentKind) => ({
+            key: agentKind,
+            icon: <AgentIcon kind={agentKind} variant="ghost" />,
+            label: AGENT_LABELS[agentKind],
+            active: category === 'history-import' && historyProvider === agentKind,
+            onClick() {
+              setCategory('history-import');
+              setHistoryProvider(agentKind);
+            },
+          })),
+        },
+      ],
+    },
+    {
+      key: 'system',
+      label: t('groups.system'),
+      items: [
+        {
+          key: 'connection',
+          icon: <WifiIcon className="size-4" />,
+          label: t('tabs.connection'),
+          keywords: searchKeywords.connection,
+          active: category === 'connection',
+          onClick: () => setCategory('connection'),
+        },
+        {
+          key: 'about',
+          icon: <InfoIcon className="size-4" />,
+          label: t('tabs.about'),
+          keywords: searchKeywords.about,
+          active: category === 'about',
+          onClick: () => setCategory('about'),
+        },
+      ],
+    },
+  ];
+  const visibleGroups = filterSettingsNavGroups(navGroups, searchQuery);
 
   return (
     <div
@@ -125,104 +243,13 @@ export function SettingsView(): React.ReactNode {
                 backAutoFocus
                 onBack={backFromOverlay}
                 searchPlaceholder={t('searchPlaceholder')}
-                groups={[
-                  {
-                    key: 'personal',
-                    label: t('groups.personal'),
-                    items: [
-                      {
-                        key: 'general',
-                        icon: <SettingsIcon className="size-4" />,
-                        label: t('tabs.general'),
-                        active: category === 'general',
-                        onClick: () => setCategory('general'),
-                      },
-                      {
-                        key: 'appearance',
-                        icon: <SunMoonIcon className="size-4" />,
-                        label: t('tabs.appearance'),
-                        active: category === 'appearance',
-                        onClick: () => setCategory('appearance'),
-                      },
-                      {
-                        key: 'notifications',
-                        icon: <BellIcon className="size-4" />,
-                        label: t('tabs.notifications'),
-                        active: category === 'notifications',
-                        onClick: () => setCategory('notifications'),
-                      },
-                    ],
-                  },
-                  {
-                    key: 'integrations',
-                    label: t('groups.integrations'),
-                    items: [
-                      {
-                        key: 'agents',
-                        icon: <BotIcon className="size-4" />,
-                        label: t('tabs.agents'),
-                        active: category === 'agents',
-                        onClick: () => setCategory('agents'),
-                      },
-                      {
-                        key: 'providers',
-                        icon: <KeyRoundIcon className="size-4" />,
-                        label: t('tabs.providers'),
-                        active: category === 'providers',
-                        onClick: () => setCategory('providers'),
-                      },
-                      {
-                        key: 'imChannel',
-                        icon: <SendIcon className="size-4" />,
-                        label: t('tabs.imChannel'),
-                        active: category === 'imChannel',
-                        onClick: () => setCategory('imChannel'),
-                      },
-                      {
-                        key: 'history-import',
-                        icon: <HistoryIcon className="size-4" />,
-                        label: t('historyImport.portalLabel'),
-                        active: category === 'history-import',
-                        // The disclosure row selects the section's first provider (the accordion
-                        // opens via `active`); it is never highlighted itself.
-                        onClick() {
-                          setCategory('history-import');
-                          setHistoryProvider(DEFAULT_HISTORY_PROVIDER);
-                        },
-                        children: AGENT_KINDS.map((agentKind) => ({
-                          key: agentKind,
-                          icon: <AgentIcon kind={agentKind} variant="ghost" />,
-                          label: AGENT_LABELS[agentKind],
-                          active: category === 'history-import' && historyProvider === agentKind,
-                          onClick() {
-                            setCategory('history-import');
-                            setHistoryProvider(agentKind);
-                          },
-                        })),
-                      },
-                    ],
-                  },
-                  {
-                    key: 'system',
-                    label: t('groups.system'),
-                    items: [
-                      {
-                        key: 'connection',
-                        icon: <WifiIcon className="size-4" />,
-                        label: t('tabs.connection'),
-                        active: category === 'connection',
-                        onClick: () => setCategory('connection'),
-                      },
-                      {
-                        key: 'about',
-                        icon: <InfoIcon className="size-4" />,
-                        label: t('tabs.about'),
-                        active: category === 'about',
-                        onClick: () => setCategory('about'),
-                      },
-                    ],
-                  },
-                ]}
+                searchValue={searchQuery}
+                onSearchChange={setSearchQuery}
+                onSearchSubmit={() => {
+                  visibleGroups.flatMap((group) => group.items)[0]?.onClick?.();
+                }}
+                searchEmptyLabel={t('searchNoResults')}
+                groups={visibleGroups}
               />
             </ShellSidebar>
           </div>

--- a/apps/webview/src/routes/settings/settings-layout.tsx
+++ b/apps/webview/src/routes/settings/settings-layout.tsx
@@ -1,4 +1,5 @@
 import { SettingsSidebarNav, ShellSidebar, TitleStrip } from '@linkcode/ui';
+import { filterSettingsNavGroups, useSettingsSearchKeywords } from '@linkcode/workbench';
 import {
   BellIcon,
   BotIcon,
@@ -8,12 +9,104 @@ import {
   SunMoonIcon,
   WifiIcon,
 } from 'lucide-react';
-import { Link, Outlet, useLocation } from 'react-router';
+import { useState } from 'react';
+import { Link, Outlet, useLocation, useNavigate } from 'react-router';
 import { useTranslations } from 'use-intl';
+
+const SETTINGS_ROUTES: Record<string, string> = {
+  general: '/settings',
+  appearance: '/settings/appearance',
+  notifications: '/settings/notifications',
+  agents: '/settings/agents',
+  providers: '/settings/providers',
+  messaging: '/settings/messaging',
+  connection: '/settings/connection',
+};
 
 export function SettingsLayout(): React.ReactNode {
   const t = useTranslations('settings');
   const { pathname } = useLocation();
+  const navigate = useNavigate();
+  const [searchQuery, setSearchQuery] = useState('');
+  const searchKeywords = useSettingsSearchKeywords();
+
+  const navGroups = [
+    {
+      key: 'personal',
+      label: t('groups.personal'),
+      items: [
+        {
+          key: 'general',
+          icon: <SettingsIcon className="size-4" />,
+          label: t('tabs.general'),
+          keywords: searchKeywords.general,
+          active: isActive(pathname, ''),
+          render: <Link to="/settings" />,
+        },
+        {
+          key: 'appearance',
+          icon: <SunMoonIcon className="size-4" />,
+          label: t('tabs.appearance'),
+          keywords: searchKeywords.appearance,
+          active: isActive(pathname, 'appearance'),
+          render: <Link to="/settings/appearance" />,
+        },
+        {
+          key: 'notifications',
+          icon: <BellIcon className="size-4" />,
+          label: t('tabs.notifications'),
+          keywords: searchKeywords.notifications,
+          active: isActive(pathname, 'notifications'),
+          render: <Link to="/settings/notifications" />,
+        },
+      ],
+    },
+    {
+      key: 'integrations',
+      label: t('groups.integrations'),
+      items: [
+        {
+          key: 'agents',
+          icon: <BotIcon className="size-4" />,
+          label: t('tabs.agents'),
+          keywords: searchKeywords.agents,
+          active: isActive(pathname, 'agents'),
+          render: <Link to="/settings/agents" />,
+        },
+        {
+          key: 'providers',
+          icon: <KeyRoundIcon className="size-4" />,
+          label: t('tabs.providers'),
+          keywords: searchKeywords.providers,
+          active: isActive(pathname, 'providers'),
+          render: <Link to="/settings/providers" />,
+        },
+        {
+          key: 'messaging',
+          icon: <SendIcon className="size-4" />,
+          label: t('tabs.imChannel'),
+          keywords: searchKeywords.imChannel,
+          active: isActive(pathname, 'messaging'),
+          render: <Link to="/settings/messaging" />,
+        },
+      ],
+    },
+    {
+      key: 'system',
+      label: t('groups.system'),
+      items: [
+        {
+          key: 'connection',
+          icon: <WifiIcon className="size-4" />,
+          label: t('tabs.connection'),
+          keywords: searchKeywords.connection,
+          active: isActive(pathname, 'connection'),
+          render: <Link to="/settings/connection" />,
+        },
+      ],
+    },
+  ];
+  const visibleGroups = filterSettingsNavGroups(navGroups, searchQuery);
 
   return (
     <div className="flex h-full min-h-0 bg-background text-foreground">
@@ -23,75 +116,15 @@ export function SettingsLayout(): React.ReactNode {
             backLabel={t('back')}
             backRender={<Link to="/" />}
             searchPlaceholder={t('searchPlaceholder')}
-            groups={[
-              {
-                key: 'personal',
-                label: t('groups.personal'),
-                items: [
-                  {
-                    key: 'general',
-                    icon: <SettingsIcon className="size-4" />,
-                    label: t('tabs.general'),
-                    active: isActive(pathname, ''),
-                    render: <Link to="/settings" />,
-                  },
-                  {
-                    key: 'appearance',
-                    icon: <SunMoonIcon className="size-4" />,
-                    label: t('tabs.appearance'),
-                    active: isActive(pathname, 'appearance'),
-                    render: <Link to="/settings/appearance" />,
-                  },
-                  {
-                    key: 'notifications',
-                    icon: <BellIcon className="size-4" />,
-                    label: t('tabs.notifications'),
-                    active: isActive(pathname, 'notifications'),
-                    render: <Link to="/settings/notifications" />,
-                  },
-                ],
-              },
-              {
-                key: 'integrations',
-                label: t('groups.integrations'),
-                items: [
-                  {
-                    key: 'agents',
-                    icon: <BotIcon className="size-4" />,
-                    label: t('tabs.agents'),
-                    active: isActive(pathname, 'agents'),
-                    render: <Link to="/settings/agents" />,
-                  },
-                  {
-                    key: 'providers',
-                    icon: <KeyRoundIcon className="size-4" />,
-                    label: t('tabs.providers'),
-                    active: isActive(pathname, 'providers'),
-                    render: <Link to="/settings/providers" />,
-                  },
-                  {
-                    key: 'messaging',
-                    icon: <SendIcon className="size-4" />,
-                    label: t('tabs.imChannel'),
-                    active: isActive(pathname, 'messaging'),
-                    render: <Link to="/settings/messaging" />,
-                  },
-                ],
-              },
-              {
-                key: 'system',
-                label: t('groups.system'),
-                items: [
-                  {
-                    key: 'connection',
-                    icon: <WifiIcon className="size-4" />,
-                    label: t('tabs.connection'),
-                    active: isActive(pathname, 'connection'),
-                    render: <Link to="/settings/connection" />,
-                  },
-                ],
-              },
-            ]}
+            searchValue={searchQuery}
+            onSearchChange={setSearchQuery}
+            onSearchSubmit={() => {
+              const first = visibleGroups.flatMap((group) => group.items)[0];
+              const route = first === undefined ? undefined : SETTINGS_ROUTES[first.key];
+              if (route !== undefined) void navigate(route);
+            }}
+            searchEmptyLabel={t('searchNoResults')}
+            groups={visibleGroups}
           />
         </ShellSidebar>
       </div>

--- a/packages/i18n/src/locales/en.ts
+++ b/packages/i18n/src/locales/en.ts
@@ -371,6 +371,7 @@ export const en = {
     title: 'Settings',
     back: 'Back',
     searchPlaceholder: 'Search settings...',
+    searchNoResults: 'No matching settings.',
     groups: {
       personal: 'Personal',
       integrations: 'Integrations',

--- a/packages/i18n/src/locales/zh-cn.ts
+++ b/packages/i18n/src/locales/zh-cn.ts
@@ -365,6 +365,7 @@ export const zhCN = {
     title: '设置',
     back: '返回',
     searchPlaceholder: '搜索设置...',
+    searchNoResults: '没有匹配的设置。',
     groups: {
       personal: '个人',
       integrations: '集成',

--- a/packages/ui/src/shell/settings-sidebar-nav.tsx
+++ b/packages/ui/src/shell/settings-sidebar-nav.tsx
@@ -1,9 +1,9 @@
 import { Collapsible, CollapsiblePanel } from 'coss-ui/components/collapsible';
+import { InputGroup, InputGroupAddon, InputGroupInput } from 'coss-ui/components/input-group';
 import {
   SidebarGroup,
   SidebarGroupContent,
   SidebarGroupLabel,
-  SidebarInput,
   SidebarMenu,
   SidebarMenuButton,
   SidebarMenuItem,
@@ -20,7 +20,7 @@ type SettingsSidebarNavRender = React.ComponentProps<typeof SidebarMenuButton>['
 export interface SettingsSidebarNavSubItem {
   key: string;
   icon: React.ReactNode;
-  label: React.ReactNode;
+  label: string;
   active?: boolean;
   onClick?: () => void;
 }
@@ -28,7 +28,9 @@ export interface SettingsSidebarNavSubItem {
 export interface SettingsSidebarNavItem {
   key: string;
   icon: React.ReactNode;
-  label: React.ReactNode;
+  label: string;
+  /** Extra searchable terms (per-tab field labels); never rendered. */
+  keywords?: readonly string[];
   /** For items with `children`, drives the accordion expansion only — the row itself never
    * takes the selected pill; the highlighted sub-item is the "you are here" signal. */
   active?: boolean;
@@ -53,18 +55,32 @@ export interface SettingsSidebarNavProps {
   /** Focuses the back control when a non-routed settings overlay opens. */
   backAutoFocus?: boolean;
   searchPlaceholder: string;
+  /** Controlled search query; the caller filters `groups` with it. */
+  searchValue: string;
+  onSearchChange: (value: string) => void;
+  /** Enter in the search field — the caller activates the first visible item. */
+  onSearchSubmit?: () => void;
+  /** Shown instead of the nav when a query matches nothing. */
+  searchEmptyLabel: string;
   groups: SettingsSidebarNavGroup[];
 }
 
-/** The settings sidebar's inner nav: back row, search placeholder, and grouped category items. */
+/** The settings sidebar's inner nav: back row, search field, and grouped category items. */
 export function SettingsSidebarNav({
   backLabel,
   onBack,
   backRender,
   backAutoFocus,
   searchPlaceholder,
+  searchValue,
+  onSearchChange,
+  onSearchSubmit,
+  searchEmptyLabel,
   groups,
 }: SettingsSidebarNavProps): React.ReactNode {
+  const searching = searchValue.trim() !== '';
+  const noMatches = searching && groups.every((group) => group.items.length === 0);
+
   return (
     <div className="px-2">
       <SidebarMenu>
@@ -76,29 +92,52 @@ export function SettingsSidebarNav({
         </SidebarMenuItem>
       </SidebarMenu>
 
-      <div className="relative py-2">
-        <SearchIcon className="-translate-y-1/2 pointer-events-none absolute top-1/2 left-2.5 z-10 size-4 text-muted-foreground" />
-        {/* Visual placeholder until settings search is backed by the shared registry. */}
-        <SidebarInput
-          aria-label={searchPlaceholder}
-          className="[&_[data-slot=input]]:pl-8"
-          nativeInput
-          placeholder={searchPlaceholder}
-          readOnly
-          type="search"
-        />
+      <div className="py-2">
+        <InputGroup className="h-8 bg-background shadow-none">
+          <InputGroupAddon>
+            <SearchIcon className="text-muted-foreground" />
+          </InputGroupAddon>
+          <InputGroupInput
+            aria-label={searchPlaceholder}
+            nativeInput
+            placeholder={searchPlaceholder}
+            type="search"
+            value={searchValue}
+            onChange={(event) => onSearchChange(event.currentTarget.value)}
+            onKeyDown={(event) => {
+              if (event.key === 'Enter') {
+                onSearchSubmit?.();
+                return;
+              }
+              // Escape clears an active query locally; when empty it bubbles on to the
+              // surface-level handler (the desktop overlay closes on Escape).
+              if (event.key === 'Escape' && searchValue !== '') {
+                event.stopPropagation();
+                onSearchChange('');
+              }
+            }}
+          />
+        </InputGroup>
       </div>
 
-      <nav>
-        {groups.map((group) => (
-          <SidebarGroup key={group.key} className="p-0 pb-3">
-            <SidebarGroupLabel className="text-muted-foreground">{group.label}</SidebarGroupLabel>
-            <SidebarGroupContent>
-              <SidebarMenu>{group.items.map(renderNavItem)}</SidebarMenu>
-            </SidebarGroupContent>
-          </SidebarGroup>
-        ))}
-      </nav>
+      {noMatches ? (
+        <p className="px-2 py-4 text-muted-foreground text-sm">{searchEmptyLabel}</p>
+      ) : (
+        <nav>
+          {groups.map((group) =>
+            group.items.length === 0 ? null : (
+              <SidebarGroup key={group.key} className="p-0 pb-3">
+                <SidebarGroupLabel className="text-muted-foreground">
+                  {group.label}
+                </SidebarGroupLabel>
+                <SidebarGroupContent>
+                  <SidebarMenu>{group.items.map(renderNavItem)}</SidebarMenu>
+                </SidebarGroupContent>
+              </SidebarGroup>
+            ),
+          )}
+        </nav>
+      )}
     </div>
   );
 }

--- a/packages/ui/src/shell/settings-sidebar-nav.tsx
+++ b/packages/ui/src/shell/settings-sidebar-nav.tsx
@@ -105,6 +105,8 @@ export function SettingsSidebarNav({
             value={searchValue}
             onChange={(event) => onSearchChange(event.currentTarget.value)}
             onKeyDown={(event) => {
+              // An IME candidate-commit Enter (or composition cancel) is not a submit.
+              if (event.nativeEvent.isComposing || event.key === 'Process') return;
               if (event.key === 'Enter') {
                 onSearchSubmit?.();
                 return;

--- a/packages/workbench/src/index.ts
+++ b/packages/workbench/src/index.ts
@@ -32,6 +32,7 @@ export * from './scripts/services-menu';
 export * from './settings/agents-settings';
 export * from './settings/providers/providers-settings';
 export * from './settings/providers/store';
+export * from './settings/search';
 export * from './sidebar/runtime-thread-im-menu';
 export * from './surface/selection-store';
 export * from './surface/shell';

--- a/packages/workbench/src/palette/match.ts
+++ b/packages/workbench/src/palette/match.ts
@@ -90,11 +90,14 @@ function awaitingBoost(session: SessionInfo): number {
   return session.status === 'awaiting-input' ? 1 : 0;
 }
 
-/** Empty query: every command in registration order. With a query: label scoring, then keywords. */
-export function matchPaletteCommands(
-  commands: readonly PaletteCommand[],
+/**
+ * Empty query: every command in registration order. With a query: label scoring, then keywords.
+ * Generic over anything label+keywords-shaped so other searchable lists (settings nav) reuse it.
+ */
+export function matchPaletteCommands<T extends Pick<PaletteCommand, 'label' | 'keywords'>>(
+  commands: readonly T[],
   query: string,
-): PaletteCommand[] {
+): T[] {
   const normalizedQuery = normalize(query);
   if (!normalizedQuery) return [...commands];
 

--- a/packages/workbench/src/settings/__tests__/search.test.ts
+++ b/packages/workbench/src/settings/__tests__/search.test.ts
@@ -1,0 +1,66 @@
+import type { SettingsSidebarNavGroup } from '@linkcode/ui';
+import { describe, expect, it } from 'vitest';
+import { filterSettingsNavGroups } from '../search';
+
+function group(key: string, items: Array<{ key: string; label: string; keywords?: string[] }>) {
+  return {
+    key,
+    label: key,
+    items: items.map((item) => ({ ...item, icon: null })),
+  } satisfies SettingsSidebarNavGroup;
+}
+
+const GROUPS = [
+  group('personal', [
+    { key: 'general', label: 'General', keywords: ['Language', 'Auto'] },
+    { key: 'appearance', label: 'Appearance', keywords: ['Theme', 'Dark', 'Light'] },
+    { key: 'notifications', label: 'Notifications', keywords: ['Turn completed'] },
+  ]),
+  group('integrations', [
+    { key: 'agents', label: 'Agents', keywords: ['Enabled'] },
+    { key: 'messaging', label: 'Messaging', keywords: ['Connect Telegram'] },
+  ]),
+];
+
+function visibleKeys(groups: readonly SettingsSidebarNavGroup[]): string[][] {
+  return groups.map((g) => g.items.map((item) => item.key));
+}
+
+describe('filterSettingsNavGroups', () => {
+  it('returns every group untouched for an empty or whitespace query', () => {
+    expect(visibleKeys(filterSettingsNavGroups(GROUPS, ''))).toEqual([
+      ['general', 'appearance', 'notifications'],
+      ['agents', 'messaging'],
+    ]);
+    expect(visibleKeys(filterSettingsNavGroups(GROUPS, '   '))).toEqual(
+      visibleKeys(filterSettingsNavGroups(GROUPS, '')),
+    );
+  });
+
+  it('matches item labels case-insensitively and empties the groups that miss', () => {
+    expect(visibleKeys(filterSettingsNavGroups(GROUPS, 'appear'))).toEqual([['appearance'], []]);
+  });
+
+  it('matches field-level keywords, not just the tab label', () => {
+    expect(visibleKeys(filterSettingsNavGroups(GROUPS, 'dark'))).toEqual([['appearance'], []]);
+    expect(visibleKeys(filterSettingsNavGroups(GROUPS, 'telegram'))).toEqual([[], ['messaging']]);
+  });
+
+  it('preserves declaration order even when a later item scores higher', () => {
+    // "general" matches General by prefix (80) and Agents by keyword (30); the label-scored
+    // item would rank first, but sidebar display order must stay declaration order.
+    const groups = [
+      group('one', [
+        { key: 'agents', label: 'Agents', keywords: ['general tools'] },
+        { key: 'general', label: 'General' },
+      ]),
+    ];
+    expect(visibleKeys(filterSettingsNavGroups(groups, 'general'))).toEqual([
+      ['agents', 'general'],
+    ]);
+  });
+
+  it('leaves every group empty when nothing matches', () => {
+    expect(visibleKeys(filterSettingsNavGroups(GROUPS, 'zzz'))).toEqual([[], []]);
+  });
+});

--- a/packages/workbench/src/settings/search.ts
+++ b/packages/workbench/src/settings/search.ts
@@ -1,0 +1,81 @@
+import type { SettingsSidebarNavGroup } from '@linkcode/ui';
+import { useTranslations } from 'use-intl';
+import { matchPaletteCommands } from '../palette/match';
+
+/**
+ * Filter grouped settings nav items by a search query. Matching reuses the palette scorer
+ * (label, then `keywords`) but display keeps declaration order — ranking is meaningless across
+ * sidebar groups. Groups left with no items are dropped by the nav (header included).
+ */
+export function filterSettingsNavGroups(
+  groups: readonly SettingsSidebarNavGroup[],
+  query: string,
+): SettingsSidebarNavGroup[] {
+  if (query.trim() === '') return [...groups];
+  return groups.map((group) => {
+    const matched = new Set(matchPaletteCommands(group.items, query));
+    return { ...group, items: group.items.filter((item) => matched.has(item)) };
+  });
+}
+
+export interface SettingsSearchKeywords {
+  general: readonly string[];
+  appearance: readonly string[];
+  notifications: readonly string[];
+  connection: readonly string[];
+  about: readonly string[];
+  agents: readonly string[];
+  providers: readonly string[];
+  imChannel: readonly string[];
+  historyImport: readonly string[];
+}
+
+const PROVIDER_SERVICES = [
+  'claude-sub',
+  'chatgpt-sub',
+  'anthropic-api',
+  'openai-api',
+  'xai',
+  'openrouter',
+  'vercel-gateway',
+  'cloudflare-gateway',
+  'custom',
+] as const;
+
+/**
+ * Per-tab field-level search terms, resolved from the active locale's `settings.*` labels —
+ * "dark" or "主题" hits Appearance, "telegram" hits Messaging. Apps attach these to their nav
+ * items; tabs an app doesn't have are simply never read.
+ */
+export function useSettingsSearchKeywords(): SettingsSearchKeywords {
+  const t = useTranslations('settings');
+
+  return {
+    general: [t('general.language'), t('general.languageAuto')],
+    appearance: [
+      t('appearance.theme'),
+      t('appearance.themeSystem'),
+      t('appearance.themeLight'),
+      t('appearance.themeDark'),
+    ],
+    notifications: [
+      t('notifications.enable'),
+      t('notifications.turnCompleted'),
+      t('notifications.awaitingApproval'),
+      t('notifications.error'),
+    ],
+    connection: [t('connection.title'), t('connection.url')],
+    about: [t('about.version'), t('about.checkForUpdates')],
+    agents: [t('agents.title'), t('agents.enabled')],
+    providers: [
+      t('providers.title'),
+      t('providers.addAccount'),
+      t('providers.credentialApiKey'),
+      t('providers.endpoint'),
+      t('providers.accountModel'),
+      ...PROVIDER_SERVICES.map((service) => t(`providers.serviceName.${service}`)),
+    ],
+    imChannel: [t('imChannel.connectTitle'), t('imChannel.bindings'), t('imChannel.autoMirror')],
+    historyImport: [t('historyImport.portalLabel')],
+  };
+}


### PR DESCRIPTION
Settings-search half of CODE-57 (⌘1–⌘9 jumps stay open on the issue). Stacked on #107 — merge that first; GitHub will retarget this to master when the base branch is deleted.

- **Live search**: the settings sidebar search input is real now (was `readOnly` scaffolding). Typing filters the grouped nav on both desktop and webview; groups whose items all miss disappear (header included), with a "no matching settings" empty state. Enter activates the first visible tab (desktop: category switch; webview: navigate). Escape clears an active query and stops there; on an empty query it bubbles on (desktop overlay still closes).
- **Matching** reuses the palette scorer per CODE-57: `matchPaletteCommands` is widened to a generic over `label`/`keywords` (no new matcher, call sites unchanged). New pure `filterSettingsNavGroups` keeps declaration order — ranking is meaningless across sidebar groups — and is unit-tested (5 cases).
- **Field-level index**: `useSettingsSearchKeywords()` resolves per-tab searchable terms from the active locale's `settings.*` labels, so "dark" lands on Appearance, "telegram" on Messaging, "openrouter" on Providers.
- **Overlap bug fixed structurally**: the absolutely-positioned icon + `[&_[data-slot=input]]:pl-8` hack (icon painted over the placeholder) is replaced with coss-ui `InputGroup`/`InputGroupAddon`, which reserves real space for the leading icon.

Verified running on both ends (Playwright): webview — "dark" filters to Appearance only, Enter routes to `/settings/appearance`, Escape restores all 7 items, gibberish shows the empty state, icon/text no longer overlap; desktop (built app, fresh `LINKCODE_PROFILE`) — same filter/Enter flow plus the two-stage Escape (clear → close overlay). `pnpm check:ci` + `pnpm test` (762) pass.