### PR TITLE
chore(deps): hold vite on major 7 until electron-vite supports vite 8

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,6 +40,13 @@ updates:
       # expects; bump react/react-dom together with Expo upgrades, not via Dependabot.
       - dependency-name: react
       - dependency-name: react-dom
+      # electron-vite (desktop renderer build) peer-caps vite at ^7; a vite 8 bump installs
+      # but breaks the desktop build, which typecheck can't catch (Invariant 4). Mirror that
+      # ceiling: hold vite on 7 until electron-vite stable supports vite 8 (only 6.0.0-beta
+      # does today), then lift this and bump both together.
+      - dependency-name: vite
+        update-types:
+          - "version-update:semver-major"
 
   - package-ecosystem: cargo # workspace: crates/linkcode-pty
     directory: /


### PR DESCRIPTION
electron-vite stable (5.0.0) peer-caps vite at `^5 || ^6 || ^7`; the desktop renderer builds through electron-vite, so a vite 8 bump (#91) installs but breaks the desktop build — which `tsc` typecheck can't catch (AGENTS Invariant 4), so CI goes green regardless.

Mirror electron-vite's ceiling in Dependabot: ignore vite major bumps so it stays on 7.x (still gets 7.x minor/patch). Lift this and bump vite + electron-vite together once electron-vite stable supports vite 8 (only `6.0.0-beta` does today).

Closes #91.