### PR TITLE
feat(workbench,i18n): let claude login auto-complete via the CLI's own loopback tab (CODE-175)

### DIFF
--- a/packages/i18n/src/locales/en.ts
+++ b/packages/i18n/src/locales/en.ts
@@ -130,7 +130,7 @@ export const en = {
       login: 'Sign in to {agent}',
       loginOpening: 'Opening the browser to sign in to {agent}…',
       loginAwaitingCode:
-        'A sign-in page opened in your browser. After authorizing, paste the code from that page below.',
+        'A sign-in page opened in your browser — authorizing there usually completes on its own. If the page shows an authorization code instead, paste it below.',
       loginAwaitingBrowser:
         'A sign-in page opened in your browser. Finish signing in there — this updates automatically.',
       loginCodePlaceholder: 'Paste the authorization code',

--- a/packages/i18n/src/locales/zh-cn.ts
+++ b/packages/i18n/src/locales/zh-cn.ts
@@ -125,7 +125,8 @@ export const zhCN = {
       needsLoginBody: '登录你的 {agent} 账号后即可开始使用。',
       login: '登录 {agent}',
       loginOpening: '正在打开浏览器登录 {agent}…',
-      loginAwaitingCode: '已在浏览器打开登录页。完成授权后，把页面上的授权码粘贴到下面。',
+      loginAwaitingCode:
+        '已在浏览器打开登录页，授权后通常会自动完成。如果页面显示了授权码，再把它粘贴到下面。',
       loginAwaitingBrowser: '已在浏览器打开登录页。在浏览器中完成登录后，这里会自动更新。',
       loginCodePlaceholder: '粘贴授权码',
       loginSubmit: '完成登录',

--- a/packages/workbench/src/agent-runtime/onboarding.ts
+++ b/packages/workbench/src/agent-runtime/onboarding.ts
@@ -26,6 +26,15 @@ const AGENT_ASSET_IDS: Partial<Record<AgentKind, ManagedAssetId>> = {
 };
 
 /**
+ * Kinds whose login CLI opens the browser ITSELF with its loopback-redirect URL (CODE-175):
+ * claude prints only the manual code-page URL to stdout while racing an auto-completing
+ * localhost callback in the tab it opens — opening the printed URL too would put the user on
+ * the paste-code page of a second tab. codex is absent: its app-server returns the URL without
+ * opening anything, so the client must open it.
+ */
+const SELF_OPENING_LOGIN_KINDS: ReadonlySet<AgentKind> = new Set(['claude-code']);
+
+/**
  * Client-local install activity per asset, layered over the pulled snapshots: `downloading` and
  * `failed` come from the `asset.progress` / `asset.settled` broadcasts, `installed` bridges the
  * gap between a successful settle and the `agent-runtime.changed` re-probe that confirms it
@@ -297,7 +306,11 @@ export function useAgentRuntimeOnboarding(): {
           onUrl(url) {
             // Desktop routes `_blank` to the system browser (main-process window handler); webview
             // opens a tab. A fallback link in the card reopens `url` if the launch was blocked.
-            window.open(url, '_blank', 'noopener,noreferrer');
+            // Self-opening CLIs already launched their auto-completing loopback tab — the printed
+            // manual URL stays on the card as the fallback instead of racing it in a second tab.
+            if (!SELF_OPENING_LOGIN_KINDS.has(kind)) {
+              window.open(url, '_blank', 'noopener,noreferrer');
+            }
             setLogin(kind, { kind: 'awaiting-code', url });
           },
           onSettled({ ok, error }) {


### PR DESCRIPTION
> ~~Stacked on #111 (CODE-174)~~ — **#110 and #111 have merged**; this PR is now a single commit based directly on `master`.

Implements [CODE-175](https://linear.app/arcbox/issue/CODE-175). One-commit change backed by binary inspection + live probes of claude-cli 2.1.209 (details in the issue):

Claude Code's login races two redirects of the same OAuth attempt — the stdout URL carries the hosted **manual code page** (constant literally named `MANUAL_REDIRECT_URL`), while the tab the CLI opens **itself** carries an auto-completing localhost callback. Verified in headless piped mode (exactly how `startClaudeLogin` runs it): the CLI still invokes the system browser-opener with the loopback URL and its local listener is bound. LinkCode was opening the printed manual URL on top of that — two tabs, and users landed on the paste-code page of the wrong one.

- `useAgentRuntimeOnboarding.onUrl`: skip the client-side open for self-opening kinds (`SELF_OPENING_LOGIN_KINDS = {claude-code}`); the manual URL stays on the card as the fallback link. codex keeps the client-side open (its app-server returns the URL without opening anything).
- Awaiting-phase copy now matches the TUI's "paste code **if prompted**" semantics; the paste input stays as the cross-machine fallback.

Manual QA (needs a real sign-out): log out of claude, click Sign in on the LinkCode card → exactly one tab opens (the CLI's own) → authorize → login completes with no code pasting and the cue clears.
