### PR TITLE
chore(deps): hold @sentry/* — bump in lockstep with @sentry/electron

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,6 +40,12 @@ updates:
       # expects; bump react/react-dom together with Expo upgrades, not via Dependabot.
       - dependency-name: react
       - dependency-name: react-dom
+      # Every @sentry/* SDK must resolve to one @sentry/core version, but @sentry/electron
+      # bundles its own core and lags the standalone train (electron 7.15 → core 10.62, while
+      # standalone is already 10.64). A unilateral bump of EITHER side trips Sentry's version-skew
+      # type guard and breaks typecheck — no @sentry/electron release matches the latest standalone
+      # SDK. Bump the whole family manually in lockstep, pinned to @sentry/electron's bundled core.
+      - dependency-name: "@sentry/*"
 
   - package-ecosystem: cargo # workspace: crates/linkcode-pty
     directory: /


### PR DESCRIPTION
Every `@sentry/*` SDK must resolve to one `@sentry/core` version, but `@sentry/electron` bundles its own core and lags the standalone release train (electron 7.15 → core 10.62, while standalone is already 10.64). A unilateral bump of *either* side trips Sentry's version-skew type guard (`..._ensure_sdks_use_version_vX`) and breaks typecheck — and no `@sentry/electron` release matches the latest standalone SDK, so Dependabot re-proposes a broken bump every week (most recently #119).

Ignore the whole `@sentry/*` family in Dependabot; bump it manually in lockstep, pinned to `@sentry/electron`'s bundled core. Same coupling pattern as the existing expo/react ignores.