### PR TITLE
fix(desktop): split linkcode:// deep-link scheme per channel

### DIFF
--- a/apps/desktop/electron-builder.devshell.yml
+++ b/apps/desktop/electron-builder.devshell.yml
@@ -6,5 +6,13 @@
 extends: ./electron-builder.yml
 appId: com.arcboxlabs.linkcode.desktop.development
 productName: LinkCode Development
+# The dev shell claims its OWN `linkcode-dev://` scheme so its OAuth callbacks never fight the
+# installed release over the OS-global `linkcode://`. The shared base declares no `protocols`, so
+# this is the only entry (electron-builder concatenates inherited arrays — a `linkcode` in the base
+# would leak in and re-collide). Matches CLOUD_AUTH_SCHEME for the development channel (constants.ts).
+protocols:
+  - name: LinkCode Development
+    schemes:
+      - linkcode-dev
 mac:
   identity: null

--- a/apps/desktop/electron-builder.release.yml
+++ b/apps/desktop/electron-builder.release.yml
@@ -1,0 +1,11 @@
+# Release packaging (`pnpm run package`): the shipped LinkCode. Extends the shared base and adds the
+# release-only `linkcode://` deep-link scheme. Kept separate from the base so the dev shell (which
+# also extends the base) does NOT inherit `linkcode` — electron-builder concatenates arrays across
+# `extends`, so both channels sharing one scheme is exactly the OS-global collision this avoids.
+extends: ./electron-builder.yml
+# `linkcode://` OAuth callback scheme — electron-builder registers it in the macOS Info.plist and the
+# Windows installer; the app also re-asserts it at runtime (see cloud-auth/client.ts).
+protocols:
+  - name: LinkCode
+    schemes:
+      - linkcode

--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -1,4 +1,7 @@
-# electron-builder configuration for @linkcode/desktop.
+# Shared electron-builder base for @linkcode/desktop. Both channels extend it:
+# electron-builder.release.yml (release) and electron-builder.devshell.yml (local dev shell); the
+# packaging entry is chosen in scripts/package-app.mts. Do NOT pass this file to electron-builder
+# directly — it declares no `protocols`, so a build off it would ship no deep-link scheme.
 #
 # Packaging only — the app itself is compiled by `electron-vite build` (run via
 # `pnpm turbo run build`) into `out/`; electron-builder just wraps that output.
@@ -11,13 +14,10 @@ appId: com.arcboxlabs.linkcode.desktop
 productName: LinkCode
 copyright: Copyright © 2026 ArcBox Labs
 
-# `linkcode://` deep-link scheme for LinkCode Cloud OAuth callbacks. electron-builder registers it
-# in the macOS Info.plist and the Windows installer; dev shells register it at runtime via
-# setAsDefaultProtocolClient (see cloud-auth/client.ts).
-protocols:
-  - name: LinkCode
-    schemes:
-      - linkcode
+# The `linkcode://` / `linkcode-dev://` deep-link scheme is declared per channel, NOT here. This
+# base is shared by both channels, and electron-builder CONCATENATES arrays inherited via `extends`
+# (builder-util-runtime deepAssign) — a shared `protocols` would leak `linkcode` into the dev shell
+# and re-collide with release on the OS-global scheme. See the two channel configs.
 
 # electron-builder needs an exact Electron version (it downloads per-platform binaries) and
 # cannot read pnpm's `catalog:` protocol. Keep in sync with the `electron` catalog entry.

--- a/apps/desktop/scripts/package-app.mts
+++ b/apps/desktop/scripts/package-app.mts
@@ -113,7 +113,9 @@ function stagedArches(): string[] {
 }
 
 function build(): void {
-  const config = devshell ? 'electron-builder.devshell.yml' : 'electron-builder.yml';
+  // Both extend the shared electron-builder.yml base; each adds its own deep-link scheme (release
+  // `linkcode://`, dev shell `linkcode-dev://`). The base is never passed directly — it has none.
+  const config = devshell ? 'electron-builder.devshell.yml' : 'electron-builder.release.yml';
   const builderArgs = [
     'exec',
     'electron-builder',

--- a/apps/desktop/src/main/cloud-auth/client.ts
+++ b/apps/desktop/src/main/cloud-auth/client.ts
@@ -1,6 +1,9 @@
+import { resolve } from 'node:path';
 import { electronClient } from '@better-auth/electron/client';
 import { createAuthClient } from 'better-auth/client';
-import { BrowserWindow } from 'electron';
+import { app, BrowserWindow, ipcMain } from 'electron';
+import { CLOUD_CLAIM_DEEP_LINK_CHANNEL } from '../../shared/cloud';
+import { CHANNEL } from '../constants';
 import { createSafeStorage } from './storage';
 
 /**
@@ -12,10 +15,23 @@ import { createSafeStorage } from './storage';
  */
 export const CLOUD_API_URL = process.env.LINKCODE_CLOUD_API_URL ?? 'https://api.linkcode.ai';
 
-const CLOUD_SIGN_IN_URL = process.env.LINKCODE_CLOUD_SIGN_IN_URL ?? 'https://linkcode.ai/sign-in';
+/**
+ * The custom protocol registered for OAuth deep-link callbacks; trusted by linkcodehq. Split per
+ * channel so a `development` build (which every `pnpm dev`, locally packaged dev shell, and prod
+ * bundle run by the dev Electron all resolve to — see constants.ts) never fights the installed
+ * `release` app over the OS-global scheme: whoever registered `linkcode://` last would otherwise
+ * win, silently routing the callback to the wrong app.
+ */
+export const CLOUD_AUTH_SCHEME = CHANNEL === 'development' ? 'linkcode-dev' : 'linkcode';
 
-/** The custom protocol registered for OAuth deep-link callbacks; trusted by linkcodehq. */
-export const CLOUD_AUTH_SCHEME = 'linkcode';
+// The HQ sign-in page decides which scheme to deep-link back on; tell it via the URL so a
+// development build's callback targets linkcode-dev:// instead of the release linkcode://. The
+// better-auth client appends its own params with `URL.searchParams.set`, preserving this one.
+const CLOUD_SIGN_IN_URL = (() => {
+  const url = new URL(process.env.LINKCODE_CLOUD_SIGN_IN_URL ?? 'https://linkcode.ai/sign-in');
+  url.searchParams.set('scheme', CLOUD_AUTH_SCHEME);
+  return url.href;
+})();
 
 export const authClient = createAuthClient({
   baseURL: CLOUD_API_URL,
@@ -48,4 +64,15 @@ export function setupCloudAuth(): void {
     bridges: true,
     getWindow: () => BrowserWindow.getAllWindows().at(0) ?? null,
   });
+  // Re-assert this app as the scheme's OS default handler on demand. The renderer calls this right
+  // before a sign-in, so the OAuth callback deep-link routes back to THIS running app even if a
+  // `pnpm dev` instance (same `linkcode-dev://`) registered the scheme after startup. Mirrors the
+  // plugin's own registration (dev shells must pass execPath + entry argv, packaged builds don't).
+  ipcMain.handle(CLOUD_CLAIM_DEEP_LINK_CHANNEL, () =>
+    process.defaultApp && typeof process.argv[1] === 'string'
+      ? app.setAsDefaultProtocolClient(CLOUD_AUTH_SCHEME, process.execPath, [
+          resolve(process.argv[1]),
+        ])
+      : app.setAsDefaultProtocolClient(CLOUD_AUTH_SCHEME),
+  );
 }

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -2,6 +2,7 @@ import { setupRenderer } from '@better-auth/electron/preload';
 import { createElectronSystemBridge } from '@linkcode/ipc/electron-renderer';
 import { contextBridge, ipcRenderer } from 'electron';
 import {
+  CLOUD_CLAIM_DEEP_LINK_CHANNEL,
   CLOUD_IM_BINDINGS_CHANNEL,
   CLOUD_IM_CREATE_BINDING_CHANNEL,
   CLOUD_IM_DELETE_BINDING_CHANNEL,
@@ -31,6 +32,7 @@ setupRenderer();
 // keychain session). Kept off the SystemBridge — it's cloud-account data, not a window/OS capability.
 contextBridge.exposeInMainWorld('linkcodeCloud', {
   listHosts: () => ipcRenderer.invoke(CLOUD_LIST_HOSTS_CHANNEL),
+  claimDeepLink: () => ipcRenderer.invoke(CLOUD_CLAIM_DEEP_LINK_CHANNEL),
   im: {
     overview: () => ipcRenderer.invoke(CLOUD_IM_OVERVIEW_CHANNEL),
     bindings: () => ipcRenderer.invoke(CLOUD_IM_BINDINGS_CHANNEL),

--- a/apps/desktop/src/renderer/src/cloud-auth/bridges.ts
+++ b/apps/desktop/src/renderer/src/cloud-auth/bridges.ts
@@ -31,6 +31,11 @@ export interface CloudDataBridges {
   linkcodeCloud: {
     /** Lists the signed-in account's online hosts; main attaches the session and validates. */
     listHosts: () => Promise<CloudHost[]>;
+    /**
+     * Re-asserts this app as the OS default handler for the deep-link scheme, so the OAuth callback
+     * routes back here. Called right before a sign-in. Resolves to whether the OS accepted it.
+     */
+    claimDeepLink: () => Promise<boolean>;
     /** IM Channel management (`/im/*`); same session-in-main model as listHosts. */
     im: CloudImSource;
   };

--- a/apps/desktop/src/renderer/src/cloud-auth/store.ts
+++ b/apps/desktop/src/renderer/src/cloud-auth/store.ts
@@ -27,11 +27,16 @@ export const useCloudAuthStore = create<CloudAuthState>((set) => {
     authenticating: false,
     signIn() {
       set({ authenticating: true });
-      // requestAuth resolves once the system browser has been handed the sign-in URL; the
-      // rest of the flow happens out-of-app (deep link → onAuthenticated). Clear the flag on
-      // that handoff — otherwise abandoning the browser leaves no callback to fire and the
-      // button stays disabled until reload.
-      void window.requestAuth().finally(() => set({ authenticating: false }));
+      // Re-assert this app as the linkcode(-dev):// default handler before the browser handoff, so
+      // the OAuth callback deep-link routes back to THIS app even if a running `pnpm dev` or the
+      // other channel grabbed the OS-global scheme after startup. `allSettled` → a failed re-assert
+      // still proceeds to sign-in (falling back to the last handler to register).
+      // requestAuth resolves once the system browser has been handed the sign-in URL; the rest of
+      // the flow happens out-of-app (deep link → onAuthenticated). Clear the flag on that handoff —
+      // otherwise abandoning the browser leaves no callback to fire and the button stays disabled.
+      void Promise.allSettled([window.linkcodeCloud.claimDeepLink()])
+        .then(() => window.requestAuth())
+        .finally(() => set({ authenticating: false }));
     },
     signOut() {
       void window.signOut();

--- a/apps/desktop/src/shared/cloud.ts
+++ b/apps/desktop/src/shared/cloud.ts
@@ -5,6 +5,10 @@
  */
 export const CLOUD_LIST_HOSTS_CHANNEL = 'linkcode.cloud.list-hosts';
 
+// Re-asserts this app as the OS default handler for the channel's `linkcode(-dev)://` scheme; the
+// renderer invokes it right before a sign-in so the OAuth deep-link callback comes back here.
+export const CLOUD_CLAIM_DEEP_LINK_CHANNEL = 'linkcode.cloud.claim-deep-link';
+
 // IM Channel management (`/im/*` on the cloud API).
 export const CLOUD_IM_OVERVIEW_CHANNEL = 'linkcode.cloud.im.overview';
 export const CLOUD_IM_BINDINGS_CHANNEL = 'linkcode.cloud.im.bindings';


### PR DESCRIPTION
Fixes **CODE-182**. Pairs with the HQ change: arcboxlabs/linkcodehq#2 (deploy that first for dev-channel).

## Problem
Packaged builds (release/dev shell): the browser IdP sign-in completes but the `linkcode://auth/callback#token=…` deep link never reaches the running app, so the footer stays signed out.

## Root cause
`linkcode://` is an **OS-global, last-writer-wins** scheme. Three parties register it: the release app (Info.plist), the dev shell (inherits `linkcode` via `extends`), and any `pnpm dev` bare Electron (the `@better-auth/electron` plugin's runtime `setAsDefaultProtocolClient`, dev branch pointing at `node_modules/electron`). On macOS, `LSCopyDefaultApplicationURLForURL("linkcode://…")` resolved to the dev Electron — the last `pnpm dev` had stolen the default, so the callback routed there instead of the running packaged app. (CODE-167 kept `linkcode://` un-scoped across **profiles** on purpose; the **channel** axis is what collides here.)

## Fix — split the scheme per channel
Release keeps `linkcode://`; the `development` channel (every `pnpm dev`, local dev-shell pack, and prod bundle run by the dev Electron — see `constants.ts`) uses `linkcode-dev://`, so `pnpm dev` no longer steals release's scheme.

- `cloud-auth/client.ts`: `CLOUD_AUTH_SCHEME` derives from `CHANNEL`; the sign-in URL carries `?scheme=` so HQ deep-links back on the right one.
- **Re-assert before sign-in**: a `claim-deep-link` IPC (`shared/cloud.ts` + preload + `bridges.ts` + `store.ts`) calls `setAsDefaultProtocolClient` right before the browser handoff, so whichever app you sign in from wins even if a same-channel `pnpm dev` grabbed the scheme after startup.
- **Packaging base-split**: electron-builder **concatenates** arrays inherited via `extends` (`builder-util-runtime` `deepAssign`), so a `protocols` override in the dev-shell config would keep *both* `linkcode` and `linkcode-dev`. `electron-builder.yml` becomes a protocols-free shared base; `electron-builder.release.yml` (new) and `electron-builder.devshell.yml` each add their own scheme; `package-app.mts` points the release build at `release.yml`. Empirically verified via `deepAssign`: release → `[linkcode]`, dev shell → `[linkcode-dev]`, no leak.

## Rollout
Release is unaffected either way (prod HQ ignores the unknown `scheme` param and still deep-links `linkcode://`). Only the dev channel needs HQ deployed. Recommend HQ first.

## Verification
`pnpm check:ci` (format + lint + typecheck) and `pnpm test` (978 passed) green; prek hooks pass. Not exercised: the real end-to-end OAuth deep-link (needs HQ deployed + real IdP creds + launching a packaged app).