### PR TITLE
fix(ui): stabilize and unify chat action previews

### DIFF
--- a/apps/desktop/src/renderer/src/__tests__/shell-state.test.ts
+++ b/apps/desktop/src/renderer/src/__tests__/shell-state.test.ts
@@ -3,6 +3,7 @@ import {
   BOTTOM_PANEL_MAX_SIZE,
   BOTTOM_PANEL_MIN_SIZE,
   closeSectionTabState,
+  createDefaultDesktopShellState,
   createDefaultRightPanelState,
   createPanelState,
   createRightFileTab,
@@ -207,6 +208,23 @@ describe('desktop shell state persistence', () => {
     expect(parsed.rightPanel.files.activeTabId).toBe(parsed.rightPanel.files.tabs[0].id);
     expect(parsed.rightPanel.browser.url).toBe('http://web--app-1a2b3c.localhost:19523');
     expect(panelTypes(parsed.bottomPanel)).toEqual(['files']);
+  });
+
+  it('drops renderer-scoped blob URLs from persisted browser state', () => {
+    const source = createDefaultDesktopShellState();
+    source.rightPanel.browser.url = 'blob:http://localhost:5173/expired-preview';
+
+    const serialized = serializeDesktopShellState(source);
+    expect(serialized.rightPanel.browserUrl).toBeNull();
+
+    const parsed = parsePersistedDesktopShellState({
+      ...serialized,
+      rightPanel: {
+        ...serialized.rightPanel,
+        browserUrl: 'blob:http://localhost:5173/expired-preview',
+      },
+    });
+    expect(parsed.rightPanel.browser.url).toBeNull();
   });
 });
 

--- a/apps/desktop/src/renderer/src/shell/browser/browser-webview-pane.tsx
+++ b/apps/desktop/src/renderer/src/shell/browser/browser-webview-pane.tsx
@@ -36,6 +36,9 @@ export function BrowserWebviewPane(): React.ReactNode {
   // React's built-in `webview` intrinsic types the element as a bare HTMLWebViewElement;
   // in Electron (webviewTag enabled) the live element is always the full WebviewTag.
   const captureWebview = (element: HTMLWebViewElement | null): void => {
+    // React 19 rejects a boolean value for this custom content attribute. Electron only
+    // cares about its presence, so set it directly before the guest navigation begins.
+    element?.toggleAttribute('allowpopups', true);
     setWebview(element as WebviewTag | null);
   };
 
@@ -97,7 +100,6 @@ export function BrowserWebviewPane(): React.ReactNode {
           ref={captureWebview}
           src={url}
           partition={BROWSER_PARTITION}
-          allowpopups
           className="h-full w-full"
         />
       )}

--- a/apps/desktop/src/renderer/src/shell/store/model.ts
+++ b/apps/desktop/src/renderer/src/shell/store/model.ts
@@ -291,6 +291,10 @@ export function serializeDesktopShellState(state: DesktopShellState): PersistedD
   };
 }
 
+function durableBrowserUrl(url: string | null): string | null {
+  return url?.startsWith('blob:') ? null : url;
+}
+
 function createPersistedShellStateSchema(): z.ZodType<DesktopShellState> {
   const fallback = createDefaultDesktopShellState();
   const rightPanelSchema = createPersistedRightPanelSchema();
@@ -407,7 +411,7 @@ function createPersistedRightPanelSchema(): z.ZodType<RightPanelState> {
             tabs: fileTabs,
             activeTabId: fileTabs.length > 0 ? fileTabs[activeFileIndex].id : null,
           },
-          browser: { url: browserUrl },
+          browser: { url: durableBrowserUrl(browserUrl) },
         };
       },
     );
@@ -429,7 +433,7 @@ function serializeRightPanel(panel: RightPanelState): PersistedRightPanelState {
       0,
       Math.max(0, panel.files.tabs.length - 1),
     ),
-    browserUrl: panel.browser.url,
+    browserUrl: durableBrowserUrl(panel.browser.url),
   };
 }
 

--- a/packages/ui/src/chat/__tests__/activity-group.test.tsx
+++ b/packages/ui/src/chat/__tests__/activity-group.test.tsx
@@ -1,0 +1,87 @@
+// @vitest-environment jsdom
+
+import type { ToolCall } from '@linkcode/schema';
+import { cleanup, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { ActivityToolGroup } from '../activity-group';
+import { ActivityGroup } from '../activity-group';
+import { ArtifactHostActionsProvider } from '../artifacts/context';
+import type { ConversationItem } from '../types';
+
+function translateKey(key: string): string {
+  return key;
+}
+
+function translationsMock(): typeof translateKey {
+  return translateKey;
+}
+
+vi.mock('use-intl', () => ({
+  useTranslations: translationsMock,
+}));
+
+afterEach(cleanup);
+
+const RE_FILES = /^files/;
+const RE_FIRST_EDIT = /^Edit · first\.ts/;
+const RE_FIRST_FILE = /first\.ts$/;
+const RE_SECOND_FILE = /second\.ts$/;
+const WINDOWS_SECOND_PATH = String.raw`C:\repo\packages\second.ts`;
+
+function fileTool(
+  id: string,
+  kind: Extract<ToolCall['kind'], 'edit' | 'delete'>,
+  path: string,
+): Extract<ConversationItem, { kind: 'tool' }> {
+  return {
+    id,
+    kind: 'tool',
+    turnId: 'turn-1',
+    toolCall: {
+      toolCallId: id,
+      title: kind === 'edit' ? 'Edit' : 'Delete',
+      kind,
+      status: 'completed',
+      rawInput: { file_path: path },
+      content: [],
+    },
+  };
+}
+
+describe('ActivityGroup', () => {
+  it('keeps file directories out of collapsed summaries and expanded rows', async () => {
+    const user = userEvent.setup();
+    const openFile = vi.fn();
+    const group: ActivityToolGroup = {
+      type: 'group',
+      id: 'files-1',
+      bucket: 'files',
+      items: [
+        fileTool('edit-1', 'edit', '/repo/packages/first.ts'),
+        fileTool('delete-1', 'delete', WINDOWS_SECOND_PATH),
+      ],
+    };
+
+    const { container } = render(
+      <ArtifactHostActionsProvider actions={{ referenceToComposer: vi.fn(), openFile }}>
+        <ActivityGroup group={group} />
+      </ArtifactHostActionsProvider>,
+    );
+
+    expect(container.textContent).toContain('first.ts, second.ts');
+    expect(container.textContent).not.toContain('/repo');
+    expect(container.textContent).not.toContain(String.raw`C:\repo`);
+
+    await user.click(screen.getByRole('button', { name: RE_FILES }));
+
+    expect(screen.getByText(RE_FIRST_FILE)).toBeDefined();
+    expect(screen.getByText(RE_SECOND_FILE)).toBeDefined();
+    expect(container.textContent).not.toContain('/repo');
+    expect(container.textContent).not.toContain(String.raw`C:\repo`);
+
+    await user.click(screen.getByRole('button', { name: RE_FIRST_EDIT }));
+    await user.click(screen.getByRole('button', { name: 'first.ts' }));
+    expect(openFile).toHaveBeenCalledWith('/repo/packages/first.ts');
+  });
+});

--- a/packages/ui/src/chat/__tests__/terminal.test.tsx
+++ b/packages/ui/src/chat/__tests__/terminal.test.tsx
@@ -1,0 +1,19 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, expect, it, vi } from 'vitest';
+import { TerminalContent } from '../terminal';
+
+vi.mock('ansi-to-react', () => ({
+  default: {
+    default: ({ children }: { children?: React.ReactNode }) => <code>{children}</code>,
+  },
+}));
+
+afterEach(cleanup);
+
+it('renders output when the ANSI component is wrapped by its CommonJS default export', () => {
+  render(<TerminalContent>command output</TerminalContent>);
+
+  expect(screen.getByText('command output')).toBeDefined();
+});

--- a/packages/ui/src/chat/__tests__/tool-call-item.test.tsx
+++ b/packages/ui/src/chat/__tests__/tool-call-item.test.tsx
@@ -5,6 +5,7 @@ import { cleanup, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { ArtifactHostActionsProvider } from '../artifacts/context';
+import { SubagentTranscript } from '../subagent-card';
 import { ToolCallBody, ToolCallItem } from '../tool-call-item';
 
 function translateKey(key: string): string {
@@ -237,5 +238,88 @@ describe('ToolCallItem', () => {
     render(<ToolCallItem toolCall={toolCall} />);
 
     expect(screen.getByText('moved.ts')).toBeDefined();
+  });
+});
+
+describe('SubagentTranscript', () => {
+  const taskToolCall: ToolCall = {
+    toolCallId: 'task-1',
+    title: 'Review previews',
+    kind: 'task',
+    status: 'completed',
+    rawOutput: 'Final review report',
+    content: [],
+  };
+  const sharedProps = {
+    awaitingApproval: new Set<string>(),
+    childrenByParent: new Map(),
+    declined: new Set<string>(),
+    toolCall: taskToolCall,
+  };
+
+  it('uses the task result as the empty-transcript fallback', () => {
+    render(<SubagentTranscript {...sharedProps} items={[]} />);
+
+    expect(screen.getByText('Final review report')).toBeDefined();
+  });
+
+  it('does not repeat the task result after the transcript report', () => {
+    render(
+      <SubagentTranscript
+        {...sharedProps}
+        items={[
+          {
+            id: 'message-1',
+            kind: 'message',
+            role: 'assistant',
+            turnId: null,
+            isStreaming: false,
+            blocks: [{ type: 'text', text: 'Final review report' }],
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getAllByText('Final review report')).toHaveLength(1);
+  });
+
+  it('appends the task result when a partial transcript does not contain it', () => {
+    render(
+      <SubagentTranscript
+        {...sharedProps}
+        items={[
+          {
+            id: 'message-1',
+            kind: 'message',
+            role: 'assistant',
+            turnId: null,
+            isStreaming: false,
+            blocks: [{ type: 'text', text: 'Reviewed the preview boundary.' }],
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getByText('Reviewed the preview boundary.')).toBeDefined();
+    expect(screen.getByText('Final review report')).toBeDefined();
+  });
+
+  it('does not mistake private reasoning for the user-facing task report', () => {
+    render(
+      <SubagentTranscript
+        {...sharedProps}
+        items={[
+          {
+            id: 'reasoning-1',
+            kind: 'reasoning',
+            turnId: null,
+            isStreaming: false,
+            blocks: [{ type: 'text', text: 'Final review report' }],
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getAllByText('Final review report')).toHaveLength(2);
   });
 });

--- a/packages/ui/src/chat/__tests__/tool-call-item.test.tsx
+++ b/packages/ui/src/chat/__tests__/tool-call-item.test.tsx
@@ -54,7 +54,7 @@ describe('ToolCallBody', () => {
     expect(LiveTerminal).not.toHaveBeenCalled();
   });
 
-  it('projects file metadata without exposing the raw read request', () => {
+  it('keeps raw read fields out of a file preview', () => {
     const toolCall: ToolCall = {
       toolCallId: 'read-1',
       title: 'Read file',
@@ -67,8 +67,8 @@ describe('ToolCallBody', () => {
 
     const { container } = render(<ToolCallBody toolCall={toolCall} />);
 
-    expect(screen.getByText('path')).toBeDefined();
-    expect(screen.getAllByText('README.md:12')).toHaveLength(2);
+    expect(screen.queryByText('path')).toBeNull();
+    expect(screen.getByText('README.md:12')).toBeDefined();
     expect(screen.queryByText('input')).toBeNull();
     expect(container.textContent).not.toContain('offset');
     expect(container.textContent).not.toContain('debug');
@@ -95,7 +95,7 @@ describe('ToolCallBody', () => {
 
     expect(container.querySelector('h1')).toBeNull();
     expect(container.querySelector('pre')?.textContent).toBe(source);
-    expect(screen.getByText('src/answer.ts')).toBeDefined();
+    expect(screen.queryByText('src/answer.ts')).toBeNull();
     expect(screen.getByText('answer.ts')).toBeDefined();
   });
 
@@ -200,10 +200,8 @@ describe('ToolCallItem', () => {
     const headerText = screen.getByRole('button', { name: RE_APPLY_GUARDED_EDIT }).textContent;
     expect(screen.getByText('+1')).toBeDefined();
     expect(screen.getByText('-1')).toBeDefined();
-    expect(headerText.indexOf('+1')).toBeLessThan(
-      headerText.indexOf('packages/ui/src/chat/target.ts'),
-    );
-    expect(screen.queryByText('target.ts')).toBeNull();
+    expect(headerText).toContain('target.ts');
+    expect(headerText).not.toContain('packages/ui/src/chat');
   });
 
   it('opens an edited file from the shared diff header', async () => {
@@ -238,7 +236,7 @@ describe('ToolCallItem', () => {
     expect(openFile).toHaveBeenCalledWith(path);
   });
 
-  it('keeps the produced-file artifact for a completed move', () => {
+  it('summarizes a completed move without exposing its directory', () => {
     const toolCall: ToolCall = {
       toolCallId: 'move-1',
       title: 'Move file',
@@ -249,9 +247,10 @@ describe('ToolCallItem', () => {
       content: [],
     };
 
-    render(<ToolCallItem toolCall={toolCall} />);
+    const { container } = render(<ToolCallItem toolCall={toolCall} />);
 
-    expect(screen.getByText('moved.ts')).toBeDefined();
+    expect(container.textContent).toContain('target.ts → moved.ts');
+    expect(container.textContent).not.toContain('packages/ui/src/chat');
   });
 });
 

--- a/packages/ui/src/chat/__tests__/tool-call-item.test.tsx
+++ b/packages/ui/src/chat/__tests__/tool-call-item.test.tsx
@@ -170,7 +170,7 @@ describe('ToolCallBody', () => {
     const tooltipTrigger = screen
       .getByText('preview.md')
       .closest<HTMLElement>('[data-slot="tooltip-trigger"]');
-    expect(tooltipTrigger?.tabIndex).toBe(0);
+    expect(tooltipTrigger?.tabIndex).toBe(-1);
   });
 
   it('surfaces an execute failure message without its raw result envelope', () => {

--- a/packages/ui/src/chat/__tests__/tool-call-item.test.tsx
+++ b/packages/ui/src/chat/__tests__/tool-call-item.test.tsx
@@ -22,6 +22,7 @@ vi.mock('use-intl', () => ({
 
 const LiveTerminal = vi.fn(({ terminalId }: { terminalId: string }) => <div>{terminalId}</div>);
 const RE_APPLY_GUARDED_EDIT = /^Apply guarded edit/;
+const RE_TARGET_PREVIEW_HEADER = /^target\.ts/;
 
 afterEach(() => {
   cleanup();
@@ -230,7 +231,7 @@ describe('ToolCallItem', () => {
     );
 
     await user.click(screen.getByRole('button', { name: RE_APPLY_GUARDED_EDIT }));
-    await user.click(screen.getByTitle('openFile'));
+    await user.click(screen.getByRole('button', { name: RE_TARGET_PREVIEW_HEADER }));
 
     expect(openFile).toHaveBeenCalledOnce();
     expect(openFile).toHaveBeenCalledWith(path);

--- a/packages/ui/src/chat/__tests__/tool-call-item.test.tsx
+++ b/packages/ui/src/chat/__tests__/tool-call-item.test.tsx
@@ -72,6 +72,41 @@ describe('ToolCallBody', () => {
     expect(container.textContent).not.toContain('debug');
   });
 
+  it('renders source reads literally instead of interpreting Markdown-looking code', () => {
+    const source = '# not-a-heading\nconst answer = 42;';
+    const toolCall: ToolCall = {
+      toolCallId: 'read-source',
+      title: 'Read source',
+      kind: 'read',
+      status: 'completed',
+      locations: [{ path: 'src/answer.ts' }],
+      content: [{ type: 'content', content: { type: 'text', text: source } }],
+    };
+
+    const { container } = render(<ToolCallBody toolCall={toolCall} />);
+
+    expect(container.querySelector('h1')).toBeNull();
+    expect(container.querySelector('pre')?.textContent).toBe(source);
+    expect(screen.getAllByText('src/answer.ts')).toHaveLength(2);
+  });
+
+  it('renders Markdown file reads as a document preview', () => {
+    const toolCall: ToolCall = {
+      toolCallId: 'read-markdown',
+      title: 'Read document',
+      kind: 'read',
+      status: 'completed',
+      locations: [{ path: 'docs/preview.md' }],
+      content: [{ type: 'content', content: { type: 'text', text: '# Preview\n\n- First item' } }],
+    };
+
+    const { container } = render(<ToolCallBody toolCall={toolCall} />);
+
+    expect(container.querySelector('h1')?.textContent).toBe('Preview');
+    expect(container.querySelector('li')?.textContent).toBe('First item');
+    expect(container.querySelector('pre')).toBeNull();
+  });
+
   it('surfaces an execute failure message without its raw result envelope', () => {
     const toolCall: ToolCall = {
       toolCallId: 'bash-2',
@@ -107,6 +142,24 @@ describe('ToolCallBody', () => {
 
     expect(container.querySelector('pre')?.textContent).toBe('825 tests passed');
     expect(container.textContent).not.toContain('exitCode');
+  });
+
+  it('does not mistake a Codex scalar exit code for terminal output', () => {
+    const toolCall: ToolCall = {
+      toolCallId: 'codex-exit-1',
+      title: 'Bash',
+      kind: 'execute',
+      status: 'completed',
+      rawInput: { command: 'true' },
+      rawOutput: 0,
+      content: [],
+    };
+
+    const { container } = render(<ToolCallBody toolCall={toolCall} />);
+
+    expect(screen.getByText('true')).toBeDefined();
+    expect(container.querySelector('pre')).toBeNull();
+    expect(container.textContent).not.toContain('0');
   });
 });
 

--- a/packages/ui/src/chat/__tests__/tool-call-item.test.tsx
+++ b/packages/ui/src/chat/__tests__/tool-call-item.test.tsx
@@ -77,11 +77,17 @@ describe('ToolCallBody', () => {
     const source = '# not-a-heading\nconst answer = 42;';
     const toolCall: ToolCall = {
       toolCallId: 'read-source',
-      title: 'Read source',
+      title: 'Read',
       kind: 'read',
       status: 'completed',
       locations: [{ path: 'src/answer.ts' }],
-      content: [{ type: 'content', content: { type: 'text', text: source } }],
+      rawInput: { file_path: 'src/answer.ts' },
+      content: [
+        {
+          type: 'content',
+          content: { type: 'text', text: '1\t# not-a-heading\n2\tconst answer = 42;' },
+        },
+      ],
     };
 
     const { container } = render(<ToolCallBody toolCall={toolCall} />);
@@ -94,11 +100,17 @@ describe('ToolCallBody', () => {
   it('renders Markdown file reads as a document preview', () => {
     const toolCall: ToolCall = {
       toolCallId: 'read-markdown',
-      title: 'Read document',
+      title: 'Read',
       kind: 'read',
       status: 'completed',
       locations: [{ path: 'docs/preview.md' }],
-      content: [{ type: 'content', content: { type: 'text', text: '# Preview\n\n- First item' } }],
+      rawInput: { file_path: 'docs/preview.md' },
+      content: [
+        {
+          type: 'content',
+          content: { type: 'text', text: '1\t# Preview\n2\t\n3\t- First item' },
+        },
+      ],
     };
 
     const { container } = render(<ToolCallBody toolCall={toolCall} />);

--- a/packages/ui/src/chat/__tests__/tool-call-item.test.tsx
+++ b/packages/ui/src/chat/__tests__/tool-call-item.test.tsx
@@ -68,7 +68,7 @@ describe('ToolCallBody', () => {
     const { container } = render(<ToolCallBody toolCall={toolCall} />);
 
     expect(screen.getByText('path')).toBeDefined();
-    expect(screen.getByText('README.md:12')).toBeDefined();
+    expect(screen.getAllByText('README.md:12')).toHaveLength(2);
     expect(screen.queryByText('input')).toBeNull();
     expect(container.textContent).not.toContain('offset');
     expect(container.textContent).not.toContain('debug');
@@ -95,7 +95,8 @@ describe('ToolCallBody', () => {
 
     expect(container.querySelector('h1')).toBeNull();
     expect(container.querySelector('pre')?.textContent).toBe(source);
-    expect(screen.getAllByText('src/answer.ts')).toHaveLength(2);
+    expect(screen.getByText('src/answer.ts')).toBeDefined();
+    expect(screen.getByText('answer.ts')).toBeDefined();
   });
 
   it('renders Markdown file reads as a document preview', () => {

--- a/packages/ui/src/chat/__tests__/tool-call-item.test.tsx
+++ b/packages/ui/src/chat/__tests__/tool-call-item.test.tsx
@@ -7,6 +7,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { ArtifactHostActionsProvider } from '../artifacts/context';
 import { SubagentTranscript } from '../subagent-card';
 import { ToolCallBody, ToolCallItem } from '../tool-call-item';
+import { hasToolBody } from '../tool-utils';
 
 function translateKey(key: string): string {
   return key;
@@ -21,8 +22,18 @@ vi.mock('use-intl', () => ({
 }));
 
 const LiveTerminal = vi.fn(({ terminalId }: { terminalId: string }) => <div>{terminalId}</div>);
+const RE_ANSWER_SOURCE_HEADER = /^answer\.ts/;
 const RE_APPLY_GUARDED_EDIT = /^Apply guarded edit/;
+const RE_DELETE_LEGACY = /^Delete legacy/;
+const RE_EDITED_GONE_PREVIEW = /^edited\.ts, gone\.ts$/;
+const RE_FAILED_MOVE_PREVIEW = /^old\.ts → new\.ts$/;
+const RE_FIRST_SECOND_PREVIEW = /^first\.ts, second\.ts$/;
+const RE_LEGACY_PREVIEW = /^legacy\.ts/;
+const RE_MOVE = /^Move file/;
+const RE_MOVE_PREVIEW = /^target\.ts → moved\.ts$/;
+const RE_READ = /^Read/;
 const RE_TARGET_PREVIEW_HEADER = /^target\.ts/;
+const RE_WRITE_PLAN = /^Write PLAN/;
 
 afterEach(() => {
   cleanup();
@@ -54,7 +65,7 @@ describe('ToolCallBody', () => {
     expect(LiveTerminal).not.toHaveBeenCalled();
   });
 
-  it('keeps raw read fields out of a file preview', () => {
+  it('renders file-path metadata as a header-only preview', () => {
     const toolCall: ToolCall = {
       toolCallId: 'read-1',
       title: 'Read file',
@@ -67,22 +78,24 @@ describe('ToolCallBody', () => {
 
     const { container } = render(<ToolCallBody toolCall={toolCall} />);
 
-    expect(screen.queryByText('path')).toBeNull();
+    expect(hasToolBody(toolCall)).toBe(true);
     expect(screen.getByText('README.md:12')).toBeDefined();
-    expect(screen.queryByText('input')).toBeNull();
     expect(container.textContent).not.toContain('offset');
     expect(container.textContent).not.toContain('debug');
   });
 
-  it('renders source reads literally instead of interpreting Markdown-looking code', () => {
+  it('renders source reads literally and opens them from the basename header', async () => {
+    const user = userEvent.setup();
+    const openFile = vi.fn();
     const source = '# not-a-heading\nconst answer = 42;';
+    const path = '/repo/src/answer.ts';
     const toolCall: ToolCall = {
       toolCallId: 'read-source',
       title: 'Read',
       kind: 'read',
       status: 'completed',
-      locations: [{ path: 'src/answer.ts' }],
-      rawInput: { file_path: 'src/answer.ts' },
+      locations: [{ path }],
+      rawInput: { file_path: path },
       content: [
         {
           type: 'content',
@@ -91,12 +104,44 @@ describe('ToolCallBody', () => {
       ],
     };
 
+    const { container } = render(
+      <ArtifactHostActionsProvider actions={{ referenceToComposer: vi.fn(), openFile }}>
+        <ToolCallItem toolCall={toolCall} />
+      </ArtifactHostActionsProvider>,
+    );
+
+    const peekHeader = screen.getByRole('button', { name: RE_READ });
+    expect(peekHeader.textContent).toContain('answer.ts');
+    expect(peekHeader.textContent).not.toContain('/repo');
+    expect(screen.queryByText(path)).toBeNull();
+
+    await user.click(peekHeader);
+    const previewHeader = screen.getByRole('button', { name: RE_ANSWER_SOURCE_HEADER });
+    expect(previewHeader.querySelector('[aria-hidden="true"] svg')).not.toBeNull();
+    await user.hover(previewHeader);
+    expect(await screen.findByText(path)).toBeDefined();
+    await user.click(previewHeader);
+
+    expect(container.querySelector('h1')).toBeNull();
+    expect(container.querySelector('pre')?.textContent).toBe(source);
+    expect(openFile).toHaveBeenCalledOnce();
+    expect(openFile).toHaveBeenCalledWith(path);
+  });
+
+  it('renders pathless reads literally instead of interpreting Markdown-looking output', () => {
+    const source = '# not-a-heading\nconst answer = 42;';
+    const toolCall: ToolCall = {
+      toolCallId: 'read-pathless',
+      title: 'Read output',
+      kind: 'read',
+      status: 'completed',
+      content: [{ type: 'content', content: { type: 'text', text: source } }],
+    };
+
     const { container } = render(<ToolCallBody toolCall={toolCall} />);
 
     expect(container.querySelector('h1')).toBeNull();
     expect(container.querySelector('pre')?.textContent).toBe(source);
-    expect(screen.queryByText('src/answer.ts')).toBeNull();
-    expect(screen.getByText('answer.ts')).toBeDefined();
   });
 
   it('renders Markdown file reads as a document preview', () => {
@@ -105,8 +150,8 @@ describe('ToolCallBody', () => {
       title: 'Read',
       kind: 'read',
       status: 'completed',
-      locations: [{ path: 'docs/preview.md' }],
-      rawInput: { file_path: 'docs/preview.md' },
+      locations: [{ path: '/repo/docs/preview.md' }],
+      rawInput: { file_path: '/repo/docs/preview.md' },
       content: [
         {
           type: 'content',
@@ -120,6 +165,12 @@ describe('ToolCallBody', () => {
     expect(container.querySelector('h1')?.textContent).toBe('Preview');
     expect(container.querySelector('li')?.textContent).toBe('First item');
     expect(container.querySelector('pre')).toBeNull();
+    expect(screen.getByText('preview.md')).toBeDefined();
+    expect(screen.queryByText('/repo/docs/preview.md')).toBeNull();
+    const tooltipTrigger = screen
+      .getByText('preview.md')
+      .closest<HTMLElement>('[data-slot="tooltip-trigger"]');
+    expect(tooltipTrigger?.tabIndex).toBe(0);
   });
 
   it('surfaces an execute failure message without its raw result envelope', () => {
@@ -179,6 +230,34 @@ describe('ToolCallBody', () => {
 });
 
 describe('ToolCallItem', () => {
+  it('opens a path-only write from its header-only preview', async () => {
+    const user = userEvent.setup();
+    const openFile = vi.fn();
+    const toolCall: ToolCall = {
+      toolCallId: 'write-plan',
+      title: 'Write PLAN.md',
+      kind: 'edit',
+      status: 'completed',
+      locations: [{ path: 'PLAN.md' }],
+      rawInput: { file_path: 'PLAN.md' },
+      content: [],
+    };
+
+    render(
+      <ArtifactHostActionsProvider actions={{ referenceToComposer: vi.fn(), openFile }}>
+        <ToolCallItem toolCall={toolCall} />
+      </ArtifactHostActionsProvider>,
+    );
+
+    await user.click(screen.getByRole('button', { name: RE_WRITE_PLAN }));
+    const previewHeader = screen.getByRole('button', { name: 'PLAN.md' });
+    previewHeader.focus();
+    await user.keyboard('{Enter}');
+
+    expect(openFile).toHaveBeenCalledOnce();
+    expect(openFile).toHaveBeenCalledWith('PLAN.md');
+  });
+
   it('summarizes a standalone edit without a redundant file artifact card', () => {
     const toolCall: ToolCall = {
       toolCallId: 'edit-1',
@@ -230,27 +309,203 @@ describe('ToolCallItem', () => {
     );
 
     await user.click(screen.getByRole('button', { name: RE_APPLY_GUARDED_EDIT }));
-    await user.click(screen.getByRole('button', { name: RE_TARGET_PREVIEW_HEADER }));
+    const previewHeader = screen.getByRole('button', { name: RE_TARGET_PREVIEW_HEADER });
+    await user.hover(previewHeader);
+    expect(await screen.findByText(path)).toBeDefined();
+    await user.click(previewHeader);
 
     expect(openFile).toHaveBeenCalledOnce();
     expect(openFile).toHaveBeenCalledWith(path);
   });
 
-  it('summarizes a completed move without exposing its directory', () => {
+  it('keeps a completed move destination reachable around a non-text result', async () => {
+    const user = userEvent.setup();
+    const openFile = vi.fn();
+    const source = 'packages/ui/src/chat/target.ts';
+    const destination = 'packages/ui/src/chat/moved.ts';
     const toolCall: ToolCall = {
       toolCallId: 'move-1',
       title: 'Move file',
       kind: 'move',
       status: 'completed',
-      locations: [{ path: 'packages/ui/src/chat/moved.ts' }],
-      rawInput: { path: 'target.ts', move_path: 'packages/ui/src/chat/moved.ts' },
+      locations: [{ path: source }],
+      rawInput: { path: source, move_path: destination },
+      content: [
+        {
+          type: 'content',
+          content: {
+            type: 'resource_link',
+            uri: 'https://example.test/move-receipt',
+            name: 'Move receipt',
+          },
+        },
+      ],
+    };
+
+    const { container } = render(
+      <ArtifactHostActionsProvider actions={{ referenceToComposer: vi.fn(), openFile }}>
+        <ToolCallItem toolCall={toolCall} />
+      </ArtifactHostActionsProvider>,
+    );
+
+    await user.click(screen.getByRole('button', { name: RE_MOVE }));
+    await user.click(screen.getByRole('button', { name: RE_MOVE_PREVIEW }));
+
+    expect(openFile).toHaveBeenCalledOnce();
+    expect(openFile).toHaveBeenCalledWith(destination);
+    expect(container.textContent).not.toContain('packages/ui/src/chat');
+  });
+
+  it('opens the surviving source after a move fails', async () => {
+    const user = userEvent.setup();
+    const openFile = vi.fn();
+    const source = '/repo/old.ts';
+    const toolCall: ToolCall = {
+      toolCallId: 'move-failed',
+      title: 'Move file',
+      kind: 'move',
+      status: 'failed',
+      rawInput: { path: source, move_path: '/repo/new.ts' },
       content: [],
     };
 
-    const { container } = render(<ToolCallItem toolCall={toolCall} />);
+    render(
+      <ArtifactHostActionsProvider actions={{ referenceToComposer: vi.fn(), openFile }}>
+        <ToolCallItem toolCall={toolCall} />
+      </ArtifactHostActionsProvider>,
+    );
 
-    expect(container.textContent).toContain('target.ts → moved.ts');
-    expect(container.textContent).not.toContain('packages/ui/src/chat');
+    await user.click(screen.getByRole('button', { name: RE_MOVE }));
+    await user.click(screen.getByRole('button', { name: RE_FAILED_MOVE_PREVIEW }));
+
+    expect(openFile).toHaveBeenCalledWith(source);
+  });
+
+  it('routes multi-file text receipts through one aggregate review header', async () => {
+    const user = userEvent.setup();
+    const openFile = vi.fn();
+    const reviewChanges = vi.fn();
+    const toolCall: ToolCall = {
+      toolCallId: 'multi-file-receipts',
+      title: 'Apply file changes',
+      kind: 'edit',
+      status: 'completed',
+      locations: [{ path: '/repo/first.ts' }, { path: '/repo/second.ts' }],
+      content: [
+        { type: 'content', content: { type: 'text', text: 'Renamed the first file' } },
+        { type: 'content', content: { type: 'text', text: 'Renamed the second file' } },
+      ],
+    };
+
+    const { container } = render(
+      <ArtifactHostActionsProvider
+        actions={{ referenceToComposer: vi.fn(), openFile, reviewChanges }}
+      >
+        <ToolCallBody toolCall={toolCall} />
+      </ArtifactHostActionsProvider>,
+    );
+
+    expect(screen.getByText('Renamed the first file')).toBeDefined();
+    expect(screen.getByText('Renamed the second file')).toBeDefined();
+    await user.click(screen.getByRole('button', { name: RE_FIRST_SECOND_PREVIEW }));
+    expect(container.textContent).not.toContain('/repo');
+    expect(openFile).not.toHaveBeenCalled();
+    expect(reviewChanges).toHaveBeenCalledOnce();
+  });
+
+  it('keeps an aggregate review header beside mixed Codex diffs and delete receipts', async () => {
+    const user = userEvent.setup();
+    const openFile = vi.fn();
+    const reviewChanges = vi.fn();
+    const editedPath = 'packages/ui/edited.ts';
+    const deletedPath = 'packages/ui/gone.ts';
+    const toolCall: ToolCall = {
+      toolCallId: 'mixed-codex-patch',
+      title: 'Apply file changes',
+      kind: 'edit',
+      status: 'completed',
+      locations: [{ path: editedPath }, { path: deletedPath }],
+      content: [
+        {
+          type: 'diff',
+          path: editedPath,
+          oldText: 'before\n',
+          newText: 'after\n',
+        },
+        {
+          type: 'content',
+          content: { type: 'text', text: `Deleted ${deletedPath}` },
+        },
+      ],
+    };
+
+    render(
+      <ArtifactHostActionsProvider
+        actions={{ referenceToComposer: vi.fn(), openFile, reviewChanges }}
+      >
+        <ToolCallBody toolCall={toolCall} />
+      </ArtifactHostActionsProvider>,
+    );
+
+    expect(screen.getByText(`Deleted ${deletedPath}`)).toBeDefined();
+    await user.click(screen.getByRole('button', { name: RE_EDITED_GONE_PREVIEW }));
+    expect(reviewChanges).toHaveBeenCalledOnce();
+    expect(openFile).not.toHaveBeenCalled();
+  });
+
+  it('routes a Codex history delete receipt to the diff viewer', async () => {
+    const user = userEvent.setup();
+    const openFile = vi.fn();
+    const reviewChanges = vi.fn();
+    const path = 'packages/ui/src/chat/gone.ts';
+    const toolCall: ToolCall = {
+      toolCallId: 'codex-delete-receipt',
+      title: 'Apply file changes',
+      kind: 'edit',
+      status: 'completed',
+      locations: [{ path }],
+      content: [{ type: 'content', content: { type: 'text', text: `Deleted ${path}` } }],
+    };
+
+    render(
+      <ArtifactHostActionsProvider
+        actions={{ referenceToComposer: vi.fn(), openFile, reviewChanges }}
+      >
+        <ToolCallBody toolCall={toolCall} />
+      </ArtifactHostActionsProvider>,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'gone.ts' }));
+    expect(reviewChanges).toHaveBeenCalledOnce();
+    expect(openFile).not.toHaveBeenCalled();
+  });
+
+  it('opens completed deletions in the diff viewer instead of the missing file', async () => {
+    const user = userEvent.setup();
+    const openFile = vi.fn();
+    const reviewChanges = vi.fn();
+    const path = '/repo/legacy.ts';
+    const toolCall: ToolCall = {
+      toolCallId: 'delete-legacy',
+      title: 'Delete legacy file',
+      kind: 'delete',
+      status: 'completed',
+      content: [{ type: 'diff', path, oldText: 'legacy\n', newText: '' }],
+    };
+
+    render(
+      <ArtifactHostActionsProvider
+        actions={{ referenceToComposer: vi.fn(), openFile, reviewChanges }}
+      >
+        <ToolCallItem toolCall={toolCall} />
+      </ArtifactHostActionsProvider>,
+    );
+
+    await user.click(screen.getByRole('button', { name: RE_DELETE_LEGACY }));
+    await user.click(screen.getByRole('button', { name: RE_LEGACY_PREVIEW }));
+
+    expect(reviewChanges).toHaveBeenCalledOnce();
+    expect(openFile).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/ui/src/chat/__tests__/tool-call-metadata.test.tsx
+++ b/packages/ui/src/chat/__tests__/tool-call-metadata.test.tsx
@@ -4,7 +4,7 @@ import type { ToolCall } from '@linkcode/schema';
 import { cleanup, render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { ToolCallBody } from '../tool-call-item';
-import { hasToolBody, toolCallSummary } from '../tool-utils';
+import { hasToolBody, toolCallHeaderSummary, toolCallMetadata } from '../tool-utils';
 
 function translateKey(key: string): string {
   return key;
@@ -238,11 +238,13 @@ describe('tool metadata policy', () => {
       },
     ];
 
-    expect(calls.map(toolCallSummary)).toEqual([
-      'README.md:3',
-      'ToolCallBody',
-      'old.ts → new.ts',
-      'pnpm test',
+    expect(calls.map(toolCallHeaderSummary)).toEqual([
+      { label: 'README.md:3', tooltip: 'README.md:3' },
+      { label: 'ToolCallBody' },
+      { label: 'old.ts → new.ts', tooltip: 'old.ts → new.ts' },
+      { label: 'pnpm test' },
     ]);
+    expect(toolCallMetadata(calls[0])).toEqual([]);
+    expect(toolCallMetadata(calls[2])).toEqual([]);
   });
 });

--- a/packages/ui/src/chat/__tests__/tool-call-metadata.test.tsx
+++ b/packages/ui/src/chat/__tests__/tool-call-metadata.test.tsx
@@ -26,7 +26,7 @@ afterEach(() => {
 });
 
 describe('tool metadata policy', () => {
-  it('shows search counts while hiding result paths and adapter timing', () => {
+  it('previews search results while hiding adapter request and timing fields', () => {
     const toolCall: ToolCall = {
       toolCallId: 'search-1',
       title: 'Search renderers',
@@ -44,15 +44,18 @@ describe('tool metadata policy', () => {
     const { container } = render(<ToolCallBody toolCall={toolCall} />);
 
     expect(screen.getByText('query')).toBeDefined();
-    expect(screen.getByText('tool-call')).toBeDefined();
+    expect(screen.getAllByText('tool-call')).toHaveLength(2);
     expect(screen.getByText('matches')).toBeDefined();
     expect(screen.getByText('files')).toBeDefined();
-    expect(container.textContent).not.toContain('tool-call-item.tsx');
+    expect(container.querySelector('pre')?.textContent).toContain('packages/ui/src/chat/tool.tsx');
+    expect(container.querySelector('pre')?.textContent).toContain(
+      'packages/ui/src/chat/tool-call-item.tsx',
+    );
     expect(container.textContent).not.toContain('elapsedMs');
     expect(container.textContent).not.toContain('glob');
   });
 
-  it('shows curated fetch failure context without request or response envelopes', () => {
+  it('previews an allowlisted fetch response without exposing its envelopes', () => {
     const toolCall: ToolCall = {
       toolCallId: 'fetch-1',
       title: 'Fetch preview',
@@ -68,37 +71,55 @@ describe('tool metadata policy', () => {
         message: 'Preview service unavailable',
         responseBody: '<internal diagnostic>',
       },
-      content: [{ type: 'content', content: { type: 'text', text: 'Request attempted.' } }],
+      content: [],
     };
 
     const { container } = render(<ToolCallBody toolCall={toolCall} />);
 
     expect(screen.getByText('url')).toBeDefined();
-    expect(screen.getByText('https://mock.invalid/preview')).toBeDefined();
+    expect(screen.getAllByText('https://mock.invalid/preview')).toHaveLength(2);
     expect(screen.getByText('status')).toBeDefined();
     expect(screen.getByText('503')).toBeDefined();
-    expect(screen.getByText('Request attempted.')).toBeDefined();
+    expect(screen.getByText('<internal diagnostic>')).toBeDefined();
     expect(screen.getByText('Preview service unavailable')).toBeDefined();
     expect(container.textContent).not.toContain('authorization');
     expect(container.textContent).not.toContain('trace-173');
     expect(container.textContent).not.toContain('responseBody');
   });
 
-  it('keeps arbitrary custom-tool payloads out of normal-mode details', () => {
+  it('previews standardized custom-tool output without exposing arbitrary fields', () => {
     const toolCall: ToolCall = {
       toolCallId: 'other-1',
       title: 'workspace.inspect',
       kind: 'other',
       status: 'completed',
       rawInput: { workspaceId: 'internal-42', includeDebug: true },
-      rawOutput: { requestId: 'request-42', ok: true },
+      rawOutput: { requestId: 'request-42', structuredContent: { ok: true } },
       content: [],
     };
 
     const { container } = render(<ToolCallBody toolCall={toolCall} />);
 
-    expect(container.textContent).toBe('');
-    expect(hasToolBody(toolCall)).toBe(false);
+    expect(container.querySelector('pre')?.textContent).toContain('"ok": true');
+    expect(container.textContent).not.toContain('request-42');
+    expect(container.textContent).not.toContain('workspaceId');
+    expect(hasToolBody(toolCall)).toBe(true);
+  });
+
+  it('prefers canonical OpenCode content over its duplicate raw string', () => {
+    const toolCall: ToolCall = {
+      toolCallId: 'opencode-read-1',
+      title: 'read',
+      kind: 'read',
+      status: 'completed',
+      locations: [{ path: 'notes.md' }],
+      rawOutput: 'Canonical result',
+      content: [{ type: 'content', content: { type: 'text', text: 'Canonical result' } }],
+    };
+
+    render(<ToolCallBody toolCall={toolCall} />);
+
+    expect(screen.getAllByText('Canonical result')).toHaveLength(1);
   });
 
   it('projects Pi AgentToolResult content without exposing its details envelope', () => {
@@ -162,6 +183,23 @@ describe('tool metadata policy', () => {
     expect(LiveTerminal).toHaveBeenCalledWith({ terminalId: 'terminal-live' }, undefined);
     expect(container.textContent).toBe('terminal-live');
     expect(container.textContent).not.toContain('description');
+  });
+
+  it('keeps a completed execute message reachable without a command', () => {
+    const toolCall: ToolCall = {
+      toolCallId: 'bash-message',
+      title: 'Bash',
+      kind: 'execute',
+      status: 'completed',
+      rawOutput: { exitCode: 1, message: 'command unavailable' },
+      content: [],
+    };
+
+    const { container } = render(<ToolCallBody toolCall={toolCall} />);
+
+    expect(hasToolBody(toolCall)).toBe(true);
+    expect(container.querySelector('pre')?.textContent).toBe('command unavailable');
+    expect(container.textContent).not.toContain('exitCode');
   });
 
   it('provides curated context for singleton headers and activity groups', () => {

--- a/packages/ui/src/chat/__tests__/tool-result-content.test.ts
+++ b/packages/ui/src/chat/__tests__/tool-result-content.test.ts
@@ -1,0 +1,79 @@
+import type { ToolCall } from '@linkcode/schema';
+import { describe, expect, it } from 'vitest';
+import {
+  toolCallDisplayContent,
+  toolCallDisplayText,
+  toolCallExecuteText,
+} from '../tool-result-content';
+
+function call(overrides: Partial<ToolCall>): ToolCall {
+  return {
+    toolCallId: 'tool-1',
+    title: 'Tool',
+    kind: 'other',
+    status: 'completed',
+    content: [],
+    ...overrides,
+  };
+}
+
+describe('tool result content policy', () => {
+  it('prefers canonical content over duplicate adapter output', () => {
+    const toolCall = call({
+      kind: 'read',
+      rawOutput: 'duplicate',
+      content: [{ type: 'content', content: { type: 'text', text: 'canonical' } }],
+    });
+
+    expect(toolCallDisplayText(toolCall)).toBe('canonical');
+  });
+
+  it('projects Pi and live Codex MCP content without their envelopes', () => {
+    const toolCall = call({
+      rawOutput: {
+        content: [{ type: 'text', text: 'projected', textSignature: 'opaque' }],
+        details: { durationMs: 12 },
+      },
+    });
+
+    expect(toolCallDisplayContent(toolCall)).toEqual([
+      { type: 'content', content: { type: 'text', text: 'projected' } },
+    ]);
+  });
+
+  it('projects only kind-specific structured result fields', () => {
+    expect(
+      toolCallDisplayText(
+        call({ kind: 'search', rawOutput: { matches: ['a.ts', 'b.ts'], elapsedMs: 4 } }),
+      ),
+    ).toBe('a.ts\nb.ts');
+    expect(
+      toolCallDisplayText(
+        call({ kind: 'fetch', rawOutput: { responseBody: { ok: true }, traceId: 'hidden' } }),
+      ),
+    ).toBe('{\n  "ok": true\n}');
+    expect(
+      toolCallDisplayText(
+        call({
+          kind: 'other',
+          rawOutput: { structuredContent: { count: 2 }, requestId: 'hidden' },
+        }),
+      ),
+    ).toBe('{\n  "count": 2\n}');
+  });
+
+  it('does not present arbitrary envelopes or scalar execute exit codes', () => {
+    expect(
+      toolCallDisplayContent(call({ kind: 'read', rawOutput: { details: 'hidden' } })),
+    ).toEqual([]);
+    expect(toolCallDisplayContent(call({ kind: 'execute', rawOutput: 0 }))).toEqual([]);
+  });
+
+  it('projects the exact execute message field without its result envelope', () => {
+    expect(
+      toolCallExecuteText(
+        call({ kind: 'execute', rawOutput: { exitCode: 1, message: 'command failed' } }),
+      ),
+    ).toBe('command failed');
+  });
+});

--- a/packages/ui/src/chat/__tests__/tool-result-content.test.ts
+++ b/packages/ui/src/chat/__tests__/tool-result-content.test.ts
@@ -4,6 +4,7 @@ import {
   toolCallDisplayContent,
   toolCallDisplayText,
   toolCallExecuteText,
+  toolCallReadPreviewText,
 } from '../tool-result-content';
 
 function call(overrides: Partial<ToolCall>): ToolCall {
@@ -75,5 +76,50 @@ describe('tool result content policy', () => {
         call({ kind: 'execute', rawOutput: { exitCode: 1, message: 'command failed' } }),
       ),
     ).toBe('command failed');
+  });
+
+  it('unwraps a complete Claude Read line-number sequence', () => {
+    const toolCall = call({
+      kind: 'read',
+      title: 'Read',
+      rawInput: { file_path: '/repo/docs/preview.md', offset: 7 },
+    });
+
+    expect(
+      toolCallReadPreviewText(toolCall, '7\t# Preview\r\n8\t\r\n9\t1. First\r\n10\t2. Second\r\n'),
+    ).toBe('# Preview\r\n\r\n1. First\r\n2. Second\r\n');
+    expect(toolCallReadPreviewText(toolCall, '7\t7\talpha\n8\t8\tbeta')).toBe('7\talpha\n8\tbeta');
+    expect(toolCallReadPreviewText(toolCall, '7\talpha\r99\tbeta\u{2028}123\tgamma')).toBe(
+      'alpha\r99\tbeta\u{2028}123\tgamma',
+    );
+    expect(
+      toolCallReadPreviewText(
+        toolCall,
+        '<system-reminder>Provider metadata.</system-reminder>\n7\t# Preview\n8\t',
+      ),
+    ).toBe('# Preview\n');
+  });
+
+  it('preserves non-Claude and incomplete numbered content', () => {
+    const text = '1\talpha\n2\tbeta';
+    expect(
+      toolCallReadPreviewText(
+        call({ kind: 'read', title: 'read', rawInput: { path: '/repo/data.tsv' } }),
+        text,
+      ),
+    ).toBe(text);
+    expect(
+      toolCallReadPreviewText(
+        call({ kind: 'read', title: 'Read', rawInput: { file_path: '/repo/data.tsv' } }),
+        '1\talpha\n3\tbeta',
+      ),
+    ).toBe('1\talpha\n3\tbeta');
+    const reminder = '<system-reminder>Short-offset warning.</system-reminder>';
+    expect(
+      toolCallReadPreviewText(
+        call({ kind: 'read', title: 'Read', rawInput: { file_path: '/repo/data.tsv' } }),
+        reminder,
+      ),
+    ).toBe(reminder);
   });
 });

--- a/packages/ui/src/chat/activity-group.tsx
+++ b/packages/ui/src/chat/activity-group.tsx
@@ -15,7 +15,7 @@ import {
   TerminalIcon,
   WrenchIcon,
 } from 'lucide-react';
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { useTranslations } from 'use-intl';
 import { cn } from '../lib/cn';
 import type { ActivityBucket, TimelineEntry } from './activity-groups';
@@ -24,7 +24,7 @@ import { toolCallDiffStats } from './diff-utils';
 import { TOOL_DETAIL_SCROLL_CLASS_NAME } from './tool';
 import { ToolCallBody } from './tool-call-item';
 import { hasToolBody, toolCallHeaderSummary } from './tool-utils';
-import { FILE_PATH_TOOLTIP_CLASS_NAME, withTooltip } from './with-tooltip';
+import { FilePathTooltip } from './with-tooltip';
 
 export type ActivityToolGroup = Extract<TimelineEntry, { type: 'group' }>;
 
@@ -36,6 +36,7 @@ export function ActivityGroup({
   group: ActivityToolGroup;
   TerminalBlockComponent?: React.ComponentType<{ terminalId: string }>;
 }): React.ReactNode {
+  const tooltipAnchorRef = useRef<HTMLSpanElement>(null);
   const t = useTranslations('workbench.toolGroup');
   const hasRunning = group.items.some((item) => item.toolCall.status === 'in_progress');
   const failedCount = group.items.reduce(
@@ -54,7 +55,10 @@ export function ActivityGroup({
 
   return (
     <Collapsible className="w-full" onOpenChange={setManualOpen} open={open}>
-      {withTooltip(
+      <FilePathTooltip
+        anchor={tooltipAnchorRef}
+        tooltip={!open && summaryTooltip.length > 0 ? summaryTooltip.join(', ') : undefined}
+      >
         <CollapsibleTrigger className="group flex w-full items-center gap-2 py-1 text-left text-sm">
           <ActivityBucketIcon bucket={group.bucket} running={hasRunning} />
           <span className="shrink-0 text-foreground">{t(group.bucket)}</span>
@@ -67,7 +71,7 @@ export function ActivityGroup({
             </Badge>
           ) : null}
           {diffTotals ? <DiffCounter stats={diffTotals} /> : null}
-          <span className="min-w-0 flex-1 truncate text-muted-foreground/70">
+          <span className="min-w-0 flex-1 truncate text-muted-foreground/70" ref={tooltipAnchorRef}>
             {open
               ? ''
               : summaries
@@ -75,10 +79,8 @@ export function ActivityGroup({
                   .join(', ')}
           </span>
           <ChevronRightIcon className="size-3.5 shrink-0 text-muted-foreground transition-transform group-data-[panel-open]:rotate-90" />
-        </CollapsibleTrigger>,
-        summaryTooltip.length > 0 ? summaryTooltip.join(', ') : undefined,
-        FILE_PATH_TOOLTIP_CLASS_NAME,
-      )}
+        </CollapsibleTrigger>
+      </FilePathTooltip>
       <CollapsibleContent
         className={cn(
           'mt-1 space-y-0.5 border-l-2 border-border pl-3',
@@ -138,18 +140,26 @@ function ActivityGroupRow({
   toolCall: ToolCall;
   TerminalBlockComponent?: React.ComponentType<{ terminalId: string }>;
 }): React.ReactNode {
+  const tooltipAnchorRef = useRef<HTMLSpanElement>(null);
   const summary = toolCallHeaderSummary(toolCall);
+  const summaryIsTitle = summary?.label === toolCall.title;
+  const titleAnchorRef = summaryIsTitle ? tooltipAnchorRef : undefined;
   const titleClassName = cn(
     'flex min-w-0 items-center py-0.5 text-left text-sm',
     toolCall.status === 'failed' ? 'text-destructive-foreground' : 'text-muted-foreground',
   );
   const label = (
     <>
-      <span className="min-w-0 truncate">{toolCall.title}</span>
-      {summary && summary.label !== toolCall.title ? (
+      <span className="min-w-0 truncate" ref={titleAnchorRef}>
+        {toolCall.title}
+      </span>
+      {summary && !summaryIsTitle ? (
         <>
           {' '}
-          <span className="ml-1 min-w-0 flex-1 truncate text-muted-foreground/70 text-xs">
+          <span
+            className="ml-1 min-w-0 flex-1 truncate text-muted-foreground/70 text-xs"
+            ref={tooltipAnchorRef}
+          >
             · {summary.label}
           </span>
         </>
@@ -158,31 +168,29 @@ function ActivityGroupRow({
   );
 
   if (!hasToolBody(toolCall)) {
-    return withTooltip(
-      <div
-        className={cn(
-          titleClassName,
-          summary?.tooltip &&
-            'rounded-sm outline-none focus-visible:ring-2 focus-visible:ring-ring',
-        )}
-        tabIndex={summary?.tooltip ? 0 : undefined}
-      >
-        {label}
-      </div>,
-      summary?.tooltip,
-      FILE_PATH_TOOLTIP_CLASS_NAME,
+    return (
+      <FilePathTooltip anchor={tooltipAnchorRef} tooltip={summary?.tooltip}>
+        <div
+          className={cn(
+            titleClassName,
+            summary?.tooltip &&
+              'rounded-sm outline-none focus-visible:ring-2 focus-visible:ring-ring',
+          )}
+          tabIndex={summary?.tooltip ? 0 : undefined}
+        >
+          {label}
+        </div>
+      </FilePathTooltip>
     );
   }
 
   return (
     <Collapsible>
-      {withTooltip(
+      <FilePathTooltip anchor={tooltipAnchorRef} tooltip={summary?.tooltip}>
         <CollapsibleTrigger className={cn(titleClassName, 'w-full hover:text-foreground')}>
           {label}
-        </CollapsibleTrigger>,
-        summary?.tooltip,
-        FILE_PATH_TOOLTIP_CLASS_NAME,
-      )}
+        </CollapsibleTrigger>
+      </FilePathTooltip>
       <CollapsibleContent className="my-1 space-y-2 pl-1.5">
         <ToolCallBody TerminalBlockComponent={TerminalBlockComponent} toolCall={toolCall} />
       </CollapsibleContent>

--- a/packages/ui/src/chat/activity-group.tsx
+++ b/packages/ui/src/chat/activity-group.tsx
@@ -23,7 +23,8 @@ import { DiffCounter } from './diff-block';
 import { toolCallDiffStats } from './diff-utils';
 import { TOOL_DETAIL_SCROLL_CLASS_NAME } from './tool';
 import { ToolCallBody } from './tool-call-item';
-import { hasToolBody, toolCallSummary } from './tool-utils';
+import { hasToolBody, toolCallHeaderSummary } from './tool-utils';
+import { FILE_PATH_TOOLTIP_CLASS_NAME, withTooltip } from './with-tooltip';
 
 export type ActivityToolGroup = Extract<TimelineEntry, { type: 'group' }>;
 
@@ -42,6 +43,10 @@ export function ActivityGroup({
     0,
   );
   const diffTotals = group.bucket === 'files' ? sumGroupDiffStats(group) : null;
+  const summaries = group.items.map((item) => toolCallHeaderSummary(item.toolCall));
+  const summaryTooltip = summaries.flatMap((summary) =>
+    summary?.tooltip ? [summary.tooltip] : [],
+  );
 
   // Forced open while a call is in flight (Codex's active cell); the user's toggle takes over after.
   const [manualOpen, setManualOpen] = useState(false);
@@ -49,27 +54,31 @@ export function ActivityGroup({
 
   return (
     <Collapsible className="w-full" onOpenChange={setManualOpen} open={open}>
-      <CollapsibleTrigger className="group flex w-full items-center gap-2 py-1 text-left text-sm">
-        <ActivityBucketIcon bucket={group.bucket} running={hasRunning} />
-        <span className="shrink-0 text-foreground">{t(group.bucket)}</span>
-        <Badge size="sm" variant="secondary">
-          {group.items.length}
-        </Badge>
-        {failedCount > 0 ? (
-          <Badge size="sm" variant="error">
-            {t('failed', { count: failedCount })}
+      {withTooltip(
+        <CollapsibleTrigger className="group flex w-full items-center gap-2 py-1 text-left text-sm">
+          <ActivityBucketIcon bucket={group.bucket} running={hasRunning} />
+          <span className="shrink-0 text-foreground">{t(group.bucket)}</span>
+          <Badge size="sm" variant="secondary">
+            {group.items.length}
           </Badge>
-        ) : null}
-        {diffTotals ? <DiffCounter stats={diffTotals} /> : null}
-        <span className="min-w-0 flex-1 truncate text-muted-foreground/70">
-          {open
-            ? ''
-            : group.items
-                .map((item) => toolCallSummary(item.toolCall) ?? item.toolCall.title)
-                .join(', ')}
-        </span>
-        <ChevronRightIcon className="size-3.5 shrink-0 text-muted-foreground transition-transform group-data-[panel-open]:rotate-90" />
-      </CollapsibleTrigger>
+          {failedCount > 0 ? (
+            <Badge size="sm" variant="error">
+              {t('failed', { count: failedCount })}
+            </Badge>
+          ) : null}
+          {diffTotals ? <DiffCounter stats={diffTotals} /> : null}
+          <span className="min-w-0 flex-1 truncate text-muted-foreground/70">
+            {open
+              ? ''
+              : summaries
+                  .map((summary, index) => summary?.label ?? group.items[index].toolCall.title)
+                  .join(', ')}
+          </span>
+          <ChevronRightIcon className="size-3.5 shrink-0 text-muted-foreground transition-transform group-data-[panel-open]:rotate-90" />
+        </CollapsibleTrigger>,
+        summaryTooltip.length > 0 ? summaryTooltip.join(', ') : undefined,
+        FILE_PATH_TOOLTIP_CLASS_NAME,
+      )}
       <CollapsibleContent
         className={cn(
           'mt-1 space-y-0.5 border-l-2 border-border pl-3',
@@ -129,7 +138,7 @@ function ActivityGroupRow({
   toolCall: ToolCall;
   TerminalBlockComponent?: React.ComponentType<{ terminalId: string }>;
 }): React.ReactNode {
-  const summary = toolCallSummary(toolCall);
+  const summary = toolCallHeaderSummary(toolCall);
   const titleClassName = cn(
     'flex min-w-0 items-center py-0.5 text-left text-sm',
     toolCall.status === 'failed' ? 'text-destructive-foreground' : 'text-muted-foreground',
@@ -137,11 +146,11 @@ function ActivityGroupRow({
   const label = (
     <>
       <span className="min-w-0 truncate">{toolCall.title}</span>
-      {summary && summary !== toolCall.title ? (
+      {summary && summary.label !== toolCall.title ? (
         <>
           {' '}
           <span className="ml-1 min-w-0 flex-1 truncate text-muted-foreground/70 text-xs">
-            · {summary}
+            · {summary.label}
           </span>
         </>
       ) : null}
@@ -149,14 +158,31 @@ function ActivityGroupRow({
   );
 
   if (!hasToolBody(toolCall)) {
-    return <div className={titleClassName}>{label}</div>;
+    return withTooltip(
+      <div
+        className={cn(
+          titleClassName,
+          summary?.tooltip &&
+            'rounded-sm outline-none focus-visible:ring-2 focus-visible:ring-ring',
+        )}
+        tabIndex={summary?.tooltip ? 0 : undefined}
+      >
+        {label}
+      </div>,
+      summary?.tooltip,
+      FILE_PATH_TOOLTIP_CLASS_NAME,
+    );
   }
 
   return (
     <Collapsible>
-      <CollapsibleTrigger className={cn(titleClassName, 'w-full hover:text-foreground')}>
-        {label}
-      </CollapsibleTrigger>
+      {withTooltip(
+        <CollapsibleTrigger className={cn(titleClassName, 'w-full hover:text-foreground')}>
+          {label}
+        </CollapsibleTrigger>,
+        summary?.tooltip,
+        FILE_PATH_TOOLTIP_CLASS_NAME,
+      )}
       <CollapsibleContent className="my-1 space-y-2 pl-1.5">
         <ToolCallBody TerminalBlockComponent={TerminalBlockComponent} toolCall={toolCall} />
       </CollapsibleContent>

--- a/packages/ui/src/chat/activity-group.tsx
+++ b/packages/ui/src/chat/activity-group.tsx
@@ -21,6 +21,7 @@ import { cn } from '../lib/cn';
 import type { ActivityBucket, TimelineEntry } from './activity-groups';
 import { DiffCounter } from './diff-block';
 import { toolCallDiffStats } from './diff-utils';
+import { TOOL_DETAIL_SCROLL_CLASS_NAME } from './tool';
 import { ToolCallBody } from './tool-call-item';
 import { hasToolBody, toolCallSummary } from './tool-utils';
 
@@ -69,7 +70,12 @@ export function ActivityGroup({
         </span>
         <ChevronRightIcon className="size-3.5 shrink-0 text-muted-foreground transition-transform group-data-[panel-open]:rotate-90" />
       </CollapsibleTrigger>
-      <CollapsibleContent className="mt-1 space-y-0.5 border-l-2 border-border pl-3">
+      <CollapsibleContent
+        className={cn(
+          'mt-1 space-y-0.5 border-l-2 border-border pl-3',
+          TOOL_DETAIL_SCROLL_CLASS_NAME,
+        )}
+      >
         {group.items.map((item) => (
           <ActivityGroupRow
             key={item.id}

--- a/packages/ui/src/chat/artifacts/__tests__/file-kind.test.ts
+++ b/packages/ui/src/chat/artifacts/__tests__/file-kind.test.ts
@@ -20,6 +20,7 @@ describe('artifactKindForPath', () => {
 describe('fileBasename', () => {
   it('strips directories', () => {
     expect(fileBasename('/a/b/c.md')).toBe('c.md');
+    expect(fileBasename(String.raw`C:\repo\docs\c.md`)).toBe('c.md');
     expect(fileBasename('c.md')).toBe('c.md');
   });
 });

--- a/packages/ui/src/chat/artifacts/artifact-frame.tsx
+++ b/packages/ui/src/chat/artifacts/artifact-frame.tsx
@@ -1,3 +1,4 @@
+import { Card } from 'coss-ui/components/card';
 import { useTranslations } from 'use-intl';
 import { cn } from '../../lib/cn';
 import {
@@ -29,10 +30,7 @@ export function ArtifactFrame({
   const t = useTranslations('workbench.artifact');
 
   return (
-    <div
-      className={cn('my-2 overflow-hidden rounded-lg border border-border bg-card', className)}
-      data-artifact-kind={kindLabel}
-    >
+    <Card className={cn('my-2 overflow-hidden', className)} data-artifact-kind={kindLabel}>
       <CodeBlockHeader>
         <CodeBlockTitle>{kindLabel}</CodeBlockTitle>
         <CodeBlockActions>
@@ -43,6 +41,6 @@ export function ArtifactFrame({
         </CodeBlockActions>
       </CodeBlockHeader>
       {children}
-    </div>
+    </Card>
   );
 }

--- a/packages/ui/src/chat/artifacts/context.tsx
+++ b/packages/ui/src/chat/artifacts/context.tsx
@@ -10,6 +10,9 @@ export interface ArtifactHostActions {
    * Relative paths are anchored to the session cwd by the host. Absent when the shell
    * has no file viewer (webview) — cards then render without the open affordance. */
   openFile?: (path: string) => void;
+  /** Open the workspace-change review surface. File results use this when the target no longer
+   * exists (for example, a completed delete) or one adapter result spans multiple files. */
+  reviewChanges?: () => void;
   /** Host inline content on the daemon's ephemeral per-artifact origin (CODE-62);
    * absent when the data plane doesn't support hosting — sandboxed previews then stay
    * unavailable and the fence renders as code. */
@@ -17,6 +20,19 @@ export interface ArtifactHostActions {
   /** Promote a hosted artifact/preview URL to the host's browser surface (desktop:
    * Browser pane). Absent → the renderer falls back to a new browser tab. */
   openPreviewUrl?: (url: string) => void;
+}
+
+export type ArtifactNavigation = { kind: 'file'; path: string } | { kind: 'review' };
+
+/** Resolve a presentation-owned navigation target against the actions its host actually wires. */
+export function artifactNavigationAction(
+  actions: ArtifactHostActions | null,
+  navigation: ArtifactNavigation | null | undefined,
+): (() => void) | undefined {
+  if (!actions || !navigation) return undefined;
+  if (navigation.kind === 'review') return actions.reviewChanges;
+  const openFile = actions.openFile;
+  return openFile ? () => openFile(navigation.path) : undefined;
 }
 
 const ArtifactHostActionsContext = createContext<ArtifactHostActions | null>(null);

--- a/packages/ui/src/chat/artifacts/context.tsx
+++ b/packages/ui/src/chat/artifacts/context.tsx
@@ -1,41 +1,5 @@
-import { createContext, useContext } from 'react';
-
-/** Host-side actions artifacts can trigger. In-process only — the sandboxed bridge
- * (CODE-64) adapts the same surface over JSON-RPC for iframe-hosted artifacts. */
-export interface ArtifactHostActions {
-  /** Insert a reference produced from an artifact interaction into the composer draft
-   * (never auto-sends). */
-  referenceToComposer: (text: string) => void;
-  /** Open a workspace file in the host's viewer (desktop: right-panel files section).
-   * Relative paths are anchored to the session cwd by the host. Absent when the shell
-   * has no file viewer (webview) — cards then render without the open affordance. */
-  openFile?: (path: string) => void;
-  /** Open the workspace-change review surface. File results use this when the target no longer
-   * exists (for example, a completed delete) or one adapter result spans multiple files. */
-  reviewChanges?: () => void;
-  /** Host inline content on the daemon's ephemeral per-artifact origin (CODE-62);
-   * absent when the data plane doesn't support hosting — sandboxed previews then stay
-   * unavailable and the fence renders as code. */
-  hostArtifact?: (content: string, mimeType: string) => Promise<{ url: string }>;
-  /** Promote a hosted artifact/preview URL to the host's browser surface (desktop:
-   * Browser pane). Absent → the renderer falls back to a new browser tab. */
-  openPreviewUrl?: (url: string) => void;
-}
-
-export type ArtifactNavigation = { kind: 'file'; path: string } | { kind: 'review' };
-
-/** Resolve a presentation-owned navigation target against the actions its host actually wires. */
-export function artifactNavigationAction(
-  actions: ArtifactHostActions | null,
-  navigation: ArtifactNavigation | null | undefined,
-): (() => void) | undefined {
-  if (!actions || !navigation) return undefined;
-  if (navigation.kind === 'review') return actions.reviewChanges;
-  const openFile = actions.openFile;
-  return openFile ? () => openFile(navigation.path) : undefined;
-}
-
-const ArtifactHostActionsContext = createContext<ArtifactHostActions | null>(null);
+import type { ArtifactHostActions } from './host-actions';
+import { ArtifactHostActionsContext } from './host-actions';
 
 export function ArtifactHostActionsProvider({
   actions,
@@ -49,10 +13,4 @@ export function ArtifactHostActionsProvider({
       {children}
     </ArtifactHostActionsContext.Provider>
   );
-}
-
-/** Null when the artifact renders outside a surface that wires host actions —
- * renderers must keep working and simply drop the interaction affordance. */
-export function useArtifactHostActions(): ArtifactHostActions | null {
-  return useContext(ArtifactHostActionsContext);
 }

--- a/packages/ui/src/chat/artifacts/file-card.tsx
+++ b/packages/ui/src/chat/artifacts/file-card.tsx
@@ -1,8 +1,9 @@
 import { Button } from 'coss-ui/components/button';
 import { Card } from 'coss-ui/components/card';
+import { useRef } from 'react';
 import { cn } from '../../lib/cn';
 import { FileIdentityIcon } from '../file-identity-icon';
-import { FILE_PATH_TOOLTIP_CLASS_NAME, withTooltip } from '../with-tooltip';
+import { FilePathTooltip } from '../with-tooltip';
 import { useArtifactHostActions } from './context';
 import { fileBasename } from './file-kind';
 
@@ -15,13 +16,14 @@ export function FileArtifactCard({
   path: string;
   className?: string;
 }): React.ReactNode {
+  const tooltipAnchorRef = useRef<HTMLSpanElement>(null);
   const actions = useArtifactHostActions();
   const openFile = actions?.openFile;
 
   const body = (
     <>
       <span className="flex size-8 shrink-0 items-center justify-center rounded-md border border-border bg-muted text-muted-foreground [&_svg]:size-4">
-        <FileIdentityIcon className="size-4" path={path} />
+        <FileIdentityIcon className="size-4" path={path} ref={tooltipAnchorRef} />
       </span>
       <span className="min-w-0 flex-1 truncate text-left font-medium text-[13px] text-foreground">
         {fileBasename(path)}
@@ -32,35 +34,33 @@ export function FileArtifactCard({
   const frame = 'my-1 w-full max-w-md overflow-hidden';
 
   if (!openFile) {
-    return withTooltip(
-      <Card
-        className={cn(
-          frame,
-          'flex-row items-center gap-2.5 px-2.5 py-2 outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring',
-          className,
-        )}
-        tabIndex={0}
-      >
-        {body}
-      </Card>,
-      path,
-      FILE_PATH_TOOLTIP_CLASS_NAME,
+    return (
+      <FilePathTooltip anchor={tooltipAnchorRef} tooltip={path}>
+        <Card
+          className={cn(
+            frame,
+            'flex-row items-center gap-2.5 px-2.5 py-2 outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring',
+            className,
+          )}
+          tabIndex={0}
+        >
+          {body}
+        </Card>
+      </FilePathTooltip>
     );
   }
 
   return (
     <Card className={cn(frame, className)}>
-      {withTooltip(
+      <FilePathTooltip anchor={tooltipAnchorRef} tooltip={path}>
         <Button
           className="h-auto w-full justify-start rounded-2xl border-0 px-2.5 py-2 font-normal focus-visible:ring-inset"
           variant="ghost"
           onClick={() => openFile(path)}
         >
           {body}
-        </Button>,
-        path,
-        FILE_PATH_TOOLTIP_CLASS_NAME,
-      )}
+        </Button>
+      </FilePathTooltip>
     </Card>
   );
 }

--- a/packages/ui/src/chat/artifacts/file-card.tsx
+++ b/packages/ui/src/chat/artifacts/file-card.tsx
@@ -1,22 +1,12 @@
 import { Button } from 'coss-ui/components/button';
 import { Card } from 'coss-ui/components/card';
-import { FileIcon, FileTextIcon, FileTypeIcon, ImageIcon } from 'lucide-react';
-import { useTranslations } from 'use-intl';
 import { cn } from '../../lib/cn';
+import { FileIdentityIcon } from '../file-identity-icon';
+import { FILE_PATH_TOOLTIP_CLASS_NAME, withTooltip } from '../with-tooltip';
 import { useArtifactHostActions } from './context';
-import { artifactKindForPath, fileBasename } from './file-kind';
+import { fileBasename } from './file-kind';
 
-const ICON_BY_KIND: Record<string, React.ReactNode> = {
-  markdown: <FileTextIcon />,
-  text: <FileTextIcon />,
-  pdf: <FileTypeIcon />,
-  image: <ImageIcon />,
-};
-
-/**
- * Produced-file card shown in chat (under completed move tools, Codex end-resource
- * style). Clicking opens the file in the host viewer when the shell provides one.
- */
+/** Compact produced-file artifact; opens the host file viewer when available. */
 export function FileArtifactCard({
   path,
   className,
@@ -25,21 +15,16 @@ export function FileArtifactCard({
   path: string;
   className?: string;
 }): React.ReactNode {
-  const t = useTranslations('workbench.artifact');
   const actions = useArtifactHostActions();
-  const kind = artifactKindForPath(path);
   const openFile = actions?.openFile;
 
   const body = (
     <>
       <span className="flex size-8 shrink-0 items-center justify-center rounded-md border border-border bg-muted text-muted-foreground [&_svg]:size-4">
-        {(kind !== null && ICON_BY_KIND[kind]) || <FileIcon />}
+        <FileIdentityIcon className="size-4" path={path} />
       </span>
-      <span className="min-w-0 flex-1 text-left">
-        <span className="block truncate font-medium text-[13px] text-foreground">
-          {fileBasename(path)}
-        </span>
-        <span className="block truncate font-mono text-[11px] text-muted-foreground">{path}</span>
+      <span className="min-w-0 flex-1 truncate text-left font-medium text-[13px] text-foreground">
+        {fileBasename(path)}
       </span>
     </>
   );
@@ -47,23 +32,35 @@ export function FileArtifactCard({
   const frame = 'my-1 w-full max-w-md overflow-hidden';
 
   if (!openFile) {
-    return (
-      <Card className={cn(frame, 'flex-row items-center gap-2.5 px-2.5 py-2', className)}>
+    return withTooltip(
+      <Card
+        className={cn(
+          frame,
+          'flex-row items-center gap-2.5 px-2.5 py-2 outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring',
+          className,
+        )}
+        tabIndex={0}
+      >
         {body}
-      </Card>
+      </Card>,
+      path,
+      FILE_PATH_TOOLTIP_CLASS_NAME,
     );
   }
 
   return (
     <Card className={cn(frame, className)}>
-      <Button
-        className="h-auto w-full justify-start rounded-2xl border-0 px-2.5 py-2 font-normal focus-visible:ring-inset"
-        title={t('openFile')}
-        variant="ghost"
-        onClick={() => openFile(path)}
-      >
-        {body}
-      </Button>
+      {withTooltip(
+        <Button
+          className="h-auto w-full justify-start rounded-2xl border-0 px-2.5 py-2 font-normal focus-visible:ring-inset"
+          variant="ghost"
+          onClick={() => openFile(path)}
+        >
+          {body}
+        </Button>,
+        path,
+        FILE_PATH_TOOLTIP_CLASS_NAME,
+      )}
     </Card>
   );
 }

--- a/packages/ui/src/chat/artifacts/file-card.tsx
+++ b/packages/ui/src/chat/artifacts/file-card.tsx
@@ -4,8 +4,8 @@ import { useRef } from 'react';
 import { cn } from '../../lib/cn';
 import { FileIdentityIcon } from '../file-identity-icon';
 import { FilePathTooltip } from '../with-tooltip';
-import { useArtifactHostActions } from './context';
 import { fileBasename } from './file-kind';
+import { useArtifactHostActions } from './host-actions';
 
 /** Compact produced-file artifact; opens the host file viewer when available. */
 export function FileArtifactCard({

--- a/packages/ui/src/chat/artifacts/file-card.tsx
+++ b/packages/ui/src/chat/artifacts/file-card.tsx
@@ -1,3 +1,5 @@
+import { Button } from 'coss-ui/components/button';
+import { Card } from 'coss-ui/components/card';
 import { FileIcon, FileTextIcon, FileTypeIcon, ImageIcon } from 'lucide-react';
 import { useTranslations } from 'use-intl';
 import { cn } from '../../lib/cn';
@@ -42,21 +44,26 @@ export function FileArtifactCard({
     </>
   );
 
-  const frame =
-    'my-1 flex w-full max-w-md items-center gap-2.5 rounded-lg border border-border bg-card px-2.5 py-2';
+  const frame = 'my-1 w-full max-w-md overflow-hidden';
 
   if (!openFile) {
-    return <div className={cn(frame, className)}>{body}</div>;
+    return (
+      <Card className={cn(frame, 'flex-row items-center gap-2.5 px-2.5 py-2', className)}>
+        {body}
+      </Card>
+    );
   }
 
   return (
-    <button
-      type="button"
-      className={cn(frame, 'transition-colors hover:bg-accent', className)}
-      title={t('openFile')}
-      onClick={() => openFile(path)}
-    >
-      {body}
-    </button>
+    <Card className={cn(frame, className)}>
+      <Button
+        className="h-auto w-full justify-start rounded-2xl border-0 px-2.5 py-2 font-normal focus-visible:ring-inset"
+        title={t('openFile')}
+        variant="ghost"
+        onClick={() => openFile(path)}
+      >
+        {body}
+      </Button>
+    </Card>
   );
 }

--- a/packages/ui/src/chat/artifacts/file-kind.ts
+++ b/packages/ui/src/chat/artifacts/file-kind.ts
@@ -20,7 +20,7 @@ export function fileExtension(path: string): string {
 }
 
 export function fileBasename(path: string): string {
-  const slash = path.lastIndexOf('/');
+  const slash = Math.max(path.lastIndexOf('/'), path.lastIndexOf('\\'));
   return slash === -1 ? path : path.slice(slash + 1);
 }
 

--- a/packages/ui/src/chat/artifacts/host-actions.ts
+++ b/packages/ui/src/chat/artifacts/host-actions.ts
@@ -1,0 +1,44 @@
+import { createContext, useContext } from 'react';
+
+/** Host-side actions artifacts can trigger. In-process only — the sandboxed bridge
+ * (CODE-64) adapts the same surface over JSON-RPC for iframe-hosted artifacts. */
+export interface ArtifactHostActions {
+  /** Insert a reference produced from an artifact interaction into the composer draft
+   * (never auto-sends). */
+  referenceToComposer: (text: string) => void;
+  /** Open a workspace file in the host's viewer (desktop: right-panel files section).
+   * Relative paths are anchored to the session cwd by the host. Absent when the shell
+   * has no file viewer (webview) — cards then render without the open affordance. */
+  openFile?: (path: string) => void;
+  /** Open the workspace-change review surface. File results use this when the target no longer
+   * exists (for example, a completed delete) or one adapter result spans multiple files. */
+  reviewChanges?: () => void;
+  /** Host inline content on the daemon's ephemeral per-artifact origin (CODE-62);
+   * absent when the data plane doesn't support hosting — sandboxed previews then stay
+   * unavailable and the fence renders as code. */
+  hostArtifact?: (content: string, mimeType: string) => Promise<{ url: string }>;
+  /** Promote a hosted artifact/preview URL to the host's browser surface (desktop:
+   * Browser pane). Absent → the renderer falls back to a new browser tab. */
+  openPreviewUrl?: (url: string) => void;
+}
+
+export type ArtifactNavigation = { kind: 'file'; path: string } | { kind: 'review' };
+
+/** Resolve a presentation-owned navigation target against the actions its host actually wires. */
+export function artifactNavigationAction(
+  actions: ArtifactHostActions | null,
+  navigation: ArtifactNavigation | null | undefined,
+): (() => void) | undefined {
+  if (!actions || !navigation) return undefined;
+  if (navigation.kind === 'review') return actions.reviewChanges;
+  const openFile = actions.openFile;
+  return openFile ? () => openFile(navigation.path) : undefined;
+}
+
+export const ArtifactHostActionsContext = createContext<ArtifactHostActions | null>(null);
+
+/** Null when the artifact renders outside a surface that wires host actions —
+ * renderers must keep working and simply drop the interaction affordance. */
+export function useArtifactHostActions(): ArtifactHostActions | null {
+  return useContext(ArtifactHostActionsContext);
+}

--- a/packages/ui/src/chat/artifacts/html-inline.tsx
+++ b/packages/ui/src/chat/artifacts/html-inline.tsx
@@ -3,8 +3,8 @@ import { AppWindowIcon, PlayIcon } from 'lucide-react';
 import { useState } from 'react';
 import { useTranslations } from 'use-intl';
 import { ArtifactFrame } from './artifact-frame';
-import { useArtifactHostActions } from './context';
 import { FenceFallback } from './fence-fallback';
+import { useArtifactHostActions } from './host-actions';
 import type { InlineArtifactProps } from './types';
 
 const HTML_MIME = 'text/html; charset=utf-8';

--- a/packages/ui/src/chat/artifacts/index.ts
+++ b/packages/ui/src/chat/artifacts/index.ts
@@ -1,8 +1,9 @@
-export type { ArtifactHostActions } from './context';
-export { ArtifactHostActionsProvider, useArtifactHostActions } from './context';
+export { ArtifactHostActionsProvider } from './context';
 export { ArtifactFenceRenderer } from './fence-renderer';
 export { FileArtifactCard } from './file-card';
 export { artifactKindForPath, detectInlineFilePath, fileBasename } from './file-kind';
+export type { ArtifactHostActions } from './host-actions';
+export { useArtifactHostActions } from './host-actions';
 export type { ResolvedInlineArtifact } from './registry';
 export {
   artifactFenceLanguages,

--- a/packages/ui/src/chat/artifacts/mermaid-inline.tsx
+++ b/packages/ui/src/chat/artifacts/mermaid-inline.tsx
@@ -3,9 +3,9 @@ import { useId, useState } from 'react';
 import { useTranslations } from 'use-intl';
 import { cn } from '../../lib/cn';
 import { ArtifactFrame } from './artifact-frame';
-import { useArtifactHostActions } from './context';
 import { extractMermaidLabel } from './element-label';
 import { FenceFallback } from './fence-fallback';
+import { useArtifactHostActions } from './host-actions';
 import type { InlineArtifactProps } from './types';
 
 interface RenderedDiagram {

--- a/packages/ui/src/chat/artifacts/svg-inline.tsx
+++ b/packages/ui/src/chat/artifacts/svg-inline.tsx
@@ -2,9 +2,9 @@ import dompurify from 'dompurify';
 import { useTranslations } from 'use-intl';
 import { cn } from '../../lib/cn';
 import { ArtifactFrame } from './artifact-frame';
-import { useArtifactHostActions } from './context';
 import { extractSvgLabel } from './element-label';
 import { FenceFallback } from './fence-fallback';
+import { useArtifactHostActions } from './host-actions';
 import type { InlineArtifactProps } from './types';
 
 const SVG_ROOT_RE = /<svg[\s>]/i;

--- a/packages/ui/src/chat/code-block.tsx
+++ b/packages/ui/src/chat/code-block.tsx
@@ -1,8 +1,9 @@
+import { Card, CardHeader, CardPanel, CardTitle } from 'coss-ui/components/card';
 import { cn } from '../lib/cn';
 import type { CopyIconButtonProps } from './copy-icon-button';
 import { CopyIconButton } from './copy-icon-button';
 
-export interface CodeBlockProps extends React.ComponentProps<'div'> {
+export interface CodeBlockProps extends React.ComponentProps<typeof Card> {
   code: string;
   language?: string;
   title?: string;
@@ -19,31 +20,29 @@ export function CodeBlock({
   const hasHeader = Boolean(title || language || children);
 
   return (
-    <div
-      className={cn('my-2 overflow-hidden rounded-lg border border-border', className)}
-      data-language={language}
-      {...props}
-    >
+    <Card className={cn('my-2 overflow-hidden', className)} data-language={language} {...props}>
       {hasHeader ? (
         <CodeBlockHeader>
           <CodeBlockTitle>{title ?? language}</CodeBlockTitle>
           {children}
         </CodeBlockHeader>
       ) : null}
-      <pre className="overflow-x-auto p-3 font-mono text-xs leading-relaxed">
-        <code>{code}</code>
-      </pre>
-    </div>
+      <CardPanel className="p-0">
+        <pre className="overflow-x-auto p-3 font-mono text-xs leading-relaxed">
+          <code>{code}</code>
+        </pre>
+      </CardPanel>
+    </Card>
   );
 }
 
-export type CodeBlockHeaderProps = React.ComponentProps<'div'>;
+export type CodeBlockHeaderProps = React.ComponentProps<typeof CardHeader>;
 
 export function CodeBlockHeader({ className, ...props }: CodeBlockHeaderProps): React.ReactNode {
   return (
-    <div
+    <CardHeader
       className={cn(
-        'flex items-center justify-between gap-2 border-b border-border bg-muted/32 px-3 py-1.5 text-xs',
+        'grid-cols-[minmax(0,1fr)_auto] grid-rows-[auto] items-center gap-2 border-b bg-muted/32 px-3 py-1.5 text-xs',
         className,
       )}
       {...props}
@@ -51,10 +50,18 @@ export function CodeBlockHeader({ className, ...props }: CodeBlockHeaderProps): 
   );
 }
 
-export type CodeBlockTitleProps = React.ComponentProps<'div'>;
+export type CodeBlockTitleProps = React.ComponentProps<typeof CardTitle>;
 
 export function CodeBlockTitle({ className, ...props }: CodeBlockTitleProps): React.ReactNode {
-  return <div className={cn('truncate font-mono text-muted-foreground', className)} {...props} />;
+  return (
+    <CardTitle
+      className={cn(
+        'truncate font-mono font-normal text-muted-foreground text-xs leading-normal',
+        className,
+      )}
+      {...props}
+    />
+  );
 }
 
 export type CodeBlockActionsProps = React.ComponentProps<'div'>;

--- a/packages/ui/src/chat/code-block.tsx
+++ b/packages/ui/src/chat/code-block.tsx
@@ -42,7 +42,7 @@ export function CodeBlockHeader({ className, ...props }: CodeBlockHeaderProps): 
   return (
     <CardHeader
       className={cn(
-        'grid-cols-[minmax(0,1fr)_auto] grid-rows-[auto] items-center gap-2 border-b bg-muted/32 px-3 py-1.5 text-xs in-[[data-slot=card]:has(>[data-slot=card-panel])]:pb-1.5',
+        'grid-cols-[minmax(0,1fr)_auto] grid-rows-[auto] items-center gap-2 border-b bg-muted px-3 py-1.5 text-xs in-[[data-slot=card]:has(>[data-slot=card-panel])]:pb-1.5',
         className,
       )}
       {...props}

--- a/packages/ui/src/chat/code-block.tsx
+++ b/packages/ui/src/chat/code-block.tsx
@@ -42,7 +42,7 @@ export function CodeBlockHeader({ className, ...props }: CodeBlockHeaderProps): 
   return (
     <CardHeader
       className={cn(
-        'grid-cols-[minmax(0,1fr)_auto] grid-rows-[auto] items-center gap-2 border-b bg-muted/32 px-3 py-1.5 text-xs',
+        'grid-cols-[minmax(0,1fr)_auto] grid-rows-[auto] items-center gap-2 border-b bg-muted/32 px-3 py-1.5 text-xs in-[[data-slot=card]:has(>[data-slot=card-panel])]:pb-1.5',
         className,
       )}
       {...props}

--- a/packages/ui/src/chat/content-derived-keys.ts
+++ b/packages/ui/src/chat/content-derived-keys.ts
@@ -1,0 +1,21 @@
+import type { ContentBlock, ToolCallContent } from '@linkcode/schema';
+import { simpleStringHash } from 'foxts/simple-string-hash';
+
+type AdapterContent = ContentBlock | ToolCallContent;
+
+/** Adapter content snapshots have no block IDs, so derive keys from their wire values.
+ * Duplicate values are interchangeable; an occurrence suffix only prevents sibling collisions. */
+export function contentDerivedEntries<T extends AdapterContent>(
+  items: readonly T[],
+): Array<{ item: T; key: string }> {
+  const occurrences = new Map<string, number>();
+  return items.map((item) => {
+    const identity = simpleStringHash(JSON.stringify(item));
+    const occurrence = occurrences.get(identity) ?? 0;
+    occurrences.set(identity, occurrence + 1);
+    return {
+      item,
+      key: occurrence === 0 ? identity : `${identity}:${occurrence}`,
+    };
+  });
+}

--- a/packages/ui/src/chat/diff-block.tsx
+++ b/packages/ui/src/chat/diff-block.tsx
@@ -1,4 +1,5 @@
 import { Button } from 'coss-ui/components/button';
+import { Card, CardHeader, CardPanel } from 'coss-ui/components/card';
 import { FileTextIcon } from 'lucide-react';
 import { useTranslations } from 'use-intl';
 import { cn } from '../lib/cn';
@@ -48,8 +49,8 @@ export function DiffBlock({
   );
 
   return (
-    <div className="my-1 overflow-hidden rounded-lg border border-border">
-      <div className="border-b border-border bg-muted/32">
+    <Card className="my-1 overflow-hidden">
+      <CardHeader className="grid-cols-1 grid-rows-[auto] border-b bg-muted/32 p-0">
         {openFile ? (
           <Button
             className="w-full justify-start rounded-none border-0 px-3 font-normal text-xs sm:text-xs"
@@ -63,8 +64,8 @@ export function DiffBlock({
         ) : (
           <div className="flex items-center gap-2 px-3 py-1.5 text-xs">{header}</div>
         )}
-      </div>
-      <div className="overflow-x-auto font-mono text-xs leading-relaxed">
+      </CardHeader>
+      <CardPanel className="overflow-x-auto p-0 font-mono text-xs leading-relaxed">
         {rows.map((row) => (
           <div
             key={row.id}
@@ -81,7 +82,7 @@ export function DiffBlock({
             {row.text}
           </div>
         ))}
-      </div>
-    </div>
+      </CardPanel>
+    </Card>
   );
 }

--- a/packages/ui/src/chat/diff-block.tsx
+++ b/packages/ui/src/chat/diff-block.tsx
@@ -50,7 +50,7 @@ export function DiffBlock({
 
   return (
     <Card className="my-1 overflow-hidden">
-      <CardHeader className="grid-cols-1 grid-rows-[auto] border-b bg-muted/32 p-0 in-[[data-slot=card]:has(>[data-slot=card-panel])]:pb-0">
+      <CardHeader className="grid-cols-1 grid-rows-[auto] border-b bg-muted p-0 in-[[data-slot=card]:has(>[data-slot=card-panel])]:pb-0">
         {openFile ? (
           <Button
             className="w-full justify-start rounded-none border-0 px-3 font-normal text-xs sm:text-xs"

--- a/packages/ui/src/chat/diff-block.tsx
+++ b/packages/ui/src/chat/diff-block.tsx
@@ -1,5 +1,5 @@
 import { cn } from '../lib/cn';
-import type { ArtifactNavigation } from './artifacts/context';
+import type { ArtifactNavigation } from './artifacts/host-actions';
 import type { DiffStats } from './diff-utils';
 import { diffLines } from './diff-utils';
 import { FilePreviewCard } from './file-preview-card';

--- a/packages/ui/src/chat/diff-block.tsx
+++ b/packages/ui/src/chat/diff-block.tsx
@@ -1,11 +1,8 @@
-import { Button } from 'coss-ui/components/button';
-import { Card, CardHeader, CardPanel } from 'coss-ui/components/card';
-import { FileTextIcon } from 'lucide-react';
-import { useTranslations } from 'use-intl';
 import { cn } from '../lib/cn';
-import { useArtifactHostActions } from './artifacts/context';
+import type { ArtifactNavigation } from './artifacts/context';
 import type { DiffStats } from './diff-utils';
 import { diffLines } from './diff-utils';
+import { FilePreviewCard } from './file-preview-card';
 
 export function DiffCounter({
   className,
@@ -28,61 +25,41 @@ export function DiffBlock({
   path,
   oldText,
   newText,
+  navigation,
 }: {
   path: string;
   oldText?: string;
   newText: string;
+  navigation?: ArtifactNavigation | null;
 }): React.ReactNode {
-  const t = useTranslations('workbench.artifact');
-  const openFile = useArtifactHostActions()?.openFile;
   const rows = diffLines(oldText ?? '', newText);
   const stats = {
     additions: rows.filter((row) => row.type === 'add').length,
     deletions: rows.filter((row) => row.type === 'del').length,
   };
-  const header = (
-    <>
-      <FileTextIcon className="size-3.5 text-muted-foreground" />
-      <span className="min-w-0 truncate font-mono text-muted-foreground">{path}</span>
-      <DiffCounter className="ml-auto gap-1.5" stats={stats} />
-    </>
-  );
-
   return (
-    <Card className="my-1 overflow-hidden">
-      <CardHeader className="grid-cols-1 grid-rows-[auto] border-b bg-muted p-0 in-[[data-slot=card]:has(>[data-slot=card-panel])]:pb-0">
-        {openFile ? (
-          <Button
-            className="w-full justify-start rounded-none border-0 px-3 font-normal text-xs sm:text-xs"
-            size="sm"
-            title={t('openFile')}
-            variant="ghost"
-            onClick={() => openFile(path)}
-          >
-            {header}
-          </Button>
-        ) : (
-          <div className="flex items-center gap-2 px-3 py-1.5 text-xs">{header}</div>
-        )}
-      </CardHeader>
-      <CardPanel className="overflow-x-auto p-0 font-mono text-xs leading-relaxed">
-        {rows.map((row) => (
-          <div
-            key={row.id}
-            className={cn(
-              'whitespace-pre px-3',
-              row.type === 'add' && 'bg-success/10 text-success-foreground',
-              row.type === 'del' && 'bg-destructive/10 text-destructive-foreground',
-              row.type === 'ctx' && 'text-muted-foreground',
-            )}
-          >
-            <span className="select-none opacity-50">
-              {row.type === 'add' ? '+' : row.type === 'del' ? '-' : ' '}
-            </span>
-            {row.text}
-          </div>
-        ))}
-      </CardPanel>
-    </Card>
+    <FilePreviewCard
+      headerEnd={<DiffCounter className="ml-auto gap-1.5" stats={stats} />}
+      navigation={navigation}
+      panelClassName="overflow-x-auto p-0 font-mono text-xs leading-relaxed"
+      path={path}
+    >
+      {rows.map((row) => (
+        <div
+          key={row.id}
+          className={cn(
+            'whitespace-pre px-3',
+            row.type === 'add' && 'bg-success/10 text-success-foreground',
+            row.type === 'del' && 'bg-destructive/10 text-destructive-foreground',
+            row.type === 'ctx' && 'text-muted-foreground',
+          )}
+        >
+          <span className="select-none opacity-50">
+            {row.type === 'add' ? '+' : row.type === 'del' ? '-' : ' '}
+          </span>
+          {row.text}
+        </div>
+      ))}
+    </FilePreviewCard>
   );
 }

--- a/packages/ui/src/chat/diff-block.tsx
+++ b/packages/ui/src/chat/diff-block.tsx
@@ -50,7 +50,7 @@ export function DiffBlock({
 
   return (
     <Card className="my-1 overflow-hidden">
-      <CardHeader className="grid-cols-1 grid-rows-[auto] border-b bg-muted/32 p-0">
+      <CardHeader className="grid-cols-1 grid-rows-[auto] border-b bg-muted/32 p-0 in-[[data-slot=card]:has(>[data-slot=card-panel])]:pb-0">
         {openFile ? (
           <Button
             className="w-full justify-start rounded-none border-0 px-3 font-normal text-xs sm:text-xs"

--- a/packages/ui/src/chat/file-identity-icon.tsx
+++ b/packages/ui/src/chat/file-identity-icon.tsx
@@ -10,12 +10,14 @@ function FileIcon({ icon: Icon }: { icon: FileIconComponent }): React.ReactNode 
 export function FileIdentityIcon({
   className,
   path,
+  ref,
 }: {
   className?: string;
   path: string;
+  ref?: React.Ref<HTMLSpanElement>;
 }): React.ReactNode {
   return (
-    <span aria-hidden className={cn('inline-flex size-3.5 shrink-0', className)}>
+    <span aria-hidden className={cn('inline-flex size-3.5 shrink-0', className)} ref={ref}>
       <FileIcon icon={fileIconFor({ name: path })} />
     </span>
   );

--- a/packages/ui/src/chat/file-identity-icon.tsx
+++ b/packages/ui/src/chat/file-identity-icon.tsx
@@ -1,0 +1,22 @@
+import { cn } from '../lib/cn';
+import type { FileIconComponent } from '../lib/file-icon';
+import { fileIconFor } from '../lib/file-icon';
+
+function FileIcon({ icon: Icon }: { icon: FileIconComponent }): React.ReactNode {
+  return <Icon className="size-full" />;
+}
+
+/** File-format identity shared by chat file surfaces. Material icons retain their own colors. */
+export function FileIdentityIcon({
+  className,
+  path,
+}: {
+  className?: string;
+  path: string;
+}): React.ReactNode {
+  return (
+    <span aria-hidden className={cn('inline-flex size-3.5 shrink-0', className)}>
+      <FileIcon icon={fileIconFor({ name: path })} />
+    </span>
+  );
+}

--- a/packages/ui/src/chat/file-preview-card.tsx
+++ b/packages/ui/src/chat/file-preview-card.tsx
@@ -1,0 +1,87 @@
+import { Badge } from 'coss-ui/components/badge';
+import { Button } from 'coss-ui/components/button';
+import { Card, CardHeader, CardPanel, CardTitle } from 'coss-ui/components/card';
+import { cn } from '../lib/cn';
+import type { ArtifactNavigation } from './artifacts/context';
+import { artifactNavigationAction, useArtifactHostActions } from './artifacts/context';
+import { fileBasename } from './artifacts/file-kind';
+import { FileIdentityIcon } from './file-identity-icon';
+import { FILE_PATH_TOOLTIP_CLASS_NAME, withTooltip } from './with-tooltip';
+
+/** Shared file-result surface: basename in chrome, full path in a coss tooltip, and host navigation. */
+export function FilePreviewCard({
+  badge,
+  children,
+  className,
+  headerEnd,
+  label,
+  navigation,
+  panelClassName,
+  path,
+  tooltip,
+}: {
+  badge?: string;
+  children?: React.ReactNode;
+  className?: string;
+  headerEnd?: React.ReactNode;
+  label?: string;
+  navigation?: ArtifactNavigation | null;
+  panelClassName?: string;
+  path: string;
+  tooltip?: string;
+}): React.ReactNode {
+  const actions = useArtifactHostActions();
+  const target = navigation === undefined ? { kind: 'file' as const, path } : navigation;
+  const onOpen = artifactNavigationAction(actions, target);
+  const fullPath = tooltip ?? path;
+  const content = (
+    <>
+      <FileIdentityIcon className="shrink-0" path={path} />
+      <CardTitle
+        className="min-w-0 flex-1 truncate text-left font-mono font-normal text-xs leading-normal"
+        render={<span />}
+      >
+        {label ?? fileBasename(path)}
+      </CardTitle>
+      {badge ? (
+        <Badge size="sm" variant="secondary">
+          {badge}
+        </Badge>
+      ) : null}
+      {headerEnd}
+    </>
+  );
+  const header = onOpen ? (
+    <Button
+      className="w-full justify-start rounded-none border-0 px-3 font-normal text-muted-foreground text-xs focus-visible:ring-inset sm:text-xs"
+      size="sm"
+      variant="ghost"
+      onClick={onOpen}
+    >
+      {content}
+    </Button>
+  ) : (
+    <div
+      className="flex items-center gap-2 px-3 py-1.5 text-muted-foreground text-xs outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
+      tabIndex={0}
+    >
+      {content}
+    </div>
+  );
+
+  return (
+    <Card className={cn('my-1 overflow-hidden', className)}>
+      <CardHeader
+        className={cn(
+          'grid-cols-1 grid-rows-[auto] bg-muted p-0 in-[[data-slot=card]:has(>[data-slot=card-panel])]:pb-0',
+          children !== undefined && 'border-b',
+        )}
+      >
+        {withTooltip(header, fullPath, FILE_PATH_TOOLTIP_CLASS_NAME)}
+      </CardHeader>
+      {children === undefined ? null : (
+        <CardPanel className={cn('px-3 py-2', panelClassName)}>{children}</CardPanel>
+      )}
+    </Card>
+  );
+}

--- a/packages/ui/src/chat/file-preview-card.tsx
+++ b/packages/ui/src/chat/file-preview-card.tsx
@@ -3,9 +3,9 @@ import { Button } from 'coss-ui/components/button';
 import { Card, CardHeader, CardPanel, CardTitle } from 'coss-ui/components/card';
 import { useRef } from 'react';
 import { cn } from '../lib/cn';
-import type { ArtifactNavigation } from './artifacts/context';
-import { artifactNavigationAction, useArtifactHostActions } from './artifacts/context';
 import { fileBasename } from './artifacts/file-kind';
+import type { ArtifactNavigation } from './artifacts/host-actions';
+import { artifactNavigationAction, useArtifactHostActions } from './artifacts/host-actions';
 import { FileIdentityIcon } from './file-identity-icon';
 import { FilePathTooltip } from './with-tooltip';
 
@@ -63,10 +63,7 @@ export function FilePreviewCard({
       {content}
     </Button>
   ) : (
-    <div
-      className="flex items-center gap-2 px-3 py-1.5 text-muted-foreground text-xs outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
-      tabIndex={0}
-    >
+    <div className="flex items-center gap-2 px-3 py-1.5 text-muted-foreground text-xs">
       {content}
     </div>
   );

--- a/packages/ui/src/chat/file-preview-card.tsx
+++ b/packages/ui/src/chat/file-preview-card.tsx
@@ -1,12 +1,13 @@
 import { Badge } from 'coss-ui/components/badge';
 import { Button } from 'coss-ui/components/button';
 import { Card, CardHeader, CardPanel, CardTitle } from 'coss-ui/components/card';
+import { useRef } from 'react';
 import { cn } from '../lib/cn';
 import type { ArtifactNavigation } from './artifacts/context';
 import { artifactNavigationAction, useArtifactHostActions } from './artifacts/context';
 import { fileBasename } from './artifacts/file-kind';
 import { FileIdentityIcon } from './file-identity-icon';
-import { FILE_PATH_TOOLTIP_CLASS_NAME, withTooltip } from './with-tooltip';
+import { FilePathTooltip } from './with-tooltip';
 
 /** Shared file-result surface: basename in chrome, full path in a coss tooltip, and host navigation. */
 export function FilePreviewCard({
@@ -30,13 +31,14 @@ export function FilePreviewCard({
   path: string;
   tooltip?: string;
 }): React.ReactNode {
+  const tooltipAnchorRef = useRef<HTMLSpanElement>(null);
   const actions = useArtifactHostActions();
   const target = navigation === undefined ? { kind: 'file' as const, path } : navigation;
   const onOpen = artifactNavigationAction(actions, target);
   const fullPath = tooltip ?? path;
   const content = (
     <>
-      <FileIdentityIcon className="shrink-0" path={path} />
+      <FileIdentityIcon className="shrink-0" path={path} ref={tooltipAnchorRef} />
       <CardTitle
         className="min-w-0 flex-1 truncate text-left font-mono font-normal text-xs leading-normal"
         render={<span />}
@@ -77,7 +79,9 @@ export function FilePreviewCard({
           children !== undefined && 'border-b',
         )}
       >
-        {withTooltip(header, fullPath, FILE_PATH_TOOLTIP_CLASS_NAME)}
+        <FilePathTooltip anchor={tooltipAnchorRef} tooltip={fullPath}>
+          {header}
+        </FilePathTooltip>
       </CardHeader>
       {children === undefined ? null : (
         <CardPanel className={cn('px-3 py-2', panelClassName)}>{children}</CardPanel>

--- a/packages/ui/src/chat/file-preview-card.tsx
+++ b/packages/ui/src/chat/file-preview-card.tsx
@@ -53,7 +53,7 @@ export function FilePreviewCard({
   );
   const header = onOpen ? (
     <Button
-      className="w-full justify-start rounded-none border-0 px-3 font-normal text-muted-foreground text-xs focus-visible:ring-inset sm:text-xs"
+      className="w-full justify-start rounded-none border-0 px-3 py-1.5 font-normal text-muted-foreground text-xs focus-visible:ring-inset sm:text-xs"
       size="sm"
       variant="ghost"
       onClick={onOpen}

--- a/packages/ui/src/chat/file-tool-presentation.ts
+++ b/packages/ui/src/chat/file-tool-presentation.ts
@@ -1,0 +1,110 @@
+import type { ToolCall } from '@linkcode/schema';
+import type { ArtifactNavigation } from './artifacts/context';
+import { fileBasename } from './artifacts/file-kind';
+import { recordValue, stringValue, TOOL_PATH_KEYS, toolCallFilePath } from './tool-result-content';
+
+const MOVE_SOURCE_KEYS = ['source', 'from', 'old_path', 'oldPath', ...TOOL_PATH_KEYS] as const;
+const MOVE_DESTINATION_KEYS = ['destination', 'to', 'new_path', 'newPath', 'move_path'] as const;
+
+export interface ToolCallFilePresentation {
+  /** Representative file used for the preview icon. */
+  path: string;
+  /** Compact outer-row context. */
+  label: string;
+  /** Unshortened context shown only in a tooltip. */
+  tooltip: string;
+  /** Text receipts cannot be paired with one file when an adapter reports several locations. */
+  ambiguous: boolean;
+  /** File viewer for a surviving target; review surface for deletes and multi-file changes. */
+  navigation?: ArtifactNavigation;
+}
+
+function filePaths(toolCall: ToolCall): string[] {
+  const paths = new Set(toolCall.locations?.map((location) => location.path));
+  for (const content of toolCall.content) {
+    if (content.type === 'diff') paths.add(content.path);
+  }
+  const fallback = toolCallFilePath(toolCall);
+  if (fallback) paths.add(fallback);
+  return [...paths];
+}
+
+function isCompletedDeletion(toolCall: ToolCall, path: string): boolean {
+  if (toolCall.status !== 'completed') return false;
+  if (toolCall.kind === 'delete') return true;
+
+  // Codex normalizes every fileChange/apply_patch operation as `edit`; its schema loses the
+  // delete kind, leaving either an empty new side or the exact history receipt as the signal.
+  return toolCall.content.some((content) => {
+    if (content.type === 'diff') {
+      return content.path === path && content.oldText !== undefined && content.newText.length === 0;
+    }
+    return content.type === 'content' && content.content.type === 'text'
+      ? content.content.text === `Deleted ${path}`
+      : false;
+  });
+}
+
+/** Adapter-tolerant file identity and navigation projected once for every transcript surface. */
+export function toolCallFilePresentation(toolCall: ToolCall): ToolCallFilePresentation | undefined {
+  if (
+    toolCall.kind !== 'read' &&
+    toolCall.kind !== 'edit' &&
+    toolCall.kind !== 'delete' &&
+    toolCall.kind !== 'move'
+  ) {
+    return undefined;
+  }
+
+  if (toolCall.kind === 'move') {
+    const input = recordValue(toolCall.rawInput);
+    const source = stringValue(input, MOVE_SOURCE_KEYS);
+    const destination = stringValue(input, MOVE_DESTINATION_KEYS);
+    if (source && destination) {
+      // Pi/OpenCode-style move inputs keep the source in `path`; until the call completes (and
+      // after a failure) that source is the file which still exists. Completed moves open the target.
+      const path = toolCall.status === 'completed' ? destination : source;
+      return {
+        path,
+        label: `${fileBasename(source)} → ${fileBasename(destination)}`,
+        tooltip: `${source} → ${destination}`,
+        ambiguous: false,
+        navigation: { kind: 'file', path },
+      };
+    }
+  }
+
+  const paths = filePaths(toolCall);
+  const path = paths[0];
+  if (!path) return undefined;
+  const ambiguous = paths.length > 1;
+  const location = toolCall.locations?.find((item) => item.path === path);
+  const suffix = !ambiguous && location?.line !== undefined ? `:${location.line}` : '';
+  const deleted = !ambiguous && isCompletedDeletion(toolCall, path);
+  const navigation: ArtifactNavigation | undefined =
+    deleted || (ambiguous && toolCall.status === 'completed' && toolCall.kind !== 'read')
+      ? { kind: 'review' }
+      : ambiguous
+        ? undefined
+        : { kind: 'file', path };
+  return {
+    path,
+    label: ambiguous
+      ? paths.map((candidate) => fileBasename(candidate)).join(', ')
+      : `${fileBasename(path)}${suffix}`,
+    tooltip: ambiguous ? paths.join(', ') : `${path}${suffix}`,
+    ambiguous,
+    navigation,
+  };
+}
+
+/** Structured diff blocks identify their own path, unlike adapter text receipts. */
+export function toolCallDiffNavigation(
+  toolCall: ToolCall,
+  path: string,
+  newText: string,
+): ArtifactNavigation {
+  return toolCall.status === 'completed' && newText.length === 0
+    ? { kind: 'review' }
+    : { kind: 'file', path };
+}

--- a/packages/ui/src/chat/file-tool-presentation.ts
+++ b/packages/ui/src/chat/file-tool-presentation.ts
@@ -1,6 +1,6 @@
 import type { ToolCall } from '@linkcode/schema';
-import type { ArtifactNavigation } from './artifacts/context';
 import { fileBasename } from './artifacts/file-kind';
+import type { ArtifactNavigation } from './artifacts/host-actions';
 import { recordValue, stringValue, TOOL_PATH_KEYS, toolCallFilePath } from './tool-result-content';
 
 const MOVE_SOURCE_KEYS = ['source', 'from', 'old_path', 'oldPath', ...TOOL_PATH_KEYS] as const;

--- a/packages/ui/src/chat/markdown.tsx
+++ b/packages/ui/src/chat/markdown.tsx
@@ -3,8 +3,10 @@ import { code } from '@streamdown/code';
 import type { Components, PluginConfig } from 'streamdown';
 import { Streamdown } from 'streamdown';
 import { cn } from '../lib/cn';
-import { ArtifactFenceRenderer, artifactFenceLanguages, useArtifactHostActions } from './artifacts';
+import { ArtifactFenceRenderer } from './artifacts/fence-renderer';
 import { detectInlineFilePath } from './artifacts/file-kind';
+import { useArtifactHostActions } from './artifacts/host-actions';
+import { artifactFenceLanguages } from './artifacts/registry';
 
 const INLINE_CODE_CLASS = 'rounded bg-muted px-1 py-0.5 font-mono text-[0.85em]';
 

--- a/packages/ui/src/chat/markdown.tsx
+++ b/packages/ui/src/chat/markdown.tsx
@@ -61,17 +61,17 @@ const components: Components = {
     </p>
   ),
   h1: ({ className, children, node: _node, ...rest }) => (
-    <h1 className={cn('mt-4 mb-2 font-semibold text-lg', className)} {...rest}>
+    <h1 className={cn('mt-4 mb-2 font-semibold text-lg first:mt-0', className)} {...rest}>
       {children}
     </h1>
   ),
   h2: ({ className, children, node: _node, ...rest }) => (
-    <h2 className={cn('mt-4 mb-2 font-semibold text-base', className)} {...rest}>
+    <h2 className={cn('mt-4 mb-2 font-semibold text-base first:mt-0', className)} {...rest}>
       {children}
     </h2>
   ),
   h3: ({ className, children, node: _node, ...rest }) => (
-    <h3 className={cn('mt-3 mb-1.5 font-semibold text-sm', className)} {...rest}>
+    <h3 className={cn('mt-3 mb-1.5 font-semibold text-sm first:mt-0', className)} {...rest}>
       {children}
     </h3>
   ),

--- a/packages/ui/src/chat/message.tsx
+++ b/packages/ui/src/chat/message.tsx
@@ -1,6 +1,6 @@
 import { Button } from 'coss-ui/components/button';
 import { cn } from '../lib/cn';
-import { withTooltip } from './with-tooltip';
+import { WithTooltip } from './with-tooltip';
 
 export type MessageProps = React.HTMLAttributes<HTMLDivElement> & {
   from: 'user' | 'assistant';
@@ -61,11 +61,12 @@ export function MessageAction({
   variant = 'ghost',
   ...props
 }: MessageActionProps): React.ReactNode {
-  return withTooltip(
-    <Button aria-label={label ?? tooltip} size={size} type="button" variant={variant} {...props}>
-      {children}
-    </Button>,
-    tooltip,
+  return (
+    <WithTooltip tooltip={tooltip}>
+      <Button aria-label={label ?? tooltip} size={size} type="button" variant={variant} {...props}>
+        {children}
+      </Button>
+    </WithTooltip>
   );
 }
 

--- a/packages/ui/src/chat/subagent-card.tsx
+++ b/packages/ui/src/chat/subagent-card.tsx
@@ -12,28 +12,15 @@ import { useState } from 'react';
 import { useTranslations } from 'use-intl';
 import { cn } from '../lib/cn';
 import { ContentBlockView } from './content-block-view';
+import { contentDerivedEntries } from './content-derived-keys';
 import { Message, MessageContent } from './message';
+import { subagentTaskInput } from './subagent-task-input';
 import { ThoughtBlock } from './thought-block';
 import { TOOL_DETAIL_SCROLL_CLASS_NAME } from './tool';
 import { ToolCallBody, ToolCallItem } from './tool-call-item';
 import { toolCallDisplayText } from './tool-result-content';
 import { toolCallFailureMessage } from './tool-utils';
 import type { ConversationItem } from './types';
-
-export interface SubagentTaskInput {
-  description?: string;
-  subagentType?: string;
-}
-
-/** The Task tool's input fields the header displays (see the SDK's `AgentInput`). */
-export function subagentTaskInput(rawInput: unknown): SubagentTaskInput {
-  if (typeof rawInput !== 'object' || rawInput === null || Array.isArray(rawInput)) return {};
-  const raw = rawInput as Record<string, unknown>;
-  return {
-    description: typeof raw.description === 'string' ? raw.description : undefined,
-    subagentType: typeof raw.subagent_type === 'string' ? raw.subagent_type : undefined,
-  };
-}
 
 interface SubagentTranscriptProps {
   /** The spawning `task`-kind tool call. */
@@ -80,9 +67,8 @@ export function SubagentTranscript({
             return (
               <Message key={item.id} from="assistant">
                 <MessageContent className="space-y-1">
-                  {item.blocks.map((block, index) => (
-                    // eslint-disable-next-line @eslint-react/no-array-index-key -- append-only stream: index+type is a stable position key
-                    <ContentBlockView key={`${index}:${block.type}`} block={block} />
+                  {contentDerivedEntries(item.blocks).map(({ item: block, key }) => (
+                    <ContentBlockView key={key} block={block} />
                   ))}
                 </MessageContent>
               </Message>

--- a/packages/ui/src/chat/subagent-card.tsx
+++ b/packages/ui/src/chat/subagent-card.tsx
@@ -1,5 +1,6 @@
 import type { ToolCall } from '@linkcode/schema';
 import { Badge } from 'coss-ui/components/badge';
+import { Button } from 'coss-ui/components/button';
 import {
   Collapsible,
   CollapsibleContent,
@@ -9,10 +10,14 @@ import { Spinner } from 'coss-ui/components/spinner';
 import { BotIcon, ChevronRightIcon, Maximize2Icon } from 'lucide-react';
 import { useState } from 'react';
 import { useTranslations } from 'use-intl';
+import { cn } from '../lib/cn';
 import { ContentBlockView } from './content-block-view';
 import { Message, MessageContent } from './message';
 import { ThoughtBlock } from './thought-block';
+import { TOOL_DETAIL_SCROLL_CLASS_NAME } from './tool';
 import { ToolCallBody, ToolCallItem } from './tool-call-item';
+import { toolCallDisplayText } from './tool-result-content';
+import { toolCallFailureMessage } from './tool-utils';
 import type { ConversationItem } from './types';
 
 export interface SubagentTaskInput {
@@ -48,7 +53,7 @@ interface SubagentTranscriptProps {
  * which recurses into its own SubagentCard — partitioning buckets grandchildren under the inner
  * task, so a plain tool row would silently drop them. The Task's own rawOutput is not repeated —
  * the transcript already ends with the subagent's report — except as the empty-transcript
- * fallback (e.g. a degraded history read), so the report is never lost. */
+ * fallback when a degraded/partial history does not contain that report. */
 export function SubagentTranscript({
   toolCall,
   items,
@@ -58,6 +63,8 @@ export function SubagentTranscript({
   TerminalBlockComponent,
   onExpand,
 }: SubagentTranscriptProps): React.ReactNode {
+  const taskResult =
+    toolCallDisplayText(toolCall).trim() || toolCallFailureMessage(toolCall)?.trim();
   if (items.length === 0) {
     return (
       <div className="space-y-2">
@@ -85,10 +92,11 @@ export function SubagentTranscript({
           case 'tool':
             if (item.toolCall.kind === 'task') {
               return (
-                <SubagentCard
+                <SubagentCardContent
                   key={item.id}
                   awaitingApproval={awaitingApproval}
                   childrenByParent={childrenByParent}
+                  constrainHeight={false}
                   declined={declined}
                   items={childrenByParent.get(item.toolCall.toolCallId) ?? []}
                   onExpand={onExpand}
@@ -101,6 +109,7 @@ export function SubagentTranscript({
               <ToolCallItem
                 key={item.id}
                 awaitingApproval={awaitingApproval.has(item.toolCall.toolCallId)}
+                constrainHeight={false}
                 declined={declined.has(item.toolCall.toolCallId)}
                 toolCall={item.toolCall}
                 TerminalBlockComponent={TerminalBlockComponent}
@@ -110,16 +119,34 @@ export function SubagentTranscript({
             return null;
         }
       })}
+      {taskResult && !transcriptIncludes(items, taskResult) ? (
+        <div className="space-y-2">
+          <ToolCallBody TerminalBlockComponent={TerminalBlockComponent} toolCall={toolCall} />
+        </div>
+      ) : null}
     </>
+  );
+}
+
+function transcriptIncludes(items: readonly ConversationItem[], text: string): boolean {
+  return items.some(
+    (item) =>
+      item.kind === 'message' &&
+      item.role === 'assistant' &&
+      item.blocks.some((block) => block.type === 'text' && block.text.includes(text)),
   );
 }
 
 export type SubagentCardProps = SubagentTranscriptProps;
 
+export function SubagentCard(props: SubagentCardProps): React.ReactNode {
+  return <SubagentCardContent {...props} constrainHeight />;
+}
+
 /** Inline collapsible card for one subagent run: header shows the agent type + task description
  * and live status; the body nests the full transcript. Auto-open while running but the user's
  * toggle always wins (unlike ActivityGroup's forced-open) — a subagent can run for minutes. */
-export function SubagentCard({
+function SubagentCardContent({
   toolCall,
   items,
   childrenByParent,
@@ -127,7 +154,8 @@ export function SubagentCard({
   declined,
   TerminalBlockComponent,
   onExpand,
-}: SubagentCardProps): React.ReactNode {
+  constrainHeight,
+}: SubagentCardProps & { constrainHeight: boolean }): React.ReactNode {
   const t = useTranslations('workbench.subagent');
   const tg = useTranslations('workbench.toolGroup');
 
@@ -174,18 +202,26 @@ export function SubagentCard({
           <ChevronRightIcon className="size-3.5 shrink-0 text-muted-foreground transition-transform group-data-[panel-open]:rotate-90" />
         </CollapsibleTrigger>
         {onExpand ? (
-          <button
+          <Button
             aria-label={t('viewTranscript')}
-            className="shrink-0 rounded p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
+            className="shrink-0"
             onClick={() => onExpand(toolCall.toolCallId)}
+            size="icon-xs"
             title={t('viewTranscript')}
             type="button"
+            variant="ghost"
           >
             <Maximize2Icon className="size-3.5" />
-          </button>
+          </Button>
         ) : null}
       </div>
-      <CollapsibleContent className="mt-1 space-y-2 border-l-2 border-border pl-3">
+      <CollapsibleContent
+        className={cn(
+          'mt-1 space-y-2 border-l-2 border-border pl-3',
+          // Nested task cards share the root card's scroll container to avoid scroll traps.
+          constrainHeight && TOOL_DETAIL_SCROLL_CLASS_NAME,
+        )}
+      >
         <SubagentTranscript
           awaitingApproval={awaitingApproval}
           childrenByParent={childrenByParent}

--- a/packages/ui/src/chat/subagent-task-input.ts
+++ b/packages/ui/src/chat/subagent-task-input.ts
@@ -1,0 +1,14 @@
+export interface SubagentTaskInput {
+  description?: string;
+  subagentType?: string;
+}
+
+/** The Task tool's input fields the header displays (see the SDK's `AgentInput`). */
+export function subagentTaskInput(rawInput: unknown): SubagentTaskInput {
+  if (typeof rawInput !== 'object' || rawInput === null || Array.isArray(rawInput)) return {};
+  const raw = rawInput as Record<string, unknown>;
+  return {
+    description: typeof raw.description === 'string' ? raw.description : undefined,
+    subagentType: typeof raw.subagent_type === 'string' ? raw.subagent_type : undefined,
+  };
+}

--- a/packages/ui/src/chat/subagent-viewer.tsx
+++ b/packages/ui/src/chat/subagent-viewer.tsx
@@ -5,7 +5,8 @@ import { BotIcon } from 'lucide-react';
 import { useTranslations } from 'use-intl';
 import { cn } from '../lib/cn';
 import type { ToolTimelineItem } from './activity-groups';
-import { SubagentTranscript, subagentTaskInput } from './subagent-card';
+import { SubagentTranscript } from './subagent-card';
+import { subagentTaskInput } from './subagent-task-input';
 import type { ConversationItem } from './types';
 
 export interface SubagentViewerProps {

--- a/packages/ui/src/chat/terminal.tsx
+++ b/packages/ui/src/chat/terminal.tsx
@@ -45,7 +45,7 @@ export function TerminalHeader({ className, ...props }: TerminalHeaderProps): Re
   return (
     <CardHeader
       className={cn(
-        'grid-cols-[minmax(0,1fr)_auto] grid-rows-[auto] items-center gap-2 px-3 py-2 text-xs',
+        'grid-cols-[minmax(0,1fr)_auto] grid-rows-[auto] items-center gap-2 px-3 py-1.5 text-xs',
         className,
       )}
       {...props}
@@ -84,7 +84,7 @@ export function TerminalContent({
   return (
     <pre
       className={cn(
-        'max-h-80 overflow-auto border-t border-border px-3 py-2 font-mono text-xs leading-relaxed',
+        'max-h-80 overflow-auto border-t border-border px-3 py-2 font-mono text-xs leading-relaxed bg-background',
         className,
       )}
       {...props}

--- a/packages/ui/src/chat/terminal.tsx
+++ b/packages/ui/src/chat/terminal.tsx
@@ -1,4 +1,5 @@
 import AnsiImport from 'ansi-to-react';
+import { Card, CardHeader, CardTitle } from 'coss-ui/components/card';
 import { TerminalIcon } from 'lucide-react';
 import { cn } from '../lib/cn';
 import { Shimmer } from './shimmer';
@@ -10,7 +11,7 @@ type AnsiComponent = typeof AnsiImport;
 const ansiModule = AnsiImport as AnsiComponent | { default: AnsiComponent };
 const Ansi = typeof ansiModule === 'function' ? ansiModule : ansiModule.default;
 
-export interface TerminalProps extends React.ComponentProps<'div'> {
+export interface TerminalProps extends React.ComponentProps<typeof Card> {
   title?: string;
   output?: string;
   isStreaming?: boolean;
@@ -25,11 +26,8 @@ export function Terminal({
   ...props
 }: TerminalProps): React.ReactNode {
   return (
-    <div
-      className={cn(
-        'my-1 overflow-hidden rounded-lg border border-border bg-muted text-muted-foreground',
-        className,
-      )}
+    <Card
+      className={cn('my-1 overflow-hidden bg-muted text-muted-foreground', className)}
       {...props}
     >
       <TerminalHeader>
@@ -37,22 +35,25 @@ export function Terminal({
         {isStreaming ? <Shimmer className="text-xs">running</Shimmer> : null}
       </TerminalHeader>
       {children ?? (output ? <TerminalContent>{output}</TerminalContent> : null)}
-    </div>
+    </Card>
   );
 }
 
-export type TerminalHeaderProps = React.ComponentProps<'div'>;
+export type TerminalHeaderProps = React.ComponentProps<typeof CardHeader>;
 
 export function TerminalHeader({ className, ...props }: TerminalHeaderProps): React.ReactNode {
   return (
-    <div
-      className={cn('flex items-center justify-between gap-2 px-3 py-2 text-xs', className)}
+    <CardHeader
+      className={cn(
+        'grid-cols-[minmax(0,1fr)_auto] grid-rows-[auto] items-center gap-2 px-3 py-2 text-xs',
+        className,
+      )}
       {...props}
     />
   );
 }
 
-export type TerminalTitleProps = React.ComponentProps<'div'>;
+export type TerminalTitleProps = React.ComponentProps<typeof CardTitle>;
 
 export function TerminalTitle({
   className,
@@ -60,10 +61,16 @@ export function TerminalTitle({
   ...props
 }: TerminalTitleProps): React.ReactNode {
   return (
-    <div className={cn('flex min-w-0 items-center gap-2 font-mono', className)} {...props}>
+    <CardTitle
+      className={cn(
+        'flex min-w-0 items-center gap-2 font-mono font-normal text-xs leading-normal',
+        className,
+      )}
+      {...props}
+    >
       <TerminalIcon className="size-3.5 shrink-0" />
       <span className="truncate">{children ?? 'Terminal'}</span>
-    </div>
+    </CardTitle>
   );
 }
 

--- a/packages/ui/src/chat/terminal.tsx
+++ b/packages/ui/src/chat/terminal.tsx
@@ -1,7 +1,14 @@
-import Ansi from 'ansi-to-react';
+import AnsiImport from 'ansi-to-react';
 import { TerminalIcon } from 'lucide-react';
 import { cn } from '../lib/cn';
 import { Shimmer } from './shimmer';
+
+type AnsiComponent = typeof AnsiImport;
+
+// ansi-to-react is CommonJS with its component stored on `exports.default` while also
+// advertising `__esModule`; Vite 8 therefore exposes either the component or that wrapper.
+const ansiModule = AnsiImport as AnsiComponent | { default: AnsiComponent };
+const Ansi = typeof ansiModule === 'function' ? ansiModule : ansiModule.default;
 
 export interface TerminalProps extends React.ComponentProps<'div'> {
   title?: string;

--- a/packages/ui/src/chat/tool-call-item.tsx
+++ b/packages/ui/src/chat/tool-call-item.tsx
@@ -2,18 +2,14 @@ import type { ToolCall } from '@linkcode/schema';
 import { Badge } from 'coss-ui/components/badge';
 import { useTranslations } from 'use-intl';
 import { FileArtifactCard } from './artifacts/file-card';
-import { ContentBlockView } from './content-block-view';
-import { DiffBlock } from './diff-block';
 import { toolCallDiffStats } from './diff-utils';
-import { Terminal } from './terminal';
-import { TerminalBlock } from './terminal-block';
 import { Tool, ToolContent, ToolHeader } from './tool';
+import { toolCallDisplayText } from './tool-result-content';
+import { ToolResultPreview } from './tool-result-preview';
 import type { ToolMetadata } from './tool-utils';
 import {
   hasToolBody,
-  toolCallCommand,
   toolCallFailureMessage,
-  toolCallFallbackContent,
   toolCallMetadata,
   toolCallSummary,
 } from './tool-utils';
@@ -30,30 +26,6 @@ function producedFilePaths(toolCall: ToolCall): string[] {
     if (content.type === 'diff') paths.add(content.path);
   }
   return [...paths].slice(0, MAX_PRODUCED_FILE_CARDS);
-}
-
-function executeOutput(
-  toolCall: ToolCall,
-  fallbackContent: ReturnType<typeof toolCallFallbackContent>,
-): string | undefined {
-  const text = [
-    ...toolCall.content.flatMap((content) =>
-      content.type === 'content' && content.content.type === 'text' ? [content.content.text] : [],
-    ),
-    ...fallbackContent.flatMap((content) => (content.type === 'text' ? [content.text] : [])),
-  ].join('\n');
-  if (text.length > 0) return text;
-  if (toolCall.rawOutput === undefined) return undefined;
-  if (typeof toolCall.rawOutput === 'string') return toolCall.rawOutput;
-  if (
-    typeof toolCall.rawOutput === 'object' &&
-    toolCall.rawOutput !== null &&
-    'message' in toolCall.rawOutput &&
-    typeof toolCall.rawOutput.message === 'string'
-  ) {
-    return toolCall.rawOutput.message;
-  }
-  return undefined;
 }
 
 function ToolMetadataList({ metadata }: { metadata: ToolMetadata[] }): React.ReactNode {
@@ -77,23 +49,6 @@ function ToolMetadataList({ metadata }: { metadata: ToolMetadata[] }): React.Rea
   );
 }
 
-function ToolCallContentView({
-  content,
-  TerminalBlockComponent,
-}: {
-  content: ToolCall['content'][number];
-  TerminalBlockComponent?: React.ComponentType<{ terminalId: string }>;
-}): React.ReactNode {
-  if (content.type === 'content') return <ContentBlockView block={content.content} />;
-  if (content.type === 'diff') {
-    return <DiffBlock path={content.path} oldText={content.oldText} newText={content.newText} />;
-  }
-  if (TerminalBlockComponent) {
-    return <TerminalBlockComponent terminalId={content.terminalId} />;
-  }
-  return <TerminalBlock terminalId={content.terminalId} />;
-}
-
 /** The expandable detail of one call. Raw adapter payloads never render directly: known scalar
  * metadata is projected into badges, while structured content keeps its purpose-built surface. */
 export function ToolCallBody({
@@ -103,15 +58,7 @@ export function ToolCallBody({
   toolCall: ToolCall;
   TerminalBlockComponent?: React.ComponentType<{ terminalId: string }>;
 }): React.ReactNode {
-  const fallbackContent = toolCallFallbackContent(toolCall);
-  const isStaticExecute =
-    toolCall.kind === 'execute' && toolCall.content.every((content) => content.type !== 'terminal');
-  const contentText = [
-    ...toolCall.content.flatMap((content) =>
-      content.type === 'content' && content.content.type === 'text' ? [content.content.text] : [],
-    ),
-    ...fallbackContent.flatMap((content) => (content.type === 'text' ? [content.text] : [])),
-  ].join('\n');
+  const contentText = toolCallDisplayText(toolCall);
   const rawFailureMessage =
     toolCall.kind === 'execute' ? undefined : toolCallFailureMessage(toolCall);
   const failureMessage =
@@ -120,34 +67,7 @@ export function ToolCallBody({
   return (
     <>
       <ToolMetadataList metadata={toolCallMetadata(toolCall)} />
-
-      {isStaticExecute ? (
-        <Terminal
-          title={toolCallCommand(toolCall) ?? toolCall.title}
-          output={executeOutput(toolCall, fallbackContent)}
-        />
-      ) : null}
-
-      {toolCall.content.map((content, index) => {
-        if (isStaticExecute && content.type === 'content' && content.content.type === 'text') {
-          return null;
-        }
-        // Tool content is a full snapshot replaced by id each event, so index+type is stable.
-        const key = `${index}:${content.type}`;
-        return (
-          <ToolCallContentView
-            key={key}
-            TerminalBlockComponent={TerminalBlockComponent}
-            content={content}
-          />
-        );
-      })}
-
-      {fallbackContent.map((content, index) => {
-        if (isStaticExecute && content.type === 'text') return null;
-        // eslint-disable-next-line @eslint-react/no-array-index-key -- raw result content is a full snapshot with no block ids; index+type is its stable position key
-        return <ContentBlockView key={`${index}:${content.type}`} block={content} />;
-      })}
+      <ToolResultPreview TerminalBlockComponent={TerminalBlockComponent} toolCall={toolCall} />
 
       {failureMessage ? (
         <p className="text-destructive-foreground text-sm">{failureMessage}</p>
@@ -162,6 +82,7 @@ export function ToolCallItem({
   awaitingApproval = false,
   icon,
   TerminalBlockComponent,
+  constrainHeight = true,
 }: {
   toolCall: ToolCall;
   /** The user declined this call's gating permission (shown instead of a separate receipt row). */
@@ -171,6 +92,8 @@ export function ToolCallItem({
   /** Custom glyph for plugin / MCP / custom tool calls. */
   icon?: React.ReactNode;
   TerminalBlockComponent?: React.ComponentType<{ terminalId: string }>;
+  /** Disable when a parent transcript owns the capped scroll container. */
+  constrainHeight?: boolean;
 }): React.ReactNode {
   const t = useTranslations('workbench.tool');
   const tp = useTranslations('workbench.permission');
@@ -197,7 +120,7 @@ export function ToolCallItem({
       />
 
       {hasBody && (
-        <ToolContent>
+        <ToolContent constrainHeight={constrainHeight}>
           <ToolCallBody TerminalBlockComponent={TerminalBlockComponent} toolCall={toolCall} />
         </ToolContent>
       )}

--- a/packages/ui/src/chat/tool-call-item.tsx
+++ b/packages/ui/src/chat/tool-call-item.tsx
@@ -1,7 +1,6 @@
 import type { ToolCall } from '@linkcode/schema';
 import { Badge } from 'coss-ui/components/badge';
 import { useTranslations } from 'use-intl';
-import { FileArtifactCard } from './artifacts/file-card';
 import { toolCallDiffStats } from './diff-utils';
 import { Tool, ToolContent, ToolHeader } from './tool';
 import { toolCallDisplayText } from './tool-result-content';
@@ -10,23 +9,9 @@ import type { ToolMetadata } from './tool-utils';
 import {
   hasToolBody,
   toolCallFailureMessage,
+  toolCallHeaderSummary,
   toolCallMetadata,
-  toolCallSummary,
 } from './tool-utils';
-
-const MAX_PRODUCED_FILE_CARDS = 4;
-
-/** Files a completed move produced — edits keep their file context in the summary and diff. */
-function producedFilePaths(toolCall: ToolCall): string[] {
-  if (toolCall.status !== 'completed') return [];
-  if (toolCall.kind !== 'move') return [];
-  const paths = new Set<string>();
-  for (const location of toolCall.locations ?? []) paths.add(location.path);
-  for (const content of toolCall.content) {
-    if (content.type === 'diff') paths.add(content.path);
-  }
-  return [...paths].slice(0, MAX_PRODUCED_FILE_CARDS);
-}
 
 function ToolMetadataList({ metadata }: { metadata: ToolMetadata[] }): React.ReactNode {
   const t = useTranslations('workbench.tool');
@@ -100,8 +85,7 @@ export function ToolCallItem({
 
   const kindKey = `kind${toolCall.kind[0].toUpperCase()}${toolCall.kind.slice(1)}`;
   const hasBody = hasToolBody(toolCall);
-  const producedFiles = producedFilePaths(toolCall);
-  const summary = toolCallSummary(toolCall);
+  const summary = toolCallHeaderSummary(toolCall);
   const diffTotals = toolCallDiffStats(toolCall);
 
   return (
@@ -115,22 +99,15 @@ export function ToolCallItem({
         icon={icon}
         kind={toolCall.kind}
         status={toolCall.status}
-        summary={summary === toolCall.title ? undefined : summary}
+        summary={summary?.label === toolCall.title ? undefined : summary?.label}
         title={toolCall.title}
+        tooltip={summary?.tooltip}
       />
 
       {hasBody && (
         <ToolContent constrainHeight={constrainHeight}>
           <ToolCallBody TerminalBlockComponent={TerminalBlockComponent} toolCall={toolCall} />
         </ToolContent>
-      )}
-
-      {producedFiles.length > 0 && (
-        <div className="mt-1">
-          {producedFiles.map((path) => (
-            <FileArtifactCard key={path} path={path} />
-          ))}
-        </div>
       )}
     </Tool>
   );

--- a/packages/ui/src/chat/tool-preview-card.tsx
+++ b/packages/ui/src/chat/tool-preview-card.tsx
@@ -14,9 +14,9 @@ export function ToolPreviewCard({
 }): React.ReactNode {
   return (
     <Card className="my-1 overflow-hidden">
-      <CardHeader className="grid-cols-[auto_minmax(0,1fr)_auto] grid-rows-[auto] items-center gap-2 border-b px-3 py-2">
+      <CardHeader className="grid-cols-[auto_minmax(0,1fr)_auto] grid-rows-[auto] items-center gap-2 border-b bg-muted/32 px-3 py-1.5 in-[[data-slot=card]:has(>[data-slot=card-panel])]:pb-1.5">
         <Icon className="size-3.5 text-muted-foreground" />
-        <CardTitle className="truncate font-mono font-normal text-xs leading-normal">
+        <CardTitle className="truncate font-mono font-normal text-muted-foreground text-xs leading-normal">
           {title}
         </CardTitle>
         {badge ? (
@@ -25,7 +25,7 @@ export function ToolPreviewCard({
           </Badge>
         ) : null}
       </CardHeader>
-      <CardPanel className="p-3">{children}</CardPanel>
+      <CardPanel className="px-3 py-2">{children}</CardPanel>
     </Card>
   );
 }

--- a/packages/ui/src/chat/tool-preview-card.tsx
+++ b/packages/ui/src/chat/tool-preview-card.tsx
@@ -14,7 +14,7 @@ export function ToolPreviewCard({
 }): React.ReactNode {
   return (
     <Card className="my-1 overflow-hidden">
-      <CardHeader className="grid-cols-[auto_minmax(0,1fr)_auto] grid-rows-[auto] items-center gap-2 border-b bg-muted/32 px-3 py-1.5 in-[[data-slot=card]:has(>[data-slot=card-panel])]:pb-1.5">
+      <CardHeader className="grid-cols-[auto_minmax(0,1fr)_auto] grid-rows-[auto] items-center gap-2 border-b bg-muted px-3 py-1.5 in-[[data-slot=card]:has(>[data-slot=card-panel])]:pb-1.5">
         <Icon className="size-3.5 text-muted-foreground" />
         <CardTitle className="truncate font-mono font-normal text-muted-foreground text-xs leading-normal">
           {title}

--- a/packages/ui/src/chat/tool-preview-card.tsx
+++ b/packages/ui/src/chat/tool-preview-card.tsx
@@ -1,0 +1,31 @@
+import { Badge } from 'coss-ui/components/badge';
+import { Card, CardHeader, CardPanel, CardTitle } from 'coss-ui/components/card';
+
+export function ToolPreviewCard({
+  badge,
+  children,
+  icon: Icon,
+  title,
+}: {
+  badge?: string;
+  children: React.ReactNode;
+  icon: React.ComponentType<{ className?: string }>;
+  title: string;
+}): React.ReactNode {
+  return (
+    <Card className="my-1 overflow-hidden">
+      <CardHeader className="grid-cols-[auto_minmax(0,1fr)_auto] grid-rows-[auto] items-center gap-2 border-b px-3 py-2">
+        <Icon className="size-3.5 text-muted-foreground" />
+        <CardTitle className="truncate font-mono font-normal text-xs leading-normal">
+          {title}
+        </CardTitle>
+        {badge ? (
+          <Badge size="sm" variant="secondary">
+            {badge}
+          </Badge>
+        ) : null}
+      </CardHeader>
+      <CardPanel className="p-3">{children}</CardPanel>
+    </Card>
+  );
+}

--- a/packages/ui/src/chat/tool-result-content.ts
+++ b/packages/ui/src/chat/tool-result-content.ts
@@ -2,6 +2,8 @@ import type { ContentBlock, ToolCall, ToolCallContent } from '@linkcode/schema';
 import { ContentBlockSchema, textBlock } from '@linkcode/schema';
 
 export const TOOL_PATH_KEYS = ['file_path', 'path', 'file', 'notebook_path', 'filePath'] as const;
+const CLAUDE_SYSTEM_REMINDER_OPEN = '<system-reminder>';
+const CLAUDE_SYSTEM_REMINDER_CLOSE = '</system-reminder>\n';
 
 export function recordValue(value: unknown): Record<string, unknown> | undefined {
   if (typeof value !== 'object' || value === null || Array.isArray(value)) return undefined;
@@ -65,6 +67,67 @@ export function toolCallExecuteText(toolCall: ToolCall): string | undefined {
   if (displayText) return displayText;
   if (typeof toolCall.rawOutput === 'string') return toolCall.rawOutput;
   return stringValue(recordValue(toolCall.rawOutput), ['message']);
+}
+
+/**
+ * Claude's Read `tool_result.content` numbers every line even though its parallel
+ * `toolUseResult.file.content` is clean, and may prepend an unnumbered system reminder. ToolCall has
+ * no adapter id and currently receives only that rendered block, so unwrap only the exact Claude
+ * title/input shape and a complete consecutive run.
+ */
+export function toolCallReadPreviewText(toolCall: ToolCall, text: string): string {
+  const input = recordValue(toolCall.rawInput);
+  if (
+    toolCall.kind !== 'read' ||
+    toolCall.title !== 'Read' ||
+    !stringValue(input, ['file_path']) ||
+    text.length === 0
+  ) {
+    return text;
+  }
+
+  let numberedText = text;
+  if (text.startsWith(CLAUDE_SYSTEM_REMINDER_OPEN)) {
+    const reminderEnd = text.indexOf(CLAUDE_SYSTEM_REMINDER_CLOSE);
+    if (reminderEnd === -1) return text;
+    numberedText = text.slice(reminderEnd + CLAUDE_SYSTEM_REMINDER_CLOSE.length);
+    if (numberedText.length === 0) return text;
+  }
+
+  const offset = input?.offset;
+  if (
+    offset !== undefined &&
+    (typeof offset !== 'number' || !Number.isSafeInteger(offset) || offset < 1)
+  ) {
+    return text;
+  }
+
+  let cursor = 0;
+  let expectedLine = typeof offset === 'number' ? offset : 1;
+  const lines: string[] = [];
+  while (cursor < numberedText.length) {
+    const lineFeed = numberedText.indexOf('\n', cursor);
+    const lineEnd = lineFeed === -1 ? numberedText.length : lineFeed;
+    let prefixEnd = cursor;
+    while (prefixEnd < lineEnd) {
+      const codePoint = numberedText.codePointAt(prefixEnd);
+      if (codePoint === undefined || codePoint < 48 || codePoint > 57) break;
+      prefixEnd += 1;
+    }
+
+    if (prefixEnd === cursor || numberedText.codePointAt(prefixEnd) !== 9) return text;
+    const lineNumber = Number.parseInt(numberedText.slice(cursor, prefixEnd), 10);
+    if (!Number.isSafeInteger(lineNumber) || lineNumber < 1 || lineNumber !== expectedLine) {
+      return text;
+    }
+
+    expectedLine = lineNumber + 1;
+    lines.push(numberedText.slice(prefixEnd + 1, lineFeed === -1 ? lineEnd : lineFeed + 1));
+    if (lineFeed === -1) break;
+    cursor = lineFeed + 1;
+  }
+
+  return lines.join('');
 }
 
 function fallbackContent(toolCall: ToolCall): ContentBlock[] {

--- a/packages/ui/src/chat/tool-result-content.ts
+++ b/packages/ui/src/chat/tool-result-content.ts
@@ -1,0 +1,135 @@
+import type { ContentBlock, ToolCall, ToolCallContent } from '@linkcode/schema';
+import { ContentBlockSchema, textBlock } from '@linkcode/schema';
+
+export const TOOL_PATH_KEYS = ['file_path', 'path', 'file', 'notebook_path', 'filePath'] as const;
+
+export function recordValue(value: unknown): Record<string, unknown> | undefined {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return undefined;
+  return value as Record<string, unknown>;
+}
+
+export function stringValue(
+  record: Record<string, unknown> | undefined,
+  keys: readonly string[],
+): string | undefined {
+  if (!record) return undefined;
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === 'string' && value.length > 0) return value;
+  }
+  return undefined;
+}
+
+export function toolCallFilePath(toolCall: ToolCall): string | undefined {
+  const location = toolCall.locations?.[0];
+  if (location) return location.path;
+  const diff = toolCall.content.find((content) => content.type === 'diff');
+  if (diff?.type === 'diff') return diff.path;
+  return stringValue(recordValue(toolCall.rawInput), TOOL_PATH_KEYS);
+}
+
+export function toolCallSearchQuery(toolCall: ToolCall): string | undefined {
+  return stringValue(recordValue(toolCall.rawInput), ['query', 'pattern']);
+}
+
+export function toolCallFetchUrl(toolCall: ToolCall): string | undefined {
+  return stringValue(recordValue(toolCall.rawInput), ['url', 'uri']);
+}
+
+export function toolCallFetchStatus(toolCall: ToolCall): string | undefined {
+  const output = recordValue(toolCall.rawOutput);
+  const status = output?.status ?? output?.statusCode;
+  return typeof status === 'string' || typeof status === 'number' ? String(status) : undefined;
+}
+
+/**
+ * Claude and OpenCode normally duplicate display text in canonical `content` and `rawOutput`,
+ * while Pi and live Codex MCP may leave user-facing blocks in `rawOutput.content`. Canonical data
+ * therefore wins; fallbacks project only known result fields and never stringify the envelope.
+ */
+export function toolCallDisplayContent(toolCall: ToolCall): ToolCallContent[] {
+  if (toolCall.content.length > 0) return toolCall.content;
+  return fallbackContent(toolCall).map((content) => ({ type: 'content', content }));
+}
+
+export function toolCallDisplayText(toolCall: ToolCall): string {
+  return toolCallDisplayContent(toolCall)
+    .flatMap((content) =>
+      content.type === 'content' && content.content.type === 'text' ? [content.content.text] : [],
+    )
+    .join('\n');
+}
+
+export function toolCallExecuteText(toolCall: ToolCall): string | undefined {
+  const displayText = toolCallDisplayText(toolCall);
+  if (displayText) return displayText;
+  if (typeof toolCall.rawOutput === 'string') return toolCall.rawOutput;
+  return stringValue(recordValue(toolCall.rawOutput), ['message']);
+}
+
+function fallbackContent(toolCall: ToolCall): ContentBlock[] {
+  const rawOutput = toolCall.rawOutput;
+  const output = recordValue(rawOutput);
+  const rawContent = output?.content;
+
+  if (Array.isArray(rawContent)) {
+    const projected = rawContent.flatMap((value) => {
+      const result = ContentBlockSchema.safeParse(value);
+      return result.success ? [result.data] : [];
+    });
+    if (projected.length > 0) return projected;
+  }
+
+  // Codex execute uses rawOutput for an exit code and the terminal path owns string output.
+  if (toolCall.kind !== 'execute' && typeof rawOutput === 'string' && rawOutput.length > 0) {
+    return [textBlock(rawOutput)];
+  }
+
+  const fallbackText = kindSpecificFallbackText(toolCall, output);
+  return fallbackText ? [textBlock(fallbackText)] : [];
+}
+
+function kindSpecificFallbackText(
+  toolCall: ToolCall,
+  output: Record<string, unknown> | undefined,
+): string | undefined {
+  if (!output) return undefined;
+
+  switch (toolCall.kind) {
+    case 'search':
+      return stringArrayFields(output, ['matches', 'files']);
+    case 'fetch':
+      return displayValue(output.body ?? output.responseBody ?? output.text ?? output.data);
+    case 'other':
+      return displayValue(output.structuredContent);
+    case 'read':
+    case 'edit':
+    case 'delete':
+    case 'move':
+    case 'execute':
+    case 'think':
+    case 'task':
+      return undefined;
+    default:
+      return toolCall.kind satisfies never;
+  }
+}
+
+function stringArrayFields(
+  record: Record<string, unknown>,
+  keys: readonly string[],
+): string | undefined {
+  const values = keys.flatMap((key) => {
+    const value = record[key];
+    return Array.isArray(value)
+      ? value.filter((item): item is string => typeof item === 'string')
+      : [];
+  });
+  return values.length > 0 ? [...new Set(values)].join('\n') : undefined;
+}
+
+function displayValue(value: unknown): string | undefined {
+  if (typeof value === 'string') return value.length > 0 ? value : undefined;
+  if (value === undefined) return undefined;
+  return JSON.stringify(value, null, 2);
+}

--- a/packages/ui/src/chat/tool-result-preview.tsx
+++ b/packages/ui/src/chat/tool-result-preview.tsx
@@ -14,6 +14,7 @@ import {
   toolCallFetchStatus,
   toolCallFetchUrl,
   toolCallFilePath,
+  toolCallReadPreviewText,
   toolCallSearchQuery,
 } from './tool-result-content';
 import { TOOL_KIND_ICONS, toolCallCommand } from './tool-utils';
@@ -85,12 +86,13 @@ function renderTextPreview(toolCall: ToolCall, text: string): React.ReactNode {
     case 'read': {
       const path = toolCallFilePath(toolCall) ?? toolCall.title;
       const language = fileExtension(path) || undefined;
+      const previewText = toolCallReadPreviewText(toolCall, text);
       return artifactKindForPath(path) === 'markdown' ? (
         <ToolPreviewCard badge={language} icon={FileTextIcon} title={path}>
-          <Markdown>{text}</Markdown>
+          <Markdown>{previewText}</Markdown>
         </ToolPreviewCard>
       ) : (
-        <CodeBlock code={text} language={language} title={path} />
+        <CodeBlock code={previewText} language={language} title={path} />
       );
     }
     case 'edit':

--- a/packages/ui/src/chat/tool-result-preview.tsx
+++ b/packages/ui/src/chat/tool-result-preview.tsx
@@ -44,7 +44,7 @@ function SearchRows({ toolCall, text }: { toolCall: ToolCall; text: string }): R
   let resultCount = 0;
   let lineStart = 0;
   for (let index = 0; index < text.length; index += 1) {
-    if (text.charCodeAt(index) !== 10) continue;
+    if (text.codePointAt(index) !== 10) continue;
     if (index > lineStart) resultCount += 1;
     lineStart = index + 1;
   }

--- a/packages/ui/src/chat/tool-result-preview.tsx
+++ b/packages/ui/src/chat/tool-result-preview.tsx
@@ -3,6 +3,7 @@ import { FileTextIcon, GlobeIcon, SearchIcon, WrenchIcon } from 'lucide-react';
 import { artifactKindForPath, fileExtension } from './artifacts/file-kind';
 import { CodeBlock } from './code-block';
 import { ContentBlockView } from './content-block-view';
+import { contentDerivedEntries } from './content-derived-keys';
 import { DiffBlock } from './diff-block';
 import { FilePreviewCard } from './file-preview-card';
 import type { ToolCallFilePresentation } from './file-tool-presentation';
@@ -138,11 +139,8 @@ function FileCallPreview({
     >
       {content.length === 0
         ? undefined
-        : content.map((item, index) => (
-            <div
-              // eslint-disable-next-line @eslint-react/no-array-index-key -- tool content is a full ordered snapshot without block ids
-              key={`${index}:${item.type}`}
-            >
+        : contentDerivedEntries(content).map(({ item, key }) => (
+            <div key={key}>
               {item.type === 'content' && item.content.type === 'text' ? (
                 <FileCallText file={file} text={item.content.text} toolCall={toolCall} />
               ) : (
@@ -168,15 +166,12 @@ function MixedFilePreview({
   file: ToolCallFilePresentation;
 }): React.ReactNode {
   const receiptContent = content.filter((item) => item.type !== 'diff');
-  const receiptIndex = content.findIndex((item) => item.type !== 'diff');
+  const firstReceipt = receiptContent[0];
 
-  return content.map((item, index) => {
+  return contentDerivedEntries(content).map(({ item, key }) => {
     if (item.type === 'diff') {
       return (
-        <div
-          // eslint-disable-next-line @eslint-react/no-array-index-key -- tool content is a full ordered snapshot without block ids
-          key={`${index}:${item.type}`}
-        >
+        <div key={key}>
           <RenderedContent
             content={item}
             TerminalBlockComponent={TerminalBlockComponent}
@@ -185,7 +180,7 @@ function MixedFilePreview({
         </div>
       );
     }
-    if (index !== receiptIndex) return null;
+    if (item !== firstReceipt) return null;
     return (
       <FileCallPreview
         key={`${toolCall.toolCallId}:receipts`}
@@ -258,11 +253,8 @@ function ContentList({
   content,
   TerminalBlockComponent,
 }: ToolResultPreviewProps & { content: readonly ToolCallContent[] }): React.ReactNode {
-  return content.map((item, index) => (
-    <div
-      // eslint-disable-next-line @eslint-react/no-array-index-key -- tool content is a full ordered snapshot without block ids
-      key={`${index}:${item.type}`}
-    >
+  return contentDerivedEntries(content).map(({ item, key }) => (
+    <div key={key}>
       {item.type === 'content' && item.content.type === 'text' ? (
         renderTextPreview(toolCall, item.content.text)
       ) : (
@@ -289,10 +281,9 @@ function ExecutePreview({
 
   return (
     <>
-      {terminalContent.map((item, index) => (
+      {contentDerivedEntries(terminalContent).map(({ item, key }) => (
         <RenderedContent
-          // eslint-disable-next-line @eslint-react/no-array-index-key -- terminal references are an ordered full snapshot without block ids
-          key={`${index}:${item.type}`}
+          key={key}
           content={item}
           TerminalBlockComponent={TerminalBlockComponent}
           toolCall={toolCall}

--- a/packages/ui/src/chat/tool-result-preview.tsx
+++ b/packages/ui/src/chat/tool-result-preview.tsx
@@ -4,6 +4,9 @@ import { artifactKindForPath, fileExtension } from './artifacts/file-kind';
 import { CodeBlock } from './code-block';
 import { ContentBlockView } from './content-block-view';
 import { DiffBlock } from './diff-block';
+import { FilePreviewCard } from './file-preview-card';
+import type { ToolCallFilePresentation } from './file-tool-presentation';
+import { toolCallDiffNavigation, toolCallFilePresentation } from './file-tool-presentation';
 import { Markdown } from './markdown';
 import { Terminal } from './terminal';
 import { TerminalBlock } from './terminal-block';
@@ -13,7 +16,6 @@ import {
   toolCallExecuteText,
   toolCallFetchStatus,
   toolCallFetchUrl,
-  toolCallFilePath,
   toolCallReadPreviewText,
   toolCallSearchQuery,
 } from './tool-result-content';
@@ -27,13 +29,22 @@ interface ToolResultPreviewProps {
 function RenderedContent({
   content,
   TerminalBlockComponent,
+  toolCall,
 }: {
   content: ToolCallContent;
   TerminalBlockComponent?: React.ComponentType<{ terminalId: string }>;
+  toolCall: ToolCall;
 }): React.ReactNode {
   if (content.type === 'content') return <ContentBlockView block={content.content} />;
   if (content.type === 'diff') {
-    return <DiffBlock path={content.path} oldText={content.oldText} newText={content.newText} />;
+    return (
+      <DiffBlock
+        navigation={toolCallDiffNavigation(toolCall, content.path, content.newText)}
+        path={content.path}
+        oldText={content.oldText}
+        newText={content.newText}
+      />
+    );
   }
   if (TerminalBlockComponent) {
     return <TerminalBlockComponent terminalId={content.terminalId} />;
@@ -81,18 +92,121 @@ function markupLanguage(text: string): 'html' | 'xml' | undefined {
   return trimmed.startsWith('<!doctype html') || trimmed.startsWith('<html') ? 'html' : 'xml';
 }
 
+function FileCallText({
+  file,
+  text,
+  toolCall,
+}: {
+  file: ToolCallFilePresentation;
+  text: string;
+  toolCall: ToolCall;
+}): React.ReactNode {
+  if (toolCall.kind !== 'read') return <Markdown>{text}</Markdown>;
+
+  const previewText = file.ambiguous ? text : toolCallReadPreviewText(toolCall, text);
+  if (!file.ambiguous && artifactKindForPath(file.path) === 'markdown') {
+    return <Markdown>{previewText}</Markdown>;
+  }
+  return (
+    <pre className="overflow-x-auto whitespace-pre font-mono text-xs leading-relaxed">
+      <code>{previewText}</code>
+    </pre>
+  );
+}
+
+/** File calls without structured diffs share one identity/navigation header across every block.
+ * This matters for Pi resource results and Codex multi-file receipts whose text has no path key. */
+function FileCallPreview({
+  content,
+  file,
+  TerminalBlockComponent,
+  toolCall,
+}: ToolResultPreviewProps & {
+  content: readonly ToolCallContent[];
+  file: ToolCallFilePresentation;
+}): React.ReactNode {
+  const badge =
+    toolCall.kind === 'read' && !file.ambiguous ? fileExtension(file.path) || undefined : undefined;
+
+  return (
+    <FilePreviewCard
+      badge={badge}
+      label={file.label}
+      navigation={file.navigation ?? null}
+      path={file.path}
+      tooltip={file.tooltip}
+    >
+      {content.length === 0
+        ? undefined
+        : content.map((item, index) => (
+            <div
+              // eslint-disable-next-line @eslint-react/no-array-index-key -- tool content is a full ordered snapshot without block ids
+              key={`${index}:${item.type}`}
+            >
+              {item.type === 'content' && item.content.type === 'text' ? (
+                <FileCallText file={file} text={item.content.text} toolCall={toolCall} />
+              ) : (
+                <RenderedContent
+                  content={item}
+                  TerminalBlockComponent={TerminalBlockComponent}
+                  toolCall={toolCall}
+                />
+              )}
+            </div>
+          ))}
+    </FilePreviewCard>
+  );
+}
+
+function MixedFilePreview({
+  content,
+  file,
+  TerminalBlockComponent,
+  toolCall,
+}: ToolResultPreviewProps & {
+  content: readonly ToolCallContent[];
+  file: ToolCallFilePresentation;
+}): React.ReactNode {
+  const receiptContent = content.filter((item) => item.type !== 'diff');
+  const receiptIndex = content.findIndex((item) => item.type !== 'diff');
+
+  return content.map((item, index) => {
+    if (item.type === 'diff') {
+      return (
+        <div
+          // eslint-disable-next-line @eslint-react/no-array-index-key -- tool content is a full ordered snapshot without block ids
+          key={`${index}:${item.type}`}
+        >
+          <RenderedContent
+            content={item}
+            TerminalBlockComponent={TerminalBlockComponent}
+            toolCall={toolCall}
+          />
+        </div>
+      );
+    }
+    if (index !== receiptIndex) return null;
+    return (
+      <FileCallPreview
+        key={`${toolCall.toolCallId}:receipts`}
+        content={receiptContent}
+        file={file}
+        toolCall={toolCall}
+        TerminalBlockComponent={TerminalBlockComponent}
+      />
+    );
+  });
+}
+
 function renderTextPreview(toolCall: ToolCall, text: string): React.ReactNode {
   switch (toolCall.kind) {
     case 'read': {
-      const path = toolCallFilePath(toolCall) ?? toolCall.title;
-      const language = fileExtension(path) || undefined;
-      const previewText = toolCallReadPreviewText(toolCall, text);
-      return artifactKindForPath(path) === 'markdown' ? (
-        <ToolPreviewCard badge={language} icon={FileTextIcon} title={path}>
-          <Markdown>{previewText}</Markdown>
+      return (
+        <ToolPreviewCard icon={FileTextIcon} title={toolCall.title}>
+          <pre className="overflow-x-auto whitespace-pre font-mono text-xs leading-relaxed">
+            <code>{text}</code>
+          </pre>
         </ToolPreviewCard>
-      ) : (
-        <CodeBlock code={previewText} language={language} title={path} />
       );
     }
     case 'edit':
@@ -100,7 +214,7 @@ function renderTextPreview(toolCall: ToolCall, text: string): React.ReactNode {
     case 'move': {
       const Icon = TOOL_KIND_ICONS[toolCall.kind];
       return (
-        <ToolPreviewCard icon={Icon} title={toolCallFilePath(toolCall) ?? toolCall.title}>
+        <ToolPreviewCard icon={Icon} title={toolCall.title}>
           <Markdown>{text}</Markdown>
         </ToolPreviewCard>
       );
@@ -152,7 +266,11 @@ function ContentList({
       {item.type === 'content' && item.content.type === 'text' ? (
         renderTextPreview(toolCall, item.content.text)
       ) : (
-        <RenderedContent content={item} TerminalBlockComponent={TerminalBlockComponent} />
+        <RenderedContent
+          content={item}
+          TerminalBlockComponent={TerminalBlockComponent}
+          toolCall={toolCall}
+        />
       )}
     </div>
   ));
@@ -177,6 +295,7 @@ function ExecutePreview({
           key={`${index}:${item.type}`}
           content={item}
           TerminalBlockComponent={TerminalBlockComponent}
+          toolCall={toolCall}
         />
       ))}
       {terminalContent.length === 0 || output ? (
@@ -197,6 +316,30 @@ export function ToolResultPreview({
   TerminalBlockComponent,
 }: ToolResultPreviewProps): React.ReactNode {
   const content = toolCallDisplayContent(toolCall);
+  const file = toolCallFilePresentation(toolCall);
+  if (file) {
+    const hasDiff = content.some((item) => item.type === 'diff');
+    if (!hasDiff) {
+      return (
+        <FileCallPreview
+          content={content}
+          file={file}
+          toolCall={toolCall}
+          TerminalBlockComponent={TerminalBlockComponent}
+        />
+      );
+    }
+    if (content.some((item) => item.type !== 'diff')) {
+      return (
+        <MixedFilePreview
+          content={content}
+          file={file}
+          toolCall={toolCall}
+          TerminalBlockComponent={TerminalBlockComponent}
+        />
+      );
+    }
+  }
   return toolCall.kind === 'execute' ? (
     <ExecutePreview
       content={content}

--- a/packages/ui/src/chat/tool-result-preview.tsx
+++ b/packages/ui/src/chat/tool-result-preview.tsx
@@ -1,0 +1,211 @@
+import type { ToolCall, ToolCallContent } from '@linkcode/schema';
+import { FileTextIcon, GlobeIcon, SearchIcon, WrenchIcon } from 'lucide-react';
+import { artifactKindForPath, fileExtension } from './artifacts/file-kind';
+import { CodeBlock } from './code-block';
+import { ContentBlockView } from './content-block-view';
+import { DiffBlock } from './diff-block';
+import { Markdown } from './markdown';
+import { Terminal } from './terminal';
+import { TerminalBlock } from './terminal-block';
+import { ToolPreviewCard } from './tool-preview-card';
+import {
+  toolCallDisplayContent,
+  toolCallExecuteText,
+  toolCallFetchStatus,
+  toolCallFetchUrl,
+  toolCallFilePath,
+  toolCallSearchQuery,
+} from './tool-result-content';
+import { TOOL_KIND_ICONS, toolCallCommand } from './tool-utils';
+
+interface ToolResultPreviewProps {
+  toolCall: ToolCall;
+  TerminalBlockComponent?: React.ComponentType<{ terminalId: string }>;
+}
+
+function RenderedContent({
+  content,
+  TerminalBlockComponent,
+}: {
+  content: ToolCallContent;
+  TerminalBlockComponent?: React.ComponentType<{ terminalId: string }>;
+}): React.ReactNode {
+  if (content.type === 'content') return <ContentBlockView block={content.content} />;
+  if (content.type === 'diff') {
+    return <DiffBlock path={content.path} oldText={content.oldText} newText={content.newText} />;
+  }
+  if (TerminalBlockComponent) {
+    return <TerminalBlockComponent terminalId={content.terminalId} />;
+  }
+  return <TerminalBlock terminalId={content.terminalId} />;
+}
+
+function SearchRows({ toolCall, text }: { toolCall: ToolCall; text: string }): React.ReactNode {
+  let resultCount = 0;
+  let lineStart = 0;
+  for (let index = 0; index < text.length; index += 1) {
+    if (text.charCodeAt(index) !== 10) continue;
+    if (index > lineStart) resultCount += 1;
+    lineStart = index + 1;
+  }
+  if (lineStart < text.length) resultCount += 1;
+  // Search adapters return paths, grep-style lines, or prose. Preserve their text as one node:
+  // splitting an unbounded grep result into rows can freeze the Electron renderer.
+  return (
+    <ToolPreviewCard
+      badge={String(resultCount)}
+      icon={SearchIcon}
+      title={toolCallSearchQuery(toolCall) ?? toolCall.title}
+    >
+      <pre className="overflow-x-auto whitespace-pre font-mono text-xs leading-relaxed">
+        <code>{text}</code>
+      </pre>
+    </ToolPreviewCard>
+  );
+}
+
+function formattedJson(text: string): string | undefined {
+  const trimmed = text.trim();
+  if (trimmed[0] !== '{' && trimmed[0] !== '[') return undefined;
+  try {
+    return JSON.stringify(JSON.parse(trimmed), null, 2);
+  } catch {
+    return undefined;
+  }
+}
+
+function markupLanguage(text: string): 'html' | 'xml' | undefined {
+  const trimmed = text.trimStart().toLowerCase();
+  if (trimmed[0] !== '<') return undefined;
+  return trimmed.startsWith('<!doctype html') || trimmed.startsWith('<html') ? 'html' : 'xml';
+}
+
+function renderTextPreview(toolCall: ToolCall, text: string): React.ReactNode {
+  switch (toolCall.kind) {
+    case 'read': {
+      const path = toolCallFilePath(toolCall) ?? toolCall.title;
+      const language = fileExtension(path) || undefined;
+      return artifactKindForPath(path) === 'markdown' ? (
+        <ToolPreviewCard badge={language} icon={FileTextIcon} title={path}>
+          <Markdown>{text}</Markdown>
+        </ToolPreviewCard>
+      ) : (
+        <CodeBlock code={text} language={language} title={path} />
+      );
+    }
+    case 'edit':
+    case 'delete':
+    case 'move': {
+      const Icon = TOOL_KIND_ICONS[toolCall.kind];
+      return (
+        <ToolPreviewCard icon={Icon} title={toolCallFilePath(toolCall) ?? toolCall.title}>
+          <Markdown>{text}</Markdown>
+        </ToolPreviewCard>
+      );
+    }
+    case 'search':
+      return <SearchRows text={text} toolCall={toolCall} />;
+    case 'fetch': {
+      const title = toolCallFetchUrl(toolCall) ?? toolCall.title;
+      const json = formattedJson(text);
+      if (json) return <CodeBlock code={json} language="json" title={title} />;
+      const markup = markupLanguage(text);
+      if (markup) return <CodeBlock code={text} language={markup} title={title} />;
+      return (
+        <ToolPreviewCard badge={toolCallFetchStatus(toolCall)} icon={GlobeIcon} title={title}>
+          <Markdown>{text}</Markdown>
+        </ToolPreviewCard>
+      );
+    }
+    case 'other': {
+      const json = formattedJson(text);
+      return json ? (
+        <CodeBlock code={json} language="json" title={toolCall.title} />
+      ) : (
+        <ToolPreviewCard icon={WrenchIcon} title={toolCall.title}>
+          <Markdown>{text}</Markdown>
+        </ToolPreviewCard>
+      );
+    }
+    case 'think':
+    case 'task':
+      return <Markdown>{text}</Markdown>;
+    case 'execute':
+      return null;
+    default:
+      return toolCall.kind satisfies never;
+  }
+}
+
+function ContentList({
+  toolCall,
+  content,
+  TerminalBlockComponent,
+}: ToolResultPreviewProps & { content: readonly ToolCallContent[] }): React.ReactNode {
+  return content.map((item, index) => (
+    <div
+      // eslint-disable-next-line @eslint-react/no-array-index-key -- tool content is a full ordered snapshot without block ids
+      key={`${index}:${item.type}`}
+    >
+      {item.type === 'content' && item.content.type === 'text' ? (
+        renderTextPreview(toolCall, item.content.text)
+      ) : (
+        <RenderedContent content={item} TerminalBlockComponent={TerminalBlockComponent} />
+      )}
+    </div>
+  ));
+}
+
+function ExecutePreview({
+  toolCall,
+  content,
+  TerminalBlockComponent,
+}: ToolResultPreviewProps & { content: readonly ToolCallContent[] }): React.ReactNode {
+  const terminalContent = content.filter((item) => item.type === 'terminal');
+  const otherContent = content.filter(
+    (item) => item.type !== 'terminal' && (item.type !== 'content' || item.content.type !== 'text'),
+  );
+  const output = toolCallExecuteText(toolCall);
+
+  return (
+    <>
+      {terminalContent.map((item, index) => (
+        <RenderedContent
+          // eslint-disable-next-line @eslint-react/no-array-index-key -- terminal references are an ordered full snapshot without block ids
+          key={`${index}:${item.type}`}
+          content={item}
+          TerminalBlockComponent={TerminalBlockComponent}
+        />
+      ))}
+      {terminalContent.length === 0 || output ? (
+        <Terminal title={toolCallCommand(toolCall) ?? toolCall.title} output={output} />
+      ) : null}
+      <ContentList
+        content={otherContent}
+        toolCall={toolCall}
+        TerminalBlockComponent={TerminalBlockComponent}
+      />
+    </>
+  );
+}
+
+/** Kind-aware result boundary: each action renders through a purpose-built, read-only surface. */
+export function ToolResultPreview({
+  toolCall,
+  TerminalBlockComponent,
+}: ToolResultPreviewProps): React.ReactNode {
+  const content = toolCallDisplayContent(toolCall);
+  return toolCall.kind === 'execute' ? (
+    <ExecutePreview
+      content={content}
+      toolCall={toolCall}
+      TerminalBlockComponent={TerminalBlockComponent}
+    />
+  ) : (
+    <ContentList
+      content={content}
+      toolCall={toolCall}
+      TerminalBlockComponent={TerminalBlockComponent}
+    />
+  );
+}

--- a/packages/ui/src/chat/tool-utils.ts
+++ b/packages/ui/src/chat/tool-utils.ts
@@ -15,16 +15,14 @@ import { toolCallFilePresentation } from './file-tool-presentation';
 import {
   recordValue,
   stringValue,
-  TOOL_PATH_KEYS,
   toolCallDisplayContent,
   toolCallExecuteText,
   toolCallFetchStatus,
   toolCallFetchUrl,
-  toolCallFilePath,
   toolCallSearchQuery,
 } from './tool-result-content';
 
-export type ToolMetadataKey = 'files' | 'matches' | 'path' | 'query' | 'status' | 'url';
+export type ToolMetadataKey = 'files' | 'matches' | 'query' | 'status' | 'url';
 
 export interface ToolMetadata {
   key: ToolMetadataKey;
@@ -32,26 +30,10 @@ export interface ToolMetadata {
   tone?: 'error';
 }
 
-const MOVE_SOURCE_KEYS = ['source', 'from', 'old_path', 'oldPath', ...TOOL_PATH_KEYS] as const;
-const MOVE_DESTINATION_KEYS = ['destination', 'to', 'new_path', 'newPath', 'move_path'] as const;
-
 function countValue(value: unknown): number | undefined {
   if (Array.isArray(value)) return value.length;
   if (typeof value === 'number' && Number.isFinite(value) && value >= 0) return value;
   return undefined;
-}
-
-function fileSummary(toolCall: ToolCall): string | undefined {
-  if (toolCall.kind === 'move') {
-    const input = recordValue(toolCall.rawInput);
-    const source = stringValue(input, MOVE_SOURCE_KEYS);
-    const destination = stringValue(input, MOVE_DESTINATION_KEYS);
-    if (source && destination) return `${source} → ${destination}`;
-  }
-
-  const path = toolCallFilePath(toolCall);
-  const location = toolCall.locations?.find((item) => item.path === path);
-  return path && location?.line !== undefined ? `${path}:${location.line}` : path;
 }
 
 export function toolCallCommand(toolCall: ToolCall): string | undefined {
@@ -75,16 +57,10 @@ export function toolCallMetadata(toolCall: ToolCall): ToolMetadata[] {
 
   switch (toolCall.kind) {
     case 'read':
-    case 'move': {
-      const path = fileSummary(toolCall);
-      return path ? [{ key: 'path', value: path }] : [];
-    }
     case 'edit':
-    case 'delete': {
-      if (toolCall.content.some((content) => content.type === 'diff')) return [];
-      const path = fileSummary(toolCall);
-      return path ? [{ key: 'path', value: path }] : [];
-    }
+    case 'delete':
+    case 'move':
+      return [];
     case 'search': {
       const metadata: ToolMetadata[] = [];
       const query = toolCallSearchQuery(toolCall);
@@ -119,20 +95,31 @@ export function toolCallMetadata(toolCall: ToolCall): ToolMetadata[] {
   }
 }
 
+export interface ToolCallHeaderSummary {
+  label: string;
+  tooltip?: string;
+}
+
 /** One compact, non-debug detail for singleton headers and collapsed group summaries. */
-export function toolCallSummary(toolCall: ToolCall): string | undefined {
+export function toolCallHeaderSummary(toolCall: ToolCall): ToolCallHeaderSummary | undefined {
+  let label: string | undefined;
   switch (toolCall.kind) {
     case 'execute':
-      return toolCallCommand(toolCall);
+      label = toolCallCommand(toolCall);
+      break;
     case 'read':
     case 'edit':
     case 'delete':
-    case 'move':
-      return fileSummary(toolCall);
+    case 'move': {
+      const file = toolCallFilePresentation(toolCall);
+      return file ? { label: file.label, tooltip: file.tooltip } : undefined;
+    }
     case 'search':
-      return toolCallSearchQuery(toolCall);
+      label = toolCallSearchQuery(toolCall);
+      break;
     case 'fetch':
-      return toolCallFetchUrl(toolCall);
+      label = toolCallFetchUrl(toolCall);
+      break;
     case 'think':
     case 'task':
     case 'other':
@@ -140,6 +127,7 @@ export function toolCallSummary(toolCall: ToolCall): string | undefined {
     default:
       return toolCall.kind satisfies never;
   }
+  return label ? { label } : undefined;
 }
 
 export function hasToolBody(toolCall: ToolCall): boolean {

--- a/packages/ui/src/chat/tool-utils.ts
+++ b/packages/ui/src/chat/tool-utils.ts
@@ -1,5 +1,4 @@
-import type { ContentBlock, ToolCall } from '@linkcode/schema';
-import { ContentBlockSchema } from '@linkcode/schema';
+import type { ToolCall } from '@linkcode/schema';
 import {
   BotIcon,
   BrainIcon,
@@ -12,6 +11,17 @@ import {
   Trash2Icon,
   WrenchIcon,
 } from 'lucide-react';
+import {
+  recordValue,
+  stringValue,
+  TOOL_PATH_KEYS,
+  toolCallDisplayContent,
+  toolCallExecuteText,
+  toolCallFetchStatus,
+  toolCallFetchUrl,
+  toolCallFilePath,
+  toolCallSearchQuery,
+} from './tool-result-content';
 
 export type ToolMetadataKey = 'files' | 'matches' | 'path' | 'query' | 'status' | 'url';
 
@@ -21,26 +31,8 @@ export interface ToolMetadata {
   tone?: 'error';
 }
 
-const PATH_KEYS = ['file_path', 'path', 'notebook_path', 'filePath'] as const;
-const MOVE_SOURCE_KEYS = ['source', 'from', 'old_path', 'oldPath', ...PATH_KEYS] as const;
+const MOVE_SOURCE_KEYS = ['source', 'from', 'old_path', 'oldPath', ...TOOL_PATH_KEYS] as const;
 const MOVE_DESTINATION_KEYS = ['destination', 'to', 'new_path', 'newPath', 'move_path'] as const;
-
-function recordValue(value: unknown): Record<string, unknown> | undefined {
-  if (typeof value !== 'object' || value === null || Array.isArray(value)) return undefined;
-  return value as Record<string, unknown>;
-}
-
-function stringValue(
-  record: Record<string, unknown> | undefined,
-  keys: readonly string[],
-): string | undefined {
-  if (!record) return undefined;
-  for (const key of keys) {
-    const value = record[key];
-    if (typeof value === 'string' && value.length > 0) return value;
-  }
-  return undefined;
-}
 
 function countValue(value: unknown): number | undefined {
   if (Array.isArray(value)) return value.length;
@@ -56,14 +48,9 @@ function fileSummary(toolCall: ToolCall): string | undefined {
     if (source && destination) return `${source} → ${destination}`;
   }
 
-  const location = toolCall.locations?.[0];
-  if (location) {
-    return location.line === undefined ? location.path : `${location.path}:${location.line}`;
-  }
-
-  const diff = toolCall.content.find((content) => content.type === 'diff');
-  if (diff?.type === 'diff') return diff.path;
-  return stringValue(recordValue(toolCall.rawInput), PATH_KEYS);
+  const path = toolCallFilePath(toolCall);
+  const location = toolCall.locations?.find((item) => item.path === path);
+  return path && location?.line !== undefined ? `${path}:${location.line}` : path;
 }
 
 export function toolCallCommand(toolCall: ToolCall): string | undefined {
@@ -81,25 +68,8 @@ export function toolCallFailureMessage(toolCall: ToolCall): string | undefined {
   return stringValue(recordValue(toolCall.rawOutput), ['message']);
 }
 
-/**
- * Pi AgentToolResult and live Codex MCP results currently arrive in `rawOutput.content` while
- * canonical tool content is empty. Project only schema-valid content blocks so the useful result
- * survives without exposing the rest of either backend envelope in the transcript.
- */
-export function toolCallFallbackContent(toolCall: ToolCall): ContentBlock[] {
-  if (toolCall.content.length > 0) return [];
-  const rawContent = recordValue(toolCall.rawOutput)?.content;
-  if (!Array.isArray(rawContent)) return [];
-
-  return rawContent.flatMap((value) => {
-    const result = ContentBlockSchema.safeParse(value);
-    return result.success ? [result.data] : [];
-  });
-}
-
 /** Whitelisted normal-mode metadata. Arbitrary raw payloads stay in the model, not the transcript. */
 export function toolCallMetadata(toolCall: ToolCall): ToolMetadata[] {
-  const input = recordValue(toolCall.rawInput);
   const output = recordValue(toolCall.rawOutput);
 
   switch (toolCall.kind) {
@@ -116,7 +86,7 @@ export function toolCallMetadata(toolCall: ToolCall): ToolMetadata[] {
     }
     case 'search': {
       const metadata: ToolMetadata[] = [];
-      const query = stringValue(input, ['query', 'pattern']);
+      const query = toolCallSearchQuery(toolCall);
       if (query) metadata.push({ key: 'query', value: query });
       const matches = countValue(output?.matches);
       if (matches !== undefined) metadata.push({ key: 'matches', value: String(matches) });
@@ -126,13 +96,13 @@ export function toolCallMetadata(toolCall: ToolCall): ToolMetadata[] {
     }
     case 'fetch': {
       const metadata: ToolMetadata[] = [];
-      const url = stringValue(input, ['url', 'uri']);
+      const url = toolCallFetchUrl(toolCall);
       if (url) metadata.push({ key: 'url', value: url });
-      const status = output?.status ?? output?.statusCode;
-      if (typeof status === 'string' || typeof status === 'number') {
+      const status = toolCallFetchStatus(toolCall);
+      if (status) {
         metadata.push({
           key: 'status',
-          value: String(status),
+          value: status,
           tone: toolCall.status === 'failed' ? 'error' : undefined,
         });
       }
@@ -159,9 +129,9 @@ export function toolCallSummary(toolCall: ToolCall): string | undefined {
     case 'move':
       return fileSummary(toolCall);
     case 'search':
-      return stringValue(recordValue(toolCall.rawInput), ['query', 'pattern']);
+      return toolCallSearchQuery(toolCall);
     case 'fetch':
-      return stringValue(recordValue(toolCall.rawInput), ['url', 'uri']);
+      return toolCallFetchUrl(toolCall);
     case 'think':
     case 'task':
     case 'other':
@@ -172,11 +142,10 @@ export function toolCallSummary(toolCall: ToolCall): string | undefined {
 }
 
 export function hasToolBody(toolCall: ToolCall): boolean {
-  if (toolCall.content.length > 0) return true;
-  if (toolCallFallbackContent(toolCall).length > 0) return true;
+  if (toolCallDisplayContent(toolCall).length > 0) return true;
   if (toolCall.kind === 'execute') {
     if (toolCallCommand(toolCall)) return true;
-    if (typeof toolCall.rawOutput === 'string') return true;
+    if (toolCallExecuteText(toolCall)) return true;
   }
   return toolCallMetadata(toolCall).length > 0 || toolCallFailureMessage(toolCall) !== undefined;
 }

--- a/packages/ui/src/chat/tool-utils.ts
+++ b/packages/ui/src/chat/tool-utils.ts
@@ -11,6 +11,7 @@ import {
   Trash2Icon,
   WrenchIcon,
 } from 'lucide-react';
+import { toolCallFilePresentation } from './file-tool-presentation';
 import {
   recordValue,
   stringValue,
@@ -143,6 +144,7 @@ export function toolCallSummary(toolCall: ToolCall): string | undefined {
 
 export function hasToolBody(toolCall: ToolCall): boolean {
   if (toolCallDisplayContent(toolCall).length > 0) return true;
+  if (toolCallFilePresentation(toolCall)) return true;
   if (toolCall.kind === 'execute') {
     if (toolCallCommand(toolCall)) return true;
     if (toolCallExecuteText(toolCall)) return true;

--- a/packages/ui/src/chat/tool.tsx
+++ b/packages/ui/src/chat/tool.tsx
@@ -12,6 +12,8 @@ import { DiffCounter } from './diff-block';
 import type { DiffStats } from './diff-utils';
 import { TOOL_KIND_ICONS } from './tool-utils';
 
+export const TOOL_DETAIL_SCROLL_CLASS_NAME = 'max-h-96 overflow-y-auto overscroll-contain';
+
 export type ToolProps = React.ComponentProps<typeof Collapsible>;
 
 export function Tool({ className, ...props }: ToolProps): React.ReactNode {
@@ -110,7 +112,11 @@ export type ToolContentProps = React.ComponentProps<typeof CollapsibleContent>;
 export function ToolContent({ className, ...props }: ToolContentProps): React.ReactNode {
   return (
     <CollapsibleContent
-      className={cn('mt-1 space-y-2 border-l-2 border-border pl-3', className)}
+      className={cn(
+        'mt-1 space-y-2 border-l-2 border-border pl-3',
+        TOOL_DETAIL_SCROLL_CLASS_NAME,
+        className,
+      )}
       {...props}
     />
   );

--- a/packages/ui/src/chat/tool.tsx
+++ b/packages/ui/src/chat/tool.tsx
@@ -7,13 +7,14 @@ import {
 } from 'coss-ui/components/collapsible';
 import { Spinner } from 'coss-ui/components/spinner';
 import { ChevronRightIcon, ShieldIcon } from 'lucide-react';
+import { useRef } from 'react';
 import { cn } from '../lib/cn';
 import { DiffCounter } from './diff-block';
 import type { DiffStats } from './diff-utils';
 import { TOOL_KIND_ICONS } from './tool-utils';
-import { FILE_PATH_TOOLTIP_CLASS_NAME, withTooltip } from './with-tooltip';
+import { FilePathTooltip } from './with-tooltip';
 
-export const TOOL_DETAIL_SCROLL_CLASS_NAME = 'max-h-96 overflow-y-auto overscroll-contain';
+export const TOOL_DETAIL_SCROLL_CLASS_NAME = 'max-h-96 overflow-y-auto';
 
 export type ToolProps = React.ComponentProps<typeof Collapsible>;
 
@@ -55,15 +56,22 @@ export function ToolHeader({
   hasBody = false,
   ...props
 }: ToolHeaderProps): React.ReactNode {
+  const tooltipAnchorRef = useRef<HTMLSpanElement>(null);
+  const titleAnchorRef = tooltip && !summary ? tooltipAnchorRef : undefined;
   const content = (
     <>
       <ToolIcon awaitingApproval={awaitingApproval} icon={icon} kind={kind} status={status} />
-      <span className={cn('min-w-0 truncate text-foreground', summary ? 'shrink' : 'flex-1')}>
+      <span
+        className={cn('min-w-0 truncate text-foreground', summary ? 'shrink' : 'flex-1')}
+        ref={titleAnchorRef}
+      >
         {title}
       </span>
       {diffStats ? <DiffCounter stats={diffStats} /> : null}
       {summary ? (
-        <span className="min-w-0 flex-1 truncate text-muted-foreground">· {summary}</span>
+        <span className="min-w-0 flex-1 truncate text-muted-foreground" ref={tooltipAnchorRef}>
+          · {summary}
+        </span>
       ) : null}
       {declinedBadge ? <Badge variant="error">{declinedBadge}</Badge> : null}
       {badge ? <Badge variant="secondary">{badge}</Badge> : null}
@@ -77,25 +85,25 @@ export function ToolHeader({
     className,
   );
 
-  return withTooltip(
-    hasBody ? (
-      <CollapsibleTrigger className={headerClassName} {...props}>
-        {content}
-      </CollapsibleTrigger>
-    ) : (
-      <div
-        className={cn(
-          headerClassName,
-          tooltip &&
-            'rounded-md outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background',
-        )}
-        tabIndex={tooltip ? 0 : undefined}
-      >
-        {content}
-      </div>
-    ),
-    tooltip,
-    FILE_PATH_TOOLTIP_CLASS_NAME,
+  return (
+    <FilePathTooltip anchor={tooltipAnchorRef} tooltip={tooltip}>
+      {hasBody ? (
+        <CollapsibleTrigger className={headerClassName} {...props}>
+          {content}
+        </CollapsibleTrigger>
+      ) : (
+        <div
+          className={cn(
+            headerClassName,
+            tooltip &&
+              'rounded-md outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background',
+          )}
+          tabIndex={tooltip ? 0 : undefined}
+        >
+          {content}
+        </div>
+      )}
+    </FilePathTooltip>
   );
 }
 

--- a/packages/ui/src/chat/tool.tsx
+++ b/packages/ui/src/chat/tool.tsx
@@ -107,14 +107,20 @@ export function ToolIcon({
   );
 }
 
-export type ToolContentProps = React.ComponentProps<typeof CollapsibleContent>;
+export type ToolContentProps = React.ComponentProps<typeof CollapsibleContent> & {
+  constrainHeight?: boolean;
+};
 
-export function ToolContent({ className, ...props }: ToolContentProps): React.ReactNode {
+export function ToolContent({
+  className,
+  constrainHeight = true,
+  ...props
+}: ToolContentProps): React.ReactNode {
   return (
     <CollapsibleContent
       className={cn(
         'mt-1 space-y-2 border-l-2 border-border pl-3',
-        TOOL_DETAIL_SCROLL_CLASS_NAME,
+        constrainHeight && TOOL_DETAIL_SCROLL_CLASS_NAME,
         className,
       )}
       {...props}

--- a/packages/ui/src/chat/tool.tsx
+++ b/packages/ui/src/chat/tool.tsx
@@ -11,6 +11,7 @@ import { cn } from '../lib/cn';
 import { DiffCounter } from './diff-block';
 import type { DiffStats } from './diff-utils';
 import { TOOL_KIND_ICONS } from './tool-utils';
+import { FILE_PATH_TOOLTIP_CLASS_NAME, withTooltip } from './with-tooltip';
 
 export const TOOL_DETAIL_SCROLL_CLASS_NAME = 'max-h-96 overflow-y-auto overscroll-contain';
 
@@ -24,6 +25,8 @@ export type ToolHeaderProps = React.ComponentProps<typeof CollapsibleTrigger> & 
   title: string;
   /** Curated context such as a path, query, URL, or command. */
   summary?: string;
+  /** Unshortened context for a compact summary. */
+  tooltip?: string;
   diffStats?: DiffStats;
   badge?: string;
   /** Localized marker for a call whose gating permission the user declined. */
@@ -41,6 +44,7 @@ export function ToolHeader({
   className,
   title,
   summary,
+  tooltip,
   diffStats,
   badge,
   declinedBadge,
@@ -51,15 +55,8 @@ export function ToolHeader({
   hasBody = false,
   ...props
 }: ToolHeaderProps): React.ReactNode {
-  return (
-    <CollapsibleTrigger
-      className={cn(
-        'group/header flex w-full items-center gap-2 py-1 text-left text-sm disabled:cursor-default',
-        className,
-      )}
-      disabled={!hasBody}
-      {...props}
-    >
+  const content = (
+    <>
       <ToolIcon awaitingApproval={awaitingApproval} icon={icon} kind={kind} status={status} />
       <span className={cn('min-w-0 truncate text-foreground', summary ? 'shrink' : 'flex-1')}>
         {title}
@@ -73,7 +70,32 @@ export function ToolHeader({
       {hasBody ? (
         <ChevronRightIcon className="size-3.5 shrink-0 text-muted-foreground transition-transform group-data-[panel-open]/header:rotate-90" />
       ) : null}
-    </CollapsibleTrigger>
+    </>
+  );
+  const headerClassName = cn(
+    'group/header flex w-full items-center gap-2 py-1 text-left text-sm',
+    className,
+  );
+
+  return withTooltip(
+    hasBody ? (
+      <CollapsibleTrigger className={headerClassName} {...props}>
+        {content}
+      </CollapsibleTrigger>
+    ) : (
+      <div
+        className={cn(
+          headerClassName,
+          tooltip &&
+            'rounded-md outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background',
+        )}
+        tabIndex={tooltip ? 0 : undefined}
+      >
+        {content}
+      </div>
+    ),
+    tooltip,
+    FILE_PATH_TOOLTIP_CLASS_NAME,
   );
 }
 

--- a/packages/ui/src/chat/turn-diff-summary.tsx
+++ b/packages/ui/src/chat/turn-diff-summary.tsx
@@ -6,7 +6,7 @@ import {
 } from 'coss-ui/components/collapsible';
 import { ChevronDownIcon, FileDiffIcon, Undo2Icon } from 'lucide-react';
 import { useTranslations } from 'use-intl';
-import { useArtifactHostActions } from './artifacts/context';
+import { useArtifactHostActions } from './artifacts/host-actions';
 import type { TurnEdits, TurnFileEdit } from './turn-edits';
 
 const COLLAPSED_FILE_COUNT = 3;

--- a/packages/ui/src/chat/with-tooltip.tsx
+++ b/packages/ui/src/chat/with-tooltip.tsx
@@ -1,17 +1,20 @@
 import { Tooltip, TooltipContent, TooltipTrigger } from 'coss-ui/components/tooltip';
 
+export const FILE_PATH_TOOLTIP_CLASS_NAME = 'max-w-80 break-all font-mono text-left';
+
 /** Wraps an action element in a coss-ui Tooltip; passes it through untouched when no tooltip is given. */
 export function withTooltip(
   // eslint-disable-next-line @typescript-eslint/no-restricted-types -- TooltipTrigger's `render` prop clones a concrete element; ReactNode is not assignable to it.
   trigger: React.ReactElement,
   tooltip: string | undefined,
+  contentClassName?: string,
 ): React.ReactNode {
   if (!tooltip) return trigger;
 
   return (
     <Tooltip>
       <TooltipTrigger render={trigger} />
-      <TooltipContent>{tooltip}</TooltipContent>
+      <TooltipContent className={contentClassName}>{tooltip}</TooltipContent>
     </Tooltip>
   );
 }

--- a/packages/ui/src/chat/with-tooltip.tsx
+++ b/packages/ui/src/chat/with-tooltip.tsx
@@ -2,10 +2,12 @@ import { Tooltip, TooltipContent, TooltipTrigger } from 'coss-ui/components/tool
 
 export const FILE_PATH_TOOLTIP_CLASS_NAME = 'max-w-80 break-all font-mono text-left';
 
+// eslint-disable-next-line @typescript-eslint/no-restricted-types -- TooltipTrigger's `render` prop clones a concrete element; ReactNode is not assignable to it.
+type TooltipTriggerElement = React.ReactElement;
+
 /** Wraps an action element in a coss-ui Tooltip; passes it through untouched when no tooltip is given. */
 export function withTooltip(
-  // eslint-disable-next-line @typescript-eslint/no-restricted-types -- TooltipTrigger's `render` prop clones a concrete element; ReactNode is not assignable to it.
-  trigger: React.ReactElement,
+  trigger: TooltipTriggerElement,
   tooltip: string | undefined,
   contentClassName?: string,
 ): React.ReactNode {
@@ -15,6 +17,28 @@ export function withTooltip(
     <Tooltip>
       <TooltipTrigger render={trigger} />
       <TooltipContent className={contentClassName}>{tooltip}</TooltipContent>
+    </Tooltip>
+  );
+}
+
+/** Keeps the whole control focusable while positioning a long path beside its file identity. */
+export function FilePathTooltip({
+  anchor,
+  children,
+  tooltip,
+}: {
+  anchor: NonNullable<React.ComponentProps<typeof TooltipContent>['anchor']>;
+  children: TooltipTriggerElement;
+  tooltip: string | undefined;
+}): React.ReactNode {
+  if (!tooltip) return children;
+
+  return (
+    <Tooltip>
+      <TooltipTrigger render={children} />
+      <TooltipContent align="start" anchor={anchor} className={FILE_PATH_TOOLTIP_CLASS_NAME}>
+        {tooltip}
+      </TooltipContent>
     </Tooltip>
   );
 }

--- a/packages/ui/src/chat/with-tooltip.tsx
+++ b/packages/ui/src/chat/with-tooltip.tsx
@@ -1,21 +1,25 @@
 import { Tooltip, TooltipContent, TooltipTrigger } from 'coss-ui/components/tooltip';
 
-export const FILE_PATH_TOOLTIP_CLASS_NAME = 'max-w-80 break-all font-mono text-left';
+const FILE_PATH_TOOLTIP_CLASS_NAME = 'max-w-80 break-all font-mono text-left';
 
 // eslint-disable-next-line @typescript-eslint/no-restricted-types -- TooltipTrigger's `render` prop clones a concrete element; ReactNode is not assignable to it.
 type TooltipTriggerElement = React.ReactElement;
 
 /** Wraps an action element in a coss-ui Tooltip; passes it through untouched when no tooltip is given. */
-export function withTooltip(
-  trigger: TooltipTriggerElement,
-  tooltip: string | undefined,
-  contentClassName?: string,
-): React.ReactNode {
-  if (!tooltip) return trigger;
+export function WithTooltip({
+  children,
+  tooltip,
+  contentClassName,
+}: {
+  children: TooltipTriggerElement;
+  tooltip: string | undefined;
+  contentClassName?: string;
+}): React.ReactNode {
+  if (!tooltip) return children;
 
   return (
     <Tooltip>
-      <TooltipTrigger render={trigger} />
+      <TooltipTrigger render={children} />
       <TooltipContent className={contentClassName}>{tooltip}</TooltipContent>
     </Tooltip>
   );

--- a/packages/ui/src/shell/command-palette.tsx
+++ b/packages/ui/src/shell/command-palette.tsx
@@ -27,7 +27,7 @@ import { AgentIcon } from '../chat/agent-icon';
 import { useKeyboardShortcut } from '../keyboard';
 import { preventBaseUIHandler } from '../lib/base-ui';
 import { cn } from '../lib/cn';
-import { SESSION_STATUS_DOT_CLASS } from './sidebar/thread-row';
+import { SESSION_STATUS_DOT_CLASS } from './sidebar/thread-status';
 
 export interface PaletteThreadViewModel {
   sessionId: SessionId;

--- a/packages/ui/src/shell/conversation-surface.tsx
+++ b/packages/ui/src/shell/conversation-surface.tsx
@@ -122,6 +122,7 @@ export function ConversationSurface({
   const artifactActions = {
     referenceToComposer: (text: string) => composerRef.current?.insertText(text),
     openFile: onOpenFileArtifact,
+    reviewChanges: onReviewChanges,
     hostArtifact: onHostArtifact,
     openPreviewUrl: onOpenPreviewUrl,
   };

--- a/packages/ui/src/shell/conversation-surface.tsx
+++ b/packages/ui/src/shell/conversation-surface.tsx
@@ -1,6 +1,6 @@
 import type { AgentKind, ContentBlock, EffortLevel, QuestionOutcome } from '@linkcode/schema';
 import { useRef } from 'react';
-import { ArtifactHostActionsProvider } from '../chat/artifacts';
+import { ArtifactHostActionsProvider } from '../chat/artifacts/context';
 import type { PermissionDecision } from '../chat/conversation-prompts';
 import { ConversationView } from '../chat/conversation-view';
 import type { ConversationViewModel } from '../chat/types';

--- a/packages/ui/src/shell/sidebar/thread-row.tsx
+++ b/packages/ui/src/shell/sidebar/thread-row.tsx
@@ -1,12 +1,12 @@
 import { useSortable } from '@dnd-kit/react/sortable';
-import type { SessionInfo, SessionStatus } from '@linkcode/schema';
+import type { SessionInfo } from '@linkcode/schema';
 import { Button } from 'coss-ui/components/button';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuTrigger } from 'coss-ui/components/menu';
 import { SidebarMenuButton, SidebarMenuItem } from 'coss-ui/components/sidebar';
 import { EllipsisIcon, PinIcon, XIcon } from 'lucide-react';
 import { useTranslations } from 'use-intl';
 import { AGENT_LABELS, AgentIcon } from '../../chat/agent-icon';
-import { withTooltip } from '../../chat/with-tooltip';
+import { WithTooltip } from '../../chat/with-tooltip';
 import { cn } from '../../lib/cn';
 import { repositoryLabel } from '../repository-label';
 import { useRelativeTimeLabel } from '../use-relative-time-label';
@@ -17,14 +17,7 @@ import {
   RowActionsCluster,
 } from './row-actions';
 import type { ThreadImMenuComponentType } from './thread-im-menu';
-
-export const SESSION_STATUS_DOT_CLASS: Record<SessionStatus, string> = {
-  starting: 'bg-info',
-  idle: 'bg-muted-foreground/40',
-  running: 'bg-success',
-  'awaiting-input': 'bg-warning',
-  stopped: 'bg-muted-foreground/25',
-};
+import { SESSION_STATUS_DOT_CLASS } from './thread-status';
 
 export interface ThreadRowProps {
   session: SessionInfo;
@@ -70,7 +63,7 @@ export function ThreadRow({
 
   return (
     <SidebarMenuItem ref={sortableRef}>
-      {withTooltip(
+      <WithTooltip tooltip={createdAtLabel}>
         <SidebarMenuButton
           isActive={active}
           onClick={onSelect}
@@ -92,9 +85,8 @@ export function ThreadRow({
             />
           </span>
           <span className="min-w-0 flex-1 truncate">{title}</span>
-        </SidebarMenuButton>,
-        createdAtLabel,
-      )}
+        </SidebarMenuButton>
+      </WithTooltip>
       <RowActionsCluster>
         {ImMenuComponent && (
           <DropdownMenu>

--- a/packages/ui/src/shell/sidebar/thread-status.ts
+++ b/packages/ui/src/shell/sidebar/thread-status.ts
@@ -1,0 +1,9 @@
+import type { SessionStatus } from '@linkcode/schema';
+
+export const SESSION_STATUS_DOT_CLASS: Record<SessionStatus, string> = {
+  starting: 'bg-info',
+  idle: 'bg-muted-foreground/40',
+  running: 'bg-success',
+  'awaiting-input': 'bg-warning',
+  stopped: 'bg-muted-foreground/25',
+};


### PR DESCRIPTION
## Summary

Fixes chat action details that could crash the Electron renderer, produce React errors, or consume excessive conversation space.

Also unifies tool-result previews across adapters and file-related actions using the existing coss-ui primitives.

## Changes

- Normalize `ansi-to-react` interop so expanding completed terminal output no longer crashes the renderer.
- Fix Electron webview `allowpopups` rendering under React 19.
- Add a shared `24rem` maximum height for expanded action details with nested-to-parent scroll chaining.
- Route Read, Edit, Delete, Move, Search, Fetch, Execute, and fallback results through kind-aware preview components.
- Normalize adapter differences between canonical content and `rawOutput` without exposing raw result envelopes.
- Render Markdown file reads as document previews while keeping pathless reads literal.
- Unify file-result and diff chrome:
  - show only the filename in headers;
  - expose the full path through a coss-ui tooltip;
  - use file-kind icons;
  - make navigable headers open the file or changes viewer.
- Replace index-based React keys with content-derived stable keys.
- Remove internal barrel imports and split non-component exports into Fast Refresh-safe modules.
- Remove keyboard focus from non-interactive preview headers.
- Add regression coverage for terminal expansion, adapter result normalization, file actions, grouped actions, and preview navigation.

## Verification

- `pnpm check:ci`
- `pnpm test`
  - 130 test files passed
  - 1006 tests passed
- Focused UI suite: 27 tests passed

## Linear

[CODE-198](https://linear.app/arcbox/issue/CODE-198/fixui-prevent-chat-detail-interactions-from-crashing-the-renderer)