### PR TITLE
build(desktop): shrink packaged app (CODE-215)

### DIFF
--- a/apps/daemon/package.json
+++ b/apps/daemon/package.json
@@ -28,7 +28,6 @@
     "@sentry/node": "10.62.0",
     "@sentry/profiling-node": "10.62.0",
     "better-sqlite3": "^12.11.1",
-    "drizzle-orm": "^0.45.2",
     "foxts": "^5.8.0"
   },
   "devDependencies": {
@@ -37,6 +36,7 @@
     "@types/node": "catalog:",
     "cross-spawn": "^7.0.6",
     "drizzle-kit": "^0.31.10",
+    "drizzle-orm": "^0.45.2",
     "tsup": "catalog:",
     "tsx": "catalog:",
     "typescript": "catalog:"

--- a/apps/daemon/scripts/package-daemon.mts
+++ b/apps/daemon/scripts/package-daemon.mts
@@ -7,9 +7,9 @@
  *   node scripts/package-daemon.mts <outDir> # explicit destination (CI)
  *
  * `pnpm --prod deploy` materializes the daemon's production closure — the tsup bundle's runtime
- * externals (better-sqlite3 + its native binding, drizzle-orm, ws, socket.io, @sentry, the agent
- * SDKs, the @linkcode/assets fetch stack) flat in the dir's own node_modules — so the result runs
- * as `node --import ./dist/instrument.js dist/index.js` with nothing else on disk.
+ * externals (better-sqlite3 + its native binding, ws, socket.io, @sentry, the agent SDKs, the
+ * @linkcode/assets fetch stack) flat in the dir's own node_modules — so the result runs as
+ * `node --import ./dist/instrument.js dist/index.js` with nothing else on disk.
  *
  * Unlike the desktop bundle (Electron `utilityProcess`, native modules rebuilt to Electron's ABI),
  * this targets plain Node: better-sqlite3 keeps the prebuild-install binary for the build host's

--- a/apps/daemon/tsup.config.ts
+++ b/apps/daemon/tsup.config.ts
@@ -20,8 +20,11 @@ export default defineConfig({
   banner: {
     js: "import { createRequire as __linkcodeCreateRequire } from 'node:module'; const require = __linkcodeCreateRequire(import.meta.url);",
   },
-  // Workspace packages are exported as TS source and must be bundled in.
-  noExternal: [/^@linkcode\//],
+  // Workspace packages are exported as TS source and must be bundled in. drizzle-orm is bundled
+  // too (it's pure JS and daemon-only, and lives in devDependencies): keeping it external would
+  // put its whole 15 MB dual-format dist into both deploy closures (desktop asar + standalone)
+  // when the bundle only uses the better-sqlite3 dialect.
+  noExternal: [/^@linkcode\//, 'drizzle-orm'],
   // The agent SDKs are pulled in (lazily) via @linkcode/agent-adapter, but must stay external: several
   // ship platform-specific native binaries / spawn subprocesses and break if bundled. They load from
   // node_modules at runtime. `ws` (via @linkcode/transport/server) is externalized for the same reason.

--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -23,6 +23,18 @@ copyright: Copyright © 2026 ArcBox Labs
 # cannot read pnpm's `catalog:` protocol. Keep in sync with the `electron` catalog entry.
 electronVersion: 42.4.1
 
+# Keep only the Chromium locales for languages the app ships (packages/i18n/src/index.ts —
+# extend this list when a locale is added there). Drops ~48 MB of framework .lproj/.pak data.
+# The matcher lowercases but does NOT normalize separators, and locale file names differ per
+# platform, so both spellings are load-bearing: mac frameworks use `en.lproj`/`zh_CN.lproj`
+# (underscore), win/linux use `locales/en-US.pak`/`zh-CN.pak` (dash) — and Chromium requires
+# its en-US default pak to exist.
+electronLanguages:
+  - en
+  - en-US
+  - zh-CN
+  - zh_CN
+
 directories:
   output: release # MUST match OUTPUT_DIR in .github/workflows/build-desktop.yml
   buildResources: build-resources # not `build/`: that path is gitignored and is a turbo build output

--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -41,6 +41,13 @@ files:
   - '!node_modules/@openai/codex-darwin-*/**'
   - '!node_modules/@openai/codex-linux-*/**'
   - '!node_modules/@openai/codex-win32-*/**'
+  # Dead weight in the deploy closure (CODE-215). @linkcode/* are raw-TS workspace sources —
+  # main/preload/daemon all bundle them, and migrations run from out/drizzle, so nothing resolves
+  # them from node_modules at runtime. better-sqlite3/deps is the sqlite3 C amalgamation:
+  # @electron/rebuild needs it at BUILD time (which is why the staging prune must not delete it),
+  # but the compiled build/Release binding is all the app loads.
+  - '!node_modules/@linkcode/**'
+  - '!node_modules/better-sqlite3/deps/**'
 
 # The PTY sidecar (crates/linkcode-pty), staged per arch by scripts/stage-sidecar.mjs. It is a
 # real executable, so it must live outside the asar; the daemon supervisor points
@@ -92,6 +99,12 @@ mac:
       arch: [x64, arm64]
     - target: zip # REQUIRED for macOS auto-update (electron-updater pulls the .zip, not the .dmg)
       arch: [x64, arm64]
+
+# UDBZ (bzip2) instead of the default ULFO (lzfse): smaller first-download dmg for slower mount.
+# ULMO (lzma) would be smaller still but electron-builder's schema doesn't accept it. Only the
+# dmg is affected — auto-update pulls the zip, whose deflate format electron-updater requires.
+dmg:
+  format: UDBZ
 
 win:
   icon: ../../assets/icon.png # shared repo-root raster (no Liquid Glass on Windows)

--- a/apps/desktop/scripts/package-app.mts
+++ b/apps/desktop/scripts/package-app.mts
@@ -29,7 +29,7 @@
  * collector patch; the .pnpmfile.cjs drizzle-orm↔expo-sqlite sever stays — it keeps the expo tree
  * out of this deploy closure, which is orthogonal to the collector.
  */
-import { cpSync, readdirSync, rmSync } from 'node:fs';
+import { cpSync, readdirSync, rmSync, statSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import process from 'node:process';
@@ -97,6 +97,39 @@ function materializeStaging(): void {
   }
 }
 
+/** Doc files that must survive the prune: license/attribution texts we redistribute. */
+const KEEP_DOC = /^(?:licen[cs]e|notice|copying)/i;
+
+/**
+ * Drop build-time-only file classes from the staged node_modules before electron-builder collects
+ * the asar (CODE-215): sourcemaps, TypeScript sources and declarations, and markdown docs — ~50 MB
+ * of the deploy closure that Node never loads at runtime. Whole-package dead weight is excluded via
+ * `files` globs in electron-builder.yml instead; notably better-sqlite3/deps must stay HERE in
+ * staging because @electron/rebuild compiles from it before collection.
+ */
+function pruneStaging(): void {
+  let files = 0;
+  let bytes = 0;
+  for (const entry of readdirSync(join(stagingDir, 'node_modules'), {
+    recursive: true,
+    withFileTypes: true,
+  })) {
+    if (!entry.isFile()) continue;
+    const prunable =
+      entry.name.endsWith('.map') ||
+      /\.[mc]?ts$/.test(entry.name) ||
+      (/\.(?:md|markdown)$/i.test(entry.name) && !KEEP_DOC.test(entry.name));
+    if (!prunable) continue;
+    const path = join(entry.parentPath, entry.name);
+    bytes += statSync(path).size;
+    files += 1;
+    rmSync(path);
+  }
+  console.log(
+    `pruned ${files} runtime-dead files (${Math.round(bytes / 1048576)} MB) from staging`,
+  );
+}
+
 /**
  * Build only the arches whose PTY sidecar was staged. electron-builder.yml targets both x64 and
  * arm64, but `extraResources: sidecar/${arch}` can only resolve an arch that was staged — CI stages
@@ -141,4 +174,5 @@ function build(): void {
 }
 
 materializeStaging();
+pruneStaging();
 build();

--- a/packages/ui/src/chat/__tests__/markdown.test.tsx
+++ b/packages/ui/src/chat/__tests__/markdown.test.tsx
@@ -1,0 +1,25 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, waitFor } from '@testing-library/react';
+import { afterEach, expect, it } from 'vitest';
+import { Markdown } from '../markdown';
+
+afterEach(cleanup);
+
+const FENCE = '```ts\nconst greeting: string = "hello";\n```';
+
+// Pins the @streamdown/code ↔ shiki contract: the workspace override forces shiki 4 under the
+// plugin (which pins ^3) to keep a single copy in the renderer bundle (CODE-215). If the plugin's
+// createHighlighter/bundledLanguages usage ever breaks against the resolved shiki major, the
+// fence renders as plain text and this fails.
+it('highlights a fenced code block through the shiki pipeline', async () => {
+  const { container } = render(<Markdown>{FENCE}</Markdown>);
+  // The plugin emits per-token spans carrying the theme color as the --sdm-c custom property.
+  await waitFor(
+    () => {
+      const tokens = container.querySelectorAll('code span[style*="--sdm-c"]');
+      expect(tokens.length).toBeGreaterThan(2);
+    },
+    { timeout: 10000 },
+  );
+}, 15000);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,6 +105,7 @@ catalogs:
 
 overrides:
   esbuild@<=0.24.2: ^0.25.0
+  shiki@<4.0.0: ^4.3.0
   linkify-it@<=5.0.0: ^5.0.1
   undici@>=8.0.0 <8.5.0: ^8.5.0
   uuid@<11.1.1: ^11.1.1
@@ -209,9 +210,6 @@ importers:
       better-sqlite3:
         specifier: ^12.11.1
         version: 12.11.1
-      drizzle-orm:
-        specifier: ^0.45.2
-        version: 0.45.2(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(kysely@0.29.2)
       foxts:
         specifier: ^5.8.0
         version: 5.8.0
@@ -231,6 +229,9 @@ importers:
       drizzle-kit:
         specifier: ^0.31.10
         version: 0.31.10
+      drizzle-orm:
+        specifier: ^0.45.2
+        version: 0.45.2(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(kysely@0.29.2)
       tsup:
         specifier: 'catalog:'
         version: 8.5.1(@typescript/typescript6@6.0.2)(jiti@2.7.0)(postcss@8.5.16)(tsx@4.23.1)(yaml@2.9.0)
@@ -3427,7 +3428,7 @@ packages:
       '@shikijs/themes': ^3.0.0 || ^4.0.0
       react: ^18.3.1 || ^19.0.0
       react-dom: ^18.3.1 || ^19.0.0
-      shiki: ^3.0.0 || ^4.0.0
+      shiki: ^4.3.0
     peerDependenciesMeta:
       '@pierre/theme':
         optional: true
@@ -4239,29 +4240,17 @@ packages:
     resolution: {integrity: sha512-umpnUKRC0AAbJrADg6SlFtqN2yzf7NHciCF9lkHau+ax2PIZ/NDmoG4RQujFVflVaVoD60Ly2t+CcPnYIWMPlw==}
     engines: {node: '>=18'}
 
-  '@shikijs/core@3.23.0':
-    resolution: {integrity: sha512-NSWQz0riNb67xthdm5br6lAkvpDJRTgB36fxlo37ZzM2yq0PQFFzbd8psqC2XMPgCzo1fW6cVi18+ArJ44wqgA==}
-
   '@shikijs/core@4.3.0':
     resolution: {integrity: sha512-EooU3i9F6IAE8kEu+AnGf9DFZWkQBZ+hJn3tLVbsH+61mtQiva5biai66fAA6nvFPXkLgvrh7BrR7YcJU83xQQ==}
     engines: {node: '>=20'}
-
-  '@shikijs/engine-javascript@3.23.0':
-    resolution: {integrity: sha512-aHt9eiGFobmWR5uqJUViySI1bHMqrAgamWE1TYSUoftkAeCCAiGawPMwM+VCadylQtF4V3VNOZ5LmfItH5f3yA==}
 
   '@shikijs/engine-javascript@4.3.0':
     resolution: {integrity: sha512-hTv/KiFf2tpiqlACPiztGGurEARWIutB8YUhcrA1pUC7VzzwKO+g5crUocrLztrZ5ro5Z4hbXg7bYclETn3gSQ==}
     engines: {node: '>=20'}
 
-  '@shikijs/engine-oniguruma@3.23.0':
-    resolution: {integrity: sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g==}
-
   '@shikijs/engine-oniguruma@4.3.0':
     resolution: {integrity: sha512-1vMdN3gHfnKfLYwecUI2ITJI4RhHt96xEaJumVn7Heb0IlJ8WQMIH0Voak+2j22BpSNKdnOfB/pCTPnPm2gq7A==}
     engines: {node: '>=20'}
-
-  '@shikijs/langs@3.23.0':
-    resolution: {integrity: sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg==}
 
   '@shikijs/langs@4.3.0':
     resolution: {integrity: sha512-rnlqFbBRSys9bT4gl/5rw9RnS0W/I84ZldXPkO7cvlEMoV85TyF/aU01N7/NbSR776RNLjrJKjfFUXJR6wN1Cg==}
@@ -4271,9 +4260,6 @@ packages:
     resolution: {integrity: sha512-CPkz64PTa5diRW1ggzMZH9VM/du4RNChYgVtgqrFcgruvIybmCvySv8GkiHSczUHXYuuR8TdKEwFx+UnZMpgdg==}
     engines: {node: '>=20'}
 
-  '@shikijs/themes@3.23.0':
-    resolution: {integrity: sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA==}
-
   '@shikijs/themes@4.3.0':
     resolution: {integrity: sha512-Avgt05YiT+Y3prjIc9lmQxhJzHBcCfR6cjiFW4OyaMBbt2A6trX5rfjUzx+Vj/mE9qpArYjatnqo9XPjQNW/AQ==}
     engines: {node: '>=20'}
@@ -4281,9 +4267,6 @@ packages:
   '@shikijs/transformers@4.3.0':
     resolution: {integrity: sha512-5/elhJEcUrxdyQ95SSx0HzrnbzVPuipk6TYiXZL67tHhw8J+4N5shzmrTYyCaudiSnpuuwPdpaVtciwRFwSA7A==}
     engines: {node: '>=20'}
-
-  '@shikijs/types@3.23.0':
-    resolution: {integrity: sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ==}
 
   '@shikijs/types@4.3.0':
     resolution: {integrity: sha512-oc8b9U2SYvofKZk8e/737nIX0qwf6eV2vHFATeObAu7r+mUVpLs8Re0BmVkIjAWAYgkmG/CzLNo7rzuBzRu/wQ==}
@@ -9570,9 +9553,6 @@ packages:
     resolution: {integrity: sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==}
     engines: {node: '>= 0.4'}
 
-  shiki@3.23.0:
-    resolution: {integrity: sha512-55Dj73uq9ZXL5zyeRPzHQsK7Nbyt6Y10k5s7OjuFZGMhpp4r/rsLBH0o/0fstIzX1Lep9VxefWljK/SKCzygIA==}
-
   shiki@4.3.0:
     resolution: {integrity: sha512-NKKjWzR6LIGL3sXBrWDw9sDS9cxx42/DkysaNqJEeOWE8Kix5gpak0bc00OfDVEO4oyXSyz8+aRaqKoBD1yo7A==}
     engines: {node: '>=20'}
@@ -13842,13 +13822,6 @@ snapshots:
     dependencies:
       '@sentry/core': 10.37.0
 
-  '@shikijs/core@3.23.0':
-    dependencies:
-      '@shikijs/types': 3.23.0
-      '@shikijs/vscode-textmate': 10.0.2
-      '@types/hast': 3.0.4
-      hast-util-to-html: 9.0.5
-
   '@shikijs/core@4.3.0':
     dependencies:
       '@shikijs/primitive': 4.3.0
@@ -13857,31 +13830,16 @@ snapshots:
       '@types/hast': 3.0.4
       hast-util-to-html: 9.0.5
 
-  '@shikijs/engine-javascript@3.23.0':
-    dependencies:
-      '@shikijs/types': 3.23.0
-      '@shikijs/vscode-textmate': 10.0.2
-      oniguruma-to-es: 4.3.6
-
   '@shikijs/engine-javascript@4.3.0':
     dependencies:
       '@shikijs/types': 4.3.0
       '@shikijs/vscode-textmate': 10.0.2
       oniguruma-to-es: 4.3.6
 
-  '@shikijs/engine-oniguruma@3.23.0':
-    dependencies:
-      '@shikijs/types': 3.23.0
-      '@shikijs/vscode-textmate': 10.0.2
-
   '@shikijs/engine-oniguruma@4.3.0':
     dependencies:
       '@shikijs/types': 4.3.0
       '@shikijs/vscode-textmate': 10.0.2
-
-  '@shikijs/langs@3.23.0':
-    dependencies:
-      '@shikijs/types': 3.23.0
 
   '@shikijs/langs@4.3.0':
     dependencies:
@@ -13893,10 +13851,6 @@ snapshots:
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
 
-  '@shikijs/themes@3.23.0':
-    dependencies:
-      '@shikijs/types': 3.23.0
-
   '@shikijs/themes@4.3.0':
     dependencies:
       '@shikijs/types': 4.3.0
@@ -13905,11 +13859,6 @@ snapshots:
     dependencies:
       '@shikijs/core': 4.3.0
       '@shikijs/types': 4.3.0
-
-  '@shikijs/types@3.23.0':
-    dependencies:
-      '@shikijs/vscode-textmate': 10.0.2
-      '@types/hast': 3.0.4
 
   '@shikijs/types@4.3.0':
     dependencies:
@@ -14002,7 +13951,7 @@ snapshots:
   '@streamdown/code@1.1.1(react@19.2.7)':
     dependencies:
       react: 19.2.7
-      shiki: 3.23.0
+      shiki: 4.3.0
 
   '@stylexjs/eslint-plugin@0.19.0':
     dependencies:
@@ -19985,17 +19934,6 @@ snapshots:
   shebang-regex@3.0.0: {}
 
   shell-quote@1.8.4: {}
-
-  shiki@3.23.0:
-    dependencies:
-      '@shikijs/core': 3.23.0
-      '@shikijs/engine-javascript': 3.23.0
-      '@shikijs/engine-oniguruma': 3.23.0
-      '@shikijs/langs': 3.23.0
-      '@shikijs/themes': 3.23.0
-      '@shikijs/types': 3.23.0
-      '@shikijs/vscode-textmate': 10.0.2
-      '@types/hast': 3.0.4
 
   shiki@4.3.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -178,6 +178,11 @@ overrides:
   # GHSA-67mh-4wv8-2f99: advisory metadata claims 0.24.3, but esbuild 0.24.x
   # ends at 0.24.2 on npm — the fix actually shipped in 0.25.0.
   esbuild@<=0.24.2: ^0.25.0
+  # Dedup: @streamdown/code pins shiki ^3 while @pierre/diffs resolves shiki 4, so the
+  # renderer bundles two complete language+theme chunk graphs (~9 MB / 300 files, CODE-215).
+  # The plugin only uses createHighlighter/bundledLanguages/createJavaScriptRegexEngine —
+  # all unchanged in shiki 4.
+  shiki@<4.0.0: ^4.3.0
   linkify-it@<=5.0.0: ^5.0.1
   undici@>=8.0.0 <8.5.0: ^8.5.0
   uuid@<11.1.1: ^11.1.1


### PR DESCRIPTION
## Summary

Shrinks the desktop artifacts (CODE-215). arm64 measurements against the released v0.4.2:

| artifact | v0.4.2 | this PR | delta |
| --- | --- | --- | --- |
| dmg (first download) | 167.5 MB | 118.3 MB | −29% |
| zip (auto-update feed) | 167.0 MB | 130.9 MB | −22% |
| app.asar (raw) | 233 MB | 109 MB | −53% |
| installed .app | 531 MB | 349 MB | −34% |

## Changes

- **Staging prune** (`package-app.mts`): drops sourcemaps, TS sources/declarations, and non-license markdown from the deployed `node_modules` before electron-builder collects the asar (~24k files / 134 MB in staging). `better-sqlite3/deps` is intentionally NOT pruned here — `@electron/rebuild` compiles from it — and is excluded at collection time instead.
- **electron-builder `files` excludes**: `node_modules/@linkcode/**` (raw-TS workspace sources; main/preload/daemon bundle them, migrations run from `out/drizzle`) and `node_modules/better-sqlite3/deps/**` (10 MB sqlite3 C amalgamation that shipped inside `app.asar.unpacked`).
- **`electronLanguages`**: keeps only the locales the app ships (`packages/i18n`: en, zh-CN) — the Electron framework carried 220 locale dirs (48 MB raw), now 2. Both `zh-CN` and `zh_CN` spellings are load-bearing: the matcher doesn't normalize separators, and mac `.lproj` uses underscores while win/linux `.pak` files use dashes (Chromium also requires its `en-US` default pak).
- **shiki dedup** (`pnpm-workspace.yaml` override `shiki@<4.0.0: ^4.3.0`): `@streamdown/code` pins shiki `^3` while `@pierre/diffs` resolves 4.x, so the renderer bundled two complete language+theme chunk graphs (302 duplicate files, 9 MB; renderer assets 720 → 457 files). The plugin only uses `createHighlighter`/`bundledLanguages`/`createJavaScriptRegexEngine`, all unchanged in shiki 4; a new regression test pins the highlight pipeline.
- **drizzle-orm inlined into the daemon bundle** (tsup `noExternal`, moved to devDependencies): pure JS, daemon-only; keeping it external shipped its whole 15 MB dual-format dist in both deploy closures.
- **dmg format UDBZ** (bzip2) instead of default ULFO — smaller first download; the auto-update zip is unaffected. (ULMO would be smaller still but electron-builder 26.15.3's schema rejects it.)

Out of scope per review decisions: Sentry packages are untouched; moving the pi provider-SDK closure (~43 MB raw remaining) to a managed download is CODE-219.

## Verification

- `check:ci` 0 errors; `pnpm test` 1046 passed (includes the new shiki-pipeline regression test).
- Packaged app launched with isolated HOME/profile twice (devshell build, then the locale-trimmed release-config build): window + renderer OK, supervisor-spawned daemon boots and runs drizzle migrations from the bundled migrator (`daemon.db` created, identity endpoint healthy), Settings → Appearance renders with the shiki theme catalog populated.
- Extracted the new asar: `@linkcode/**`, `drizzle-orm`, `better-sqlite3/deps`, `*.map`/`*.ts`/`*.d.ts` all absent; Sentry chain, agent SDKs, pi closure, `ws`, `out/drizzle` all present; only LICENSE docs remain. Framework locales reduced to `en.lproj` + `zh_CN.lproj`.
- `verify-artifacts.mts mac`: all arm64 checks pass (x64 fails locally only because no x64 sidecar is staged on this machine — pre-existing; CI stages both).

Closes CODE-215.