### PR TITLE
feat(daemon): prompt-first managed agent installs (CODE-221)

### DIFF
--- a/apps/daemon/AGENTS.md
+++ b/apps/daemon/AGENTS.md
@@ -53,9 +53,12 @@ Runs via `tsx` in dev (`pnpm -F @linkcode/daemon dev`) and a `tsup` bundle in pr
   `~/Library/Application Support/LinkCode/assets`, `LINKCODE_ASSETS_DIR` override for tests/E2E;
   SDK-pinned exact pair, SRI-verified, GC'd at boot) → detected user install at known locations
   (brew, `~/.local/bin`; version-verified) → SDK self-resolution from node_modules
-  (dev/standalone). Boot never waits on a download: missing agent pairs warm in the background
-  and win resolution as soon as they land. The engine must be constructed **before** that warm
-  loop kicks off — it subscribes to the AssetManager and forwards install progress to clients
+  (dev/standalone). **The first managed download is always user-prompted** (CODE-221): boot
+  auto-refreshes only agents with a prior install in the asset store (standing consent,
+  snapshotted before GC sweeps superseded versions); an agent never installed there waits for
+  the client's explicit `asset.ensure` (the onboarding Download card). Boot never waits on a
+  download either way. The engine must be constructed **before** that refresh loop kicks off —
+  it subscribes to the AssetManager and forwards install progress to clients
   (`asset.progress`/`asset.settled`), re-probing and pushing `agent-runtime.changed` when an
   agent install completes (CODE-112). opencode self-spawns the `opencode` command via PATH
   (CODE-76); pi runs in-process and spawns nothing.

--- a/apps/daemon/AGENTS.md
+++ b/apps/daemon/AGENTS.md
@@ -54,10 +54,11 @@ Runs via `tsx` in dev (`pnpm -F @linkcode/daemon dev`) and a `tsup` bundle in pr
   SDK-pinned exact pair, SRI-verified, GC'd at boot) → detected user install at known locations
   (brew, `~/.local/bin`; version-verified) → SDK self-resolution from node_modules
   (dev/standalone). **The first managed download is always user-prompted** (CODE-221): boot
-  auto-refreshes only agents with a prior install in the asset store (standing consent,
-  snapshotted before GC sweeps superseded versions); an agent never installed there waits for
-  the client's explicit `asset.ensure` (the onboarding Download card). Boot never waits on a
-  download either way. The engine must be constructed **before** that refresh loop kicks off —
+  auto-refreshes only agents with a prior install in the asset store (standing consent — GC
+  retains superseded versions until the replacement lands, so an offline refresh failure keeps
+  retrying on later boots); an agent never installed there waits for the client's explicit
+  `asset.ensure` (the onboarding Download card). Boot never waits on a download either way. The
+  engine must be constructed **before** that refresh loop kicks off —
   it subscribes to the AssetManager and forwards install progress to clients
   (`asset.progress`/`asset.settled`), re-probing and pushing `agent-runtime.changed` when an
   agent install completes (CODE-112). opencode self-spawns the `opencode` command via PATH

--- a/apps/daemon/src/__tests__/managed-agent-refresh.test.ts
+++ b/apps/daemon/src/__tests__/managed-agent-refresh.test.ts
@@ -1,0 +1,59 @@
+import { mkdirSync, mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { AssetManager } from '@linkcode/assets';
+import type { AgentRuntimes } from '@linkcode/schema';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { agentsToRefresh, consentedManagedAgents } from '../managed-agent-refresh';
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+function freshStore(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'refresh-store-'));
+  vi.stubEnv('LINKCODE_ASSETS_DIR', dir);
+  return dir;
+}
+
+/** Seed a prior managed install: any version dir under `<store>/agent/<kind>/`. */
+function seedInstall(store: string, kind: string, version: string): void {
+  mkdirSync(join(store, 'agent', kind, version), { recursive: true });
+}
+
+const MISSING: AgentRuntimes = {
+  'claude-code': { status: 'missing' },
+  codex: { status: 'missing' },
+};
+
+describe('boot managed-agent refresh (CODE-221)', () => {
+  it('never downloads unprompted: a fresh store yields no consent and no refresh', () => {
+    freshStore();
+    const consented = consentedManagedAgents(new AssetManager());
+    expect(consented).toEqual([]);
+    expect(agentsToRefresh(consented, MISSING)).toEqual([]);
+  });
+
+  it('a prior install of any version is consent, and only unavailable agents refresh', () => {
+    const store = freshStore();
+    seedInstall(store, 'claude-code', '0.0.1');
+    const consented = consentedManagedAgents(new AssetManager());
+    expect(consented).toEqual(['claude-code']);
+
+    expect(agentsToRefresh(consented, MISSING)).toEqual(['claude-code']);
+    const detected: AgentRuntimes = {
+      'claude-code': { status: 'available', source: 'detected', path: '/usr/local/bin/claude' },
+    };
+    expect(agentsToRefresh(consented, detected)).toEqual([]);
+  });
+
+  it('consent must be snapshotted before gcAtBoot sweeps the superseded version', () => {
+    const store = freshStore();
+    seedInstall(store, 'codex', '0.0.1');
+    const assets = new AssetManager();
+    const consented = consentedManagedAgents(assets);
+    assets.gcAtBoot();
+    expect(consented).toEqual(['codex']);
+    expect(consentedManagedAgents(assets)).toEqual([]);
+  });
+});

--- a/apps/daemon/src/__tests__/managed-agent-refresh.test.ts
+++ b/apps/daemon/src/__tests__/managed-agent-refresh.test.ts
@@ -47,13 +47,15 @@ describe('boot managed-agent refresh (CODE-221)', () => {
     expect(agentsToRefresh(consented, detected)).toEqual([]);
   });
 
-  it('consent must be snapshotted before gcAtBoot sweeps the superseded version', () => {
+  it('consent survives gcAtBoot while the replacement is not installed (offline refresh failure)', () => {
     const store = freshStore();
     seedInstall(store, 'codex', '0.0.1');
     const assets = new AssetManager();
     const consented = consentedManagedAgents(assets);
     assets.gcAtBoot();
     expect(consented).toEqual(['codex']);
-    expect(consentedManagedAgents(assets)).toEqual([]);
+    // GC keeps the superseded version until the pinned one lands, so a boot whose background
+    // refresh fails still reads consent on the NEXT boot and retries.
+    expect(consentedManagedAgents(assets)).toEqual(['codex']);
   });
 });

--- a/apps/daemon/src/index.ts
+++ b/apps/daemon/src/index.ts
@@ -95,8 +95,7 @@ async function main(): Promise<void> {
   // Managed assets (CODE-111): GC superseded versions before anything can spawn, then feed the
   // store into spawn resolution — managed wins over detected as soon as an install lands on disk.
   const assets = new AssetManager();
-  // Prior managed install = standing consent to keep that agent current (CODE-221); snapshot
-  // BEFORE GC sweeps superseded versions.
+  // Prior managed install = standing consent to keep that agent current (CODE-221).
   const consentedAgents = consentedManagedAgents(assets);
   const gc = assets.gcAtBoot();
   if (gc.removed.length > 0) {

--- a/apps/daemon/src/index.ts
+++ b/apps/daemon/src/index.ts
@@ -13,6 +13,7 @@ import { installAsarSpawnFix } from './asar-spawn';
 import { chatWorkspaceRoot, daemonProfile, databasePath, loadConfig } from './config';
 import { runLoginCommand, runLogoutCommand } from './hq/login';
 import { startHqUplink } from './hq/uplink';
+import { agentsToRefresh, consentedManagedAgents } from './managed-agent-refresh';
 import { createProviderConfigStore } from './provider-store';
 import { resolveSidecarPath, SidecarPtyBackend } from './pty/sidecar';
 import {
@@ -94,6 +95,9 @@ async function main(): Promise<void> {
   // Managed assets (CODE-111): GC superseded versions before anything can spawn, then feed the
   // store into spawn resolution — managed wins over detected as soon as an install lands on disk.
   const assets = new AssetManager();
+  // Prior managed install = standing consent to keep that agent current (CODE-221); snapshot
+  // BEFORE GC sweeps superseded versions.
+  const consentedAgents = consentedManagedAgents(assets);
   const gc = assets.gcAtBoot();
   if (gc.removed.length > 0) {
     console.log(`[linkcode/daemon] assets gc: removed ${gc.removed.join(', ')}`);
@@ -126,11 +130,10 @@ async function main(): Promise<void> {
       ensureBinary: async () => (await assets.ensure('tool:aigateway'))?.path,
     }),
   });
-  // Warm missing agent pairs in the background — boot never waits on a download. Anything the
-  // probe already found usable (detected CLI, SDK platform package) is left alone. Runs after
-  // the engine exists so its asset subscription sees the whole install lifecycle.
-  for (const kind of ['claude-code', 'codex'] as const) {
-    if (agentRuntimes[kind]?.status === 'available') continue;
+  // Refresh consented managed installs in the background — boot never waits on a download. A
+  // never-installed agent waits for the client's explicit `asset.ensure` instead (CODE-221).
+  // Runs after the engine exists so its asset subscription sees the whole install lifecycle.
+  for (const kind of agentsToRefresh(consentedAgents, agentRuntimes)) {
     void assets
       .ensure(`agent:${kind}`)
       .catch((err) => {

--- a/apps/daemon/src/managed-agent-refresh.ts
+++ b/apps/daemon/src/managed-agent-refresh.ts
@@ -1,0 +1,27 @@
+import type { AssetManager } from '@linkcode/assets';
+import type { AgentRuntimes } from '@linkcode/schema';
+
+/** The agent kinds whose CLI pair the managed-asset store can install (CODE-111/114). */
+export const MANAGED_AGENT_KINDS = ['claude-code', 'codex'] as const;
+
+export type ManagedAgentKind = (typeof MANAGED_AGENT_KINDS)[number];
+
+/**
+ * Consent snapshot: agents with a prior managed install of any version. Must run BEFORE
+ * `gcAtBoot` sweeps superseded versions, or a pin bump erases the consent it proves (CODE-221).
+ */
+export function consentedManagedAgents(assets: AssetManager): ManagedAgentKind[] {
+  return MANAGED_AGENT_KINDS.filter((kind) => assets.hasInstallOnDisk(`agent:${kind}`));
+}
+
+/**
+ * The boot background-refresh set: consented agents the probe found unusable. Agents never
+ * installed here are excluded — their first download comes from the client's `asset.ensure`
+ * (the onboarding Download card), never unprompted (CODE-221).
+ */
+export function agentsToRefresh(
+  consented: readonly ManagedAgentKind[],
+  runtimes: AgentRuntimes,
+): ManagedAgentKind[] {
+  return consented.filter((kind) => runtimes[kind]?.status !== 'available');
+}

--- a/apps/daemon/src/managed-agent-refresh.ts
+++ b/apps/daemon/src/managed-agent-refresh.ts
@@ -7,8 +7,8 @@ export const MANAGED_AGENT_KINDS = ['claude-code', 'codex'] as const;
 export type ManagedAgentKind = (typeof MANAGED_AGENT_KINDS)[number];
 
 /**
- * Consent snapshot: agents with a prior managed install of any version. Must run BEFORE
- * `gcAtBoot` sweeps superseded versions, or a pin bump erases the consent it proves (CODE-221).
+ * Consent snapshot: agents with a prior managed install of any version (CODE-221). GC retains
+ * superseded versions until their replacement lands, so this reads the same before or after it.
  */
 export function consentedManagedAgents(assets: AssetManager): ManagedAgentKind[] {
   return MANAGED_AGENT_KINDS.filter((kind) => assets.hasInstallOnDisk(`agent:${kind}`));

--- a/packages/assets/AGENTS.md
+++ b/packages/assets/AGENTS.md
@@ -44,11 +44,15 @@ the `asset.list` wire resource; presentation belongs to the onboarding UI (CODE-
 
 ## Consumers
 
-The daemon constructs one `AssetManager` at boot: GC → `setManagedResolver` into
-`agentRuntimeProber` (managed wins over detected the moment an install lands) → background
-`ensure()` for agent pairs the probe found unusable. The engine serves `statuses()` on
-`asset.list`, triggers `ensure()` on `asset.ensure`, and forwards install lifecycle to the wire
-via the injected `AssetService`. Tectonic consumers (CODE-81) resolve by asset id.
+The daemon constructs one `AssetManager` at boot: consent snapshot (`hasInstallOnDisk` — a
+prior install of any version is the user's standing consent, read BEFORE GC deletes superseded
+versions) → GC → `setManagedResolver` into `agentRuntimeProber` (managed wins over detected the
+moment an install lands) → background `ensure()` only for consented agent pairs the probe found
+unusable. An agent never installed here is NOT auto-downloaded (CODE-221) — its first install
+comes from the client's `asset.ensure` (the onboarding Download card). The engine serves
+`statuses()` on `asset.list`, triggers `ensure()` on `asset.ensure`, and forwards install
+lifecycle to the wire via the injected `AssetService`. Tectonic consumers (CODE-81) resolve by
+asset id.
 
 Observers use `subscribe()` (progress / installed / failed events), never a per-call
 `onProgress`: install.ts's in-flight dedupe keeps only the first caller's callback, so per-call

--- a/packages/assets/AGENTS.md
+++ b/packages/assets/AGENTS.md
@@ -26,7 +26,9 @@ the `asset.list` wire resource; presentation belongs to the onboarding UI (CODE-
   tests and E2E must set it). All paths resolve at call time so a fake `$HOME` redirects them.
   Installs stage in a `.tmp-*` sibling and publish with one same-volume `rename`; losing the
   rename race to a concurrent install is success (hash-verified identical bytes). Boot GC
-  removes superseded versions and `.tmp-*` orphans, best-effort, before anything can spawn.
+  removes `.tmp-*` orphans and superseded versions, best-effort, before anything can spawn —
+  but a superseded version only once the wanted one is installed: until then it is the consent
+  marker that keeps a failed post-upgrade refresh retrying on later boots (CODE-221).
 - **codex registry quirk:** `@openai/codex-<platform>` names are npm aliases that 404 — the
   real artifacts are `@openai/codex` versions keyed `<ver>-<platform>-<arch>`, with the binary
   at `package/vendor/<rust-triple>/bin/codex`. All members in `catalog.ts` were read off real
@@ -45,11 +47,12 @@ the `asset.list` wire resource; presentation belongs to the onboarding UI (CODE-
 ## Consumers
 
 The daemon constructs one `AssetManager` at boot: consent snapshot (`hasInstallOnDisk` — a
-prior install of any version is the user's standing consent, read BEFORE GC deletes superseded
-versions) → GC → `setManagedResolver` into `agentRuntimeProber` (managed wins over detected the
-moment an install lands) → background `ensure()` only for consented agent pairs the probe found
-unusable. An agent never installed here is NOT auto-downloaded (CODE-221) — its first install
-comes from the client's `asset.ensure` (the onboarding Download card). The engine serves
+prior install of any version is the user's standing consent; GC retains superseded versions
+until their replacement lands, so a failed refresh never erases it) → GC → `setManagedResolver`
+into `agentRuntimeProber` (managed wins over detected the moment an install lands) → background
+`ensure()` only for consented agent pairs the probe found unusable. An agent never installed
+here is NOT auto-downloaded (CODE-221) — its first install comes from the client's
+`asset.ensure` (the onboarding Download card). The engine serves
 `statuses()` on `asset.list`, triggers `ensure()` on `asset.ensure`, and forwards install
 lifecycle to the wire via the injected `AssetService`. Tectonic consumers (CODE-81) resolve by
 asset id.

--- a/packages/assets/src/__tests__/manager.test.ts
+++ b/packages/assets/src/__tests__/manager.test.ts
@@ -70,6 +70,10 @@ describe('AssetManager', () => {
     mkdirSync(join(assetDir('tool:tectonic'), '.tmp-orphan'), { recursive: true });
     expect(manager.hasInstallOnDisk('tool:tectonic')).toBe(false);
 
+    // Neither is a stray file (Finder's .DS_Store) — consent needs a version directory.
+    writeFileSync(join(assetDir('tool:tectonic'), '.DS_Store'), '');
+    expect(manager.hasInstallOnDisk('tool:tectonic')).toBe(false);
+
     await manager.ensure('tool:tectonic');
     expect(manager.hasInstallOnDisk('tool:tectonic')).toBe(true);
 

--- a/packages/assets/src/__tests__/manager.test.ts
+++ b/packages/assets/src/__tests__/manager.test.ts
@@ -60,6 +60,27 @@ describe('AssetManager', () => {
     expect(manager.managedBinary('tool:tectonic')).toBe(installed?.path);
   });
 
+  it('hasInstallOnDisk reports any non-tmp version until GC sweeps it (consent survives a pin bump)', async () => {
+    freshStore();
+    const manager = new AssetManager({ catalog: [await servedDescriptor('2.0.0')] });
+    expect(manager.hasInstallOnDisk('tool:tectonic')).toBe(false);
+    expect(manager.hasInstallOnDisk('agent:claude-code')).toBe(false); // not in this catalog
+
+    // A .tmp-* orphan (aborted install) is not an install.
+    mkdirSync(join(assetDir('tool:tectonic'), '.tmp-orphan'), { recursive: true });
+    expect(manager.hasInstallOnDisk('tool:tectonic')).toBe(false);
+
+    await manager.ensure('tool:tectonic');
+    expect(manager.hasInstallOnDisk('tool:tectonic')).toBe(true);
+
+    // After a pin bump the superseded install still reads as consent — until gcAtBoot runs,
+    // which is why the daemon snapshots consent first.
+    const bumped = new AssetManager({ catalog: [await servedDescriptor('3.0.0')] });
+    expect(bumped.hasInstallOnDisk('tool:tectonic')).toBe(true);
+    bumped.gcAtBoot();
+    expect(bumped.hasInstallOnDisk('tool:tectonic')).toBe(false);
+  });
+
   it('gcAtBoot removes superseded versions and tmp orphans but keeps the wanted version', async () => {
     freshStore();
     const manager = new AssetManager({ catalog: [await servedDescriptor('2.0.0')] });

--- a/packages/assets/src/__tests__/manager.test.ts
+++ b/packages/assets/src/__tests__/manager.test.ts
@@ -60,7 +60,7 @@ describe('AssetManager', () => {
     expect(manager.managedBinary('tool:tectonic')).toBe(installed?.path);
   });
 
-  it('hasInstallOnDisk reports any non-tmp version until GC sweeps it (consent survives a pin bump)', async () => {
+  it('hasInstallOnDisk: consent survives a pin bump and a failed refresh, until the replacement lands', async () => {
     freshStore();
     const manager = new AssetManager({ catalog: [await servedDescriptor('2.0.0')] });
     expect(manager.hasInstallOnDisk('tool:tectonic')).toBe(false);
@@ -73,12 +73,18 @@ describe('AssetManager', () => {
     await manager.ensure('tool:tectonic');
     expect(manager.hasInstallOnDisk('tool:tectonic')).toBe(true);
 
-    // After a pin bump the superseded install still reads as consent — until gcAtBoot runs,
-    // which is why the daemon snapshots consent first.
+    // A pin bump keeps the superseded install through GC while 3.0.0 is not yet installed —
+    // an offline refresh failure on the first post-upgrade boot must not erase consent.
     const bumped = new AssetManager({ catalog: [await servedDescriptor('3.0.0')] });
-    expect(bumped.hasInstallOnDisk('tool:tectonic')).toBe(true);
     bumped.gcAtBoot();
-    expect(bumped.hasInstallOnDisk('tool:tectonic')).toBe(false);
+    expect(bumped.hasInstallOnDisk('tool:tectonic')).toBe(true);
+    expect(existsSync(join(assetDir('tool:tectonic'), '2.0.0'))).toBe(true);
+
+    // Once the replacement lands, the next GC sweeps the superseded version.
+    await bumped.ensure('tool:tectonic');
+    bumped.gcAtBoot();
+    expect(existsSync(join(assetDir('tool:tectonic'), '2.0.0'))).toBe(false);
+    expect(bumped.hasInstallOnDisk('tool:tectonic')).toBe(true);
   });
 
   it('gcAtBoot removes superseded versions and tmp orphans but keeps the wanted version', async () => {
@@ -107,10 +113,15 @@ describe('AssetManager', () => {
     const blocked = assetDir('agent:claude-code');
     mkdirSync(dirname(blocked), { recursive: true });
     writeFileSync(blocked, 'not a directory');
+    // The wanted 2.0.0 is not installed, so the stale version survives (consent, CODE-221)
+    // while the tmp orphan still goes.
     const stale = join(assetDir('agent:codex'), '1.0.0');
     mkdirSync(stale, { recursive: true });
+    const orphan = join(assetDir('agent:codex'), '.tmp-orphan');
+    mkdirSync(orphan, { recursive: true });
 
-    expect(manager.gcAtBoot()).toEqual({ removed: [stale], skipped: [blocked] });
+    expect(manager.gcAtBoot()).toEqual({ removed: [orphan], skipped: [blocked] });
+    expect(existsSync(stale)).toBe(true);
   });
 
   it('leaves unpinnable assets alone: ensure() is undefined and GC does not touch their dirs', async () => {

--- a/packages/assets/src/gc.ts
+++ b/packages/assets/src/gc.ts
@@ -12,12 +12,13 @@ export interface GcReport {
 }
 
 /**
- * Boot-time GC: inside each asset dir, delete everything that is not the wanted version —
- * superseded versions and orphaned `.tmp-*` install dirs. Runs before any agent spawns, so
- * nothing here is in use by this daemon, and the one-per-machine contract means no other
- * daemon's children hold these files. An asset whose pin is `undefined` is skipped entirely:
- * "cannot pin" must never translate into deleting a working install. Strictly best-effort —
- * GC never takes the boot down.
+ * Boot-time GC: inside each asset dir, delete superseded versions and orphaned `.tmp-*` install
+ * dirs. Runs before any agent spawns, so nothing here is in use by this daemon, and the
+ * one-per-machine contract means no other daemon's children hold these files. An asset whose pin
+ * is `undefined` is skipped entirely: "cannot pin" must never translate into deleting a working
+ * install. Superseded versions are deleted only once the wanted version is on disk — until the
+ * replacement lands they are the only evidence of the user's install consent (CODE-221), and an
+ * offline refresh failure must not erase it. Strictly best-effort — GC never takes the boot down.
  */
 export function collectGarbage(wanted: ReadonlyMap<ManagedAssetId, string | undefined>): GcReport {
   const report: GcReport = { removed: [], skipped: [] };
@@ -31,8 +32,11 @@ export function collectGarbage(wanted: ReadonlyMap<ManagedAssetId, string | unde
       if ((error as NodeJS.ErrnoException).code !== 'ENOENT') report.skipped.push(dir);
       continue;
     }
+    // Version dirs publish via atomic rename, so presence = a complete install.
+    const wantedInstalled = entries.includes(version);
     for (const entry of entries) {
       if (entry === version) continue;
+      if (!wantedInstalled && !entry.startsWith('.tmp-')) continue;
       const target = join(dir, entry);
       try {
         rmSync(target, { recursive: true, force: true });

--- a/packages/assets/src/manager.ts
+++ b/packages/assets/src/manager.ts
@@ -60,19 +60,20 @@ export class AssetManager {
   }
 
   /**
-   * Any non-`.tmp-*` version on disk, regardless of the wanted pin: a prior install = standing
-   * consent to auto-refresh (CODE-221). GC keeps superseded versions until their replacement
-   * lands, so a failed refresh never erases this.
+   * Any completed (non-`.tmp-*`) version directory on disk, regardless of the wanted pin: a prior
+   * install = standing consent to auto-refresh (CODE-221). GC keeps superseded versions until
+   * their replacement lands, so a failed refresh never erases this. Directories only — a stray
+   * file (Finder's `.DS_Store`) must not read as consent.
    */
   hasInstallOnDisk(id: ManagedAssetId): boolean {
     if (!this.descriptors.has(id)) return false;
-    let entries: string[];
     try {
-      entries = readdirSync(assetDir(id));
+      return readdirSync(assetDir(id), { withFileTypes: true }).some(
+        (entry) => entry.isDirectory() && !entry.name.startsWith('.tmp-'),
+      );
     } catch {
       return false;
     }
-    return entries.some((entry) => !entry.startsWith('.tmp-'));
   }
 
   /** Live snapshot for the `asset.list` wire resource. */

--- a/packages/assets/src/manager.ts
+++ b/packages/assets/src/manager.ts
@@ -1,3 +1,4 @@
+import { readdirSync } from 'node:fs';
 import type {
   AssetInstallEvent,
   InstalledAsset,
@@ -12,6 +13,7 @@ import type { GcReport } from './gc';
 import { collectGarbage } from './gc';
 import type { InstallOptions } from './install';
 import { installAsset, installedPath } from './install';
+import { assetDir } from './paths';
 import { wantedVersion } from './version-pin';
 
 export interface AssetManagerOptions extends InstallOptions {
@@ -55,6 +57,21 @@ export class AssetManager {
   /** Drop superseded versions and tmp orphans. Best-effort; never throws. */
   gcAtBoot(): GcReport {
     return collectGarbage(this.wanted);
+  }
+
+  /**
+   * Any non-`.tmp-*` version on disk, regardless of the wanted pin. Read BEFORE {@link gcAtBoot}
+   * sweeps superseded versions: a prior install = standing consent to auto-refresh (CODE-221).
+   */
+  hasInstallOnDisk(id: ManagedAssetId): boolean {
+    if (!this.descriptors.has(id)) return false;
+    let entries: string[];
+    try {
+      entries = readdirSync(assetDir(id));
+    } catch {
+      return false;
+    }
+    return entries.some((entry) => !entry.startsWith('.tmp-'));
   }
 
   /** Live snapshot for the `asset.list` wire resource. */

--- a/packages/assets/src/manager.ts
+++ b/packages/assets/src/manager.ts
@@ -60,8 +60,9 @@ export class AssetManager {
   }
 
   /**
-   * Any non-`.tmp-*` version on disk, regardless of the wanted pin. Read BEFORE {@link gcAtBoot}
-   * sweeps superseded versions: a prior install = standing consent to auto-refresh (CODE-221).
+   * Any non-`.tmp-*` version on disk, regardless of the wanted pin: a prior install = standing
+   * consent to auto-refresh (CODE-221). GC keeps superseded versions until their replacement
+   * lands, so a failed refresh never erases this.
    */
   hasInstallOnDisk(id: ManagedAssetId): boolean {
     if (!this.descriptors.has(id)) return false;


### PR DESCRIPTION
## Summary

The daemon no longer downloads agent binaries unprompted at boot (CODE-221). Previously, any claude-code/codex the probe found unusable was immediately `ensure()`d — ~90 MB-class downloads the user never agreed to, racing ahead of the onboarding Download card (CODE-112).

New semantics — **a prior managed install is standing consent**:

- **First install is always user-prompted.** An agent never installed in the asset store is skipped at boot; its download starts only from the client's explicit `asset.ensure` (the existing onboarding Download card in the new-session surface — no UI or wire changes needed).
- **Upgrades stay automatic.** An agent with any managed version on disk (the user clicked Download once) keeps refreshing to the current SDK pin in the background — otherwise an app update whose boot GC sweeps the superseded version would silently *remove* a working agent and demand a re-click.
- The consent snapshot is read **before** `gcAtBoot()` — GC deletes superseded versions, which is exactly the evidence consent is read from. `AssetManager.hasInstallOnDisk()` (any non-`.tmp-*` version dir) is the marker; the boot decision lives in `apps/daemon/src/managed-agent-refresh.ts` (`consentedManagedAgents` + `agentsToRefresh`).
- On-demand tool assets (aigateway translator, tectonic) are untouched — they were already user-action-triggered.

Scope decisions (flagged on the issue): no settings toggle (store presence *is* the consent state); standalone daemons behave identically (clients connect over the wire and prompt the same way — a headless daemon shouldn't silently download either); pin-bump upgrade downloads ride the original consent.

## Verification

- Unit: `managed-agent-refresh.test.ts` covers fresh-store → no refresh even when `missing`; prior install + `missing` → refresh; prior install + `available` → skip; and that the consent snapshot must precede GC (post-GC it reads empty). `manager.test.ts` covers `hasInstallOnDisk` (`.tmp-*` excluded, survives a pin bump until GC).
- Real daemon (tsup bundle, isolated HOME + `LINKCODE_ASSETS_DIR`): cold boot with an empty store performs **no** network download and stays healthy; a seeded stale version is GC'd at boot (logged) with no ensure fired (claude is `available` via detection on this machine).
- The `missing → prompt → download` UI flow is unchanged code (CODE-112, live-verified then); the negative case (`missing`, no consent → no download) can't be reproduced on this dev machine — both CLIs are always detected at `/opt/homebrew/bin` — hence the unit-level coverage above. A clean-machine pass rides the CODE-113/CODE-220 Windows verification.
- `check:ci` 0 errors; `pnpm test` 1047 passed.

Closes CODE-221.