### PR TITLE
fix(ui): simplify sidebar and add hover preview cards

### DIFF
--- a/packages/i18n/src/locales/en.ts
+++ b/packages/i18n/src/locales/en.ts
@@ -300,6 +300,7 @@ export const en = {
       pinThread: 'Pin thread',
       unpinThread: 'Unpin thread',
       closeThread: 'Close thread',
+      threadCount: '{count, plural, one {# thread} other {# threads}}',
       chooseDirectory: 'Choose directory…',
       registerWorkspaceError: 'Failed to add workspace: {message}',
       organization: 'Organization',

--- a/packages/i18n/src/locales/zh-cn.ts
+++ b/packages/i18n/src/locales/zh-cn.ts
@@ -293,6 +293,7 @@ export const zhCN = {
       pinThread: '置顶线程',
       unpinThread: '取消置顶',
       closeThread: '关闭线程',
+      threadCount: '{count} 个线程',
       chooseDirectory: '选择目录…',
       registerWorkspaceError: '添加工作区失败：{message}',
       organization: '组织',

--- a/packages/ui/src/shell/sidebar/branch-status.tsx
+++ b/packages/ui/src/shell/sidebar/branch-status.tsx
@@ -7,15 +7,23 @@ export interface BranchStatusProps {
   status: GitStatus | undefined;
   /** Show a dirty-file-count badge alongside the branch name (workspace rows, not group headers). */
   showDirty?: boolean;
+  /** Leading icon; rendered only when there is a branch to show, so it never dangles. */
+  icon?: React.ReactNode;
   className?: string;
 }
 
-export type BranchStatusComponentType = React.ComponentType<{ cwd: string; showDirty?: boolean }>;
+export type BranchStatusComponentType = React.ComponentType<{
+  cwd: string;
+  showDirty?: boolean;
+  icon?: React.ReactNode;
+  className?: string;
+}>;
 
 /** Compact branch name (+ optional dirty-file badge) for a sidebar group header or workspace row. */
 export function BranchStatus({
   status,
   showDirty = false,
+  icon,
   className,
 }: BranchStatusProps): React.ReactNode {
   const t = useTranslations('workbench.git');
@@ -24,6 +32,7 @@ export function BranchStatus({
 
   return (
     <span className={cn('inline-flex min-w-0 items-center gap-1 text-muted-foreground', className)}>
+      {icon}
       <span className="truncate">{status.branch ?? t('detachedHead')}</span>
       {showDirty && status.dirtyFileCount > 0 && (
         <Badge size="sm" variant="warning">

--- a/packages/ui/src/shell/sidebar/chats-section.tsx
+++ b/packages/ui/src/shell/sidebar/chats-section.tsx
@@ -5,6 +5,7 @@ import { Skeleton } from 'coss-ui/components/skeleton';
 import { createFixedArray } from 'foxact/create-fixed-array';
 import { PlusIcon } from 'lucide-react';
 import { useTranslations } from 'use-intl';
+import type { BranchStatusComponentType } from './branch-status';
 import { SectionAccordionTrigger } from './section-header';
 import { ShowMoreToggle } from './show-more-toggle';
 import type { ThreadImMenuComponentType } from './thread-im-menu';
@@ -32,6 +33,7 @@ export interface ChatsSectionProps {
   onStartDraft: (workspaceId: WorkspaceId) => void;
   onTogglePreviewExpanded: (groupKey: string) => void;
   ImMenuComponent?: ThreadImMenuComponentType;
+  BranchStatusComponent?: BranchStatusComponentType;
 }
 
 /**
@@ -56,6 +58,7 @@ export function ChatsSection({
   onStartDraft,
   onTogglePreviewExpanded,
   ImMenuComponent,
+  BranchStatusComponent,
 }: ChatsSectionProps): React.ReactNode {
   const t = useTranslations('workbench.sidebar');
 
@@ -87,6 +90,7 @@ export function ChatsSection({
                 onClose={() => onClose(session.sessionId)}
                 onTogglePin={() => onToggleSessionPinned(session.sessionId)}
                 ImMenuComponent={ImMenuComponent}
+                BranchStatusComponent={BranchStatusComponent}
               />
             ))}
             {hasOverflow && (

--- a/packages/ui/src/shell/sidebar/group-header.tsx
+++ b/packages/ui/src/shell/sidebar/group-header.tsx
@@ -38,7 +38,6 @@ import { ROW_ACTION_CLASS, ROW_HOVER_PE_CLASS, RowActionsCluster } from './row-a
 export interface ThreadGroupHeaderProps {
   title: string;
   workspace: WorkspaceRecord | null;
-  sessionCount: number;
   /** Mirrors the surrounding accordion item's open state (the trigger owns toggling). */
   collapsed: boolean;
   /** Opens the new-session page preselecting this group's workspace. Undefined for the
@@ -85,7 +84,6 @@ function FolderToggleIcon({ open }: { open: boolean }): React.ReactNode {
 export function ThreadGroupHeader({
   title,
   workspace,
-  sessionCount,
   collapsed,
   onNewThread,
   onRename,
@@ -168,9 +166,12 @@ export function ThreadGroupHeader({
               )}
             >
               <FolderToggleIcon open={!collapsed} />
-              <span className="min-w-0 truncate">{title}</span>
-              {workspace && BranchStatusComponent && <BranchStatusComponent cwd={workspace.cwd} />}
-              <span className="ml-auto shrink-0 tabular-nums">{sessionCount}</span>
+              <span className="flex min-w-0 flex-1 items-center gap-2">
+                <span className="max-w-full shrink-0 truncate">{title}</span>
+                {workspace && BranchStatusComponent && (
+                  <BranchStatusComponent cwd={workspace.cwd} />
+                )}
+              </span>
             </SidebarMenuButton>
           }
         />

--- a/packages/ui/src/shell/sidebar/group-header.tsx
+++ b/packages/ui/src/shell/sidebar/group-header.tsx
@@ -18,6 +18,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from 'coss-ui/components/menu';
+import { PreviewCard, PreviewCardTrigger } from 'coss-ui/components/preview-card';
 import { SidebarMenuButton } from 'coss-ui/components/sidebar';
 import { extractErrorMessage } from 'foxts/extract-error-message';
 import {
@@ -25,6 +26,7 @@ import {
   EllipsisIcon,
   FolderIcon,
   FolderOpenIcon,
+  MessagesSquareIcon,
   PencilIcon,
   PlusIcon,
 } from 'lucide-react';
@@ -33,11 +35,14 @@ import { useState } from 'react';
 import { useTranslations } from 'use-intl';
 import { cn } from '../../lib/cn';
 import type { BranchStatusComponentType } from './branch-status';
+import { SidebarPreviewCardPopup } from './preview-card';
 import { ROW_ACTION_CLASS, ROW_HOVER_PE_CLASS, RowActionsCluster } from './row-actions';
 
 export interface ThreadGroupHeaderProps {
   title: string;
   workspace: WorkspaceRecord | null;
+  /** The group's full session count, shown in the header's preview card. */
+  threadCount: number;
   /** Mirrors the surrounding accordion item's open state (the trigger owns toggling). */
   collapsed: boolean;
   /** Opens the new-session page preselecting this group's workspace. Undefined for the
@@ -84,6 +89,7 @@ function FolderToggleIcon({ open }: { open: boolean }): React.ReactNode {
 export function ThreadGroupHeader({
   title,
   workspace,
+  threadCount,
   collapsed,
   onNewThread,
   onRename,
@@ -161,26 +167,48 @@ export function ThreadGroupHeader({
           />
         </div>
       ) : (
-        <AccordionPrimitive.Trigger
-          render={
-            <SidebarMenuButton
-              title={workspace?.cwd}
-              aria-label={collapsed ? t('expandGroup') : t('collapseGroup')}
-              className={cn(
-                'hover:bg-transparent focus-visible:ring-1 focus-visible:ring-inset',
-                hasActions && ROW_HOVER_PE_CLASS,
-              )}
-            >
-              <FolderToggleIcon open={!collapsed} />
-              <span className="flex min-w-0 flex-1 items-center gap-2">
-                <span className="max-w-full shrink-0 truncate">{title}</span>
-                {workspace && BranchStatusComponent && (
-                  <BranchStatusComponent cwd={workspace.cwd} />
-                )}
-              </span>
-            </SidebarMenuButton>
-          }
-        />
+        <PreviewCard>
+          <AccordionPrimitive.Trigger
+            render={
+              <PreviewCardTrigger
+                render={
+                  <SidebarMenuButton
+                    aria-label={collapsed ? t('expandGroup') : t('collapseGroup')}
+                    className={cn(
+                      'hover:bg-transparent focus-visible:ring-1 focus-visible:ring-inset',
+                      hasActions && ROW_HOVER_PE_CLASS,
+                    )}
+                  />
+                }
+              >
+                <FolderToggleIcon open={!collapsed} />
+                <span className="flex min-w-0 flex-1 items-center gap-2">
+                  <span className="max-w-full shrink-0 truncate">{title}</span>
+                  {workspace && BranchStatusComponent && (
+                    <BranchStatusComponent cwd={workspace.cwd} />
+                  )}
+                </span>
+              </PreviewCardTrigger>
+            }
+          />
+          {workspace && (
+            <SidebarPreviewCardPopup>
+              <div className="flex min-w-0 flex-1 flex-col gap-2">
+                <span>{title}</span>
+                <div className="flex flex-col gap-1.5 text-muted-foreground text-xs">
+                  <span className="flex items-center gap-1.5">
+                    <MessagesSquareIcon className="size-3.5 shrink-0" />
+                    <span>{t('threadCount', { count: threadCount })}</span>
+                  </span>
+                  <span className="flex gap-1.5">
+                    <FolderIcon className="mt-px size-3.5 shrink-0" />
+                    <span className="break-all">{workspace.cwd}</span>
+                  </span>
+                </div>
+              </div>
+            </SidebarPreviewCardPopup>
+          )}
+        </PreviewCard>
       )}
       {renameError != null && (
         <div className="-bottom-5 absolute left-0 z-10 px-1 text-destructive text-xs">

--- a/packages/ui/src/shell/sidebar/group-header.tsx
+++ b/packages/ui/src/shell/sidebar/group-header.tsx
@@ -137,23 +137,29 @@ export function ThreadGroupHeader({
       render={<div ref={dragHandleRef} className="group/menu-item relative flex" />}
     >
       {renaming ? (
-        <Input
-          // biome-ignore lint/a11y/noAutofocus: opening the rename field is itself the user's action.
-          autoFocus
-          aria-label={t('renameWorkspace')}
-          value={draftName}
-          onChange={(event) => setDraftName(event.target.value)}
-          onKeyDown={(event) => {
-            if (event.key === 'Enter') {
-              event.preventDefault();
-              commitRename();
-            } else if (event.key === 'Escape') {
-              event.preventDefault();
-              cancelRename();
-            }
-          }}
-          onBlur={commitRename}
-        />
+        <div className="flex h-8 w-full min-w-0 items-center gap-2 rounded-lg px-2 text-sidebar-foreground text-sm transition-[background-color,box-shadow] focus-within:bg-sidebar-accent focus-within:ring-1 focus-within:ring-inset focus-within:ring-sidebar-ring">
+          <FolderToggleIcon open={!collapsed} />
+          <Input
+            unstyled
+            size="sm"
+            // biome-ignore lint/a11y/noAutofocus: opening the rename field is itself the user's action.
+            autoFocus
+            aria-label={t('renameWorkspace')}
+            value={draftName}
+            className="min-w-0 flex-1 [&>[data-slot=input]]:px-0"
+            onChange={(event) => setDraftName(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === 'Enter') {
+                event.preventDefault();
+                commitRename();
+              } else if (event.key === 'Escape') {
+                event.preventDefault();
+                cancelRename();
+              }
+            }}
+            onBlur={commitRename}
+          />
+        </div>
       ) : (
         <AccordionPrimitive.Trigger
           render={

--- a/packages/ui/src/shell/sidebar/pinned-section.tsx
+++ b/packages/ui/src/shell/sidebar/pinned-section.tsx
@@ -2,6 +2,7 @@ import type { SessionId, SessionInfo } from '@linkcode/schema';
 import { AccordionItem, AccordionPanel } from 'coss-ui/components/accordion';
 import { SidebarGroup, SidebarMenu } from 'coss-ui/components/sidebar';
 import { useTranslations } from 'use-intl';
+import type { BranchStatusComponentType } from './branch-status';
 import { SectionAccordionTrigger } from './section-header';
 import { ShowMoreToggle } from './show-more-toggle';
 import type { ThreadImMenuComponentType } from './thread-im-menu';
@@ -22,6 +23,7 @@ export interface PinnedSectionProps {
   onToggleSessionPinned: (id: SessionId) => void;
   onTogglePreviewExpanded: (groupKey: string) => void;
   ImMenuComponent?: ThreadImMenuComponentType;
+  BranchStatusComponent?: BranchStatusComponentType;
 }
 
 /**
@@ -41,6 +43,7 @@ export function PinnedSection({
   onToggleSessionPinned,
   onTogglePreviewExpanded,
   ImMenuComponent,
+  BranchStatusComponent,
 }: PinnedSectionProps): React.ReactNode {
   const t = useTranslations('workbench.sidebar');
 
@@ -61,6 +64,7 @@ export function PinnedSection({
               onClose={() => onClose(session.sessionId)}
               onTogglePin={() => onToggleSessionPinned(session.sessionId)}
               ImMenuComponent={ImMenuComponent}
+              BranchStatusComponent={BranchStatusComponent}
             />
           ))}
           {hasOverflow && (

--- a/packages/ui/src/shell/sidebar/preview-card.tsx
+++ b/packages/ui/src/shell/sidebar/preview-card.tsx
@@ -1,0 +1,37 @@
+import { PreviewCardPrimitive } from 'coss-ui/components/preview-card';
+import { cn } from '../../lib/cn';
+
+/**
+ * Minimal fork of coss-ui's `PreviewCardPopup` (same popup styling) that exposes the positioner's
+ * `side`, which the vendored component hard-defaults to `bottom`. Sidebar cards open to the right
+ * of their row — like the row dropdown menus — so they never cover the list they annotate.
+ * Compose with `PreviewCard` + `PreviewCardTrigger` from coss-ui.
+ */
+export function SidebarPreviewCardPopup({
+  className,
+  children,
+  ...props
+}: PreviewCardPrimitive.Popup.Props): React.ReactNode {
+  return (
+    <PreviewCardPrimitive.Portal>
+      <PreviewCardPrimitive.Positioner
+        side="right"
+        align="start"
+        sideOffset={8}
+        className="z-50"
+        data-slot="preview-card-positioner"
+      >
+        <PreviewCardPrimitive.Popup
+          className={cn(
+            'relative flex w-64 origin-(--transform-origin) text-balance rounded-lg border bg-popover not-dark:bg-clip-padding p-4 text-popover-foreground text-sm shadow-lg/5 transition-[scale,opacity] before:pointer-events-none before:absolute before:inset-0 before:rounded-[calc(var(--radius-lg)-1px)] before:shadow-[0_1px_--theme(--color-black/4%)] data-ending-style:scale-98 data-starting-style:scale-98 data-ending-style:opacity-0 data-starting-style:opacity-0 dark:before:shadow-[0_-1px_--theme(--color-white/6%)]',
+            className,
+          )}
+          data-slot="preview-card-content"
+          {...props}
+        >
+          {children}
+        </PreviewCardPrimitive.Popup>
+      </PreviewCardPrimitive.Positioner>
+    </PreviewCardPrimitive.Portal>
+  );
+}

--- a/packages/ui/src/shell/sidebar/thread-row.tsx
+++ b/packages/ui/src/shell/sidebar/thread-row.tsx
@@ -2,14 +2,16 @@ import { useSortable } from '@dnd-kit/react/sortable';
 import type { SessionInfo } from '@linkcode/schema';
 import { Button } from 'coss-ui/components/button';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuTrigger } from 'coss-ui/components/menu';
+import { PreviewCard, PreviewCardTrigger } from 'coss-ui/components/preview-card';
 import { SidebarMenuButton, SidebarMenuItem } from 'coss-ui/components/sidebar';
-import { EllipsisIcon, PinIcon, XIcon } from 'lucide-react';
+import { ClockIcon, EllipsisIcon, FolderIcon, GitBranchIcon, PinIcon, XIcon } from 'lucide-react';
 import { useTranslations } from 'use-intl';
 import { AGENT_LABELS, AgentIcon } from '../../chat/agent-icon';
-import { WithTooltip } from '../../chat/with-tooltip';
 import { cn } from '../../lib/cn';
 import { repositoryLabel } from '../repository-label';
 import { useRelativeTimeLabel } from '../use-relative-time-label';
+import type { BranchStatusComponentType } from './branch-status';
+import { SidebarPreviewCardPopup } from './preview-card';
 import {
   ROW_ACTION_CLASS,
   ROW_HOVER_PE_CLASS,
@@ -33,9 +35,12 @@ export interface ThreadRowProps {
   onTogglePin: () => void;
   /** Runtime-backed IM menu items; the ellipsis menu only renders when this is provided. */
   ImMenuComponent?: ThreadImMenuComponentType;
+  /** Runtime-backed branch badge for the preview card; the branch row hides without it. */
+  BranchStatusComponent?: BranchStatusComponentType;
 }
 
-/** One thread row: ghost agent icon, single-line title, status dot. The relative time lives in a tooltip. */
+/** One thread row: ghost agent icon, single-line title, status dot. Full title, relative time,
+ * project, and branch live in a hover preview card. */
 export function ThreadRow({
   session,
   active,
@@ -46,6 +51,7 @@ export function ThreadRow({
   onClose,
   onTogglePin,
   ImMenuComponent,
+  BranchStatusComponent,
 }: ThreadRowProps): React.ReactNode {
   const t = useTranslations('workbench.sidebar');
   const agent = AGENT_LABELS[session.kind];
@@ -63,16 +69,20 @@ export function ThreadRow({
 
   return (
     <SidebarMenuItem ref={sortableRef}>
-      <WithTooltip tooltip={createdAtLabel}>
-        <SidebarMenuButton
-          isActive={active}
-          onClick={onSelect}
-          className={cn(
-            // No font-medium when active: IBM Plex Sans lacks CJK, so 500 falls back to
-            // PingFang Medium and mixed-script titles read artificially bold.
-            'data-[active=true]:font-normal hover:bg-transparent data-[active=true]:hover:bg-sidebar-accent',
-            ImMenuComponent ? ROW_HOVER_PE_WIDE_CLASS : ROW_HOVER_PE_CLASS,
-          )}
+      <PreviewCard>
+        <PreviewCardTrigger
+          render={
+            <SidebarMenuButton
+              isActive={active}
+              onClick={onSelect}
+              className={cn(
+                // No font-medium when active: IBM Plex Sans lacks CJK, so 500 falls back to
+                // PingFang Medium and mixed-script titles read artificially bold.
+                'data-[active=true]:font-normal hover:bg-transparent data-[active=true]:hover:bg-sidebar-accent',
+                ImMenuComponent ? ROW_HOVER_PE_WIDE_CLASS : ROW_HOVER_PE_CLASS,
+              )}
+            />
+          }
         >
           <span className="relative shrink-0">
             <AgentIcon kind={session.kind} variant="ghost" className="text-muted-foreground" />
@@ -85,8 +95,30 @@ export function ThreadRow({
             />
           </span>
           <span className="min-w-0 flex-1 truncate">{title}</span>
-        </SidebarMenuButton>
-      </WithTooltip>
+        </PreviewCardTrigger>
+        <SidebarPreviewCardPopup>
+          <div className="flex min-w-0 flex-1 flex-col gap-2">
+            <span>{title}</span>
+            <div className="flex flex-col gap-1.5 text-muted-foreground text-xs">
+              <span className="flex min-w-0 items-center gap-1.5">
+                <FolderIcon className="size-3.5 shrink-0" />
+                <span className="truncate">{repositoryLabel(session.cwd)}</span>
+              </span>
+              {BranchStatusComponent && (
+                <BranchStatusComponent
+                  cwd={session.cwd}
+                  className="gap-1.5"
+                  icon={<GitBranchIcon className="size-3.5 shrink-0" />}
+                />
+              )}
+              <span className="flex items-center gap-1.5">
+                <ClockIcon className="size-3.5 shrink-0" />
+                <span>{createdAtLabel}</span>
+              </span>
+            </div>
+          </div>
+        </SidebarPreviewCardPopup>
+      </PreviewCard>
       <RowActionsCluster>
         {ImMenuComponent && (
           <DropdownMenu>

--- a/packages/ui/src/shell/threads-view.tsx
+++ b/packages/ui/src/shell/threads-view.tsx
@@ -334,7 +334,6 @@ function ThreadGroupSection({
         dragHandleRef={workspace ? handleRef : undefined}
         title={title}
         workspace={workspace}
-        sessionCount={group.sessions.length}
         collapsed={group.collapsed}
         onNewThread={workspace ? () => onStartDraft(workspace.workspaceId) : undefined}
         onRename={workspace ? (name) => onRenameWorkspace(workspace.workspaceId, name) : undefined}

--- a/packages/ui/src/shell/threads-view.tsx
+++ b/packages/ui/src/shell/threads-view.tsx
@@ -185,6 +185,7 @@ export function ThreadsView({
             onToggleSessionPinned={onToggleSessionPinned}
             onTogglePreviewExpanded={onTogglePreviewExpanded}
             ImMenuComponent={ImMenuComponent}
+            BranchStatusComponent={BranchStatusComponent}
           />
         )}
 
@@ -259,6 +260,7 @@ export function ThreadsView({
           onStartDraft={onStartDraft}
           onTogglePreviewExpanded={onTogglePreviewExpanded}
           ImMenuComponent={ImMenuComponent}
+          BranchStatusComponent={BranchStatusComponent}
         />
       </Accordion>
     </DragDropProvider>
@@ -325,6 +327,7 @@ function ThreadGroupSection({
       onClose={() => onClose(session.sessionId)}
       onTogglePin={() => onToggleSessionPinned(session.sessionId)}
       ImMenuComponent={ImMenuComponent}
+      BranchStatusComponent={BranchStatusComponent}
     />
   );
 
@@ -334,6 +337,7 @@ function ThreadGroupSection({
         dragHandleRef={workspace ? handleRef : undefined}
         title={title}
         workspace={workspace}
+        threadCount={group.sessions.length}
         collapsed={group.collapsed}
         onNewThread={workspace ? () => onStartDraft(workspace.workspaceId) : undefined}
         onRename={workspace ? (name) => onRenameWorkspace(workspace.workspaceId, name) : undefined}

--- a/packages/workbench/src/sidebar/branch-status.tsx
+++ b/packages/workbench/src/sidebar/branch-status.tsx
@@ -4,10 +4,17 @@ import { useGitStatus } from '../git/hooks';
 export interface RuntimeBranchStatusProps {
   cwd: string;
   showDirty?: boolean;
+  icon?: React.ReactNode;
+  className?: string;
 }
 
 /** Hook-backed adapter: each instance owns its own `useGitStatus` poll for one `cwd`. */
-export function RuntimeBranchStatus({ cwd, showDirty }: RuntimeBranchStatusProps): React.ReactNode {
+export function RuntimeBranchStatus({
+  cwd,
+  showDirty,
+  icon,
+  className,
+}: RuntimeBranchStatusProps): React.ReactNode {
   const { data: status } = useGitStatus(cwd);
-  return <BranchStatus status={status} showDirty={showDirty} />;
+  return <BranchStatus status={status} showDirty={showDirty} icon={icon} className={className} />;
 }


### PR DESCRIPTION
# Rebase upon `master` before merging. This is a dependent PR upon #146. Only merge after #146 got merged into `master`. 

## Summary
- Remove per-project session counts and prioritize project names in the sidebar group header — count was redundant clutter next to the branch badge
- Keep group rename inline instead of navigating away
- Replace the sidebar's plain time tooltip with a coss-ui Preview Card (thread rows + project accordion headers): full title, project, branch, relative time on hover, matching coss-ui tone (no mono font, minimal styling on top of primitive components)

## Test plan
- [x] `pnpm check:ci` (lint + typecheck) and `pnpm test` (1062 tests) pass
- [x] Manually verified in webview mock mode: dirty-repo / clean-repo / non-repo thread cards, project header card (singular/plural/zero thread counts), accordion toggle, thread select, inline rename, pin/unpin — no regressions