### PR TITLE
chore(deps): bump restty to 0.2.5 for the VS16 emoji fix

### DIFF
--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -17,7 +17,7 @@
     "@linkcode/schema": "workspace:*",
     "@linkcode/transport": "workspace:*",
     "foxts": "^5.8.0",
-    "restty": "^0.2.3",
+    "restty": "^0.2.5",
     "zod": "catalog:"
   },
   "devDependencies": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -42,7 +42,7 @@
     "lucide-react": "^1.23.0",
     "mermaid": "^11.16.0",
     "motion": "^12.42.2",
-    "restty": "^0.2.3",
+    "restty": "^0.2.5",
     "streamdown": "^2.5.0",
     "tailwind-merge": "^3.6.0",
     "use-intl": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -896,8 +896,8 @@ importers:
         specifier: ^5.8.0
         version: 5.8.0
       restty:
-        specifier: ^0.2.3
-        version: 0.2.3
+        specifier: ^0.2.5
+        version: 0.2.5
       zod:
         specifier: 'catalog:'
         version: 4.4.3
@@ -1088,8 +1088,8 @@ importers:
         specifier: '>=5.0.0'
         version: 5.7.0(react-native@0.86.0(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.7))(react@19.2.7)
       restty:
-        specifier: ^0.2.3
-        version: 0.2.3
+        specifier: ^0.2.5
+        version: 0.2.5
       streamdown:
         specifier: ^2.5.0
         version: 2.5.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -9400,8 +9400,8 @@ packages:
     resolution: {integrity: sha512-6IzJLuGi4+R14vwagDHX+JrXmPVtPpn4mffDJ1UdR7/Edm87fl6yi8mMBIVvFtJaNTUvjughmW4hwLhRG7gC1Q==}
     engines: {node: '>=4'}
 
-  restty@0.2.3:
-    resolution: {integrity: sha512-7jaRmthX3Og5xgdgq5f3Di7egy/+BEj8FeKFBdbBQPdagT/UKqghbCX3v1uiC5Y/T/e83a4lwIUr+5qTrv1k7Q==}
+  restty@0.2.5:
+    resolution: {integrity: sha512-2VABUX7p4/5J+hbCOjEaBKjBCAj7SyJNMt98XleePeUe4hH24kmmhBPAhGlg7ZbybFvKC7nwIppITePm5lAMKA==}
     engines: {bun: '>=1.2.0'}
 
   retry@0.12.0:
@@ -9896,8 +9896,8 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
-  text-shaper@0.1.26:
-    resolution: {integrity: sha512-tTLEZskIQYadTw7pNQpGstZGLZX/TPbMreexrxtJzTQCQe9upWYfEcJxDW3yN+m3NhO1kI2v/BUor+qyCpOm+Q==}
+  text-shaper@0.1.27:
+    resolution: {integrity: sha512-kfuOgxNHEHGfYaMJ5uaMbNfnmS5adMG3qPjLAgwwEy9pBsqAj4F0oSkOl8QoOdnQ8+wyIkX7M+hBYA4btWB4sw==}
 
   thenify-all@1.6.0:
     resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
@@ -19731,9 +19731,9 @@ snapshots:
       onetime: 2.0.1
       signal-exit: 3.0.7
 
-  restty@0.2.3:
+  restty@0.2.5:
     dependencies:
-      text-shaper: 0.1.26
+      text-shaper: 0.1.27
 
   retry@0.12.0: {}
 
@@ -20342,7 +20342,7 @@ snapshots:
       commander: 2.20.3
       source-map-support: 0.5.21
 
-  text-shaper@0.1.26: {}
+  text-shaper@0.1.27: {}
 
   thenify-all@1.6.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -172,9 +172,10 @@ minimumReleaseAgeExclude:
   - '@typescript/typescript-win32-arm64@7.0.2'
   - '@typescript/typescript-win32-x64@7.0.2'
   - typescript@7.0.2
-  # Upstream fixes for our terminal font reports (restty#24/#25, text-shaper#3), adopted same-day (CODE-223).
-  - restty@0.2.3
-  - text-shaper@0.1.26
+  # Upstream fixes for our terminal font reports, adopted same-day: restty#24/#25 + text-shaper#3
+  # (CODE-223), then VS16/format 14 via our text-shaper#5 plus the CJK ic_width fix (CODE-241).
+  - restty@0.2.3 || 0.2.5
+  - text-shaper@0.1.26 || 0.1.27
 
 overrides:
   # GHSA-67mh-4wv8-2f99: advisory metadata claims 0.24.3, but esbuild 0.24.x


### PR DESCRIPTION
Closes CODE-241. Follow-up to #142 (CODE-223).

Our [text-shaper#5](https://github.com/wiedymi/text-shaper/pull/5) (cmap format 14 wiring + variation-selector removal, fixing [restty#30](https://github.com/wiedymi/restty/issues/30)) was merged upstream and released as `text-shaper@0.1.27`. text-shaper is inlined into restty's dist by its bundler, so the fix reaches us via `restty@0.2.5`; 0.2.4 additionally ships a Ghostty-style em-normalized `ic_width` adjustment that removes the excess spacing around CJK fallback glyphs.

During upstream review the maintainer fixed one ordering bug in our submission: selector glyphs are now removed before GPOS/kerning, so `A + VS16 + V` keeps its `AV` kern pair.

## Changes

- `restty` `^0.2.3` → `^0.2.5` in `packages/ui` + `packages/engine`; release-age exclude entries consolidated (`restty@0.2.3 || 0.2.5`, `text-shaper@0.1.26 || 0.1.27`).

## Verification

- Harness against the published 0.2.5 artifact: every VS16 sequence from the restty#30 matrix now renders (original failing order, after other emoji, and in later PTY chunks); the IVS pair `U+793C U+FE00` vs bare `U+793C` renders two distinct glyphs; CJK spacing reflects the 0.2.4 ic_width fix.
- `pnpm check:ci` 0 errors; `pnpm test` 1070 passed.