### PR TITLE
feat(chat): smooth streamed message rendering

### DIFF
--- a/packages/ui/src/chat/__tests__/smooth-text-controller.test.ts
+++ b/packages/ui/src/chat/__tests__/smooth-text-controller.test.ts
@@ -1,0 +1,71 @@
+// @vitest-environment jsdom
+
+import { act, render } from '@testing-library/react';
+import { createElement } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  advanceSmoothText,
+  createSmoothTextState,
+  reconcileSmoothText,
+  useSmoothText,
+} from '../smooth-text-controller';
+
+function SmoothTextProbe({ source, isStreaming }: { source: string; isStreaming: boolean }) {
+  return createElement('span', null, useSmoothText(source, isStreaming));
+}
+
+describe('smooth text controller', () => {
+  afterEach(() => vi.useRealTimers());
+
+  it('renders buffered live text on ticks and settles at completion', () => {
+    vi.useFakeTimers();
+    const source = 'first live burst';
+    const view = render(createElement(SmoothTextProbe, { source, isStreaming: true }));
+    expect(view.container.textContent).toBe('');
+
+    act(() => vi.advanceTimersByTime(32));
+    expect(view.container.textContent).toBe('fi');
+
+    const grown = `${source} grows`;
+    view.rerender(createElement(SmoothTextProbe, { source: grown, isStreaming: true }));
+    act(() => vi.advanceTimersByTime(32));
+    expect(grown.startsWith(view.container.textContent)).toBe(true);
+    expect(view.container.textContent).not.toBe(grown);
+
+    view.rerender(createElement(SmoothTextProbe, { source: grown, isStreaming: false }));
+    expect(view.container.textContent).not.toBe(grown);
+    act(() => vi.advanceTimersByTime(8 * 32));
+    expect(view.container.textContent).toBe(grown);
+  });
+
+  it('drains bursts exactly without splitting graphemes', () => {
+    const prefix = 'Answer: ';
+    const family = '👨\u{200D}👩\u{200D}👧\u{200D}👦';
+    const accent = 'é';
+    let state = createSmoothTextState(prefix, false);
+
+    state = reconcileSmoothText(state, `${prefix}${family}${accent}abcdefghi`, false);
+    state = advanceSmoothText(state);
+    expect(state.visible).toBe(`${prefix}${family}${accent}`);
+
+    const source = `${state.source} — complete`;
+    state = reconcileSmoothText(state, source, false);
+    const seen = [state.visible];
+    for (let tick = 0; tick < 8; tick++) {
+      state = advanceSmoothText(state);
+      seen.push(state.visible);
+    }
+
+    expect(state.visible).toBe(source);
+    expect(seen.every((visible) => source.startsWith(visible))).toBe(true);
+
+    for (const [initial, nextSource, firstStep] of [
+      ['👨', '👨\u{200D}👩x', '👨\u{200D}👩'],
+      ['🇺', '🇺🇸x', '🇺🇸'],
+      ['e', 'éx', 'é'],
+    ]) {
+      const joined = reconcileSmoothText(createSmoothTextState(initial, false), nextSource, false);
+      expect(advanceSmoothText(joined).visible).toBe(firstStep);
+    }
+  });
+});

--- a/packages/ui/src/chat/content-block-view.tsx
+++ b/packages/ui/src/chat/content-block-view.tsx
@@ -2,14 +2,26 @@ import type { ContentBlock } from '@linkcode/schema';
 import { FileTextIcon } from 'lucide-react';
 import { useTranslations } from 'use-intl';
 import { CodeBlock } from './code-block';
-import { Markdown } from './markdown';
+import { Markdown, SmoothMarkdown } from './markdown';
 
-export function ContentBlockView({ block }: { block: ContentBlock }): React.ReactNode {
+export function ContentBlockView({
+  block,
+  smoothText = false,
+  isStreaming = false,
+}: {
+  block: ContentBlock;
+  smoothText?: boolean;
+  isStreaming?: boolean;
+}): React.ReactNode {
   const t = useTranslations('workbench.content');
 
   switch (block.type) {
     case 'text':
-      return <Markdown>{block.text}</Markdown>;
+      return smoothText ? (
+        <SmoothMarkdown isStreaming={isStreaming}>{block.text}</SmoothMarkdown>
+      ) : (
+        <Markdown>{block.text}</Markdown>
+      );
     case 'image':
       return (
         <img

--- a/packages/ui/src/chat/conversation-view.tsx
+++ b/packages/ui/src/chat/conversation-view.tsx
@@ -146,8 +146,13 @@ export function ConversationView({
           <Message key={item.id} from="assistant">
             <MessageContent className="space-y-1">
               {item.blocks.map((block, index) => (
-                // eslint-disable-next-line @eslint-react/no-array-index-key -- append-only stream: appendBlock only pushes or extends the last block, so index+type is a stable position key across token-by-token re-renders
-                <ContentBlockView key={`${index}:${block.type}`} block={block} />
+                <ContentBlockView
+                  // eslint-disable-next-line @eslint-react/no-array-index-key -- append-only stream: appendBlock only pushes or extends the last block, so index+type is a stable position key across token-by-token re-renders
+                  key={`${index}:${block.type}`}
+                  block={block}
+                  smoothText
+                  isStreaming={item.isStreaming}
+                />
               ))}
             </MessageContent>
           </Message>

--- a/packages/ui/src/chat/markdown.tsx
+++ b/packages/ui/src/chat/markdown.tsx
@@ -1,6 +1,6 @@
 import { cjk } from '@streamdown/cjk';
 import { createCodePlugin } from '@streamdown/code';
-import type { Components, PluginConfig } from 'streamdown';
+import type { Components, PluginConfig, StreamdownProps } from 'streamdown';
 import { Streamdown } from 'streamdown';
 import { cn } from '../lib/cn';
 import { useRenderPrefs } from '../render-prefs';
@@ -8,6 +8,7 @@ import { ArtifactFenceRenderer } from './artifacts/fence-renderer';
 import { detectInlineFilePath } from './artifacts/file-kind';
 import { useArtifactHostActions } from './artifacts/host-actions';
 import { artifactFenceLanguages } from './artifacts/registry';
+import { useSmoothText } from './smooth-text-controller';
 
 const INLINE_CODE_CLASS = 'rounded bg-muted px-1 py-0.5 font-mono text-[0.85em]';
 
@@ -143,13 +144,22 @@ const artifactRenderers = [
   { language: artifactFenceLanguages(), component: ArtifactFenceRenderer },
 ];
 
-export function Markdown({
-  children,
-  className,
-}: {
+const INSTANT_STREAM_ANIMATION = {
+  duration: 0,
+  stagger: 0,
+} satisfies NonNullable<StreamdownProps['animated']>;
+
+interface MarkdownProps {
   children: string;
   className?: string;
-}): React.ReactNode {
+  animated?: StreamdownProps['animated'];
+}
+
+interface SmoothMarkdownProps extends MarkdownProps {
+  isStreaming: boolean;
+}
+
+export function Markdown({ children, className, animated }: MarkdownProps): React.ReactNode {
   const { codeTheme } = useRenderPrefs();
   // The @streamdown/code plugin's getThemes() wins over the shikiTheme prop, so the selected theme
   // must be baked into the plugin. createCodePlugin is cheap — its highlighter is created lazily.
@@ -164,9 +174,24 @@ export function Markdown({
       // matching the previous react-markdown renderer.
       className={cn('space-y-0 break-words text-sm leading-relaxed', className)}
       components={components}
+      animated={animated}
       plugins={plugins}
     >
       {children}
     </Streamdown>
+  );
+}
+
+/** Markdown whose append-only source growth is drained from a small presentation buffer. */
+export function SmoothMarkdown({
+  children,
+  isStreaming,
+  ...props
+}: SmoothMarkdownProps): React.ReactNode {
+  const visibleText = useSmoothText(children, isStreaming);
+  return (
+    <Markdown {...props} animated={INSTANT_STREAM_ANIMATION}>
+      {visibleText}
+    </Markdown>
   );
 }

--- a/packages/ui/src/chat/smooth-text-controller.ts
+++ b/packages/ui/src/chat/smooth-text-controller.ts
@@ -1,0 +1,105 @@
+import { useAbortableEffect } from 'foxact/use-abortable-effect';
+import { useEffect, useRef, useState } from 'react';
+import { useRenderPrefs } from '../render-prefs';
+
+const DRAIN_TICKS = 8;
+const TICK_MS = 32;
+const GRAPHEME_SEGMENTER = new Intl.Segmenter(undefined, { granularity: 'grapheme' });
+
+export interface SmoothTextState {
+  readonly source: string;
+  readonly visible: string;
+  readonly pending: readonly string[];
+  readonly ticksLeft: number;
+}
+
+function settledSmoothText(source: string): SmoothTextState {
+  return { source, visible: source, pending: [], ticksLeft: 0 };
+}
+
+function pendingGraphemes(source: string, visibleLength: number): string[] {
+  const pending: string[] = [];
+  for (const { index, segment } of GRAPHEME_SEGMENTER.segment(source)) {
+    const offset = visibleLength - index;
+    if (offset < segment.length) pending.push(segment.slice(Math.max(0, offset)));
+  }
+  return pending;
+}
+
+export function createSmoothTextState(source: string, buffered: boolean): SmoothTextState {
+  if (!buffered || source.length === 0) return settledSmoothText(source);
+  return {
+    source,
+    visible: '',
+    pending: pendingGraphemes(source, 0),
+    ticksLeft: DRAIN_TICKS,
+  };
+}
+
+/** Buffer append-only growth; replacements and reduced-motion rendering settle immediately. */
+export function reconcileSmoothText(
+  current: SmoothTextState,
+  source: string,
+  immediate: boolean,
+): SmoothTextState {
+  if (source === current.source) {
+    return immediate && current.visible !== source ? settledSmoothText(source) : current;
+  }
+  if (immediate || !source.startsWith(current.source)) return settledSmoothText(source);
+
+  return {
+    source,
+    visible: current.visible,
+    pending: pendingGraphemes(source, current.visible.length),
+    ticksLeft: DRAIN_TICKS,
+  };
+}
+
+/** Reveal one share of the backlog, reaching the exact source within the remaining ticks. */
+export function advanceSmoothText(current: SmoothTextState): SmoothTextState {
+  if (current.pending.length === 0) return current;
+
+  const count = Math.ceil(current.pending.length / Math.max(1, current.ticksLeft));
+  if (count >= current.pending.length) return settledSmoothText(current.source);
+
+  return {
+    ...current,
+    visible: current.visible + current.pending.slice(0, count).join(''),
+    pending: current.pending.slice(count),
+    ticksLeft: Math.max(1, current.ticksLeft - 1),
+  };
+}
+
+export function useSmoothText(source: string, isStreaming: boolean): string {
+  const { reduceMotion } = useRenderPrefs();
+  const [state, setState] = useState(() =>
+    createSmoothTextState(source, isStreaming && !reduceMotion),
+  );
+  const sourceRef = useRef(source);
+  useEffect(() => {
+    sourceRef.current = source;
+  }, [source]);
+
+  const immediate = reduceMotion;
+  const replaced = source !== state.source && !source.startsWith(state.source);
+  const current = immediate || replaced ? reconcileSmoothText(state, source, true) : state;
+  if (current !== state) setState(current);
+
+  const active =
+    !immediate && (isStreaming || source !== current.source || current.pending.length > 0);
+  useAbortableEffect(
+    (signal) => {
+      if (!active) return;
+      const timer = window.setInterval(() => {
+        if (signal.aborted) return;
+        setState((latest) =>
+          advanceSmoothText(reconcileSmoothText(latest, sourceRef.current, false)),
+        );
+      }, TICK_MS);
+      return () => window.clearInterval(timer);
+    },
+    [active],
+  );
+
+  return current.visible;
+}


### PR DESCRIPTION
## Summary

- add a presentation-only grapheme buffer for streamed assistant Markdown
- drain bursty updates at a dynamic rate while preserving exact final text
- respect reduced motion and keep Streamdown's incomplete-Markdown handling

## Why

Transport chunks were rendered immediately, so bursty arrivals appeared as whole fragments jumping into the conversation. The canonical conversation state remains unchanged; smoothing happens only at the Markdown presentation boundary.

## Validation

- `pnpm check:ci`
- `pnpm test` — 137 files, 1047 tests
- Desktop mock trace — 49 visible frames, 2-character first frame, monotonic prefixes, max 9-character frame delta, exact 284-character final output

Linear: CODE-218