### PR TITLE
feat(ui): richer tool-call details and stored-session time/model fidelity

### DIFF
--- a/packages/agent-adapter/src/__tests__/claude-code-compaction.test.ts
+++ b/packages/agent-adapter/src/__tests__/claude-code-compaction.test.ts
@@ -2,8 +2,8 @@ import type { SDKMessage, SessionMessage } from '@anthropic-ai/claude-agent-sdk'
 import type { AgentEvent } from '@linkcode/schema';
 import { describe, expect, it } from 'vitest';
 import { asHistoryId } from '../history-util';
-import type { ClaudeCompactionSupplement } from '../native/claude-code';
-import { buildClaudeCompactionSupplement, ClaudeCodeAdapter } from '../native/claude-code';
+import type { ClaudeTranscriptSupplement } from '../native/claude-code';
+import { buildClaudeTranscriptSupplement, ClaudeCodeAdapter } from '../native/claude-code';
 
 /**
  * Context compaction (CODE-141). Verified live against SDK 0.3.179: the CLI compacts **in place**
@@ -117,7 +117,7 @@ describe('ClaudeCodeAdapter live compaction', () => {
   });
 });
 
-describe('buildClaudeCompactionSupplement', () => {
+describe('buildClaudeTranscriptSupplement', () => {
   const boundaryRow = JSON.stringify({
     type: 'system',
     subtype: 'compact_boundary',
@@ -140,7 +140,7 @@ describe('buildClaudeCompactionSupplement', () => {
     });
 
   it('keys the boundary record by the summary row uuid', () => {
-    const supplement = buildClaudeCompactionSupplement([boundaryRow, summaryRow]);
+    const supplement = buildClaudeTranscriptSupplement([boundaryRow, summaryRow]);
     expect(supplement.records.get(ANCHOR_UUID)).toEqual({
       compactionId: BOUNDARY_UUID,
       trigger: 'manual',
@@ -150,7 +150,7 @@ describe('buildClaudeCompactionSupplement', () => {
   });
 
   it('collects the rows before the last boundary as dropped, excluding meta/sidechain rows', () => {
-    const supplement = buildClaudeCompactionSupplement([
+    const supplement = buildClaudeTranscriptSupplement([
       convRow('user', 'u0'),
       convRow('assistant', 'a0'),
       convRow('user', 'meta0', { isMeta: true }),
@@ -180,7 +180,7 @@ describe('buildClaudeCompactionSupplement', () => {
       isCompactSummary: true,
       message: { role: 'user', content: 'Second summary.' },
     });
-    const supplement = buildClaudeCompactionSupplement([
+    const supplement = buildClaudeTranscriptSupplement([
       convRow('user', 'u0'),
       boundaryRow,
       summaryRow,
@@ -196,7 +196,7 @@ describe('buildClaudeCompactionSupplement', () => {
   });
 
   it('skips corrupt lines and rows without the markers', () => {
-    const supplement = buildClaudeCompactionSupplement([
+    const supplement = buildClaudeTranscriptSupplement([
       '{"type":"system","subtype":"compact_boundary"', // torn write
       JSON.stringify({ type: 'user', uuid: 'u1', message: { content: 'plain compact talk' } }),
       boundaryRow,
@@ -206,18 +206,41 @@ describe('buildClaudeCompactionSupplement', () => {
   });
 
   it('keys an orphaned summary row by its own uuid', () => {
-    const supplement = buildClaudeCompactionSupplement([summaryRow]);
+    const supplement = buildClaudeTranscriptSupplement([summaryRow]);
     expect(supplement.records.get(ANCHOR_UUID)).toEqual({ compactionId: ANCHOR_UUID });
   });
 
   it('drops nothing when the session never compacted', () => {
-    const supplement = buildClaudeCompactionSupplement([convRow('user', 'u0')]);
+    const supplement = buildClaudeTranscriptSupplement([convRow('user', 'u0')]);
     expect(supplement.droppedRows).toEqual([]);
     expect(supplement.records.size).toBe(0);
   });
+
+  it('harvests single-result toolUseResult envelopes keyed by tool_use_id', () => {
+    const resultRow = (uuid: string, ids: string[], toolUseResult: unknown) =>
+      JSON.stringify({
+        type: 'user',
+        uuid,
+        message: {
+          role: 'user',
+          content: ids.map((id) => ({ type: 'tool_result', tool_use_id: id, content: 'ok' })),
+        },
+        toolUseResult,
+      });
+    const supplement = buildClaudeTranscriptSupplement([
+      resultRow('r1', ['toolu_1'], { code: 200, codeText: 'OK', result: 'x'.repeat(400) }),
+      // Ambiguous multi-result row: the row-level field cannot be paired, so it is skipped.
+      resultRow('r2', ['toolu_2', 'toolu_3'], { code: 404 }),
+      // Error results carry a plain string — nothing to project.
+      resultRow('r3', ['toolu_4'], 'String to replace not found'),
+    ]);
+    expect([...supplement.toolUseResults.entries()]).toEqual([
+      ['toolu_1', { code: 200, codeText: 'OK' }],
+    ]);
+  });
 });
 
-describe('ClaudeCodeAdapter readHistory compaction', () => {
+describe('ClaudeCodeAdapter readHistory transcript supplement', () => {
   const SESSION = 'session-compact';
 
   function row(type: 'user' | 'assistant', uuid: string, content: unknown): SessionMessage {
@@ -231,12 +254,16 @@ describe('ClaudeCodeAdapter readHistory compaction', () => {
     };
   }
 
+  function supplementOf(partial: Partial<ClaudeTranscriptSupplement>): ClaudeTranscriptSupplement {
+    return { records: new Map(), droppedRows: [], toolUseResults: new Map(), ...partial };
+  }
+
   class HistoryClaude extends ClaudeCodeAdapter {
     supplementReads = 0;
 
     constructor(
       private readonly messages: SessionMessage[],
-      private readonly supplement: ClaudeCompactionSupplement,
+      private readonly supplement: ClaudeTranscriptSupplement,
     ) {
       super();
     }
@@ -249,7 +276,7 @@ describe('ClaudeCodeAdapter readHistory compaction', () => {
       } as T);
     }
 
-    protected override readCompactionSupplement(): Promise<ClaudeCompactionSupplement> {
+    protected override readTranscriptSupplement(): Promise<ClaudeTranscriptSupplement> {
       this.supplementReads += 1;
       return Promise.resolve(this.supplement);
     }
@@ -270,7 +297,7 @@ describe('ClaudeCodeAdapter readHistory compaction', () => {
         row('user', ANCHOR_UUID, 'Summary: everything so far.'),
         row('user', 'u2', [{ type: 'text', text: 'continue' }]),
       ],
-      { records: new Map([[ANCHOR_UUID, record]]), droppedRows: [] },
+      supplementOf({ records: new Map([[ANCHOR_UUID, record]]) }),
     );
     const result = await adapter.readHistory({ historyId: asHistoryId(SESSION) });
     expect(result.events.map((e) => `${e.event.type}:${e.itemId ?? ''}`)).toEqual([
@@ -298,7 +325,7 @@ describe('ClaudeCodeAdapter readHistory compaction', () => {
         row('assistant', 'kept', [{ type: 'text', text: 'preserved reply' }]),
         row('user', 'after', [{ type: 'text', text: 'continue' }]),
       ],
-      {
+      supplementOf({
         records: new Map([[ANCHOR_UUID, record]]),
         // The raw transcript's pre-boundary rows include the preserved row ('kept'), which the
         // SDK also returned — it must not appear twice.
@@ -307,7 +334,7 @@ describe('ClaudeCodeAdapter readHistory compaction', () => {
           row('assistant', 'pre1', [{ type: 'text', text: 'first reply' }]),
           row('assistant', 'kept', [{ type: 'text', text: 'preserved reply' }]),
         ],
-      },
+      }),
     );
     const result = await adapter.readHistory({ historyId: asHistoryId(SESSION) });
     expect(result.events.map((e) => `${e.event.type}:${e.itemId ?? ''}`)).toEqual([
@@ -320,22 +347,48 @@ describe('ClaudeCodeAdapter readHistory compaction', () => {
   });
 
   it('reads history unchanged when the session has no compactions', async () => {
-    const adapter = new HistoryClaude([row('user', 'u0', [{ type: 'text', text: 'hello' }])], {
-      records: new Map(),
-      droppedRows: [],
-    });
+    const adapter = new HistoryClaude(
+      [row('user', 'u0', [{ type: 'text', text: 'hello' }])],
+      supplementOf({}),
+    );
     const result = await adapter.readHistory({ historyId: asHistoryId(SESSION) });
     expect(result.events.map((e) => e.event.type)).toEqual(['user-message']);
   });
 
-  it('skips the transcript read on pages after the first', async () => {
-    const adapter = new HistoryClaude([row('user', 'u0', [{ type: 'text', text: 'hello' }])], {
-      records: new Map([[ANCHOR_UUID, record]]),
-      droppedRows: [],
-    });
-    await adapter.readHistory({ historyId: asHistoryId(SESSION) });
-    expect(adapter.supplementReads).toBe(1);
-    await adapter.readHistory({ historyId: asHistoryId(SESSION), cursor: '1000' });
-    expect(adapter.supplementReads).toBe(1);
+  it('attaches recovered toolUseResult envelopes to replayed settles', async () => {
+    const envelope = { code: 200, codeText: 'OK', durationMs: 12 };
+    const adapter = new HistoryClaude(
+      [
+        row('assistant', 'a0', [
+          { type: 'tool_use', id: 'toolu_1', name: 'WebFetch', input: { url: 'https://a.test' } },
+        ]),
+        row('user', 'u0', [{ type: 'tool_result', tool_use_id: 'toolu_1', content: '# Page' }]),
+      ],
+      supplementOf({ toolUseResults: new Map([['toolu_1', envelope]]) }),
+    );
+    const result = await adapter.readHistory({ historyId: asHistoryId(SESSION) });
+    const settle = result.events.at(-1)?.event;
+    expect(settle?.type).toBe('tool-call');
+    if (settle?.type === 'tool-call') {
+      expect(settle.toolCall.status).toBe('completed');
+      expect(settle.toolCall.rawOutput).toEqual(envelope);
+    }
+  });
+
+  it('reads the supplement on every page but splices dropped rows only into the first', async () => {
+    const adapter = new HistoryClaude(
+      [row('user', 'u0', [{ type: 'text', text: 'hello' }])],
+      supplementOf({
+        records: new Map([[ANCHOR_UUID, record]]),
+        droppedRows: [row('user', 'pre0', [{ type: 'text', text: 'first prompt' }])],
+      }),
+    );
+    const first = await adapter.readHistory({ historyId: asHistoryId(SESSION) });
+    expect(first.events.map((e) => e.itemId)).toEqual(['pre0', 'u0']);
+    // Later pages still read the supplement (their settles need the envelope map) without
+    // re-splicing the pre-compaction rows the first page already emitted.
+    const second = await adapter.readHistory({ historyId: asHistoryId(SESSION), cursor: '1000' });
+    expect(adapter.supplementReads).toBe(2);
+    expect(second.events.map((e) => e.itemId)).toEqual(['u0']);
   });
 });

--- a/packages/agent-adapter/src/__tests__/claude-code-compaction.test.ts
+++ b/packages/agent-adapter/src/__tests__/claude-code-compaction.test.ts
@@ -151,7 +151,7 @@ describe('buildClaudeTranscriptSupplement', () => {
 
   it('collects the rows before the last boundary as dropped, excluding meta/sidechain rows', () => {
     const supplement = buildClaudeTranscriptSupplement([
-      convRow('user', 'u0'),
+      convRow('user', 'u0', { timestamp: '2026-07-16T08:00:00.000Z' }),
       convRow('assistant', 'a0'),
       convRow('user', 'meta0', { isMeta: true }),
       convRow('assistant', 'side0', { isSidechain: true }),
@@ -164,6 +164,8 @@ describe('buildClaudeTranscriptSupplement', () => {
       type: 'user',
       session_id: 'sid-1',
       parent_tool_use_id: null,
+      // The raw row's timestamp rides along so replayed pre-compaction rows keep their times.
+      timestamp: '2026-07-16T08:00:00.000Z',
     });
   });
 

--- a/packages/agent-adapter/src/__tests__/normalize.test.ts
+++ b/packages/agent-adapter/src/__tests__/normalize.test.ts
@@ -10,6 +10,7 @@ import {
   ClaudeCodeAdapter,
   createClaudeHistoryEventMapper,
   mapClaudeStop,
+  toolUseResultEnvelope,
 } from '../native/claude-code';
 import {
   CodexAdapter,
@@ -142,6 +143,41 @@ describe('createClaudeHistoryEventMapper', () => {
     }
   });
 
+  it('flattens a ToolSearch tool_reference settle into a name-per-line text block', () => {
+    const map = createClaudeHistoryEventMapper(historyId);
+    map(
+      row('assistant', 'u1', [
+        {
+          type: 'tool_use',
+          id: 'toolu_1',
+          name: 'ToolSearch',
+          input: { query: 'select:WebFetch' },
+        },
+      ]),
+    );
+    const settle = map(
+      row('user', 'u2', [
+        {
+          type: 'tool_result',
+          tool_use_id: 'toolu_1',
+          content: [
+            { type: 'tool_reference', tool_name: 'WebFetch' },
+            { type: 'tool_reference', tool_name: 'mcp__linear__get_issue' },
+          ],
+        },
+      ]),
+    );
+    expect(settle).toHaveLength(1);
+    if (settle[0].event.type === 'tool-call') {
+      expect(settle[0].event.toolCall.content).toEqual([
+        {
+          type: 'content',
+          content: { type: 'text', text: 'WebFetch\nmcp__linear__get_issue' },
+        },
+      ]);
+    }
+  });
+
   it('keeps plain user prompts and assistant text as message events', () => {
     const map = createClaudeHistoryEventMapper(historyId);
     const prompt = map(row('user', 'u1', 'fix the bug'));
@@ -218,6 +254,39 @@ function toolSnapshots(events: AgentEvent[]) {
   );
 }
 
+describe('toolUseResultEnvelope', () => {
+  it('keeps small scalars and drops payload fields', () => {
+    expect(
+      toolUseResultEnvelope({
+        bytes: 192511,
+        code: 200,
+        codeText: 'OK',
+        durationMs: 5404,
+        url: 'https://en.wikipedia.org/wiki/Arknights',
+        result: 'fetched page text — '.repeat(20),
+        file: { content: 'whole file' },
+        matches: ['a', 'b'],
+        interrupted: false,
+      }),
+    ).toEqual({
+      bytes: 192511,
+      code: 200,
+      codeText: 'OK',
+      durationMs: 5404,
+      url: 'https://en.wikipedia.org/wiki/Arknights',
+      interrupted: false,
+    });
+  });
+
+  it('returns undefined for strings, arrays, and all-payload records', () => {
+    expect(toolUseResultEnvelope('String to replace not found')).toBeUndefined();
+    expect(toolUseResultEnvelope(['a'])).toBeUndefined();
+    expect(
+      toolUseResultEnvelope({ file: { content: 'x' }, stdout: 'y'.repeat(300) }),
+    ).toBeUndefined();
+  });
+});
+
 describe('ClaudeCodeAdapter Edit diff normalization', () => {
   it('announces the Edit diff and keeps it through the settle', () => {
     const adapter = new TestClaude();
@@ -250,6 +319,45 @@ describe('ClaudeCodeAdapter Edit diff normalization', () => {
     expect(tools[1].toolCall.content).toEqual([
       diff,
       { type: 'content', content: { type: 'text', text: 'updated' } },
+    ]);
+  });
+
+  it('projects the live tool_use_result envelope onto the settle rawOutput', () => {
+    const adapter = new TestClaude();
+    const seen: AgentEvent[] = [];
+    adapter.onEvent((e) => seen.push(e));
+
+    adapter.feed({
+      type: 'assistant',
+      message: {
+        content: [
+          { type: 'tool_use', id: 't1', name: 'WebFetch', input: { url: 'https://a.test' } },
+        ],
+      },
+    });
+    adapter.feed({
+      type: 'user',
+      message: { content: [{ type: 'tool_result', tool_use_id: 't1', content: '# Page' }] },
+      tool_use_result: {
+        bytes: 9,
+        code: 200,
+        codeText: 'OK',
+        durationMs: 12,
+        result: 'fetched page text — '.repeat(20),
+        url: 'https://a.test',
+      },
+    });
+
+    const tools = toolSnapshots(seen);
+    expect(tools[1].toolCall.rawOutput).toEqual({
+      bytes: 9,
+      code: 200,
+      codeText: 'OK',
+      durationMs: 12,
+      url: 'https://a.test',
+    });
+    expect(tools[1].toolCall.content).toEqual([
+      { type: 'content', content: { type: 'text', text: '# Page' } },
     ]);
   });
 

--- a/packages/agent-adapter/src/__tests__/normalize.test.ts
+++ b/packages/agent-adapter/src/__tests__/normalize.test.ts
@@ -51,6 +51,7 @@ function row(
   uuid: string,
   content: string | unknown[],
   parentToolUseId: string | null = null,
+  extra?: { timestamp?: string; model?: string },
 ): SessionMessage {
   return {
     type,
@@ -58,7 +59,8 @@ function row(
     session_id: 'h1',
     parent_tool_use_id: parentToolUseId,
     parent_agent_id: null,
-    message: { content },
+    message: { content, ...(extra?.model && { model: extra.model }) },
+    ...(extra?.timestamp && { timestamp: extra.timestamp }),
   };
 }
 
@@ -176,6 +178,61 @@ describe('createClaudeHistoryEventMapper', () => {
         },
       ]);
     }
+  });
+
+  it('stamps ts from the row timestamp and replays the served model as model-update', () => {
+    const map = createClaudeHistoryEventMapper(historyId);
+    const at = '2026-07-16T12:00:00.000Z';
+    const first = map(
+      row('assistant', 'u1', [{ type: 'text', text: 'hello' }], null, {
+        timestamp: at,
+        model: 'claude-opus-4-8',
+      }),
+    );
+    expect(first.map((e) => `${e.event.type}@${e.ts ?? ''}`)).toEqual([
+      `model-update@${Date.parse(at)}`,
+      `agent-message-chunk@${Date.parse(at)}`,
+    ]);
+    if (first[0].event.type === 'model-update') {
+      expect(first[0].event.model).toBe('claude-opus-4-8');
+    }
+
+    // Same model on the next row: no repeat announcement.
+    const second = map(
+      row('assistant', 'u2', [{ type: 'text', text: 'more' }], null, {
+        model: 'claude-opus-4-8',
+      }),
+    );
+    expect(second.map((e) => e.event.type)).toEqual(['agent-message-chunk']);
+
+    // A switch re-announces; a subagent row's model never does.
+    const switched = map(
+      row('assistant', 'u3', [{ type: 'text', text: 'switched' }], null, {
+        model: 'claude-sonnet-5',
+      }),
+    );
+    expect(switched.map((e) => e.event.type)).toEqual(['model-update', 'agent-message-chunk']);
+    const subagent = map(
+      row('assistant', 'u4', [{ type: 'text', text: 'sub' }], 'toolu_task', {
+        model: 'claude-haiku-4-5',
+      }),
+    );
+    expect(subagent.map((e) => e.event.type)).toEqual(['agent-message-chunk']);
+  });
+
+  it('stamps ts on user prompts and tool settles', () => {
+    const map = createClaudeHistoryEventMapper(historyId);
+    const at = '2026-07-16T12:34:56.000Z';
+    const prompt = map(row('user', 'u1', 'fix the bug', null, { timestamp: at }));
+    expect(prompt[0].ts).toBe(Date.parse(at));
+
+    map(row('assistant', 'u2', [{ type: 'tool_use', id: 'toolu_1', name: 'Read', input: {} }]));
+    const settle = map(
+      row('user', 'u3', [{ type: 'tool_result', tool_use_id: 'toolu_1', content: 'body' }], null, {
+        timestamp: at,
+      }),
+    );
+    expect(settle[0].ts).toBe(Date.parse(at));
   });
 
   it('keeps plain user prompts and assistant text as message events', () => {

--- a/packages/agent-adapter/src/native/claude-code.ts
+++ b/packages/agent-adapter/src/native/claude-code.ts
@@ -66,6 +66,7 @@ import {
   firstText,
   isRecord,
   numberField,
+  stringField,
   textHistoryEvent,
   timestampMs,
 } from '../history-util';
@@ -1341,7 +1342,7 @@ export function buildClaudeTranscriptSupplement(
   const records = new Map<string, ClaudeCompactionRecord>();
   const toolUseResults = new Map<string, Record<string, unknown>>();
   /** Conversation rows in file order, with the index of the last boundary seen before each. */
-  const rows: Array<{ row: SessionMessage; boundariesBefore: number }> = [];
+  const rows: Array<{ row: TimestampedSessionMessage; boundariesBefore: number }> = [];
   let boundaries = 0;
   let pending: ClaudeCompactionRecord | null = null;
   for (const line of lines) {
@@ -1386,6 +1387,7 @@ export function buildClaudeTranscriptSupplement(
         message: row.message,
         parent_tool_use_id: null,
         parent_agent_id: null,
+        ...(typeof row.timestamp === 'string' && { timestamp: row.timestamp }),
       },
       boundariesBefore: boundaries,
     });
@@ -1495,6 +1497,10 @@ async function readSubagentTranscripts(
  * the provider's `toolu_` ids, so a seeded timeline and live re-emits of the same call converge
  * by id (`buildConversation` replaces tool calls by id) instead of duplicating.
  */
+/** `getSessionMessages` rows (and the supplement's raw rows) carry an ISO `timestamp` at runtime
+ * that the SDK's `SessionMessage` type omits — verified live on 0.3.206. */
+type TimestampedSessionMessage = SessionMessage & { timestamp?: string };
+
 export function createClaudeHistoryEventMapper(
   historyId: AgentHistoryId,
   compactions?: ReadonlyMap<string, ClaudeCompactionRecord>,
@@ -1503,14 +1509,16 @@ export function createClaudeHistoryEventMapper(
   toolUseResults?: ReadonlyMap<string, Record<string, unknown>>,
 ): (message: SessionMessage) => AgentHistoryEvent[] {
   const announced = new Map<string, ToolCall>();
-
-  const toolEvent = (toolCall: ToolCall): AgentHistoryEvent => {
-    announced.set(toolCall.toolCallId, toolCall);
-    return { historyId, itemId: toolCall.toolCallId, event: { type: 'tool-call', toolCall } };
-  };
+  /** Last model announced to the timeline; assistant rows re-announce only on change. */
+  let lastModel: string | undefined;
 
   return (message) => {
     if (message.type !== 'user' && message.type !== 'assistant') return [];
+    const ts = timestampMs((message as TimestampedSessionMessage).timestamp);
+    const toolEvent = (toolCall: ToolCall): AgentHistoryEvent => {
+      announced.set(toolCall.toolCallId, toolCall);
+      return { historyId, itemId: toolCall.toolCallId, ts, event: { type: 'tool-call', toolCall } };
+    };
     // A compaction's swapped-in summary is stored as a user row; replaying it as a user prompt
     // would fake a giant user turn (the reported CODE-141 symptom). It becomes the compaction
     // marker instead, placed exactly where the summary sits in the timeline.
@@ -1523,6 +1531,7 @@ export function createClaudeHistoryEventMapper(
         {
           historyId,
           itemId: compaction.compactionId,
+          ts,
           event: { type: 'compaction', ...compaction, ...(summary && { summary }) },
         },
       ];
@@ -1533,12 +1542,21 @@ export function createClaudeHistoryEventMapper(
     const parent = message.parent_tool_use_id ?? undefined;
 
     if (message.type === 'assistant') {
+      // Every assistant row records the model that served it; replay it as the same model-update
+      // the live stream emits so seeded messages get their per-turn model stamp. Subagent rows
+      // are skipped — their model must not masquerade as the session's.
+      const model =
+        !parent && isRecord(message.message) ? stringField(message.message, 'model') : undefined;
+      if (model && model !== lastModel) {
+        lastModel = model;
+        events.push({ historyId, ts, event: { type: 'model-update', model } });
+      }
       const text = textHistoryEvent(
         historyId,
         'assistant',
         message.uuid,
         message.message,
-        undefined,
+        ts,
         parent,
       );
       if (text) events.push(text);
@@ -1585,7 +1603,7 @@ export function createClaudeHistoryEventMapper(
     // tool_results is a prompt the user actually typed.
     const promptValue =
       results.length === 0 ? message.message : blocks.filter((block) => !isToolResultBlock(block));
-    const text = textHistoryEvent(historyId, 'user', message.uuid, promptValue);
+    const text = textHistoryEvent(historyId, 'user', message.uuid, promptValue, ts);
     if (text) events.push(text);
     return events;
   };

--- a/packages/agent-adapter/src/native/claude-code.ts
+++ b/packages/agent-adapter/src/native/claude-code.ts
@@ -365,7 +365,11 @@ export function mapClaudeUsageReport(raw: SDKControlGetUsageResponse): UsageRepo
   } satisfies UsageReport);
 }
 
-const EMPTY_SUPPLEMENT: ClaudeCompactionSupplement = { records: new Map(), droppedRows: [] };
+const EMPTY_SUPPLEMENT: ClaudeTranscriptSupplement = {
+  records: new Map(),
+  droppedRows: [],
+  toolUseResults: new Map(),
+};
 
 /**
  * Claude Code adapter — drives `@anthropic-ai/claude-agent-sdk` via `query()` in **streaming input
@@ -498,20 +502,24 @@ export class ClaudeCodeAdapter extends BaseAgentAdapter {
     );
     const offset = cursorOffset(opts.cursor);
     const limit = boundedLimit(opts.limit, 1000, 1000);
-    const [info, messages, subagentEvents, compactions] = await Promise.all([
+    const [info, messages, subagentEvents, supplement] = await Promise.all([
       mod.getSessionInfo(opts.historyId),
       mod.getSessionMessages(opts.historyId, {
         limit: limit + 1,
         offset,
       }),
       readSubagentTranscripts(mod, opts.historyId),
-      // The supplement only affects the first page — the swapped-in summary is the SDK chain's
-      // head row and the dropped rows are prepended before it — so later pages skip the
-      // whole-transcript read.
-      offset === 0 ? this.readCompactionSupplement(opts.historyId) : EMPTY_SUPPLEMENT,
+      // Every page needs the raw transcript: getSessionMessages strips each result row's
+      // structured toolUseResult, so the mapper re-attaches envelopes from here. The compaction
+      // splice below stays first-page-only (the swapped-in summary is the SDK chain's head row).
+      this.readTranscriptSupplement(opts.historyId),
     ]);
     const historyId = opts.historyId;
-    const mapper = createClaudeHistoryEventMapper(historyId, compactions.records);
+    const mapper = createClaudeHistoryEventMapper(
+      historyId,
+      supplement.records,
+      supplement.toolUseResults,
+    );
     const events: AgentHistoryEvent[] = [];
     // Splice each subagent's transcript in right after its spawn announce, so the seeded order
     // matches the live stream and the children land inside the parent's turn (the UI's per-segment
@@ -540,7 +548,8 @@ export class ClaudeCodeAdapter extends BaseAgentAdapter {
     // relinked into the post-compaction chain) are deduped by uuid. The dedup window is this page
     // only — safe because the preserved segment sits right after the summary head, well inside it.
     const returned = new Set(page.map((message) => message.uuid));
-    const dropped = compactions.droppedRows.filter((row) => !returned.has(row.uuid));
+    const dropped =
+      offset === 0 ? supplement.droppedRows.filter((row) => !returned.has(row.uuid)) : [];
     for (const message of [...dropped, ...page]) {
       for (const event of mapper(message)) pushWithSubagents(event);
     }
@@ -553,9 +562,9 @@ export class ClaudeCodeAdapter extends BaseAgentAdapter {
     };
   }
 
-  /** Test seam over the raw transcript probe (see `readClaudeCompactionSupplement`). */
-  protected readCompactionSupplement(sessionId: string): Promise<ClaudeCompactionSupplement> {
-    return readClaudeCompactionSupplement(sessionId);
+  /** Test seam over the raw transcript probe (see `readClaudeTranscriptSupplement`). */
+  protected readTranscriptSupplement(sessionId: string): Promise<ClaudeTranscriptSupplement> {
+    return readClaudeTranscriptSupplement(sessionId);
   }
 
   protected async onPrompt(content: ContentBlock[]): Promise<void> {
@@ -1139,6 +1148,9 @@ export class ClaudeCodeAdapter extends BaseAgentAdapter {
   private handleUser(msg: UserSDKMessage): void {
     const content = msg.message.content;
     if (typeof content === 'string') return;
+    // tool_use_result is message-level; only an unambiguous single-result frame can claim it.
+    const results = content.filter((block) => block.type === 'tool_result');
+    const envelope = results.length === 1 ? toolUseResultEnvelope(msg.tool_use_result) : undefined;
     for (const block of content) {
       if (block.type !== 'tool_result') continue;
       const diff = this.pendingEditDiffs.get(block.tool_use_id) ?? [];
@@ -1150,7 +1162,7 @@ export class ClaudeCodeAdapter extends BaseAgentAdapter {
         parentToolCallId: msg.parent_tool_use_id ?? undefined,
         status: block.is_error === true ? 'failed' : 'completed',
         content: [...diff, ...toolResultContent(block.content)],
-        rawOutput: block.content,
+        rawOutput: envelope ?? block.content,
       });
     }
   }
@@ -1219,24 +1231,59 @@ function editDiffContent(toolName: string, input: unknown): ToolCallContent[] | 
   return undefined;
 }
 
+const TOOL_USE_RESULT_SCALAR_MAX = 256;
+
+/**
+ * Claude pairs every tool_result with a structured `tool_use_result` (live SDK user frames and raw
+ * transcript rows both carry it; `getSessionMessages` strips it). It mixes small envelope fields
+ * the UI wants (WebFetch `code`/`codeText`/`durationMs`/`bytes`, ToolSearch counts) with bulk
+ * payloads duplicating the result content (`originalFile`, `file.content`, `stdout`). Project only
+ * the scalars onto `rawOutput`: badges need them, and re-shipping whole files in every settle frame
+ * is pure bloat. Strings above the cap are payload, not envelope.
+ */
+export function toolUseResultEnvelope(value: unknown): Record<string, unknown> | undefined {
+  if (!isRecord(value)) return undefined;
+  const envelope: Record<string, unknown> = {};
+  let fields = 0;
+  for (const [key, field] of Object.entries(value)) {
+    const scalar =
+      typeof field === 'string'
+        ? field.length > 0 && field.length <= TOOL_USE_RESULT_SCALAR_MAX
+        : typeof field === 'number' || typeof field === 'boolean';
+    if (!scalar) continue;
+    envelope[key] = field;
+    fields += 1;
+  }
+  return fields > 0 ? envelope : undefined;
+}
+
 /** Normalize a tool_result's payload (string or content blocks) into tool-call content. Accepts
- * `unknown` because it also runs over untyped transcript rows, not only live SDK messages. */
+ * `unknown` because it also runs over untyped transcript rows, not only live SDK messages.
+ * ToolSearch settles with `tool_reference` blocks and no text at all; flatten those to one
+ * name-per-line text block so the call doesn't render as an empty result. */
 function toolResultContent(content: unknown): ToolCallContent[] {
   if (typeof content === 'string') {
     return content.length > 0 ? [{ type: 'content', content: textBlock(content) }] : [];
   }
   if (!Array.isArray(content)) return [];
-  return content.reduce<ToolCallContent[]>((items, block) => {
-    if (
-      isRecord(block) &&
-      block.type === 'text' &&
-      typeof block.text === 'string' &&
-      block.text.length > 0
-    ) {
+  const toolReferences: string[] = [];
+  const items = content.reduce<ToolCallContent[]>((items, block) => {
+    if (!isRecord(block)) return items;
+    if (block.type === 'text' && typeof block.text === 'string' && block.text.length > 0) {
       items.push({ type: 'content', content: textBlock(block.text) });
+    } else if (
+      block.type === 'tool_reference' &&
+      typeof block.tool_name === 'string' &&
+      block.tool_name.length > 0
+    ) {
+      toolReferences.push(block.tool_name);
     }
     return items;
   }, []);
+  if (toolReferences.length > 0) {
+    items.push({ type: 'content', content: textBlock(toolReferences.join('\n')) });
+  }
+  return items;
 }
 
 /** Flatten a user message's payload (string or API content blocks) into plain text — the shape a
@@ -1263,8 +1310,8 @@ export interface ClaudeCompactionRecord {
   postTokens?: number;
 }
 
-/** What the raw transcript knows about compactions that the SDK read API loses. */
-export interface ClaudeCompactionSupplement {
+/** What the raw transcript knows that the SDK read API loses. */
+export interface ClaudeTranscriptSupplement {
   /** Swapped-in-summary row uuid → its boundary's record, for the mapper to turn the summary row
    * into a compaction marker instead of a fake user prompt. */
   records: Map<string, ClaudeCompactionRecord>;
@@ -1273,21 +1320,26 @@ export interface ClaudeCompactionSupplement {
    * before the last compaction vanishes from the read. In file (= chronological) order; rows the
    * SDK does still return (the preserved segment) are deduped by uuid at read time. */
   droppedRows: SessionMessage[];
+  /** tool_use_id → projected `toolUseResult` envelope (`toolUseResultEnvelope`), another field
+   * `getSessionMessages` strips per row. Keyed only for unambiguous single-result rows. */
+  toolUseResults: Map<string, Record<string, unknown>>;
 }
 
 /**
- * Recover, from raw transcript lines, what the SDK read API strips about compactions (verified
- * against SDK 0.3.179). On disk a compaction is a `system/compact_boundary` row (camelCase
- * `compactMetadata`) followed by an `isCompactSummary:true` user row carrying the swapped-in
- * summary; a boundary claims the next summary row. `getSessionMessages` keeps only
- * type/uuid/session_id/message/parent_tool_use_id/timestamp per row — the boundary's metadata and
- * the summary flag never survive — and its chain reconstruction drops every row logically before
- * the newest summary, so both the marker and the pre-compaction timeline must come from here.
+ * Recover, from raw transcript lines, what the SDK read API strips (verified against SDK 0.3.179;
+ * `toolUseResult` re-verified on 0.3.206). On disk a compaction is a `system/compact_boundary` row
+ * (camelCase `compactMetadata`) followed by an `isCompactSummary:true` user row carrying the
+ * swapped-in summary; a boundary claims the next summary row. `getSessionMessages` keeps only
+ * type/uuid/session_id/message/parent_tool_use_id/timestamp per row — the boundary's metadata, the
+ * summary flag, and each result row's structured `toolUseResult` never survive — and its chain
+ * reconstruction drops every row logically before the newest summary, so the marker, the
+ * pre-compaction timeline, and the result envelopes must all come from here.
  */
-export function buildClaudeCompactionSupplement(
+export function buildClaudeTranscriptSupplement(
   lines: Iterable<string>,
-): ClaudeCompactionSupplement {
+): ClaudeTranscriptSupplement {
   const records = new Map<string, ClaudeCompactionRecord>();
+  const toolUseResults = new Map<string, Record<string, unknown>>();
   /** Conversation rows in file order, with the index of the last boundary seen before each. */
   const rows: Array<{ row: SessionMessage; boundariesBefore: number }> = [];
   let boundaries = 0;
@@ -1321,6 +1373,9 @@ export function buildClaudeCompactionSupplement(
       records.set(uuid, pending ?? { compactionId: uuid });
       pending = null;
     } else if (row.type !== 'user' && row.type !== 'assistant') continue;
+    // Harvested before the exclusions: tool_use ids are globally unique, so keying a row the
+    // timeline itself skips is harmless.
+    if (row.type === 'user') harvestToolUseResult(toolUseResults, row);
     // Same exclusions as the SDK's own reader: meta rows, sidechains, and teammate rows.
     if (row.isMeta === true || row.isSidechain === true || row.teamName) continue;
     rows.push({
@@ -1343,18 +1398,39 @@ export function buildClaudeCompactionSupplement(
       if (r.boundariesBefore < boundaries) dropped.push(r.row);
       return dropped;
     }, []),
+    toolUseResults,
   };
 }
 
+/** Key a raw result row's `toolUseResult` envelope by its tool_use id. The field is row-level, so
+ * only a row with exactly one tool_result block pairs unambiguously. */
+function harvestToolUseResult(
+  map: Map<string, Record<string, unknown>>,
+  row: Record<string, unknown>,
+): void {
+  const envelope = toolUseResultEnvelope(row.toolUseResult);
+  if (!envelope) return;
+  const message = isRecord(row.message) ? row.message : undefined;
+  const content = message?.content;
+  if (!Array.isArray(content)) return;
+  const ids = content.reduce<string[]>((ids, block) => {
+    if (isRecord(block) && block.type === 'tool_result' && typeof block.tool_use_id === 'string') {
+      ids.push(block.tool_use_id);
+    }
+    return ids;
+  }, []);
+  if (ids.length === 1) map.set(ids[0], envelope);
+}
+
 /**
- * Locate the session's transcript and build its compaction supplement. `readHistory` carries no
- * cwd, so — mirroring `getSessionMessages` without `dir` — every project dir is probed for
+ * Locate the session's transcript and build its supplement. `readHistory` carries no cwd, so —
+ * mirroring `getSessionMessages` without `dir` — every project dir is probed for
  * `<sessionId>.jsonl` (the id is unique, so at most one probe succeeds). Any failure degrades to
- * an empty supplement: history still reads, just without compaction markers.
+ * an empty supplement: history still reads, just without compaction markers or result envelopes.
  */
-async function readClaudeCompactionSupplement(
+async function readClaudeTranscriptSupplement(
   sessionId: string,
-): Promise<ClaudeCompactionSupplement> {
+): Promise<ClaudeTranscriptSupplement> {
   // The id becomes a filename — refuse anything that could traverse out of the projects dir.
   if (!SAFE_SESSION_ID.test(sessionId)) return EMPTY_SUPPLEMENT;
   const projectsDir = path.join(homedir(), '.claude', 'projects');
@@ -1370,7 +1446,7 @@ async function readClaudeCompactionSupplement(
     ),
   );
   const text = texts.find((t) => t !== null);
-  return text ? buildClaudeCompactionSupplement(text.split('\n')) : EMPTY_SUPPLEMENT;
+  return text ? buildClaudeTranscriptSupplement(text.split('\n')) : EMPTY_SUPPLEMENT;
 }
 
 function mapClaudeHistorySession(session: SDKSessionInfo): AgentHistorySession {
@@ -1422,6 +1498,9 @@ async function readSubagentTranscripts(
 export function createClaudeHistoryEventMapper(
   historyId: AgentHistoryId,
   compactions?: ReadonlyMap<string, ClaudeCompactionRecord>,
+  /** Result envelopes recovered from the raw transcript (`ClaudeTranscriptSupplement`) —
+   * getSessionMessages strips them, so replayed settles read theirs from here. */
+  toolUseResults?: ReadonlyMap<string, Record<string, unknown>>,
 ): (message: SessionMessage) => AgentHistoryEvent[] {
   const announced = new Map<string, ToolCall>();
 
@@ -1495,7 +1574,7 @@ export function createClaudeHistoryEventMapper(
           // Announce-time content is the Edit diff (or empty); keep it ahead of the result text.
           content: [...(existing?.content ?? []), ...toolResultContent(block.content)],
           rawInput: existing?.rawInput,
-          rawOutput: block.content,
+          rawOutput: toolUseResults?.get(block.tool_use_id) ?? block.content,
         }),
       );
     }

--- a/packages/client-core/src/__tests__/conversation-store.test.ts
+++ b/packages/client-core/src/__tests__/conversation-store.test.ts
@@ -46,13 +46,15 @@ describe('createConversationStore', () => {
     await tick();
 
     const store = createConversationStore(client, sessionId, {
-      events: [userText('from transcript')],
+      events: [{ event: userText('from transcript'), ts: 1_700_000_000_000 }],
       uptoSeq: 2,
     });
     const seeded = store.getSnapshot();
     expect(seeded.items.map((i) => (i.kind === 'message' ? i.blocks : null))).toEqual([
       [{ type: 'text', text: 'from transcript' }],
     ]);
+    // The provider timestamp stands in for the receive time live events get.
+    expect(seeded.items[0].receivedAt).toBe(1_700_000_000_000);
     // Identity is stable until the next event — the useSyncExternalStore contract.
     expect(store.getSnapshot()).toBe(seeded);
 
@@ -94,7 +96,7 @@ describe('createConversationStore', () => {
 
     // The snapshot (read mid-turn) already covers the prompt and the announce, never the ask.
     const store = createConversationStore(client, sessionId, {
-      events: [userText('run echo'), announce],
+      events: [{ event: userText('run echo') }, { event: announce }],
       uptoSeq: 4,
     });
     const conversation = store.getSnapshot();

--- a/packages/client-core/src/__tests__/conversation.test.ts
+++ b/packages/client-core/src/__tests__/conversation.test.ts
@@ -76,6 +76,30 @@ describe('buildConversation', () => {
     expect(c.items).toEqual([]);
   });
 
+  it('stamps assistant messages with the model serving them, backfilling late reports', () => {
+    const c = buildConversation([
+      { type: 'model-update', model: 'claude-opus-4-8' },
+      userText('first'),
+      text('reply one', 'm1'),
+      { type: 'model-update', model: 'claude-sonnet-5' },
+      userText('second'),
+      text('reply two', 'm2'),
+    ]);
+    const models = c.items.flatMap((item) =>
+      item.kind === 'message' && item.role === 'assistant' ? [item.model] : [],
+    );
+    expect(models).toEqual(['claude-opus-4-8', 'claude-sonnet-5']);
+
+    // A model reported only mid-stream still lands on the already-open message.
+    const late = buildConversation([
+      text('opens dateless', 'm3'),
+      { type: 'model-update', model: 'claude-opus-4-8' },
+      text(' — continued', 'm3'),
+    ]);
+    const item = late.items[0];
+    expect(item.kind === 'message' && item.model).toBe('claude-opus-4-8');
+  });
+
   it('coalesces same-messageId agent chunks into one streaming block', () => {
     const c = buildConversation([
       { type: 'status', status: 'running' },

--- a/packages/client-core/src/conversation-store.ts
+++ b/packages/client-core/src/conversation-store.ts
@@ -71,7 +71,7 @@ export function createConversationStore(
   const sync = (): void => {
     if (!seeded) {
       seeded = true;
-      if (seed) for (const event of seed.events) builder.advance(event);
+      if (seed) for (const entry of seed.events) builder.advance(entry.event, entry.ts);
     }
     if (client.eventSeq(sessionId) <= consumedSeq) return;
     const events = client.eventsSnapshot(sessionId);

--- a/packages/client-core/src/conversation.ts
+++ b/packages/client-core/src/conversation.ts
@@ -35,9 +35,10 @@ export type QuestionResolution = Pick<
   'outcome' | 'source'
 >;
 
-/** A single semantic item in the conversation timeline. `receivedAt` is the client receive time of
- * the item's latest event (see {@link SequencedAgentEvent}); it drives relative timestamps in the
- * UI and is absent for items reconstructed from a history read. */
+/** A single semantic item in the conversation timeline. `receivedAt` is the best-known time of the
+ * item's latest event: the client receive time for live events (see {@link SequencedAgentEvent}),
+ * the provider's own timestamp for items reconstructed from a history read, absent when neither is
+ * known. It drives the timestamps in the UI. */
 export type ConversationItem = (
   | {
       kind: 'message';
@@ -48,6 +49,8 @@ export type ConversationItem = (
       isStreaming: boolean;
       /** Set on subagent narration: the `task`-kind tool call that spawned it (nested in the UI). */
       parentToolCallId?: string;
+      /** The model serving the session when this assistant message opened (from `model-update`). */
+      model?: string;
     }
   | {
       kind: 'reasoning';
@@ -160,8 +163,9 @@ function appendBlock(blocks: readonly ContentBlock[], block: ContentBlock): Cont
 }
 
 export interface ConversationBuilder {
-  /** Fold one more event into the running state. `receivedAt` is the client receive time to stamp
-   * on the item(s) this event touches (omitted for events replayed from a history read). */
+  /** Fold one more event into the running state. `receivedAt` is the time to stamp on the item(s)
+   * this event touches: the client receive time for live events, the provider's own event
+   * timestamp for history-read replays (omitted when the provider recorded none). */
   advance(event: AgentEvent, receivedAt?: number): void;
   /** The current view-model. Cached between advances; every changed item is a fresh object
    * (copy-on-write), so React memoization over items keeps working across snapshots. */
@@ -224,6 +228,8 @@ export function createConversationBuilder(): ConversationBuilder {
           ...item,
           blocks: appendBlock(item.blocks, block),
           receivedAt: receivedAt ?? item.receivedAt,
+          // Backfill a model the adapter only reported after this message opened.
+          ...(item.kind === 'message' && { model: item.model ?? currentModel ?? undefined }),
         };
         return;
       }
@@ -238,6 +244,7 @@ export function createConversationBuilder(): ConversationBuilder {
         isStreaming: false,
         parentToolCallId,
         receivedAt,
+        model: currentModel ?? undefined,
       });
     } else {
       items.push({
@@ -559,11 +566,18 @@ export function buildConversation(events: readonly AgentEvent[]): Conversation {
   return builder.snapshot();
 }
 
+/** One seeded event with the provider's own timestamp (`AgentHistoryEvent.ts`), which stands in
+ * for the receive time live events get — without it, every history-seeded item is dateless. */
+export interface ConversationSeedEvent {
+  event: AgentEvent;
+  ts?: number;
+}
+
 /** A point-in-time transcript snapshot: past events read from provider history, plus the live
  * stream's receive counter sampled when the read resolved (see `LinkCodeClient.eventSeq`). The
  * conversation store folds the seed first, then only the live events past the `uptoSeq` cut. */
 export interface ConversationSeed {
-  events: AgentEvent[];
+  events: ConversationSeedEvent[];
   /** The snapshot covers every live event with seq ≤ this; 0 = supersedes nothing. */
   uptoSeq: number;
 }

--- a/packages/engine/src/__tests__/engine-file-suggest.test.ts
+++ b/packages/engine/src/__tests__/engine-file-suggest.test.ts
@@ -8,6 +8,7 @@ import type { Transport } from '@linkcode/transport';
 import { createWireMessage } from '@linkcode/transport';
 import { nullthrow } from 'foxts/guard';
 import { noop } from 'foxts/noop';
+import { waitFor } from 'foxts/wait-for';
 import { afterAll, describe, expect, it, vi } from 'vitest';
 import { Engine } from '../engine';
 import { FileSuggestService } from '../file-suggest-service';
@@ -34,13 +35,6 @@ function fakeAdapter(): AgentAdapter {
   };
 }
 
-/** Let the fire-and-forget handle() chains settle. */
-function tick(): Promise<void> {
-  return new Promise((resolve) => {
-    setTimeout(resolve, 0);
-  });
-}
-
 function harness(store: SessionStore = new InMemorySessionStore()) {
   const sent: WirePayload[] = [];
   let handler: ((msg: WireMessage) => void) | null = null;
@@ -60,9 +54,11 @@ function harness(store: SessionStore = new InMemorySessionStore()) {
   const suggest = vi.spyOn(fileSuggest, 'suggest').mockResolvedValue([{ path: 'src/index.ts' }]);
   const engine = new Engine(transport, { factory: fakeAdapter, fileSuggest, sessionStore: store });
 
-  async function inject(payload: WirePayload): Promise<void> {
+  // handle() is fire-and-forget, so a fixed tick races the reply under parallel-suite load;
+  // every request kind replies via tryReply, so the echoed replyTo is the settled signal.
+  async function inject(payload: Extract<WirePayload, { clientReqId: string }>): Promise<void> {
     nullthrow(handler, 'engine not started')(createWireMessage(payload));
-    await tick();
+    await waitFor(() => sent.some((p) => 'replyTo' in p && p.replyTo === payload.clientReqId), 5);
   }
 
   return { engine, sent, inject, suggest };

--- a/packages/i18n/src/locales/en.ts
+++ b/packages/i18n/src/locales/en.ts
@@ -32,6 +32,8 @@ export const en = {
       status: 'Status',
       matches: 'Matches',
       files: 'Files',
+      duration: 'Duration',
+      size: 'Size',
       kindRead: 'Read',
       kindEdit: 'Edit',
       kindDelete: 'Delete',

--- a/packages/i18n/src/locales/zh-cn.ts
+++ b/packages/i18n/src/locales/zh-cn.ts
@@ -30,6 +30,8 @@ export const zhCN = {
       status: '状态',
       matches: '匹配',
       files: '文件',
+      duration: '耗时',
+      size: '大小',
       kindRead: '读取',
       kindEdit: '编辑',
       kindDelete: '删除',

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -42,6 +42,8 @@
     "lucide-react": "^1.23.0",
     "mermaid": "^11.16.0",
     "motion": "^12.42.2",
+    "pretty-bytes": "^7.1.1",
+    "pretty-ms": "^9.3.0",
     "restty": "^0.2.5",
     "streamdown": "^2.5.0",
     "tailwind-merge": "^3.6.0",

--- a/packages/ui/src/chat/__tests__/tool-call-metadata.test.tsx
+++ b/packages/ui/src/chat/__tests__/tool-call-metadata.test.tsx
@@ -3,8 +3,14 @@
 import type { ToolCall } from '@linkcode/schema';
 import { cleanup, render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { ToolCallBody } from '../tool-call-item';
-import { hasToolBody, toolCallHeaderSummary, toolCallMetadata } from '../tool-utils';
+import { ToolCallBody, ToolCallItem } from '../tool-call-item';
+import {
+  hasToolBody,
+  mcpToolName,
+  toolCallContextSummary,
+  toolCallHeaderSummary,
+  toolCallMetadata,
+} from '../tool-utils';
 
 function translateKey(key: string): string {
   return key;
@@ -87,13 +93,18 @@ describe('tool metadata policy', () => {
     expect(container.textContent).not.toContain('responseBody');
   });
 
-  it('previews standardized custom-tool output without exposing arbitrary fields', () => {
+  it('shows scalar input params for custom tools while keeping the output envelope curated', () => {
     const toolCall: ToolCall = {
       toolCallId: 'other-1',
       title: 'workspace.inspect',
       kind: 'other',
       status: 'completed',
-      rawInput: { workspaceId: 'internal-42', includeDebug: true },
+      rawInput: {
+        workspaceId: 'internal-42',
+        includeDebug: true,
+        options: { nested: 'hidden' },
+        tags: ['also-hidden'],
+      },
       rawOutput: { requestId: 'request-42', structuredContent: { ok: true } },
       content: [],
     };
@@ -101,8 +112,13 @@ describe('tool metadata policy', () => {
     const { container } = render(<ToolCallBody toolCall={toolCall} />);
 
     expect(container.querySelector('pre')?.textContent).toContain('"ok": true');
+    // Scalar inputs are the call's headline details; nested envelopes stay hidden.
+    expect(screen.getByText('workspaceId')).toBeDefined();
+    expect(screen.getByText('internal-42')).toBeDefined();
+    expect(screen.getByText('includeDebug')).toBeDefined();
+    expect(container.textContent).not.toContain('nested');
+    expect(container.textContent).not.toContain('also-hidden');
     expect(container.textContent).not.toContain('request-42');
-    expect(container.textContent).not.toContain('workspaceId');
     expect(hasToolBody(toolCall)).toBe(true);
   });
 
@@ -143,7 +159,7 @@ describe('tool metadata policy', () => {
     expect(container.textContent).not.toContain('internalPath');
   });
 
-  it('projects live Codex MCP result content without exposing its raw envelopes', () => {
+  it('projects live Codex MCP result content without exposing its raw output envelope', () => {
     const toolCall: ToolCall = {
       toolCallId: 'codex-mcp-1',
       title: 'linear.get_issue',
@@ -161,7 +177,7 @@ describe('tool metadata policy', () => {
 
     expect(hasToolBody(toolCall)).toBe(true);
     expect(screen.getByText('CODE-173 is in progress')).toBeDefined();
-    expect(container.textContent).not.toContain('issueId');
+    expect(screen.getByText('issueId')).toBeDefined();
     expect(container.textContent).not.toContain('structuredContent');
     expect(container.textContent).not.toContain('opaque-173');
   });
@@ -200,6 +216,73 @@ describe('tool metadata policy', () => {
     expect(hasToolBody(toolCall)).toBe(true);
     expect(container.querySelector('pre')?.textContent).toBe('command unavailable');
     expect(container.textContent).not.toContain('exitCode');
+  });
+
+  it('badges a Claude WebFetch envelope as status, duration, and size', () => {
+    const toolCall: ToolCall = {
+      toolCallId: 'fetch-envelope',
+      title: 'WebFetch',
+      kind: 'fetch',
+      status: 'completed',
+      rawInput: { url: 'https://en.wikipedia.org/wiki/Arknights' },
+      rawOutput: {
+        bytes: 192511,
+        code: 200,
+        codeText: 'OK',
+        durationMs: 5404,
+        url: 'https://en.wikipedia.org/wiki/Arknights',
+      },
+      content: [],
+    };
+
+    expect(toolCallMetadata(toolCall)).toEqual([
+      { key: 'url', value: 'https://en.wikipedia.org/wiki/Arknights' },
+      { key: 'status', value: '200 OK', tone: undefined },
+      { key: 'duration', value: '5.4s' },
+      { key: 'size', value: '193 kB' },
+    ]);
+  });
+
+  it('splits Claude MCP slugs into server and tool, leaving other titles alone', () => {
+    expect(mcpToolName('mcp__linear__get_issue')).toEqual({ server: 'linear', tool: 'get_issue' });
+    expect(mcpToolName('mcp__ccd_session__spawn_task')).toEqual({
+      server: 'ccd_session',
+      tool: 'spawn_task',
+    });
+    expect(mcpToolName('mcp__f5fcc7d5-d616__list_issue_labels')).toEqual({
+      server: 'f5fcc7d5-d616',
+      tool: 'list_issue_labels',
+    });
+    expect(mcpToolName('WebFetch')).toBeUndefined();
+    expect(mcpToolName('mcp__broken')).toBeUndefined();
+    expect(mcpToolName('mcp__server__')).toBeUndefined();
+    expect(mcpToolName('linear_get_issue')).toBeUndefined();
+  });
+
+  it('headlines an MCP call with its tool name, server context, and an MCP badge', () => {
+    const toolCall: ToolCall = {
+      toolCallId: 'mcp-1',
+      title: 'mcp__linear__get_issue',
+      kind: 'other',
+      status: 'completed',
+      rawInput: { id: 'CODE-228' },
+      content: [],
+    };
+
+    // The server context sits beside a visible tool name only; a collapsed group join (which
+    // shows summaries INSTEAD of names) must fall through to the tool name itself.
+    expect(toolCallHeaderSummary(toolCall)).toBeUndefined();
+    expect(toolCallContextSummary(toolCall)).toEqual({
+      label: 'linear',
+      tooltip: 'mcp__linear__get_issue',
+    });
+
+    const { container } = render(<ToolCallItem toolCall={toolCall} />);
+    expect(screen.getByText('get_issue')).toBeDefined();
+    expect(screen.getByText('MCP')).toBeDefined();
+    expect(screen.getByText('· linear')).toBeDefined();
+    expect(container.textContent).not.toContain('mcp__linear__get_issue');
+    expect(container.textContent).not.toContain('kindOther');
   });
 
   it('provides curated context for singleton headers and activity groups', () => {

--- a/packages/ui/src/chat/activity-group.tsx
+++ b/packages/ui/src/chat/activity-group.tsx
@@ -23,7 +23,12 @@ import { DiffCounter } from './diff-block';
 import { toolCallDiffStats } from './diff-utils';
 import { TOOL_DETAIL_SCROLL_CLASS_NAME } from './tool';
 import { ToolCallBody } from './tool-call-item';
-import { hasToolBody, toolCallHeaderSummary } from './tool-utils';
+import {
+  hasToolBody,
+  toolCallContextSummary,
+  toolCallDisplayTitle,
+  toolCallHeaderSummary,
+} from './tool-utils';
 import { FilePathTooltip } from './with-tooltip';
 
 export type ActivityToolGroup = Extract<TimelineEntry, { type: 'group' }>;
@@ -75,7 +80,10 @@ export function ActivityGroup({
             {open
               ? ''
               : summaries
-                  .map((summary, index) => summary?.label ?? group.items[index].toolCall.title)
+                  .map(
+                    (summary, index) =>
+                      summary?.label ?? toolCallDisplayTitle(group.items[index].toolCall),
+                  )
                   .join(', ')}
           </span>
           <ChevronRightIcon className="size-3.5 shrink-0 text-muted-foreground transition-transform group-data-[panel-open]:rotate-90" />
@@ -141,8 +149,9 @@ function ActivityGroupRow({
   TerminalBlockComponent?: React.ComponentType<{ terminalId: string }>;
 }): React.ReactNode {
   const tooltipAnchorRef = useRef<HTMLSpanElement>(null);
-  const summary = toolCallHeaderSummary(toolCall);
-  const summaryIsTitle = summary?.label === toolCall.title;
+  const summary = toolCallContextSummary(toolCall);
+  const title = toolCallDisplayTitle(toolCall);
+  const summaryIsTitle = summary?.label === title;
   const titleAnchorRef = summaryIsTitle ? tooltipAnchorRef : undefined;
   const titleClassName = cn(
     'flex min-w-0 items-center py-0.5 text-left text-sm',
@@ -151,7 +160,7 @@ function ActivityGroupRow({
   const label = (
     <>
       <span className="min-w-0 truncate" ref={titleAnchorRef}>
-        {toolCall.title}
+        {title}
       </span>
       {summary && !summaryIsTitle ? (
         <>

--- a/packages/ui/src/chat/content-derived-keys.ts
+++ b/packages/ui/src/chat/content-derived-keys.ts
@@ -3,6 +3,19 @@ import { simpleStringHash } from 'foxts/simple-string-hash';
 
 type AdapterContent = ContentBlock | ToolCallContent;
 
+/**
+ * Keys for a message's block list, where position — not content — is the identity: the builder's
+ * appendBlock only pushes a new block or extends the LAST one, so blocks never reorder, drop, or
+ * change type in place, and the streaming tail mutates every token. Content-derived keys
+ * ({@link contentDerivedEntries}) would remount that tail per token and break smooth streaming;
+ * a positional key keeps it mounted for the whole stream.
+ */
+export function positionalBlockEntries(
+  blocks: readonly ContentBlock[],
+): Array<{ block: ContentBlock; key: string }> {
+  return blocks.map((block, index) => ({ block, key: `${index}:${block.type}` }));
+}
+
 /** Adapter content snapshots have no block IDs, so derive keys from their wire values.
  * Duplicate values are interchangeable; an occurrence suffix only prevents sibling collisions. */
 export function contentDerivedEntries<T extends AdapterContent>(

--- a/packages/ui/src/chat/conversation-text.ts
+++ b/packages/ui/src/chat/conversation-text.ts
@@ -21,7 +21,16 @@ export function assistantTurnText(items: readonly ConversationItem[]): string {
   return parts.join('\n\n');
 }
 
-/** Client receive time of the latest-stamped item — the turn's approximate end time. */
+/** The model that served the turn: its last assistant message's stamp. */
+export function turnModel(items: readonly ConversationItem[]): string | undefined {
+  let model: string | undefined;
+  for (const item of items) {
+    if (item.kind === 'message' && item.role === 'assistant' && item.model) model = item.model;
+  }
+  return model;
+}
+
+/** Best-known time of the latest-stamped item — the turn's approximate end time. */
 export function latestReceivedAt(items: readonly ConversationItem[]): number | undefined {
   let latest: number | undefined;
   for (const item of items) {

--- a/packages/ui/src/chat/conversation-view.tsx
+++ b/packages/ui/src/chat/conversation-view.tsx
@@ -7,6 +7,7 @@ import type { TimelineEntry } from './activity-groups';
 import { groupTimeline } from './activity-groups';
 import { CompactionMarker } from './compaction-marker';
 import { ContentBlockView } from './content-block-view';
+import { positionalBlockEntries } from './content-derived-keys';
 import {
   Conversation,
   ConversationContent,
@@ -139,10 +140,9 @@ export function ConversationView({
         return (
           <Message key={item.id} from="assistant">
             <MessageContent className="space-y-1">
-              {item.blocks.map((block, index) => (
+              {positionalBlockEntries(item.blocks).map(({ block, key }) => (
                 <ContentBlockView
-                  // eslint-disable-next-line @eslint-react/no-array-index-key -- append-only stream: appendBlock only pushes or extends the last block, so index+type is a stable position key across token-by-token re-renders
-                  key={`${index}:${block.type}`}
+                  key={key}
                   block={block}
                   smoothText
                   isStreaming={item.isStreaming}

--- a/packages/ui/src/chat/conversation-view.tsx
+++ b/packages/ui/src/chat/conversation-view.tsx
@@ -19,7 +19,7 @@ import {
   declinedToolCallIds,
   selectPendingPromptItems,
 } from './conversation-prompts';
-import { assistantTurnText, latestReceivedAt } from './conversation-text';
+import { assistantTurnText, latestReceivedAt, turnModel } from './conversation-text';
 import { ErrorMessage } from './error-message';
 import { Message, MessageContent } from './message';
 import { SubagentCard } from './subagent-card';
@@ -37,7 +37,7 @@ export interface ConversationViewProps {
   conversation: ConversationViewModel;
   agentKind?: AgentKind;
   cwd?: string;
-  /** TODO(backend): shown in the per-turn meta once session state reflects the active model. */
+  /** Session-level fallback for the per-turn model meta (a turn's own message stamp wins). */
   modelName?: string;
   TerminalBlockComponent?: React.ComponentType<{ terminalId: string }>;
   /** Opens this turn's workspace changes in the host review surface. */
@@ -232,7 +232,7 @@ export function ConversationView({
                     <AgentTurnActions
                       agentKind={agentKind}
                       copyText={replyText}
-                      modelName={modelName}
+                      modelName={turnModel(segment.items) ?? modelName}
                       receivedAt={latestReceivedAt(segment.items)}
                     />
                   ) : null}

--- a/packages/ui/src/chat/test-results.tsx
+++ b/packages/ui/src/chat/test-results.tsx
@@ -1,5 +1,6 @@
 import { Badge } from 'coss-ui/components/badge';
 import { CheckCircleIcon, CircleIcon, XCircleIcon } from 'lucide-react';
+import prettyMilliseconds from 'pretty-ms';
 import { cn } from '../lib/cn';
 
 const EMPTY_TEST_RESULTS: readonly ChatTestResult[] = [];
@@ -108,7 +109,7 @@ export function TestResult({
       </div>
       {typeof result.durationMs === 'number' ? (
         <span className="shrink-0 text-xs text-muted-foreground">
-          {formatDuration(result.durationMs)}
+          {prettyMilliseconds(result.durationMs)}
         </span>
       ) : null}
     </div>
@@ -149,8 +150,4 @@ function testStatusClass(status: ChatTestResult['status']): string {
     default:
       return 'text-warning-foreground';
   }
-}
-
-function formatDuration(durationMs: number): string {
-  return durationMs < 1000 ? `${durationMs}ms` : `${(durationMs / 1000).toFixed(2)}s`;
 }

--- a/packages/ui/src/chat/thought-block.tsx
+++ b/packages/ui/src/chat/thought-block.tsx
@@ -1,6 +1,7 @@
 import type { ContentBlock } from '@linkcode/schema';
 import { useTranslations } from 'use-intl';
 import { ContentBlockView } from './content-block-view';
+import { positionalBlockEntries } from './content-derived-keys';
 import { contentPreview } from './content-preview';
 import { Reasoning, ReasoningContent, ReasoningTrigger } from './reasoning';
 
@@ -18,9 +19,8 @@ export function ThoughtBlock({
     <Reasoning isStreaming={isStreaming}>
       <ReasoningTrigger label={t('thought')} preview={preview} />
       <ReasoningContent>
-        {blocks.map((block, index) => (
-          // eslint-disable-next-line @eslint-react/no-array-index-key -- append-only stream: index+type is a stable position key across token-by-token re-renders
-          <ContentBlockView key={`${index}:${block.type}`} block={block} />
+        {positionalBlockEntries(blocks).map(({ block, key }) => (
+          <ContentBlockView key={key} block={block} />
         ))}
       </ReasoningContent>
     </Reasoning>

--- a/packages/ui/src/chat/tool-call-item.tsx
+++ b/packages/ui/src/chat/tool-call-item.tsx
@@ -8,8 +8,9 @@ import { ToolResultPreview } from './tool-result-preview';
 import type { ToolMetadata } from './tool-utils';
 import {
   hasToolBody,
+  mcpToolName,
+  toolCallContextSummary,
   toolCallFailureMessage,
-  toolCallHeaderSummary,
   toolCallMetadata,
 } from './tool-utils';
 
@@ -22,11 +23,11 @@ function ToolMetadataList({ metadata }: { metadata: ToolMetadata[] }): React.Rea
       {metadata.map((item) => (
         <Badge
           className="max-w-full gap-1.5 font-normal"
-          key={`${item.key}:${item.value}`}
+          key={`${item.key}:${item.label ?? ''}:${item.value}`}
           size="sm"
           variant={item.tone === 'error' ? 'error' : 'secondary'}
         >
-          <span className="text-muted-foreground">{t(item.key)}</span>
+          <span className="text-muted-foreground">{item.label ?? t(item.key)}</span>
           <code className="truncate">{item.value}</code>
         </Badge>
       ))}
@@ -85,22 +86,24 @@ export function ToolCallItem({
 
   const kindKey = `kind${toolCall.kind[0].toUpperCase()}${toolCall.kind.slice(1)}`;
   const hasBody = hasToolBody(toolCall);
-  const summary = toolCallHeaderSummary(toolCall);
+  const summary = toolCallContextSummary(toolCall);
   const diffTotals = toolCallDiffStats(toolCall);
+  const mcp = mcpToolName(toolCall.title);
+  const title = mcp?.tool ?? toolCall.title;
 
   return (
     <Tool>
       <ToolHeader
         awaitingApproval={awaitingApproval}
-        badge={t(kindKey)}
+        badge={mcp ? 'MCP' : t(kindKey)}
         declinedBadge={declined ? tp('declined') : undefined}
         diffStats={diffTotals}
         hasBody={hasBody}
         icon={icon}
         kind={toolCall.kind}
         status={toolCall.status}
-        summary={summary?.label === toolCall.title ? undefined : summary?.label}
-        title={toolCall.title}
+        summary={summary?.label === title ? undefined : summary?.label}
+        title={title}
         tooltip={summary?.tooltip}
       />
 

--- a/packages/ui/src/chat/tool-result-content.ts
+++ b/packages/ui/src/chat/tool-result-content.ts
@@ -40,8 +40,13 @@ export function toolCallFetchUrl(toolCall: ToolCall): string | undefined {
 
 export function toolCallFetchStatus(toolCall: ToolCall): string | undefined {
   const output = recordValue(toolCall.rawOutput);
-  const status = output?.status ?? output?.statusCode;
-  return typeof status === 'string' || typeof status === 'number' ? String(status) : undefined;
+  // `code`/`codeText` is Claude's WebFetch envelope ("200 OK"); status/statusCode are the rest.
+  const status = output?.status ?? output?.statusCode ?? output?.code;
+  if (typeof status !== 'string' && typeof status !== 'number') return undefined;
+  const statusText = output?.codeText;
+  return typeof statusText === 'string' && statusText.length > 0
+    ? `${status} ${statusText}`
+    : String(status);
 }
 
 /**

--- a/packages/ui/src/chat/tool-result-preview.tsx
+++ b/packages/ui/src/chat/tool-result-preview.tsx
@@ -20,7 +20,7 @@ import {
   toolCallReadPreviewText,
   toolCallSearchQuery,
 } from './tool-result-content';
-import { TOOL_KIND_ICONS, toolCallCommand } from './tool-utils';
+import { TOOL_KIND_ICONS, toolCallCommand, toolCallDisplayTitle } from './tool-utils';
 
 interface ToolResultPreviewProps {
   toolCall: ToolCall;
@@ -68,7 +68,7 @@ function SearchRows({ toolCall, text }: { toolCall: ToolCall; text: string }): R
     <ToolPreviewCard
       badge={String(resultCount)}
       icon={SearchIcon}
-      title={toolCallSearchQuery(toolCall) ?? toolCall.title}
+      title={toolCallSearchQuery(toolCall) ?? toolCallDisplayTitle(toolCall)}
     >
       <pre className="overflow-x-auto whitespace-pre font-mono text-xs leading-relaxed">
         <code>{text}</code>
@@ -194,10 +194,11 @@ function MixedFilePreview({
 }
 
 function renderTextPreview(toolCall: ToolCall, text: string): React.ReactNode {
+  const displayTitle = toolCallDisplayTitle(toolCall);
   switch (toolCall.kind) {
     case 'read': {
       return (
-        <ToolPreviewCard icon={FileTextIcon} title={toolCall.title}>
+        <ToolPreviewCard icon={FileTextIcon} title={displayTitle}>
           <pre className="overflow-x-auto whitespace-pre font-mono text-xs leading-relaxed">
             <code>{text}</code>
           </pre>
@@ -209,7 +210,7 @@ function renderTextPreview(toolCall: ToolCall, text: string): React.ReactNode {
     case 'move': {
       const Icon = TOOL_KIND_ICONS[toolCall.kind];
       return (
-        <ToolPreviewCard icon={Icon} title={toolCall.title}>
+        <ToolPreviewCard icon={Icon} title={displayTitle}>
           <Markdown>{text}</Markdown>
         </ToolPreviewCard>
       );
@@ -217,7 +218,7 @@ function renderTextPreview(toolCall: ToolCall, text: string): React.ReactNode {
     case 'search':
       return <SearchRows text={text} toolCall={toolCall} />;
     case 'fetch': {
-      const title = toolCallFetchUrl(toolCall) ?? toolCall.title;
+      const title = toolCallFetchUrl(toolCall) ?? displayTitle;
       const json = formattedJson(text);
       if (json) return <CodeBlock code={json} language="json" title={title} />;
       const markup = markupLanguage(text);
@@ -231,9 +232,9 @@ function renderTextPreview(toolCall: ToolCall, text: string): React.ReactNode {
     case 'other': {
       const json = formattedJson(text);
       return json ? (
-        <CodeBlock code={json} language="json" title={toolCall.title} />
+        <CodeBlock code={json} language="json" title={displayTitle} />
       ) : (
-        <ToolPreviewCard icon={WrenchIcon} title={toolCall.title}>
+        <ToolPreviewCard icon={WrenchIcon} title={displayTitle}>
           <Markdown>{text}</Markdown>
         </ToolPreviewCard>
       );
@@ -290,7 +291,10 @@ function ExecutePreview({
         />
       ))}
       {terminalContent.length === 0 || output ? (
-        <Terminal title={toolCallCommand(toolCall) ?? toolCall.title} output={output} />
+        <Terminal
+          title={toolCallCommand(toolCall) ?? toolCallDisplayTitle(toolCall)}
+          output={output}
+        />
       ) : null}
       <ContentList
         content={otherContent}

--- a/packages/ui/src/chat/tool-utils.ts
+++ b/packages/ui/src/chat/tool-utils.ts
@@ -11,6 +11,8 @@ import {
   Trash2Icon,
   WrenchIcon,
 } from 'lucide-react';
+import prettyBytes from 'pretty-bytes';
+import prettyMilliseconds from 'pretty-ms';
 import { toolCallFilePresentation } from './file-tool-presentation';
 import {
   recordValue,
@@ -22,10 +24,20 @@ import {
   toolCallSearchQuery,
 } from './tool-result-content';
 
-export type ToolMetadataKey = 'files' | 'matches' | 'query' | 'status' | 'url';
+export type ToolMetadataKey =
+  | 'duration'
+  | 'files'
+  | 'matches'
+  | 'param'
+  | 'query'
+  | 'size'
+  | 'status'
+  | 'url';
 
 export interface ToolMetadata {
   key: ToolMetadataKey;
+  /** Verbatim label (a tool's own parameter name); when absent the key is localized. */
+  label?: string;
   value: string;
   tone?: 'error';
 }
@@ -34,6 +46,31 @@ function countValue(value: unknown): number | undefined {
   if (Array.isArray(value)) return value.length;
   if (typeof value === 'number' && Number.isFinite(value) && value >= 0) return value;
   return undefined;
+}
+
+function numberValue(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0 ? value : undefined;
+}
+
+export interface McpToolName {
+  server: string;
+  tool: string;
+}
+
+/** Splits Claude Code's `mcp__<server>__<tool>` slug on the first `__` after the prefix (server
+ * keys never contain `__`; tool names may). Non-matching titles — including other adapters' MCP
+ * formats — return undefined and display verbatim. */
+export function mcpToolName(title: string): McpToolName | undefined {
+  if (!title.startsWith('mcp__')) return undefined;
+  const rest = title.slice(5);
+  const separator = rest.indexOf('__');
+  if (separator <= 0 || separator + 2 >= rest.length) return undefined;
+  return { server: rest.slice(0, separator), tool: rest.slice(separator + 2) };
+}
+
+/** The human-facing tool name: MCP slugs shed their `mcp__<server>__` envelope. */
+export function toolCallDisplayTitle(toolCall: ToolCall): string {
+  return mcpToolName(toolCall.title)?.tool ?? toolCall.title;
 }
 
 export function toolCallCommand(toolCall: ToolCall): string | undefined {
@@ -51,7 +88,12 @@ export function toolCallFailureMessage(toolCall: ToolCall): string | undefined {
   return stringValue(recordValue(toolCall.rawOutput), ['message']);
 }
 
-/** Whitelisted normal-mode metadata. Arbitrary raw payloads stay in the model, not the transcript. */
+/**
+ * Curated normal-mode metadata: classified kinds project only their known fields, and an
+ * unclassified (`other`) call shows its scalar input params. Raw payloads are never dumped
+ * wholesale — nested objects/arrays (request envelopes, credentials, bulk content) stay in
+ * the model, not the transcript.
+ */
 export function toolCallMetadata(toolCall: ToolCall): ToolMetadata[] {
   const output = recordValue(toolCall.rawOutput);
 
@@ -83,16 +125,48 @@ export function toolCallMetadata(toolCall: ToolCall): ToolMetadata[] {
           tone: toolCall.status === 'failed' ? 'error' : undefined,
         });
       }
+      const duration = numberValue(output?.durationMs);
+      if (duration !== undefined) {
+        metadata.push({ key: 'duration', value: prettyMilliseconds(duration) });
+      }
+      const bytes = numberValue(output?.bytes);
+      if (bytes !== undefined) metadata.push({ key: 'size', value: prettyBytes(bytes) });
       return metadata;
     }
+    case 'other':
+      return toolCallParamMetadata(toolCall);
     case 'execute':
     case 'think':
     case 'task':
-    case 'other':
       return [];
     default:
       return toolCall.kind satisfies never;
   }
+}
+
+const PARAM_BADGE_LIMIT = 8;
+const PARAM_VALUE_MAX = 160;
+
+/** Scalar inputs of an unclassified call, labeled by the tool's own param names (verbatim —
+ * they aren't localizable). Bounded so one badge is a detail, not a payload dump. */
+function toolCallParamMetadata(toolCall: ToolCall): ToolMetadata[] {
+  const input = recordValue(toolCall.rawInput);
+  if (!input) return [];
+  const metadata: ToolMetadata[] = [];
+  for (const [key, value] of Object.entries(input)) {
+    if (metadata.length >= PARAM_BADGE_LIMIT) break;
+    if (typeof value !== 'string' && typeof value !== 'number' && typeof value !== 'boolean') {
+      continue;
+    }
+    const text = String(value);
+    if (text.length === 0) continue;
+    metadata.push({
+      key: 'param',
+      label: key,
+      value: text.length > PARAM_VALUE_MAX ? `${text.slice(0, PARAM_VALUE_MAX)}…` : text,
+    });
+  }
+  return metadata;
 }
 
 export interface ToolCallHeaderSummary {
@@ -112,7 +186,8 @@ export function toolCallHeaderSummary(toolCall: ToolCall): ToolCallHeaderSummary
     case 'delete':
     case 'move': {
       const file = toolCallFilePresentation(toolCall);
-      return file ? { label: file.label, tooltip: file.tooltip } : undefined;
+      if (file) return { label: file.label, tooltip: file.tooltip };
+      break;
     }
     case 'search':
       label = toolCallSearchQuery(toolCall);
@@ -123,11 +198,21 @@ export function toolCallHeaderSummary(toolCall: ToolCall): ToolCallHeaderSummary
     case 'think':
     case 'task':
     case 'other':
-      return undefined;
+      break;
     default:
       return toolCall.kind satisfies never;
   }
   return label ? { label } : undefined;
+}
+
+/** Header context beside a visible tool name: the kind summary, else — for an MCP call, whose
+ * name alone doesn't say where it runs — the server (full slug on hover). Collapsed group joins
+ * must NOT use this: with no tool name in sight, the server label would read as one. */
+export function toolCallContextSummary(toolCall: ToolCall): ToolCallHeaderSummary | undefined {
+  const summary = toolCallHeaderSummary(toolCall);
+  if (summary) return summary;
+  const mcp = mcpToolName(toolCall.title);
+  return mcp ? { label: mcp.server, tooltip: toolCall.title } : undefined;
 }
 
 export function hasToolBody(toolCall: ToolCall): boolean {

--- a/packages/ui/src/chat/turn-actions.tsx
+++ b/packages/ui/src/chat/turn-actions.tsx
@@ -18,10 +18,10 @@ export function AgentTurnActions({
   modelName,
 }: {
   copyText: string;
-  /** Client receive time of the turn's last event (see ConversationItem.receivedAt). */
+  /** Best-known time of the turn's last event (see ConversationItem.receivedAt). */
   receivedAt?: number;
   agentKind?: AgentKind;
-  /** TODO(backend): no session state reflects the active model yet; hidden until one does. */
+  /** The model that served this turn (message stamp, else the session's reported model). */
   modelName?: string;
 }): React.ReactNode {
   const t = useTranslations('workbench.message');

--- a/packages/ui/src/chat/types.ts
+++ b/packages/ui/src/chat/types.ts
@@ -21,9 +21,9 @@ import type {
 export type ConversationTurnId = string | null;
 
 /**
- * Fields every timeline item carries. `receivedAt` is the client receive time of the item's
- * latest event — TODO(wire): approximate and absent for history-seeded items; replace with an
- * authoritative event timestamp once the wire carries one.
+ * Fields every timeline item carries. `receivedAt` is the best-known time of the item's latest
+ * event: client receive time for live events, the provider's own timestamp for history-seeded
+ * items, absent when neither is known.
  */
 interface ConversationItemBase {
   id: string;
@@ -40,6 +40,8 @@ export type ConversationItem =
       isStreaming: boolean;
       /** Set on subagent narration: the `task`-kind tool call that spawned it (nested in the UI). */
       parentToolCallId?: string;
+      /** The model serving the session when this assistant message opened (from `model-update`). */
+      model?: string;
     })
   | (ConversationItemBase & {
       kind: 'reasoning';

--- a/packages/ui/src/chat/user-message.tsx
+++ b/packages/ui/src/chat/user-message.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { useFormatter, useTranslations } from 'use-intl';
 import { cn } from '../lib/cn';
 import { ContentBlockView } from './content-block-view';
+import { positionalBlockEntries } from './content-derived-keys';
 import { contentBlocksText } from './conversation-text';
 import { Message, MessageAction, MessageActions, MessageContent } from './message';
 import type { ConversationItem } from './types';
@@ -29,9 +30,8 @@ export function UserMessage({ item }: { item: MessageItem }): React.ReactNode {
     <Message from="user">
       <MessageContent>
         <div className={collapsible && !expanded ? 'line-clamp-[20]' : undefined}>
-          {item.blocks.map((block, index) => (
-            // eslint-disable-next-line @eslint-react/no-array-index-key -- static user message; index+type is a stable position key
-            <ContentBlockView key={`${index}:${block.type}`} block={block} />
+          {positionalBlockEntries(item.blocks).map(({ block, key }) => (
+            <ContentBlockView key={key} block={block} />
           ))}
         </div>
         {collapsible ? (

--- a/packages/ui/src/shell/conversation-surface.tsx
+++ b/packages/ui/src/shell/conversation-surface.tsx
@@ -20,7 +20,7 @@ export interface ConversationSurfaceProps {
   /** Frontend capability stub used until attachment support is advertised by the session. */
   attachmentsSupported?: boolean;
   cwd?: string;
-  /** TODO(backend): thread the session's active model here once the daemon reflects it. */
+  /** Overrides the session's reported model (`conversation.currentModel`) in the per-turn meta. */
   modelName?: string;
   respondingRequestIds: ReadonlySet<string>;
   responseErrors?: ReadonlyMap<string, string>;
@@ -134,7 +134,7 @@ export function ConversationSurface({
             conversation={conversation}
             agentKind={agentKind}
             cwd={cwd}
-            modelName={modelName}
+            modelName={modelName ?? conversation.currentModel ?? undefined}
             TerminalBlockComponent={TerminalBlockComponent}
             onReviewChanges={onReviewChanges}
           />

--- a/packages/ui/src/shell/permission-prompt.tsx
+++ b/packages/ui/src/shell/permission-prompt.tsx
@@ -5,6 +5,7 @@ import { ShieldAlertIcon } from 'lucide-react';
 import { useState } from 'react';
 import { useTranslations } from 'use-intl';
 import type { PermissionConversationItem, PermissionDecision } from '../chat/conversation-prompts';
+import { mcpToolName } from '../chat/tool-utils';
 import { PromptCard } from './prompt-card';
 
 export function PermissionPrompt({
@@ -25,7 +26,10 @@ export function PermissionPrompt({
   const [lastDecision, setLastDecision] = useState<PermissionDecision | null>(null);
   const selectedOptionId =
     lastDecision?.outcome === 'selected' ? lastDecision.option.optionId : undefined;
-  const title = item.toolCall.title ?? item.toolCall.toolCallId;
+  const rawTitle = item.toolCall.title ?? item.toolCall.toolCallId;
+  const mcp = mcpToolName(rawTitle);
+  // A permission judgment needs provenance, so the MCP server rides along with the tool name.
+  const title = mcp ? `${mcp.tool} · ${mcp.server}` : rawTitle;
   const persistentOptions = item.options.filter((option) => option.kind.endsWith('_always'));
   const immediateOptions = item.options
     .filter((option) => !option.kind.endsWith('_always'))

--- a/packages/workbench/src/mock/data/showcase.ts
+++ b/packages/workbench/src/mock/data/showcase.ts
@@ -416,6 +416,26 @@ export function createShowcaseToolBursts(terminalId = SHOWCASE_TERMINAL_ID): Sho
     ],
     wrapUp: [
       {
+        toolCallId: 'mock-tool-fetch-envelope',
+        title: 'WebFetch',
+        kind: 'fetch',
+        status: 'completed',
+        content: [
+          {
+            type: 'content',
+            content: textBlock('# Arknights\n\nA tower-defense mobile game by Hypergryph.'),
+          },
+        ],
+        rawInput: { url: 'https://en.wikipedia.org/wiki/Arknights' },
+        rawOutput: {
+          bytes: 192511,
+          code: 200,
+          codeText: 'OK',
+          durationMs: 5404,
+          url: 'https://en.wikipedia.org/wiki/Arknights',
+        },
+      },
+      {
         toolCallId: 'mock-tool-fetch',
         title: 'Fetch unavailable preview',
         kind: 'fetch',
@@ -461,6 +481,20 @@ export function createShowcaseToolBursts(terminalId = SHOWCASE_TERMINAL_ID): Sho
           traceId: 'mock-other-173',
         },
         rawOutput: { ok: true, internalRequestId: 'mock-other-result-173' },
+      },
+      {
+        toolCallId: 'mock-tool-mcp-slug',
+        title: 'mcp__linear__get_issue',
+        kind: 'other',
+        status: 'completed',
+        content: [
+          {
+            type: 'content',
+            content: textBlock('CODE-228 · feat(ui): richer tool-call details'),
+          },
+        ],
+        rawInput: { id: 'CODE-228', includeRelations: true },
+        rawOutput: { content: [{ type: 'text', text: 'CODE-228' }] },
       },
       {
         toolCallId: 'mock-tool-task-review',

--- a/packages/workbench/src/surface/__tests__/seed-cache.test.ts
+++ b/packages/workbench/src/surface/__tests__/seed-cache.test.ts
@@ -11,6 +11,10 @@ function userText(text: string): AgentEvent {
   return { type: 'user-message', content: [{ type: 'text', text }] };
 }
 
+function seedEvent(text: string, ts?: number): { event: AgentEvent; ts?: number } {
+  return { event: userText(text), ts };
+}
+
 function fakeStorage(failSetItemTimes = 0): SeedCacheStorage & { map: Map<string, string> } {
   const map = new Map<string, string>();
   let failures = failSetItemTimes;
@@ -31,11 +35,16 @@ function fakeStorage(failSetItemTimes = 0): SeedCacheStorage & { map: Map<string
 }
 
 describe('seed cache', () => {
-  it('round-trips a seed and loads it back with uptoSeq 0', () => {
+  it('round-trips a seed (with event timestamps) and loads it back with uptoSeq 0', () => {
     const storage = fakeStorage();
-    persistSeed(kind, historyId('h1'), { events: [userText('hi')], uptoSeq: 42 }, storage);
+    persistSeed(
+      kind,
+      historyId('h1'),
+      { events: [seedEvent('hi', 1_700_000_000_000)], uptoSeq: 42 },
+      storage,
+    );
     expect(loadPersistedSeed(kind, historyId('h1'), storage)).toEqual({
-      events: [userText('hi')],
+      events: [seedEvent('hi', 1_700_000_000_000)],
       uptoSeq: 0,
     });
   });
@@ -52,9 +61,9 @@ describe('seed cache', () => {
     // Loading runs during render, so the stale entry stays put (purity); the memoized miss
     // prevents re-parsing, and a later persist simply overwrites it.
     expect(storage.map.has(`linkcode.seed.${kind}.stale`)).toBe(true);
-    persistSeed(kind, historyId('stale'), { events: [userText('fresh')], uptoSeq: 0 }, storage);
+    persistSeed(kind, historyId('stale'), { events: [seedEvent('fresh')], uptoSeq: 0 }, storage);
     expect(loadPersistedSeed(kind, historyId('stale'), storage)).toEqual({
-      events: [userText('fresh')],
+      events: [seedEvent('fresh')],
       uptoSeq: 0,
     });
   });
@@ -71,7 +80,7 @@ describe('seed cache', () => {
       persistSeed(
         kind,
         historyId(`h${index}`),
-        { events: [userText(`m${index}`)], uptoSeq: 0 },
+        { events: [seedEvent(`m${index}`)], uptoSeq: 0 },
         storage,
       );
     }
@@ -83,8 +92,8 @@ describe('seed cache', () => {
 
   it('sheds old entries under quota pressure and still persists the new seed', () => {
     const storage = fakeStorage();
-    persistSeed(kind, historyId('old1'), { events: [userText('a')], uptoSeq: 0 }, storage);
-    persistSeed(kind, historyId('old2'), { events: [userText('b')], uptoSeq: 0 }, storage);
+    persistSeed(kind, historyId('old1'), { events: [seedEvent('a')], uptoSeq: 0 }, storage);
+    persistSeed(kind, historyId('old2'), { events: [seedEvent('b')], uptoSeq: 0 }, storage);
 
     const failing = { ...storage, ...fakeStorage(0) };
     // Reuse the same backing map but fail the first two writes of the new entry.
@@ -102,11 +111,11 @@ describe('seed cache', () => {
       storage.map.set(key, value);
     };
 
-    persistSeed(kind, historyId('new'), { events: [userText('c')], uptoSeq: 0 }, failing);
+    persistSeed(kind, historyId('new'), { events: [seedEvent('c')], uptoSeq: 0 }, failing);
     expect(storage.map.has(`linkcode.seed.${kind}.old1`)).toBe(false);
     expect(storage.map.has(`linkcode.seed.${kind}.old2`)).toBe(false);
     expect(loadPersistedSeed(kind, historyId('new'), failing)).toEqual({
-      events: [userText('c')],
+      events: [seedEvent('c')],
       uptoSeq: 0,
     });
   });

--- a/packages/workbench/src/surface/seed-cache.ts
+++ b/packages/workbench/src/surface/seed-cache.ts
@@ -16,10 +16,11 @@ export type SeedCacheStorage = Pick<Storage, 'getItem' | 'setItem' | 'removeItem
 const INDEX_KEY = 'linkcode.seed-index';
 const MAX_ENTRIES = 20;
 
-/** Persisted seeds embed the wire version: any protocol bump invalidates them wholesale. */
+/** Persisted seeds embed the wire version: any protocol bump invalidates them wholesale.
+ * (Entries in the pre-`ts` shape fail this parse and degrade to a cache miss.) */
 const PersistedSeedSchema = z.object({
   v: z.literal(WIRE_PROTOCOL_VERSION),
-  events: z.array(AgentEventSchema),
+  events: z.array(z.object({ event: AgentEventSchema, ts: z.number().optional() })),
 });
 
 /** Parse results are memoized per storage so render-time loads don't re-parse megabyte JSON. */

--- a/packages/workbench/src/surface/use-seeded-conversation.ts
+++ b/packages/workbench/src/surface/use-seeded-conversation.ts
@@ -1,12 +1,6 @@
-import type { Conversation, ConversationSeed } from '@linkcode/client-core';
+import type { Conversation, ConversationSeed, ConversationSeedEvent } from '@linkcode/client-core';
 import { useConversation } from '@linkcode/client-core';
-import type {
-  AgentEvent,
-  AgentHistoryId,
-  AgentKind,
-  SessionId,
-  SessionInfo,
-} from '@linkcode/schema';
+import type { AgentHistoryId, AgentKind, SessionId, SessionInfo } from '@linkcode/schema';
 import type { Options, RequestResult } from '@linkcode/sdk';
 import { resolveClient } from '@linkcode/sdk';
 import { useData } from '../runtime/tayori';
@@ -25,7 +19,7 @@ async function readConversationSeed(
   options: Options<{ agentKind: AgentKind; historyId: AgentHistoryId; sessionId: SessionId }>,
 ): RequestResult<ConversationSeed> {
   const client = resolveClient(options);
-  const events: AgentEvent[] = [];
+  const events: ConversationSeedEvent[] = [];
   let cursor: string | undefined;
   for (let page = 0; page < MAX_SEED_PAGES; page += 1) {
     // eslint-disable-next-line no-await-in-loop -- cursor pagination: each page's cursor comes from the previous reply
@@ -34,7 +28,7 @@ async function readConversationSeed(
       cursor,
       forceRefresh: page === 0,
     });
-    for (const entry of data.events) events.push(entry.event);
+    for (const entry of data.events) events.push({ event: entry.event, ts: entry.ts });
     cursor = data.cursor;
     if (cursor === undefined) break;
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1087,6 +1087,12 @@ importers:
       motion:
         specifier: ^12.42.2
         version: 12.42.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      pretty-bytes:
+        specifier: ^7.1.1
+        version: 7.1.1
+      pretty-ms:
+        specifier: ^9.3.0
+        version: 9.3.0
       react-native:
         specifier: '>=0.80'
         version: 0.86.0(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.7)
@@ -8896,6 +8902,10 @@ packages:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
     engines: {node: '>=8'}
 
+  parse-ms@4.0.0:
+    resolution: {integrity: sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==}
+    engines: {node: '>=18'}
+
   parse-png@2.1.0:
     resolution: {integrity: sha512-Nt/a5SfCLiTnQAjx3fHlqp8hRgTL3z7kTQZzvIMS9uCAepnCyjpdEc6M/sz69WqMBdaDBw9sF1F1UaHROYzGkQ==}
     engines: {node: '>=10'}
@@ -9049,6 +9059,10 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
+  pretty-bytes@7.1.1:
+    resolution: {integrity: sha512-X+vn9z8nOFZQlxOLmfJ0iKDdMD7jYTsTW12OAlCpdoE3Igik6L37pugIZi+N3usuyp5McfgKPWi12q3zvHLeGQ==}
+    engines: {node: '>=20'}
+
   pretty-format@27.5.1:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
@@ -9056,6 +9070,10 @@ packages:
   pretty-format@29.7.0:
     resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  pretty-ms@9.3.0:
+    resolution: {integrity: sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==}
+    engines: {node: '>=18'}
 
   proc-log@4.2.0:
     resolution: {integrity: sha512-g8+OnU/L2v+wyiVK+D5fA34J7EH8jZ8DDlvwhRCMxmMj7UCBvxiO1mGeN+36JXIKF4zevU4kRBd8lVgG9vLelA==}
@@ -19229,6 +19247,8 @@ snapshots:
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
 
+  parse-ms@4.0.0: {}
+
   parse-png@2.1.0:
     dependencies:
       pngjs: 3.4.0
@@ -19368,6 +19388,8 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
+  pretty-bytes@7.1.1: {}
+
   pretty-format@27.5.1:
     dependencies:
       ansi-regex: 5.0.1
@@ -19379,6 +19401,10 @@ snapshots:
       '@jest/schemas': 29.6.3
       ansi-styles: 5.2.0
       react-is: 18.3.1
+
+  pretty-ms@9.3.0:
+    dependencies:
+      parse-ms: 4.0.0
 
   proc-log@4.2.0: {}
 


### PR DESCRIPTION
Closes CODE-228.

Two rounds of transcript-fidelity work, driven by the 飞书 feedback screenshots (bare tool
names / missing call detail) and two stored-session regressions found while verifying
(message times lost on reopen, per-turn model field never populated).

## Tool-call display (a84233b2)

- **MCP slugs humanized**: `mcp__<server>__<tool>` renders as `tool · server` with an `MCP`
  badge (full slug on hover); permission cards keep server provenance. Wire titles unchanged —
  parsing is presentation-only (`mcpToolName` in `packages/ui`).
- **ToolSearch results render**: its `tool_result` is entirely `tool_reference` blocks, which
  the adapter used to drop — now flattened to a name-per-line text block (shared by live +
  history paths).
- **Curated input params for `other`-kind calls**: scalar rawInput fields as badges (≤8,
  values capped); nested objects/arrays stay hidden (that's where credentials/envelopes live).
  The allowlist policy tests were deliberately relaxed for this.
- **Fetch envelopes**: `Status 200 OK` / `Duration 5.4s` / `Size 193 kB` badges sourced from
  Claude's `tool_use_result` — scalar-projected (`toolUseResultEnvelope`) so bulk payloads
  (`originalFile`, `file.content`) never hit the wire. Live reads it off the SDK user frame;
  history recovers it from the raw transcript (the compaction supplement, now
  `ClaudeTranscriptSupplement`, read on every page). Formatting via `pretty-ms`/`pretty-bytes`.

## Stored-session fidelity (20d7a9f5)

- **Message times**: the claude mapper never stamped `AgentHistoryEvent.ts` (codex/opencode
  did), and the seed boundary dropped `ts` for every agent. The mapper now reads the runtime
  `timestamp` field off `getSessionMessages` rows (undeclared in the SDK d.ts; verified on
  0.3.206), and `ConversationSeed` entries are `{event, ts?}` so provider time stands in as
  `receivedAt` for seeded items.
- **Per-turn model**: rides the existing `model-update` event — the builder stamps assistant
  messages with the current model as they open, and the claude mapper replays `model-update`
  from each transcript row's `message.model` (subagent rows excluded). Turn meta shows the
  turn's own stamp, falling back to `conversation.currentModel`.

## Notes for review

- **No wire schema change, no `WIRE_PROTOCOL_VERSION` bump** — everything rides existing
  fields (`rawOutput: z.unknown()`, `AgentHistoryEvent.ts`, `model-update`).
- The persisted seed-cache blob shape changed; old blobs fail parse and degrade to a cache miss.
- The transcript supplement moved from first-page-only to every-page reads (settles on later
  pages need the envelope map); compaction splicing stays first-page-only.

## Verification

- 1084 tests + `check:ci` green; new coverage across adapter mapper, supplement harvest,
  builder stamping, and seed folding.
- Live SDK behavior probed with `claude -p --output-format stream-json`; history verified by
  driving `readHistory` against the real feedback session (`ts` on all 16 events, exact
  original send times, `model-update: claude-sonnet-5`, WebFetch envelope recovered).
- Real product E2E: webview dev against the dev daemon, reopening the stored session shows
  9:30/10:19/10:56 AM historical times and per-turn `claude-sonnet-5`; zero console errors.

Known follow-ups (tracked separately): mobile timeline still shows raw MCP slugs; subagent
nested calls don't get envelopes; `engine-file-suggest.test.ts` flake is a pre-existing race.