### PR TITLE
feat(mobile): terminal theme prop and iOS-aligned accessory bar (expo-libghostty 0.8.1)

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -37,7 +37,7 @@
     "expo-font": "~57.0.0",
     "expo-haptics": "~57.0.0",
     "expo-image-picker": "~57.0.2",
-    "expo-libghostty": "^0.7.0",
+    "expo-libghostty": "^0.8.1",
     "expo-linking": "~57.0.2",
     "expo-local-authentication": "~57.0.0",
     "expo-network": "~57.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -471,8 +471,8 @@ importers:
         specifier: ~57.0.2
         version: 57.0.2(expo@57.0.4)
       expo-libghostty:
-        specifier: ^0.7.0
-        version: 0.7.0(expo@57.0.4)(react-native@0.86.0(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)
+        specifier: ^0.8.1
+        version: 0.8.1(expo@57.0.4)(react-native@0.86.0(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)
       expo-linking:
         specifier: ~57.0.2
         version: 57.0.2(expo@57.0.4)(react-native@0.86.0(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)
@@ -6998,8 +6998,8 @@ packages:
       expo: '*'
       react: '*'
 
-  expo-libghostty@0.7.0:
-    resolution: {integrity: sha512-KZPkN70d1P3tHkTm2nQ/vgNGoPt6B/SJ3csrgobJUYoNgDFCVa//b4UsklST8VW5LIvo9ZetGxyb4vzoIU1/Sw==}
+  expo-libghostty@0.8.1:
+    resolution: {integrity: sha512-LcWO2ydkXM0RWy0sFhp7Xc2OpeqAyy5s9IGAd1u6y1luoli7MFHXE4RCafuA6YwkUYWekb22Sd4SsfOBFaLfbw==}
     peerDependencies:
       expo: '*'
       react: '*'
@@ -16876,7 +16876,7 @@ snapshots:
       expo: 57.0.4(@babel/core@7.29.7)(@expo/dom-webview@57.0.0)(@expo/metro-runtime@57.0.3)(@typescript/typescript6@6.0.2)(expo-router@57.0.4)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-webview@13.16.1(react-native@0.86.0(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3))(react-native-worklets@0.10.0(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(react-native@0.86.0(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3))(react-native@0.86.0(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)
       react: 19.2.3
 
-  expo-libghostty@0.7.0(expo@57.0.4)(react-native@0.86.0(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3):
+  expo-libghostty@0.8.1(expo@57.0.4)(react-native@0.86.0(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3):
     dependencies:
       expo: 57.0.4(@babel/core@7.29.7)(@expo/dom-webview@57.0.0)(@expo/metro-runtime@57.0.3)(@typescript/typescript6@6.0.2)(expo-router@57.0.4)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-webview@13.16.1(react-native@0.86.0(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3))(react-native-worklets@0.10.0(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(react-native@0.86.0(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3))(react-native@0.86.0(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)
       react: 19.2.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -107,7 +107,7 @@ minimumReleaseAgeExclude:
   - effect@4.0.0-beta.98
   - "@effect/platform-node@4.0.0-beta.98"
   # First-party mobile terminal view, released same-day as the integration.
-  - expo-libghostty@0.7.0
+  - expo-libghostty@0.8.1
   # codex platform artifacts are versions of @openai/codex keyed <ver>-<platform>-<arch>.
   - '@openai/codex@0.144.1-darwin-arm64 || 0.144.1-darwin-x64 || 0.144.1-linux-arm64 || 0.144.1-linux-x64 || 0.144.1-win32-arm64 || 0.144.1-win32-x64 || 0.144.1'
   - '@earendil-works/pi-agent-core@0.80.6'


### PR DESCRIPTION
CODE-258. Bumps `expo-libghostty` to 0.8.1.

## expo-libghostty 0.8.0

- **`theme` prop on both platforms**: `background` / `foreground` / `cursorColor` / `selectionBackground` / `selectionForeground` / `palette` (overrides by index, 0–255), in ghostty config color syntax (hex or X11 names; invalid values warn and are skipped, like ghostty config). Android sets the terminal's default colors through libghostty-vt (`GHOSTTY_TERMINAL_OPT_COLOR_*`), so OSC 4/10/11/12 queries and resets stay truthful, and applies per view; iOS applies app-wide through the shared controller's config. Selection colors are a renderer concern on Android (falls back to the classic fg/bg swap when unset).
- **Android accessory bar aligned with the iOS input accessory bar**: same default key set (esc / tab / ctrl / alt · arrows · `| / ~ - _ \` ' "` · paste) as 36dp circular buttons with dot dividers, and the iOS three-state sticky cycle — tap arms Ctrl/Alt for the next key, a quick double tap locks them (bottom indicator) until tapped again.

## expo-libghostty 0.8.1 (library hardening)

- **Fixes a mount-time write race**: in release builds, `write()` issued from a mount effect was rejected by expo-modules-core ("unable to find view") and silently dropped — JS starts before the UI thread registers the view. `TerminalView` now queues imperative calls until the view reports its first grid size, then flushes in order. Verified on an R8-minified Android release build and the iOS simulator.
- Every pod ships a `PrivacyInfo.xcprivacy` (GhosttyTerminal: system-boot-time 35F9.1; GhosttyKit: file-timestamp C617.1) — fixes App Store ITMS-91053 warnings for this app.
- Library CI now gates an R8-minified Android release build and an iOS simulator build.

## Verification

- Example app, both platforms, with a Catppuccin Mocha theme: background/foreground, ANSI 16-color strip (normal + bright), SGR text colors, pink cursor, themed selection — Android emulator and iOS simulator render the same theme.
- Accessory bar: armed (blue) and locked (blue + indicator) states, locked persists across keys; symbol keys and paste wired through the terminal's existing input/paste paths.
- linkcode dev client rebuilt with 0.8.0 against a live daemon PTY: new bar renders in the app layout, armed Ctrl+C interrupts a real zsh (fresh starship prompt). 0.8.1 is a JS-only change on Android (no native fingerprint change).
- `pnpm check:ci` + `pnpm test` (1197 passed) green.

Follow-up (not in this PR): wire `theme` into the mobile terminal screen from the Terminal appearance settings.