### PR TITLE
feat(assets): managed downloads follow the OS system proxy (CODE-222)

### DIFF
--- a/packages/assets/AGENTS.md
+++ b/packages/assets/AGENTS.md
@@ -34,8 +34,13 @@ the `asset.list` wire resource; presentation belongs to the onboarding UI (CODE-
   at `package/vendor/<rust-triple>/bin/codex`. All members in `catalog.ts` were read off real
   tarballs; re-verify against a fresh tarball when bumping an SDK.
 - **The fetch/verify/extract stack is npm's own, taken at the right layer**: `make-fetch-happen`
-  (per-source retry + `HTTPS_PROXY`/`NO_PROXY` env support), `ssri` (integrity streams), `tar`
-  (node-tar, pure JS — tgz extraction assumes no system tar), `semver`. This is deliberately
+  (per-source retry + explicit `HTTPS_PROXY`/`NO_PROXY` env support, with the OS-configured manual
+  proxy filling in when the environment names none — `system-proxy/`: win32 reads WinINET via
+  `reg.exe`, darwin reads `scutil` via `mac-system-proxy`; both legs adapted from httptoolkit's
+  os-proxy-config, vendored because its win32 leg needs the native `registry-js` addon, whose
+  win32-only prebuilds would force a node-gyp toolchain on every mac/linux install. PAC
+  configurations fail explicitly), `ssri` (integrity streams), `tar` (node-tar, pure JS — tgz
+  extraction assumes no system tar), `semver`. This is deliberately
   pacote's engine *without* pacote: its extra layers (sigstore, run-script, git, packlist) are
   npm-CLI semantics that would enter the binary-installing path unused. `env-paths` was
   evaluated and rejected — it hardcodes a `\Data` level on win32 and captures `homedir` at

--- a/packages/assets/package.json
+++ b/packages/assets/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@linkcode/schema": "workspace:*",
     "foxts": "^5.8.0",
+    "mac-system-proxy": "^1.0.4",
     "make-fetch-happen": "^16.0.1",
     "p-map": "^7.0.5",
     "semver": "^7.8.5",

--- a/packages/assets/src/__tests__/darwin-proxy.test.ts
+++ b/packages/assets/src/__tests__/darwin-proxy.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import { mapMacProxySettings } from '../system-proxy/darwin';
+
+describe('mapMacProxySettings', () => {
+  it('maps an enabled HTTP proxy with its exceptions list', () => {
+    expect(
+      mapMacProxySettings({
+        HTTPEnable: '1',
+        HTTPProxy: '127.0.0.1',
+        HTTPPort: '7890',
+        ExceptionsList: ['*.local', '169.254/16'],
+      }),
+    ).toEqual({
+      kind: 'proxy',
+      proxyUrl: 'http://127.0.0.1:7890',
+      noProxy: ['*.local', '169.254/16'],
+    });
+  });
+
+  it("treats a '0' enable flag as disabled even when host and port linger", () => {
+    expect(
+      mapMacProxySettings({ HTTPEnable: '0', HTTPProxy: '127.0.0.1', HTTPPort: '7890' }),
+    ).toBeUndefined();
+  });
+
+  it('prefers http over socks over https', () => {
+    const socksAndHttps = {
+      SOCKSEnable: '1',
+      SOCKSProxy: 'socks.test',
+      SOCKSPort: '1080',
+      HTTPSEnable: '1',
+      HTTPSProxy: 'https.test',
+      HTTPSPort: '8443',
+    } as const;
+    expect(
+      mapMacProxySettings({
+        HTTPEnable: '1',
+        HTTPProxy: 'http.test',
+        HTTPPort: '8080',
+        ...socksAndHttps,
+      }),
+    ).toMatchObject({ proxyUrl: 'http://http.test:8080' });
+    expect(mapMacProxySettings(socksAndHttps)).toMatchObject({
+      proxyUrl: 'socks://socks.test:1080',
+    });
+    expect(
+      mapMacProxySettings({ HTTPSEnable: '1', HTTPSProxy: 'https.test', HTTPSPort: '8443' }),
+    ).toMatchObject({ proxyUrl: 'http://https.test:8443' });
+  });
+
+  it('reports an enabled PAC configuration over manual settings', () => {
+    expect(
+      mapMacProxySettings({
+        ProxyAutoConfigEnable: '1',
+        ProxyAutoConfigURLString: 'http://pac.test/proxy.pac',
+        HTTPEnable: '1',
+        HTTPProxy: '127.0.0.1',
+        HTTPPort: '7890',
+      }),
+    ).toEqual({ kind: 'pac', pacUrl: 'http://pac.test/proxy.pac' });
+  });
+
+  it('ignores a PAC flag without a script URL and empty settings', () => {
+    expect(mapMacProxySettings({ ProxyAutoConfigEnable: '1' })).toBeUndefined();
+    expect(mapMacProxySettings({})).toBeUndefined();
+  });
+});

--- a/packages/assets/src/__tests__/system-proxy.test.ts
+++ b/packages/assets/src/__tests__/system-proxy.test.ts
@@ -1,0 +1,158 @@
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { DownloadError } from '../errors';
+import { fetchWithSystemProxy, resolveSystemProxy } from '../system-proxy';
+
+const { fetchMock, win32Mock, darwinMock } = vi.hoisted(() => ({
+  fetchMock: vi.fn(),
+  win32Mock: vi.fn(),
+  darwinMock: vi.fn(),
+}));
+
+vi.mock('make-fetch-happen', () => ({ default: fetchMock }));
+vi.mock('../system-proxy/win32', () => ({ getWin32SystemProxy: win32Mock }));
+vi.mock('../system-proxy/darwin', () => ({ getDarwinSystemProxy: darwinMock }));
+
+const PROXY_ENV_KEYS = [
+  'HTTP_PROXY',
+  'http_proxy',
+  'HTTPS_PROXY',
+  'https_proxy',
+  'PROXY',
+  'proxy',
+  'NO_PROXY',
+  'no_proxy',
+];
+
+const originalProxyEnv = new Map(PROXY_ENV_KEYS.map((key) => [key, process.env[key]]));
+const originalPlatform = process.platform;
+
+function setPlatform(platform: NodeJS.Platform) {
+  Object.defineProperty(process, 'platform', { value: platform, configurable: true });
+}
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  win32Mock.mockReset();
+  darwinMock.mockReset();
+  for (const key of PROXY_ENV_KEYS) delete process.env[key];
+  setPlatform('win32');
+});
+
+afterEach(() => {
+  setPlatform(originalPlatform);
+});
+
+afterAll(() => {
+  for (const key of PROXY_ENV_KEYS) {
+    const value = originalProxyEnv.get(key);
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+});
+
+describe('resolveSystemProxy', () => {
+  it('leaves explicit proxy environment variables to make-fetch-happen', async () => {
+    process.env.HTTPS_PROXY = 'http://env-proxy.test:8080';
+
+    await expect(resolveSystemProxy()).resolves.toBeUndefined();
+    expect(win32Mock).not.toHaveBeenCalled();
+  });
+
+  it('returns the OS proxy and merges environment bypass entries', async () => {
+    process.env.NO_PROXY = 'env.test, shared.test, ,';
+    win32Mock.mockReturnValue({
+      kind: 'proxy',
+      proxyUrl: 'http://system-proxy.test:8080',
+      noProxy: ['os.test', 'shared.test'],
+    });
+
+    await expect(resolveSystemProxy()).resolves.toEqual({
+      proxy: 'http://system-proxy.test:8080',
+      noProxy: ['os.test', 'shared.test', 'env.test'],
+    });
+  });
+
+  it('consults the darwin leg on darwin and nothing elsewhere', async () => {
+    setPlatform('darwin');
+    darwinMock.mockResolvedValue(undefined);
+    await expect(resolveSystemProxy()).resolves.toBeUndefined();
+    expect(darwinMock).toHaveBeenCalledOnce();
+    expect(win32Mock).not.toHaveBeenCalled();
+
+    setPlatform('linux');
+    await expect(resolveSystemProxy()).resolves.toBeUndefined();
+    expect(darwinMock).toHaveBeenCalledOnce();
+    expect(win32Mock).not.toHaveBeenCalled();
+  });
+
+  it('fails with context when OS proxy detection fails', async () => {
+    const cause = new Error('reg.exe exited with 1');
+    win32Mock.mockImplementation(() => {
+      throw cause;
+    });
+
+    await expect(resolveSystemProxy()).rejects.toMatchObject({
+      name: 'DownloadError',
+      message: 'failed to read OS proxy configuration: reg.exe exited with 1',
+      cause,
+    });
+  });
+
+  it('propagates a leg DownloadError without re-wrapping', async () => {
+    win32Mock.mockImplementation(() => {
+      throw new DownloadError('no usable proxy in ProxyServer value: ftp=x');
+    });
+
+    await expect(resolveSystemProxy()).rejects.toThrow(
+      'no usable proxy in ProxyServer value: ftp=x',
+    );
+  });
+
+  it('rejects unsupported PAC configurations instead of bypassing them', async () => {
+    win32Mock.mockReturnValue({ kind: 'pac', pacUrl: 'https://proxy.test/config.pac' });
+
+    await expect(resolveSystemProxy()).rejects.toThrow(
+      'PAC system proxy configuration is unsupported',
+    );
+  });
+});
+
+describe('fetchWithSystemProxy', () => {
+  it('passes the resolved proxy to make-fetch-happen', async () => {
+    const response = new Response('ok');
+    win32Mock.mockReturnValue({
+      kind: 'proxy',
+      proxyUrl: 'http://system-proxy.test:8080',
+      noProxy: ['localhost'],
+    });
+    fetchMock.mockResolvedValue(response);
+
+    await expect(
+      fetchWithSystemProxy('https://registry.test/pkg', {
+        headers: { accept: 'application/json' },
+        retry: 0,
+      }),
+    ).resolves.toBe(response);
+    expect(fetchMock).toHaveBeenCalledWith('https://registry.test/pkg', {
+      headers: { accept: 'application/json' },
+      retry: 0,
+      proxy: 'http://system-proxy.test:8080',
+      noProxy: ['localhost'],
+    });
+  });
+
+  it('identifies the system proxy when a proxied request fails', async () => {
+    win32Mock.mockReturnValue({
+      kind: 'proxy',
+      proxyUrl: 'http://system-proxy.test:8080',
+      noProxy: [],
+    });
+    fetchMock.mockRejectedValue(new Error('connection refused'));
+
+    await expect(fetchWithSystemProxy('https://registry.test/pkg', { retry: 0 })).rejects.toEqual(
+      new DownloadError('connection refused (via system proxy http://system-proxy.test:8080)', {
+        cause: expect.any(Error),
+      }),
+    );
+  });
+});

--- a/packages/assets/src/__tests__/win32-proxy.test.ts
+++ b/packages/assets/src/__tests__/win32-proxy.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+import { DownloadError } from '../errors';
+import { interpretInternetSettings, parseRegQueryOutput } from '../system-proxy/win32';
+
+/** Verbatim shape of `reg query "HKCU\...\Internet Settings"` on Windows 10/11. */
+const TYPICAL_OUTPUT = [
+  '',
+  String.raw`HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Internet Settings`,
+  '    CertificateRevocation    REG_DWORD    0x1',
+  '    ProxyEnable    REG_DWORD    0x1',
+  '    ProxyServer    REG_SZ    127.0.0.1:7890',
+  '    ProxyOverride    REG_SZ    <local>;*.internal.test',
+  '    User Agent    REG_SZ    Mozilla/4.0 (compatible; MSIE 8.0; Win32)',
+  '',
+  '',
+].join('\r\n');
+
+describe('parseRegQueryOutput', () => {
+  it('collects string and dword values, keeping names with spaces', () => {
+    expect(parseRegQueryOutput(TYPICAL_OUTPUT)).toEqual(
+      new Map<string, string | number>([
+        ['CertificateRevocation', 1],
+        ['ProxyEnable', 1],
+        ['ProxyServer', '127.0.0.1:7890'],
+        ['ProxyOverride', '<local>;*.internal.test'],
+        ['User Agent', 'Mozilla/4.0 (compatible; MSIE 8.0; Win32)'],
+      ]),
+    );
+  });
+
+  it('skips value types registry readers do not materialize', () => {
+    const output = [
+      '    ConnectionsBlob    REG_BINARY    3C00000004000000',
+      String.raw`    SomePath    REG_EXPAND_SZ    %SystemRoot%\system32`,
+    ].join('\r\n');
+    expect(parseRegQueryOutput(output)).toEqual(
+      new Map([['SomePath', String.raw`%SystemRoot%\system32`]]),
+    );
+  });
+
+  it('returns an empty map for a value-less key', () => {
+    expect(parseRegQueryOutput('\r\nHKEY_CURRENT_USER\\Software\r\n\r\n')).toEqual(new Map());
+  });
+});
+
+const values = (entries: Record<string, string | number>) => new Map(Object.entries(entries));
+
+describe('interpretInternetSettings', () => {
+  it('maps an enabled manual proxy, expanding <local> in the bypass list', () => {
+    expect(interpretInternetSettings(parseRegQueryOutput(TYPICAL_OUTPUT))).toEqual({
+      kind: 'proxy',
+      proxyUrl: 'http://127.0.0.1:7890',
+      noProxy: ['localhost', '127.0.0.1', '::1', '*.internal.test'],
+    });
+  });
+
+  it('returns undefined when the proxy is disabled or has no server', () => {
+    expect(
+      interpretInternetSettings(values({ ProxyEnable: 0, ProxyServer: '127.0.0.1:7890' })),
+    ).toBeUndefined();
+    expect(interpretInternetSettings(values({ ProxyEnable: 1 }))).toBeUndefined();
+    expect(interpretInternetSettings(values({ ProxyEnable: 1, ProxyServer: '' }))).toBeUndefined();
+  });
+
+  it('keeps a full-URL ProxyServer as-is', () => {
+    expect(
+      interpretInternetSettings(values({ ProxyEnable: 1, ProxyServer: 'http://proxy.corp:8080' })),
+    ).toEqual({ kind: 'proxy', proxyUrl: 'http://proxy.corp:8080', noProxy: [] });
+  });
+
+  it('prefers http, then socks, then https from per-protocol pairs', () => {
+    const detect = (proxyServer: string) =>
+      interpretInternetSettings(values({ ProxyEnable: 1, ProxyServer: proxyServer }));
+    expect(detect('ftp=f:21;http=h:1;socks=k:3')).toMatchObject({ proxyUrl: 'http://h:1' });
+    expect(detect('socks=k:3;https=s:2')).toMatchObject({ proxyUrl: 'socks://k:3' });
+    expect(detect('https=s:2')).toMatchObject({ proxyUrl: 'http://s:2' });
+    expect(() => detect('ftp=f:21')).toThrow(DownloadError);
+  });
+
+  it('reports a configured setup script as PAC, over any manual settings', () => {
+    expect(
+      interpretInternetSettings(
+        values({
+          AutoConfigURL: 'http://pac.corp/proxy.pac',
+          ProxyEnable: 1,
+          ProxyServer: '127.0.0.1:7890',
+        }),
+      ),
+    ).toEqual({ kind: 'pac', pacUrl: 'http://pac.corp/proxy.pac' });
+  });
+});

--- a/packages/assets/src/__tests__/win32-proxy.test.ts
+++ b/packages/assets/src/__tests__/win32-proxy.test.ts
@@ -11,7 +11,10 @@ const TYPICAL_OUTPUT = [
   '    ProxyServer    REG_SZ    127.0.0.1:7890',
   '    ProxyOverride    REG_SZ    <local>;*.internal.test',
   '    User Agent    REG_SZ    Mozilla/4.0 (compatible; MSIE 8.0; Win32)',
+  '    LockDatabase    REG_QWORD    0x1dca9548a439845',
   '',
+  String.raw`HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Internet Settings\5.0`,
+  String.raw`HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Internet Settings\Cache`,
   '',
 ].join('\r\n');
 

--- a/packages/assets/src/download.ts
+++ b/packages/assets/src/download.ts
@@ -5,10 +5,9 @@ import { Transform } from 'node:stream';
 import { pipeline } from 'node:stream/promises';
 import type { ManagedAssetArtifact } from '@linkcode/schema';
 import { extractErrorMessage } from 'foxts/extract-error-message';
-import fetch from 'make-fetch-happen';
 import ssri from 'ssri';
-import './mfh-augment';
 import { DownloadError, IntegrityError } from './errors';
+import { fetchWithSystemProxy } from './system-proxy';
 
 export interface DownloadProgress {
   receivedBytes: number;
@@ -29,7 +28,8 @@ const INTEGRITY_CODES = new Set(['EINTEGRITY', 'EBADSIZE']);
 
 /**
  * Download to `destFile`, walking the ordered source list until one delivers SRI-verified
- * bytes (make-fetch-happen transport: per-source retry + proxy env support). The body streams
+ * bytes (make-fetch-happen transport: per-source retry + proxy env support, plus the
+ * OS-configured system proxy when the env names none — `system-proxy.ts`). The body streams
  * through `ssri.integrityStream` and the destination is deleted on any failure, so a truncated
  * or tampered transfer never leaves a "valid" file. An integrity mismatch fails just that
  * source but surfaces as `IntegrityError` when no source survives; ENOSPC aborts the walk.
@@ -66,7 +66,7 @@ async function downloadFrom(
   artifact: ManagedAssetArtifact,
   options: DownloadOptions,
 ): Promise<void> {
-  const res = await fetch(url, {
+  const res = await fetchWithSystemProxy(url, {
     retry: options.retry ?? DEFAULT_RETRY,
     signal: AbortSignal.timeout(DOWNLOAD_TIMEOUT_MS),
   });

--- a/packages/assets/src/registry-client.ts
+++ b/packages/assets/src/registry-client.ts
@@ -1,8 +1,7 @@
 import { extractErrorMessage } from 'foxts/extract-error-message';
-import fetch from 'make-fetch-happen';
 import { z } from 'zod';
-import './mfh-augment';
 import { DownloadError } from './errors';
+import { fetchWithSystemProxy } from './system-proxy';
 
 /** Default ordered registry list; a mirror (e.g. npmmirror for CN hosts) can be appended later. */
 const DEFAULT_REGISTRIES = ['https://registry.npmjs.org'] as const;
@@ -33,6 +32,8 @@ export interface FetchNpmDistOptions {
  * Resolve a package version's tarball URL + SRI integrity via the single-version manifest
  * (`<registry>/<pkg>/<version>`; the full packument runs to megabytes). Scoped names go in
  * the path unencoded. Registries are an ordered fallback list — the first answer wins.
+ * Fetching goes through make-fetch-happen (retry + proxy env support, plus the OS-configured
+ * system proxy when the env names none — `system-proxy.ts`).
  */
 export async function fetchNpmDist(
   pkg: string,
@@ -56,7 +57,7 @@ async function fetchDist(
   failures: string[],
 ): Promise<NpmDist | undefined> {
   try {
-    const res = await fetch(url, {
+    const res = await fetchWithSystemProxy(url, {
       headers: { accept: 'application/json' },
       retry,
       signal: AbortSignal.timeout(MANIFEST_TIMEOUT_MS),

--- a/packages/assets/src/system-proxy/darwin.ts
+++ b/packages/assets/src/system-proxy/darwin.ts
@@ -1,0 +1,45 @@
+import type { MacProxySettings } from 'mac-system-proxy';
+import { getMacSystemProxy } from 'mac-system-proxy';
+import type { SystemProxyDetection } from './types';
+
+/**
+ * macOS system-proxy detection over `mac-system-proxy` (`scutil --proxy`; pure JS). The mapping
+ * is adapted from httptoolkit/os-proxy-config (Apache-2.0) with two fixes: enable flags compare
+ * to `'1'` — scutil reports `'0'` for a disabled proxy whose host/port linger, and a bare
+ * truthiness check would treat it as enabled — and a PAC configuration is surfaced instead of
+ * silently ignored.
+ */
+
+export async function getDarwinSystemProxy(): Promise<SystemProxyDetection | undefined> {
+  return mapMacProxySettings(await getMacSystemProxy());
+}
+
+/** Exported for tests. */
+export function mapMacProxySettings(settings: MacProxySettings): SystemProxyDetection | undefined {
+  if (settings.ProxyAutoConfigEnable === '1' && settings.ProxyAutoConfigURLString) {
+    return { kind: 'pac', pacUrl: settings.ProxyAutoConfigURLString };
+  }
+  const noProxy = settings.ExceptionsList ?? [];
+  if (settings.HTTPEnable === '1' && settings.HTTPProxy && settings.HTTPPort) {
+    return {
+      kind: 'proxy',
+      proxyUrl: `http://${settings.HTTPProxy}:${settings.HTTPPort}`,
+      noProxy,
+    };
+  }
+  if (settings.SOCKSEnable === '1' && settings.SOCKSProxy && settings.SOCKSPort) {
+    return {
+      kind: 'proxy',
+      proxyUrl: `socks://${settings.SOCKSProxy}:${settings.SOCKSPort}`,
+      noProxy,
+    };
+  }
+  if (settings.HTTPSEnable === '1' && settings.HTTPSProxy && settings.HTTPSPort) {
+    return {
+      kind: 'proxy',
+      proxyUrl: `http://${settings.HTTPSProxy}:${settings.HTTPSPort}`,
+      noProxy,
+    };
+  }
+  return undefined;
+}

--- a/packages/assets/src/system-proxy/index.ts
+++ b/packages/assets/src/system-proxy/index.ts
@@ -1,0 +1,92 @@
+import { extractErrorMessage } from 'foxts/extract-error-message';
+import fetch from 'make-fetch-happen';
+import '../mfh-augment';
+import { DownloadError } from '../errors';
+import { getDarwinSystemProxy } from './darwin';
+import type { SystemProxyDetection } from './types';
+import { getWin32SystemProxy } from './win32';
+
+/**
+ * make-fetch-happen's per-request proxy options (consumed by @npmcli/agent, where an explicit
+ * `proxy` overrides the `*_PROXY` env vars and an explicit `noProxy` overrides `NO_PROXY`).
+ */
+export interface SystemProxyOptions {
+  proxy: string;
+  noProxy: string[];
+}
+
+/** The env vars @npmcli/agent reads (case-insensitively) to pick a proxy on its own. */
+const PROXY_ENV_KEYS = new Set(['https_proxy', 'http_proxy', 'proxy']);
+
+/**
+ * Fetch through the OS-configured proxy when the environment names none. GUI-launched desktop
+ * apps (Dock / Start menu) inherit no `*_PROXY` env vars — the system proxy lives in OS settings,
+ * which the platform legs read (win32 WinINET registry via `reg.exe`, darwin `scutil`; elsewhere
+ * the env vars are the only proxy source and make-fetch-happen already honors them). When the
+ * request fails through a system proxy, the error names the proxy so "proxy unreachable" is
+ * distinguishable from "source unreachable". Resolution is per call — a settings change applies
+ * to the next request, and the cost (one `reg.exe`/`scutil` spawn) is noise next to the transfer
+ * itself. Detection failures and unsupported PAC configurations fail explicitly rather than
+ * bypassing the configured proxy.
+ */
+export async function fetchWithSystemProxy(
+  url: string,
+  options: fetch.FetchOptions,
+): ReturnType<typeof fetch> {
+  const systemProxy = await resolveSystemProxy();
+  try {
+    return await fetch(url, { ...options, ...systemProxy });
+  } catch (error) {
+    if (!systemProxy) throw error;
+    throw new DownloadError(
+      `${extractErrorMessage(error, false)} (via system proxy ${systemProxy.proxy})`,
+      { cause: error },
+    );
+  }
+}
+
+export async function resolveSystemProxy(): Promise<SystemProxyOptions | undefined> {
+  // The env is the operator's word: when it names a proxy, make-fetch-happen already honors it
+  // (and its absence of NO_PROXY too) — never second-guess it with the OS configuration.
+  if (envNamesProxy()) return undefined;
+  const detected = await detectSystemProxy();
+  if (!detected) return undefined;
+  // A PAC URL names a script, not a proxy endpoint; @npmcli/agent cannot dial it directly.
+  if (detected.kind === 'pac') {
+    throw new DownloadError(`PAC system proxy configuration is unsupported: ${detected.pacUrl}`);
+  }
+  return { proxy: detected.proxyUrl, noProxy: mergeEnvNoProxy(detected.noProxy) };
+}
+
+async function detectSystemProxy(): Promise<SystemProxyDetection | undefined> {
+  try {
+    if (process.platform === 'win32') return getWin32SystemProxy();
+    if (process.platform === 'darwin') return await getDarwinSystemProxy();
+    return undefined;
+  } catch (error) {
+    if (error instanceof DownloadError) throw error;
+    throw new DownloadError(
+      `failed to read OS proxy configuration: ${extractErrorMessage(error, false)}`,
+      { cause: error },
+    );
+  }
+}
+
+function envNamesProxy(): boolean {
+  return Object.entries(process.env).some(
+    ([key, value]) => PROXY_ENV_KEYS.has(key.toLowerCase()) && !!value,
+  );
+}
+
+/** Passing `noProxy` makes @npmcli/agent ignore the NO_PROXY env var — merge it back in. */
+function mergeEnvNoProxy(osNoProxy: string[]): string[] {
+  const env = Object.entries(process.env).find(
+    ([key, value]) => key.toLowerCase() === 'no_proxy' && !!value,
+  )?.[1];
+  const envNoProxy: string[] = [];
+  for (const host of env?.split(',') ?? []) {
+    const trimmed = host.trim();
+    if (trimmed) envNoProxy.push(trimmed);
+  }
+  return [...new Set([...osNoProxy, ...envNoProxy])];
+}

--- a/packages/assets/src/system-proxy/types.ts
+++ b/packages/assets/src/system-proxy/types.ts
@@ -1,0 +1,4 @@
+/** What a platform leg found in the OS proxy configuration. */
+export type SystemProxyDetection =
+  | { kind: 'proxy'; proxyUrl: string; noProxy: string[] }
+  | { kind: 'pac'; pacUrl: string };

--- a/packages/assets/src/system-proxy/win32.ts
+++ b/packages/assets/src/system-proxy/win32.ts
@@ -1,0 +1,102 @@
+/// <reference types="node" />
+import { execFileSync } from 'node:child_process';
+import { join } from 'node:path';
+import { DownloadError } from '../errors';
+import type { SystemProxyDetection } from './types';
+
+/**
+ * WinINET system-proxy detection: read the Internet Settings registry key with `reg.exe`
+ * (System32 — the same guarantee extract.ts relies on for `tar.exe`) and interpret
+ * `AutoConfigURL` / `ProxyEnable` / `ProxyServer` / `ProxyOverride`. The interpretation is
+ * adapted from httptoolkit/windows-system-proxy (Apache-2.0); the registry read replaces its
+ * native `registry-js` addon, whose win32-only prebuilds would force a node-gyp toolchain on
+ * every mac/linux install.
+ */
+
+const INTERNET_SETTINGS = String.raw`HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Internet Settings`;
+
+/** A `reg.exe query` value row: 4-space indent, then name / REG_* type / data, 4-space separated. */
+const VALUE_ROW = /^ {4}(.+?) {4}(REG_[A-Z_]+) {4}(.*)$/;
+
+export function getWin32SystemProxy(): SystemProxyDetection | undefined {
+  const regExe = join(process.env.SystemRoot ?? String.raw`C:\Windows`, 'System32', 'reg.exe');
+  const output = execFileSync(regExe, ['query', INTERNET_SETTINGS], {
+    encoding: 'utf8',
+    windowsHide: true,
+  });
+  return interpretInternetSettings(parseRegQueryOutput(output));
+}
+
+/**
+ * Parse `reg.exe query` output into name → data (`REG_SZ`/`REG_EXPAND_SZ` as string, `REG_DWORD`
+ * as number — the same three types `registry-js` materializes). Exported for tests.
+ */
+export function parseRegQueryOutput(output: string): Map<string, string | number> {
+  const values = new Map<string, string | number>();
+  for (const line of output.split(/\r?\n/)) {
+    const row = VALUE_ROW.exec(line);
+    if (!row) continue;
+    const [, name, type, data] = row;
+    if (type === 'REG_SZ' || type === 'REG_EXPAND_SZ') {
+      values.set(name, data);
+    } else if (type === 'REG_DWORD') {
+      values.set(name, Number.parseInt(data, 16));
+    }
+  }
+  return values;
+}
+
+/** Exported for tests. */
+export function interpretInternetSettings(
+  values: ReadonlyMap<string, string | number>,
+): SystemProxyDetection | undefined {
+  // A configured setup script wins over manual settings, matching WinINET's own precedence.
+  const autoConfigUrl = values.get('AutoConfigURL');
+  if (typeof autoConfigUrl === 'string' && autoConfigUrl) {
+    return { kind: 'pac', pacUrl: autoConfigUrl };
+  }
+  const proxyServer = values.get('ProxyServer');
+  if (!values.get('ProxyEnable') || typeof proxyServer !== 'string' || !proxyServer) {
+    return undefined;
+  }
+  return {
+    kind: 'proxy',
+    proxyUrl: parseProxyServer(proxyServer),
+    noProxy: parseProxyOverride(values.get('ProxyOverride')),
+  };
+}
+
+/**
+ * `ProxyServer` comes in three shapes: a full URL, `protocol=host:port` pairs separated by `;`
+ * (per-protocol configuration), or a bare `host:port`. For the pair form, prefer http, then
+ * socks, then https — proxies listed under one protocol overwhelmingly serve the others too.
+ */
+function parseProxyServer(config: string): string {
+  if (config.startsWith('http://') || config.startsWith('https://')) return config;
+  if (config.includes('=')) {
+    const byProtocol = new Map(
+      config.split(';').map((pair) => pair.split('=', 2) as [string, string]),
+    );
+    const http = byProtocol.get('http');
+    if (http) return `http://${http}`;
+    const socks = byProtocol.get('socks');
+    if (socks) return `socks://${socks}`;
+    const https = byProtocol.get('https');
+    if (https) return `http://${https}`;
+    throw new DownloadError(`no usable proxy in ProxyServer value: ${config}`);
+  }
+  return `http://${config}`;
+}
+
+/** `ProxyOverride` is `;`-separated bypass hosts; `<local>` means "no dots in the hostname". */
+function parseProxyOverride(override: string | number | undefined): string[] {
+  if (typeof override !== 'string') return [];
+  const noProxy: string[] = [];
+  for (const entry of override.split(';')) {
+    const host = entry.trim();
+    if (!host) continue;
+    if (host === '<local>') noProxy.push('localhost', '127.0.0.1', '::1');
+    else noProxy.push(host);
+  }
+  return noProxy;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -777,6 +777,9 @@ importers:
       foxts:
         specifier: ^5.8.0
         version: 5.8.0
+      mac-system-proxy:
+        specifier: ^1.0.4
+        version: 1.0.4
       make-fetch-happen:
         specifier: ^16.0.1
         version: 16.0.1
@@ -8235,6 +8238,9 @@ packages:
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
     hasBin: true
+
+  mac-system-proxy@1.0.4:
+    resolution: {integrity: sha512-IAkNLxXZrYuM99A2OhPrvUoAxohsxQciJh2D2xnD+R6vypn/AVyOYLsbZsMVCS/fEbLIe67nQ8krEAfqP12BVg==}
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -18264,6 +18270,8 @@ snapshots:
       react: 19.2.7
 
   lz-string@1.5.0: {}
+
+  mac-system-proxy@1.0.4: {}
 
   magic-string@0.30.21:
     dependencies:


### PR DESCRIPTION
## Problem

Managed asset downloads (agent binaries, tectonic, npm registry queries) ignore the OS-configured system proxy. `make-fetch-happen` only reads the `*_PROXY` env vars, which GUI-launched desktop apps never inherit — the system proxy lives in OS settings (WinINET / macOS network preferences), so downloads fail or crawl in proxied environments (CODE-222).

## Change

New `packages/assets/src/system-proxy/` fills the gap at the fetch layer:

- **`win32.ts`** reads the WinINET registry key with `reg.exe` (System32, same guarantee `extract.ts` relies on for `tar.exe`) and interprets `AutoConfigURL` / `ProxyEnable` / `ProxyServer` (all three formats) / `ProxyOverride` (`<local>` expansion). Adapted from httptoolkit/windows-system-proxy (Apache-2.0) — vendored instead of depended on because its native `registry-js` addon ships win32-only prebuilds and would force a node-gyp toolchain on every mac/linux install; a pnpm `link:` override shim turned out to not materialize under `nodeLinker: hoisted`.
- **`darwin.ts`** maps `mac-system-proxy` (`scutil --proxy`; pure JS, zero deps — the only new dependency) output, fixing two upstream bugs: enable flags compare to `'1'` (the string `'0'` is truthy) and PAC configs are surfaced instead of silently ignored.
- **`index.ts`** orchestrates: env vars keep absolute precedence (make-fetch-happen already honors them); otherwise the detected proxy feeds make-fetch-happen's per-request `proxy`/`noProxy`, with the OS bypass list merged with env `NO_PROXY`. PAC configurations and detection failures throw `DownloadError` rather than silently connecting direct, and failures through a system proxy name the proxy URL so "proxy unreachable" is distinguishable from "source unreachable".

`download.ts` and `registry-client.ts` route through `fetchWithSystemProxy`. No native deps, no `allowBuilds` or tsup changes.

## Verification

- `pnpm check:ci` green; full vitest suite 1164/1167 (one pre-existing environment-specific failure: WSL2 mirrored networking times out on closed loopback ports, breaking `registry-client.test.ts`'s `http://127.0.0.1:1` fall-through assumption on master too).
- win32 leg validated against a **real** Windows registry via WSL interop: live `reg.exe query` output piped through the production parser detects the machine's actual proxy (`http://127.0.0.1:2080`, `<local>` → loopback bypass). The fixture mirrors that capture verbatim.
- Daemon tsup bundle builds with the proxy legs inlined.

## Remaining acceptance

A packaged-app run on real Windows/macOS with only a system proxy configured (no env vars) — covers the `reg.exe`/`scutil` spawn paths and make-fetch-happen dialing the detected proxy end-to-end.