### PR TITLE
perf(ui): virtualize conversation timeline (virtua) + incremental per-event derivations

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -48,7 +48,8 @@
     "streamdown": "^2.5.0",
     "tailwind-merge": "^3.6.0",
     "use-intl": "catalog:",
-    "use-stick-to-bottom": "^1.1.6"
+    "use-stick-to-bottom": "^1.1.6",
+    "virtua": "^0.49.3"
   },
   "devDependencies": {
     "@types/react": "catalog:",

--- a/packages/ui/src/__tests__/turn-edits.test.ts
+++ b/packages/ui/src/__tests__/turn-edits.test.ts
@@ -1,6 +1,6 @@
 import type { ToolCall } from '@linkcode/schema';
 import { describe, expect, it } from 'vitest';
-import { splitTurnSegments, turnFileEdits } from '../chat/turn-edits';
+import { advanceTurnSegments, splitTurnSegments, turnFileEdits } from '../chat/turn-edits';
 import type { ConversationItem } from '../chat/types';
 
 function user(turnId: string | null, id: string): ConversationItem {
@@ -71,5 +71,78 @@ describe('turn edit selectors', () => {
       ]),
     ).toBeNull();
     expect(turnFileEdits([tool('turn-1', 'no-diff', 'completed')])).toBeNull();
+  });
+});
+
+describe('advanceTurnSegments', () => {
+  const u1 = user('turn-1', 'u1');
+  const t1 = tool('turn-1', 't1', 'completed');
+  const u2 = user('turn-2', 'u2');
+  const t2 = tool('turn-2', 't2', 'in_progress');
+
+  it('matches splitTurnSegments without a previous snapshot', () => {
+    expect(advanceTurnSegments(null, [u1, t1, u2])).toEqual(splitTurnSegments([u1, t1, u2]));
+  });
+
+  it('returns the previous segments array for identical items', () => {
+    const items = [u1, t1, u2];
+    const segments = advanceTurnSegments(null, items);
+    expect(advanceTurnSegments({ items, segments }, items)).toBe(segments);
+  });
+
+  it('keeps the segments array identity when a new items array has unchanged references', () => {
+    const items = [u1, t1, u2, t2];
+    const segments = advanceTurnSegments(null, items);
+    expect(advanceTurnSegments({ items, segments }, [...items])).toBe(segments);
+  });
+
+  it('reuses settled segment objects when the active turn grows', () => {
+    const items = [u1, t1, u2];
+    const segments = advanceTurnSegments(null, items);
+    const next = [u1, t1, u2, t2];
+    const advanced = advanceTurnSegments({ items, segments }, next);
+
+    expect(advanced).toEqual(splitTurnSegments(next));
+    expect(advanced[0]).toBe(segments[0]);
+    expect(advanced[1]).not.toBe(segments[1]);
+  });
+
+  it('rebuilds the boundary segment when a new turn opens', () => {
+    const items = [u1, t1];
+    const segments = advanceTurnSegments(null, items);
+    const next = [u1, t1, u2, t2];
+    const advanced = advanceTurnSegments({ items, segments }, next);
+
+    expect(advanced).toEqual(splitTurnSegments(next));
+    expect(advanced[0]).toBe(segments[0]);
+  });
+
+  it('reuses segments below an in-place item replacement and rebuilds from it', () => {
+    const t2Done = tool('turn-2', 't2', 'completed');
+    const items = [u1, t1, u2, t2];
+    const segments = advanceTurnSegments(null, items);
+    const next = [u1, t1, u2, t2Done];
+    const advanced = advanceTurnSegments({ items, segments }, next);
+
+    expect(advanced).toEqual(splitTurnSegments(next));
+    expect(advanced[0]).toBe(segments[0]);
+    expect(advanced[1]).not.toBe(segments[1]);
+  });
+
+  it('rebuilds everything for an unrelated timeline', () => {
+    const items = [u1, t1];
+    const segments = advanceTurnSegments(null, items);
+    const other = [user('turn-9', 'u9')];
+
+    expect(advanceTurnSegments({ items, segments }, other)).toEqual(splitTurnSegments(other));
+  });
+
+  it('handles a shrunken timeline (items removed from the tail)', () => {
+    const items = [u1, t1, u2, t2];
+    const segments = advanceTurnSegments(null, items);
+    const next = [u1, t1];
+    const advanced = advanceTurnSegments({ items, segments }, next);
+
+    expect(advanced).toEqual(splitTurnSegments(next));
   });
 });

--- a/packages/ui/src/chat/conversation-view.tsx
+++ b/packages/ui/src/chat/conversation-view.tsx
@@ -74,11 +74,22 @@ export function ConversationView({
           'linear-gradient(to bottom, transparent 0, black 24px, black calc(100% - 16px), transparent 100%)',
       }}
     >
-      <ConversationContent>
-        {segments.map((segment, index) => (
+      <ConversationContent
+        data={segments}
+        trailing={
+          isThinking && (
+            <div className="flex items-center gap-2 pt-5 pb-1 text-muted-foreground text-sm">
+              <Spinner className="size-3.5" />
+              <span>{t('thinking')}</span>
+            </div>
+          )
+        }
+      >
+        {(segment, index) => (
           <TurnSegmentView
             key={segment.turnId ?? 'lead-in'}
             segment={segment}
+            first={index === 0}
             // Trailers appear once the turn has settled — the in-flight turn shows none.
             ended={index < segments.length - 1 || !isThinking}
             agentKind={agentKind}
@@ -90,12 +101,6 @@ export function ConversationView({
             onExpandTask={setExpandedTaskId}
             onReviewChanges={onReviewChanges}
           />
-        ))}
-        {isThinking && (
-          <div className="flex items-center gap-2 py-1 text-muted-foreground text-sm">
-            <Spinner className="size-3.5" />
-            <span>{t('thinking')}</span>
-          </div>
         )}
       </ConversationContent>
       <ConversationScrollButton />

--- a/packages/ui/src/chat/conversation-view.tsx
+++ b/packages/ui/src/chat/conversation-view.tsx
@@ -1,38 +1,18 @@
 import type { AgentKind } from '@linkcode/schema';
 import { Spinner } from 'coss-ui/components/spinner';
-import { Fragment, useState } from 'react';
+import { useState } from 'react';
 import { useTranslations } from 'use-intl';
-import { ActivityGroup } from './activity-group';
-import type { TimelineEntry } from './activity-groups';
-import { groupTimeline } from './activity-groups';
-import { CompactionMarker } from './compaction-marker';
-import { ContentBlockView } from './content-block-view';
-import { positionalBlockEntries } from './content-derived-keys';
 import {
   Conversation,
   ConversationContent,
   ConversationEmptyState,
   ConversationScrollButton,
 } from './conversation';
-import {
-  conversationFlowItems,
-  declinedToolCall,
-  declinedToolCallIds,
-  selectPendingPromptItems,
-} from './conversation-prompts';
-import { assistantTurnText, latestReceivedAt, turnModel } from './conversation-text';
-import { ErrorMessage } from './error-message';
-import { Message, MessageContent } from './message';
-import { SubagentCard } from './subagent-card';
 import { SubagentViewer } from './subagent-viewer';
 import { partitionSubagentItems } from './subagents';
-import { ThoughtBlock } from './thought-block';
-import { ToolCallItem } from './tool-call-item';
-import { AgentTurnActions } from './turn-actions';
-import { TurnDiffSummary } from './turn-diff-summary';
-import { splitTurnSegments, turnFileEdits } from './turn-edits';
+import { TurnSegmentView } from './turn-segment-view';
 import type { ConversationItem, ConversationViewModel } from './types';
-import { UserMessage } from './user-message';
+import { useTimelineModel } from './use-timeline-model';
 
 export interface ConversationViewProps {
   conversation: ConversationViewModel;
@@ -61,6 +41,8 @@ export function ConversationView({
   const [expandedTaskId, setExpandedTaskId] = useState<string | null>(null);
 
   const { items } = conversation;
+  const { segments, declined, snapshottedToolIds, awaitingApproval } =
+    useTimelineModel(conversation);
 
   if (items.length === 0) {
     return (
@@ -75,18 +57,6 @@ export function ConversationView({
   }
 
   const isThinking = conversation.status === 'running' || conversation.status === 'starting';
-  // Permission asks live above the composer; authoritative declines render on the gated tool row.
-  const declined = declinedToolCallIds(items);
-  const snapshottedToolIds = new Set(
-    items.flatMap((item) => (item.kind === 'tool' ? [item.toolCall.toolCallId] : [])),
-  );
-  // Gated calls whose ask is still open carry the shield glyph.
-  const awaitingApproval = new Set(
-    selectPendingPromptItems(conversation).flatMap((item) =>
-      item.kind === 'approval' ? [item.toolCall.toolCallId] : [],
-    ),
-  );
-  const segments = splitTurnSegments(conversationFlowItems(items));
   // Conversation-wide view of the same parent→children relation the per-segment partitions see
   // (a subagent never outlives its turn), for the cross-conversation viewer rail.
   const subagentTasks = items.filter(
@@ -94,104 +64,6 @@ export function ConversationView({
       item.kind === 'tool' && item.toolCall.kind === 'task',
   );
   const allSubagentChildren = partitionSubagentItems(items).childrenByParent;
-
-  const renderEntry = (
-    entry: TimelineEntry,
-    subagentChildren: ReadonlyMap<string, ConversationItem[]>,
-  ): React.ReactNode => {
-    if (entry.type === 'task') {
-      return (
-        <SubagentCard
-          key={entry.item.id}
-          awaitingApproval={awaitingApproval}
-          childrenByParent={subagentChildren}
-          declined={declined}
-          items={subagentChildren.get(entry.item.toolCall.toolCallId) ?? []}
-          onExpand={setExpandedTaskId}
-          TerminalBlockComponent={TerminalBlockComponent}
-          toolCall={entry.item.toolCall}
-        />
-      );
-    }
-    if (entry.type === 'group') {
-      return (
-        <ActivityGroup
-          key={entry.id}
-          group={entry}
-          TerminalBlockComponent={TerminalBlockComponent}
-        />
-      );
-    }
-    if (entry.type === 'single') {
-      return (
-        <ToolCallItem
-          key={entry.item.id}
-          awaitingApproval={awaitingApproval.has(entry.item.toolCall.toolCallId)}
-          declined={declined.has(entry.item.toolCall.toolCallId)}
-          toolCall={entry.item.toolCall}
-          TerminalBlockComponent={TerminalBlockComponent}
-        />
-      );
-    }
-    const item = entry.item;
-    switch (item.kind) {
-      case 'message':
-        if (item.role === 'user') return <UserMessage key={item.id} item={item} />;
-        return (
-          <Message key={item.id} from="assistant">
-            <MessageContent className="space-y-1">
-              {positionalBlockEntries(item.blocks).map(({ block, key }) => (
-                <ContentBlockView
-                  key={key}
-                  block={block}
-                  smoothText
-                  isStreaming={item.isStreaming}
-                />
-              ))}
-            </MessageContent>
-          </Message>
-        );
-      case 'reasoning':
-        return <ThoughtBlock key={item.id} blocks={item.blocks} isStreaming={item.isStreaming} />;
-      case 'compaction':
-        return (
-          <CompactionMarker
-            key={item.id}
-            preTokens={item.preTokens}
-            postTokens={item.postTokens}
-            summary={item.summary}
-          />
-        );
-      case 'approval':
-        // Accepted / pending asks leave no receipt — the tool row (or the dock card) is the
-        // record. A decline only materializes here when the agent never snapshotted the call.
-        if (
-          !declined.has(item.toolCall.toolCallId) ||
-          snapshottedToolIds.has(item.toolCall.toolCallId)
-        ) {
-          return null;
-        }
-        return (
-          <ToolCallItem
-            key={item.id}
-            declined
-            toolCall={declinedToolCall(item.toolCall)}
-            TerminalBlockComponent={TerminalBlockComponent}
-          />
-        );
-      case 'error':
-        return (
-          <ErrorMessage
-            key={item.id}
-            message={item.message}
-            code={item.code}
-            recoverable={item.recoverable}
-          />
-        );
-      default:
-        return null;
-    }
-  };
 
   return (
     <Conversation
@@ -203,44 +75,22 @@ export function ConversationView({
       }}
     >
       <ConversationContent>
-        {segments.map((segment, index) => {
-          // Per-turn trailers (edit rollup, reply actions) appear once the turn has settled —
-          // the in-flight turn shows none.
-          const ended = index < segments.length - 1 || !isThinking;
-          // Children leave the top-level timeline (they render inside their SubagentCard), but the
-          // turn's edit rollup still counts them; the copyable reply text is the main agent's only.
-          const { topLevel, childrenByParent } = partitionSubagentItems(segment.items);
-          const edits = ended ? turnFileEdits(segment.items) : null;
-          const replyText = ended ? assistantTurnText(topLevel) : '';
-          const entries = groupTimeline(topLevel);
-          const leadingUserEntry =
-            entries[0]?.type === 'item' &&
-            entries[0].item.kind === 'message' &&
-            entries[0].item.role === 'user'
-              ? entries[0]
-              : null;
-          const agentEntries = leadingUserEntry ? entries.slice(1) : entries;
-          const hasAgentTurnContent = agentEntries.length > 0 || edits || replyText;
-          return (
-            <Fragment key={segment.turnId ?? 'lead-in'}>
-              {leadingUserEntry ? renderEntry(leadingUserEntry, childrenByParent) : null}
-              {hasAgentTurnContent ? (
-                <div className="group/turn flex flex-col gap-3">
-                  {agentEntries.map((entry) => renderEntry(entry, childrenByParent))}
-                  {edits ? <TurnDiffSummary edits={edits} onReview={onReviewChanges} /> : null}
-                  {replyText ? (
-                    <AgentTurnActions
-                      agentKind={agentKind}
-                      copyText={replyText}
-                      modelName={turnModel(segment.items) ?? modelName}
-                      receivedAt={latestReceivedAt(segment.items)}
-                    />
-                  ) : null}
-                </div>
-              ) : null}
-            </Fragment>
-          );
-        })}
+        {segments.map((segment, index) => (
+          <TurnSegmentView
+            key={segment.turnId ?? 'lead-in'}
+            segment={segment}
+            // Trailers appear once the turn has settled — the in-flight turn shows none.
+            ended={index < segments.length - 1 || !isThinking}
+            agentKind={agentKind}
+            modelName={modelName}
+            declined={declined}
+            snapshottedToolIds={snapshottedToolIds}
+            awaitingApproval={awaitingApproval}
+            TerminalBlockComponent={TerminalBlockComponent}
+            onExpandTask={setExpandedTaskId}
+            onReviewChanges={onReviewChanges}
+          />
+        ))}
         {isThinking && (
           <div className="flex items-center gap-2 py-1 text-muted-foreground text-sm">
             <Spinner className="size-3.5" />

--- a/packages/ui/src/chat/conversation.tsx
+++ b/packages/ui/src/chat/conversation.tsx
@@ -9,6 +9,7 @@ import {
 import { ArrowDownIcon } from 'lucide-react';
 import { useCallback } from 'react';
 import { StickToBottom, useStickToBottomContext } from 'use-stick-to-bottom';
+import { Virtualizer } from 'virtua';
 import { cn } from '../lib/cn';
 
 export type ConversationProps = React.ComponentProps<typeof StickToBottom>;
@@ -17,7 +18,9 @@ export function Conversation({ className, ...props }: ConversationProps): React.
   return (
     <StickToBottom
       className={cn('relative h-full overflow-hidden', className)}
-      initial="smooth"
+      // Instant initial positioning: animating from the top would page the whole virtualized
+      // history through the viewport.
+      initial="instant"
       resize="smooth"
       role="log"
       {...props}
@@ -25,17 +28,40 @@ export function Conversation({ className, ...props }: ConversationProps): React.
   );
 }
 
-export type ConversationContentProps = React.ComponentProps<typeof StickToBottom.Content>;
+export interface ConversationContentProps<T> {
+  className?: string;
+  /** Timeline rows, virtualized: only rows near the viewport are mounted. */
+  data: readonly T[];
+  /** Row renderer; must return a keyed element (virtua caches measured sizes per key). */
+  // eslint-disable-next-line sukka/react-no-render-function-prop, @typescript-eslint/no-restricted-types -- virtua's windowing contract: only the virtualizer knows which rows are visible, and it requires a keyed ReactElement per row.
+  children: (item: T, index: number) => React.ReactElement;
+  /** Rendered after the virtualized rows, inside the scrolled column (e.g. the thinking row). */
+  trailing?: React.ReactNode;
+}
 
-export function ConversationContent({
+/**
+ * The scrolled conversation column. use-stick-to-bottom owns the scroll element and the
+ * pinned-to-bottom follow; virtua windows the rows inside it. Rows own their vertical spacing
+ * (the container keeps no top padding so virtua's offset math needs no startMargin).
+ */
+export function ConversationContent<T>({
   className,
-  ...props
-}: ConversationContentProps): React.ReactNode {
+  data,
+  children,
+  trailing,
+}: ConversationContentProps<T>): React.ReactNode {
+  const { scrollRef } = useStickToBottomContext();
   return (
     <StickToBottom.Content
-      className={cn('mx-auto flex max-w-3xl flex-col gap-4 px-7 py-6', className)}
-      {...props}
-    />
+      className={cn('mx-auto max-w-3xl px-7 pb-6', className)}
+      // The browser's own scroll anchoring fights both scroll owners.
+      scrollClassName="[overflow-anchor:none]"
+    >
+      <Virtualizer data={data} scrollRef={scrollRef}>
+        {children}
+      </Virtualizer>
+      {trailing}
+    </StickToBottom.Content>
   );
 }
 

--- a/packages/ui/src/chat/diff-utils.ts
+++ b/packages/ui/src/chat/diff-utils.ts
@@ -86,12 +86,26 @@ export function diffStats(oldText: string | undefined, newText: string): DiffSta
   };
 }
 
+export type DiffToolCallContent = Extract<ToolCall['content'][number], { type: 'diff' }>;
+
+// diffStats runs an O(m×n) LCS; the builder replaces content objects instead of mutating them,
+// so object identity is a sound cache key across re-renders and re-folds.
+const diffContentStatsCache = new WeakMap<DiffToolCallContent, DiffStats>();
+
+export function diffContentStats(content: DiffToolCallContent): DiffStats {
+  const cached = diffContentStatsCache.get(content);
+  if (cached) return cached;
+  const stats = diffStats(content.oldText, content.newText);
+  diffContentStatsCache.set(content, stats);
+  return stats;
+}
+
 export function toolCallDiffStats(toolCall: Pick<ToolCall, 'content'>): DiffStats {
   let additions = 0;
   let deletions = 0;
   for (const content of toolCall.content) {
     if (content.type !== 'diff') continue;
-    const stats = diffStats(content.oldText, content.newText);
+    const stats = diffContentStats(content);
     additions += stats.additions;
     deletions += stats.deletions;
   }

--- a/packages/ui/src/chat/turn-edits.ts
+++ b/packages/ui/src/chat/turn-edits.ts
@@ -1,4 +1,4 @@
-import { diffStats } from './diff-utils';
+import { diffContentStats } from './diff-utils';
 import type { ConversationItem, ConversationTurnId } from './types';
 
 export interface TurnSegment<T extends ConversationItem = ConversationItem> {
@@ -18,6 +18,46 @@ export function splitTurnSegments<T extends ConversationItem>(
     else segments.push({ turnId: item.turnId, items: [item] });
   }
   return segments;
+}
+
+export interface TurnSegmentsSnapshot<T extends ConversationItem = ConversationItem> {
+  items: readonly T[];
+  segments: Array<TurnSegment<T>>;
+}
+
+/**
+ * Re-derive segments incrementally: the conversation builder replaces only changed items (the
+ * live tail), so every segment fully inside the shared item prefix is reused by reference —
+ * settled turns keep segment identity across events and memoized per-turn views skip them.
+ */
+export function advanceTurnSegments<T extends ConversationItem>(
+  prev: TurnSegmentsSnapshot<T> | null,
+  items: readonly T[],
+): Array<TurnSegment<T>> {
+  if (!prev) return splitTurnSegments(items);
+  if (prev.items === items) return prev.segments;
+
+  const shared = Math.min(prev.items.length, items.length);
+  let stable = 0;
+  while (stable < shared && prev.items[stable] === items[stable]) stable += 1;
+
+  const reused: Array<TurnSegment<T>> = [];
+  let covered = 0;
+  for (const segment of prev.segments) {
+    if (covered + segment.items.length > stable) break;
+    reused.push(segment);
+    covered += segment.items.length;
+  }
+  // The run at the cut may continue into the rebuilt suffix (same turnId); rebuild that segment
+  // from its start so the run stays one segment. Consecutive segments never share a turnId, so
+  // one step back suffices.
+  const boundary = reused.at(-1);
+  if (boundary && covered < items.length && items[covered].turnId === boundary.turnId) {
+    reused.pop();
+    covered -= boundary.items.length;
+  }
+  if (covered === items.length && reused.length === prev.segments.length) return prev.segments;
+  return [...reused, ...splitTurnSegments(items.slice(covered))];
 }
 
 export interface TurnFileEdit {
@@ -40,7 +80,7 @@ export function turnFileEdits(items: readonly ConversationItem[]): TurnEdits | n
     if (item.kind !== 'tool' || item.toolCall.status !== 'completed') continue;
     for (const content of item.toolCall.content) {
       if (content.type !== 'diff') continue;
-      const stats = diffStats(content.oldText, content.newText);
+      const stats = diffContentStats(content);
       const edit = byPath.get(content.path) ?? { path: content.path, additions: 0, deletions: 0 };
       edit.additions += stats.additions;
       edit.deletions += stats.deletions;

--- a/packages/ui/src/chat/turn-segment-view.tsx
+++ b/packages/ui/src/chat/turn-segment-view.tsx
@@ -1,4 +1,5 @@
 import type { AgentKind } from '@linkcode/schema';
+import { cn } from '../lib/cn';
 import { ActivityGroup } from './activity-group';
 import type { TimelineEntry } from './activity-groups';
 import { groupTimeline } from './activity-groups';
@@ -21,6 +22,8 @@ import { UserMessage } from './user-message';
 
 export interface TurnSegmentViewProps {
   segment: TurnSegment;
+  /** First row of the timeline — carries the column's top padding (rows own vertical spacing). */
+  first: boolean;
   /** Whether the turn has settled — trailers (edit rollup, reply actions) appear only then. */
   ended: boolean;
   agentKind?: AgentKind;
@@ -43,6 +46,7 @@ export interface TurnSegmentViewProps {
  */
 export function TurnSegmentView({
   segment,
+  first,
   ended,
   agentKind,
   modelName,
@@ -164,7 +168,9 @@ export function TurnSegmentView({
   };
 
   return (
-    <div className="flex flex-col gap-4">
+    // Rows own their top spacing (virtua positions them absolutely, so column gap can't).
+    // Layout containment keeps one row's reflow from invalidating its mounted siblings.
+    <div className={cn('flex flex-col gap-4 [contain:layout_style]', first ? 'pt-6' : 'pt-4')}>
       {leadingUserEntry ? renderEntry(leadingUserEntry) : null}
       {hasAgentTurnContent ? (
         <div className="group/turn flex flex-col gap-3">

--- a/packages/ui/src/chat/turn-segment-view.tsx
+++ b/packages/ui/src/chat/turn-segment-view.tsx
@@ -1,0 +1,185 @@
+import type { AgentKind } from '@linkcode/schema';
+import { ActivityGroup } from './activity-group';
+import type { TimelineEntry } from './activity-groups';
+import { groupTimeline } from './activity-groups';
+import { CompactionMarker } from './compaction-marker';
+import { ContentBlockView } from './content-block-view';
+import { positionalBlockEntries } from './content-derived-keys';
+import { declinedToolCall } from './conversation-prompts';
+import { assistantTurnText, latestReceivedAt, turnModel } from './conversation-text';
+import { ErrorMessage } from './error-message';
+import { Message, MessageContent } from './message';
+import { SubagentCard } from './subagent-card';
+import { partitionSubagentItems } from './subagents';
+import { ThoughtBlock } from './thought-block';
+import { ToolCallItem } from './tool-call-item';
+import { AgentTurnActions } from './turn-actions';
+import { TurnDiffSummary } from './turn-diff-summary';
+import type { TurnSegment } from './turn-edits';
+import { turnFileEdits } from './turn-edits';
+import { UserMessage } from './user-message';
+
+export interface TurnSegmentViewProps {
+  segment: TurnSegment;
+  /** Whether the turn has settled — trailers (edit rollup, reply actions) appear only then. */
+  ended: boolean;
+  agentKind?: AgentKind;
+  /** Session-level fallback for the per-turn model meta (a turn's own message stamp wins). */
+  modelName?: string;
+  declined: ReadonlySet<string>;
+  snapshottedToolIds: ReadonlySet<string>;
+  awaitingApproval: ReadonlySet<string>;
+  TerminalBlockComponent?: React.ComponentType<{ terminalId: string }>;
+  /** Opens a subagent's full transcript in the conversation's viewer rail. */
+  onExpandTask: (toolCallId: string) => void;
+  /** Opens this turn's workspace changes in the host review surface. */
+  onReviewChanges?: () => void;
+}
+
+/**
+ * One turn of the timeline: the opening user message plus the agent's activity and trailers.
+ * Props stay identity-stable for settled turns (see useTimelineModel), so re-renders during
+ * streaming reach only the active turn.
+ */
+export function TurnSegmentView({
+  segment,
+  ended,
+  agentKind,
+  modelName,
+  declined,
+  snapshottedToolIds,
+  awaitingApproval,
+  TerminalBlockComponent,
+  onExpandTask,
+  onReviewChanges,
+}: TurnSegmentViewProps): React.ReactNode {
+  // Children leave the top-level timeline (they render inside their SubagentCard), but the
+  // turn's edit rollup still counts them; the copyable reply text is the main agent's only.
+  const { topLevel, childrenByParent } = partitionSubagentItems(segment.items);
+  const edits = ended ? turnFileEdits(segment.items) : null;
+  const replyText = ended ? assistantTurnText(topLevel) : '';
+  const entries = groupTimeline(topLevel);
+  const leadingUserEntry =
+    entries[0]?.type === 'item' &&
+    entries[0].item.kind === 'message' &&
+    entries[0].item.role === 'user'
+      ? entries[0]
+      : null;
+  const agentEntries = leadingUserEntry ? entries.slice(1) : entries;
+  const hasAgentTurnContent = agentEntries.length > 0 || edits || replyText;
+
+  const renderEntry = (entry: TimelineEntry): React.ReactNode => {
+    if (entry.type === 'task') {
+      return (
+        <SubagentCard
+          key={entry.item.id}
+          awaitingApproval={awaitingApproval}
+          childrenByParent={childrenByParent}
+          declined={declined}
+          items={childrenByParent.get(entry.item.toolCall.toolCallId) ?? []}
+          onExpand={onExpandTask}
+          TerminalBlockComponent={TerminalBlockComponent}
+          toolCall={entry.item.toolCall}
+        />
+      );
+    }
+    if (entry.type === 'group') {
+      return (
+        <ActivityGroup
+          key={entry.id}
+          group={entry}
+          TerminalBlockComponent={TerminalBlockComponent}
+        />
+      );
+    }
+    if (entry.type === 'single') {
+      return (
+        <ToolCallItem
+          key={entry.item.id}
+          awaitingApproval={awaitingApproval.has(entry.item.toolCall.toolCallId)}
+          declined={declined.has(entry.item.toolCall.toolCallId)}
+          toolCall={entry.item.toolCall}
+          TerminalBlockComponent={TerminalBlockComponent}
+        />
+      );
+    }
+    const item = entry.item;
+    switch (item.kind) {
+      case 'message':
+        if (item.role === 'user') return <UserMessage key={item.id} item={item} />;
+        return (
+          <Message key={item.id} from="assistant">
+            <MessageContent className="space-y-1">
+              {positionalBlockEntries(item.blocks).map(({ block, key }) => (
+                <ContentBlockView
+                  key={key}
+                  block={block}
+                  smoothText
+                  isStreaming={item.isStreaming}
+                />
+              ))}
+            </MessageContent>
+          </Message>
+        );
+      case 'reasoning':
+        return <ThoughtBlock key={item.id} blocks={item.blocks} isStreaming={item.isStreaming} />;
+      case 'compaction':
+        return (
+          <CompactionMarker
+            key={item.id}
+            preTokens={item.preTokens}
+            postTokens={item.postTokens}
+            summary={item.summary}
+          />
+        );
+      case 'approval':
+        // Accepted / pending asks leave no receipt — the tool row (or the dock card) is the
+        // record. A decline only materializes here when the agent never snapshotted the call.
+        if (
+          !declined.has(item.toolCall.toolCallId) ||
+          snapshottedToolIds.has(item.toolCall.toolCallId)
+        ) {
+          return null;
+        }
+        return (
+          <ToolCallItem
+            key={item.id}
+            declined
+            toolCall={declinedToolCall(item.toolCall)}
+            TerminalBlockComponent={TerminalBlockComponent}
+          />
+        );
+      case 'error':
+        return (
+          <ErrorMessage
+            key={item.id}
+            message={item.message}
+            code={item.code}
+            recoverable={item.recoverable}
+          />
+        );
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-4">
+      {leadingUserEntry ? renderEntry(leadingUserEntry) : null}
+      {hasAgentTurnContent ? (
+        <div className="group/turn flex flex-col gap-3">
+          {agentEntries.map((entry) => renderEntry(entry))}
+          {edits ? <TurnDiffSummary edits={edits} onReview={onReviewChanges} /> : null}
+          {replyText ? (
+            <AgentTurnActions
+              agentKind={agentKind}
+              copyText={replyText}
+              modelName={turnModel(segment.items) ?? modelName}
+              receivedAt={latestReceivedAt(segment.items)}
+            />
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/packages/ui/src/chat/use-timeline-model.ts
+++ b/packages/ui/src/chat/use-timeline-model.ts
@@ -1,0 +1,87 @@
+import { useState } from 'react';
+import {
+  conversationFlowItems,
+  declinedToolCallIds,
+  selectPendingPromptItems,
+} from './conversation-prompts';
+import type { TurnSegment, TurnSegmentsSnapshot } from './turn-edits';
+import { advanceTurnSegments } from './turn-edits';
+import type { ConversationViewModel } from './types';
+
+/**
+ * Identity-stable projection the timeline renders from. Settled segments and unchanged sets keep
+ * their object identity across events, so a memoized per-turn view re-renders only for the turn
+ * that actually changed.
+ */
+export interface TimelineModel {
+  segments: TurnSegment[];
+  /** Tool calls declined by an authoritative resolution — render the gated row struck through. */
+  declined: ReadonlySet<string>;
+  /** Every tool call the agent snapshotted — a declined ask with no snapshot renders its own receipt. */
+  snapshottedToolIds: ReadonlySet<string>;
+  /** Gated calls whose ask is still open — these carry the shield glyph. */
+  awaitingApproval: ReadonlySet<string>;
+}
+
+interface TimelineCache {
+  conversation: ConversationViewModel;
+  segmentsSnapshot: TurnSegmentsSnapshot;
+  model: TimelineModel;
+}
+
+function setsEqual(a: ReadonlySet<string>, b: ReadonlySet<string>): boolean {
+  if (a.size !== b.size) return false;
+  for (const value of a) if (!b.has(value)) return false;
+  return true;
+}
+
+/** The previous set when contents match, so unchanged sets keep identity across events. */
+function stableSet(
+  prev: ReadonlySet<string> | undefined,
+  next: ReadonlySet<string>,
+): ReadonlySet<string> {
+  return prev && setsEqual(prev, next) ? prev : next;
+}
+
+function advanceTimeline(
+  prev: TimelineCache | null,
+  conversation: ConversationViewModel,
+): TimelineCache {
+  const { items } = conversation;
+  // Plan items live in the dock, not the stream; filtered items keep identity, so the
+  // incremental prefix walk still sees settled turns as unchanged.
+  const flowItems = conversationFlowItems(items);
+  const segments = advanceTurnSegments(prev?.segmentsSnapshot ?? null, flowItems);
+
+  const snapshotted = new Set<string>();
+  for (const item of items) {
+    if (item.kind === 'tool') snapshotted.add(item.toolCall.toolCallId);
+  }
+  const awaiting = new Set<string>();
+  for (const item of selectPendingPromptItems(conversation)) {
+    if (item.kind === 'approval') awaiting.add(item.toolCall.toolCallId);
+  }
+
+  const model: TimelineModel = {
+    segments,
+    declined: stableSet(prev?.model.declined, declinedToolCallIds(items)),
+    snapshottedToolIds: stableSet(prev?.model.snapshottedToolIds, snapshotted),
+    awaitingApproval: stableSet(prev?.model.awaitingApproval, awaiting),
+  };
+  return { conversation, segmentsSnapshot: { items: flowItems, segments }, model };
+}
+
+/**
+ * Fold the conversation into a {@link TimelineModel}, advancing incrementally from the previous
+ * render — the render-phase "storing information from previous renders" pattern, so the fold is
+ * O(changed tail) instead of O(timeline) per event.
+ */
+export function useTimelineModel(conversation: ConversationViewModel): TimelineModel {
+  const [cache, setCache] = useState<TimelineCache | null>(null);
+  if (cache?.conversation !== conversation) {
+    const next = advanceTimeline(cache, conversation);
+    setCache(next);
+    return next.model;
+  }
+  return cache.model;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1126,6 +1126,9 @@ importers:
       use-stick-to-bottom:
         specifier: ^1.1.6
         version: 1.1.6(react@19.2.7)
+      virtua:
+        specifier: ^0.49.3
+        version: 0.49.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
     devDependencies:
       '@types/react':
         specifier: 'catalog:'
@@ -10459,6 +10462,26 @@ packages:
 
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
+
+  virtua@0.49.3:
+    resolution: {integrity: sha512-k1Yn988Vz/L40uDtEWPjfdVo15Suumh4tU4/z5Srs0elNcU9DgBskqdh3llpHyAlXrCeHWTfcclYvY1uU4MmIg==}
+    peerDependencies:
+      react: '>=16.14.0'
+      react-dom: '>=16.14.0'
+      solid-js: '>=1.0'
+      svelte: '>=5.0'
+      vue: '>=3.2'
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
+      solid-js:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
 
   vite@8.1.4:
     resolution: {integrity: sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==}
@@ -21059,6 +21082,11 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
+
+  virtua@0.49.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+    optionalDependencies:
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
 
   vite@8.1.4(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.1)(yaml@2.9.0):
     dependencies:


### PR DESCRIPTION
Implements the timeline half of CODE-227 (tracked as CODE-259).

## Problem

Long sessions degrade linearly with no bound, on two layers below the (already O(delta)) conversation fold:

- **Per-event full derivations** — every wire event re-ran O(n) selectors over the whole timeline in `ConversationView`, the worst being `turnFileEdits` → `diffStats` (an O(m×n) LCS per historical diff, per event) and `assistantTurnText` (O(total text) per event). Settled turns never change, but `splitTurnSegments` rebuilt segment arrays each render, severing the identity React Compiler memoization needs.
- **No virtualization / no layout isolation** — the whole session's DOM stayed mounted (Streamdown/shiki/diff/ANSI views); smooth-text ticks (32ms) plus `use-stick-to-bottom`'s per-frame scroll writes forced synchronous layout over an unbounded tree.

## Change

1. **Incremental derivations** (`7a3f9012`): `advanceTurnSegments` reuses settled segment objects across events (prefix-stable by item identity); per-turn rendering moves into `TurnSegmentView` so compiler memoization skips settled turns; `diffStats` results cache per diff-content object (WeakMap); tool-gate sets keep identity while contents are unchanged (`useTimelineModel`).
2. **Virtualization** (`7c4faf38`): `virtua`'s `Virtualizer` windows the turn rows inside the existing `use-stick-to-bottom` scroller (which keeps pinned-to-bottom follow, escape-from-lock, and the scroll button). Rows own their vertical spacing (no container top padding → no `startMargin` sync) and get `contain: layout style`. Initial positioning is now instant instead of a smooth sweep from the top.

## Verification

- `pnpm check:ci` + `pnpm test` green (new unit tests for `advanceTurnSegments` identity/merge/shrink edges).
- Playwright against `dev:mock` with a temporary 300-turn seeded session, 17/17 checks: opens pinned to bottom with **3–4 of 300 rows (~665 DOM nodes) mounted**, windowing both directions, scroll-button return, streamed reply stays pinned, scrolling up mid-stream escapes the follow, session switch round-trip, zero console errors.

Closes CODE-259.