### PR TITLE
feat(ui): add GPT-5.6 Sol/Terra/Luna to the codex static model table

### DIFF
--- a/packages/ui/src/shell/agent-models.ts
+++ b/packages/ui/src/shell/agent-models.ts
@@ -46,6 +46,9 @@ export const AGENT_MODEL_OPTIONS: Partial<Record<AgentKind, ModelOption[]>> = {
     { id: 'claude-haiku-4-5', label: 'Haiku 4.5' },
   ],
   codex: [
+    { id: 'gpt-5.6-sol', label: 'GPT-5.6-Sol' },
+    { id: 'gpt-5.6-terra', label: 'GPT-5.6-Terra' },
+    { id: 'gpt-5.6-luna', label: 'GPT-5.6-Luna' },
     { id: 'gpt-5.5', label: 'GPT-5.5' },
     { id: 'gpt-5.4', label: 'GPT-5.4' },
     { id: 'gpt-5.4-mini', label: 'GPT-5.4-Mini' },


### PR DESCRIPTION
## Summary

Adds the GPT-5.6 generation to the codex entry of the static `AGENT_MODEL_OPTIONS` table (`packages/ui/src/shell/agent-models.ts`).

Per the table's discipline, ids and labels were taken verbatim from a live `codex app-server` `model/list` (codex-cli 0.144.1, the adapter-verified version). There is no bare `gpt-5.6` id — sending it gets a 400 from the API; the 5.6 generation ships as three variants:

| id | displayName | positioning |
| --- | --- | --- |
| `gpt-5.6-sol` | GPT-5.6-Sol | frontier (current default) |
| `gpt-5.6-terra` | GPT-5.6-Terra | balanced everyday |
| `gpt-5.6-luna` | GPT-5.6-Luna | fast and affordable |

## Not in scope

`model/list` advertises `max`/`ultra` reasoning efforts on Sol and Terra, but the codex adapter still hard-rejects anything above `xhigh` and `agent-efforts.ts` has no such tiers. Relaxing the effort channel is a separate follow-up.

## Verification

- `pnpm test` — 1215 passed
- `pnpm check:ci` — passed