### PR TITLE
test(perf): conversation hot-path timing harness

### DIFF
--- a/packages/client-core/src/__tests__/conversation-perf.bench.ts
+++ b/packages/client-core/src/__tests__/conversation-perf.bench.ts
@@ -1,0 +1,210 @@
+/**
+ * Microbenchmarks for the conversation fold path — run with:
+ *   pnpm exec vitest bench packages/client-core/src/__tests__/conversation-perf.bench.ts
+ *
+ * Scenarios mirror a mid/long agent session: multi-turn history, then high-frequency
+ * agent-message-chunk streaming on top of an already-large timeline.
+ */
+import type { AgentEvent, MessageId, SessionId } from '@linkcode/schema';
+import { bench, describe } from 'vitest';
+import type { LinkCodeClient } from '../client';
+import { EventBuffer } from '../client/event-buffer';
+import { createConversationBuilder } from '../conversation';
+import { createConversationStore } from '../conversation-store';
+
+interface LoadShape {
+  turns: number;
+  toolsPerTurn: number;
+  /** Completed edit tools per turn (drive turnFileEdits / toolCallDiffStats downstream). */
+  editsPerTurn: number;
+  editLines: number;
+  /** Stream chunks to append after the seeded history (last assistant message). */
+  streamChunks: number;
+  chunkChars: number;
+}
+
+const SMALL: LoadShape = {
+  turns: 20,
+  toolsPerTurn: 4,
+  editsPerTurn: 1,
+  editLines: 40,
+  streamChunks: 100,
+  chunkChars: 24,
+};
+
+const LARGE: LoadShape = {
+  turns: 80,
+  toolsPerTurn: 8,
+  editsPerTurn: 2,
+  editLines: 120,
+  streamChunks: 200,
+  chunkChars: 32,
+};
+
+function lines(count: number, prefix: string): string {
+  let out = '';
+  for (let i = 0; i < count; i += 1) out += `${prefix}${i}\n`;
+  return out;
+}
+
+function textChunk(messageId: string, text: string): AgentEvent {
+  return {
+    type: 'agent-message-chunk',
+    messageId: messageId as MessageId,
+    content: { type: 'text', text },
+  };
+}
+
+/** Synthetic multi-turn transcript: user → tools (read/search/edit) → assistant reply. */
+function seedHistory(shape: LoadShape): AgentEvent[] {
+  const events: AgentEvent[] = [{ type: 'status', status: 'running' }];
+  for (let t = 0; t < shape.turns; t += 1) {
+    events.push({
+      type: 'user-message',
+      content: [{ type: 'text', text: `Please work on task ${t}` }],
+    });
+    for (let k = 0; k < shape.toolsPerTurn; k += 1) {
+      const kind = k % 3 === 0 ? 'read' : k % 3 === 1 ? 'search' : 'execute';
+      const id = `t${t}-tool-${k}`;
+      events.push({
+        type: 'tool-call',
+        toolCall: {
+          toolCallId: id,
+          title: `${kind} ${id}`,
+          kind,
+          status: 'completed',
+          content:
+            kind === 'search'
+              ? [
+                  {
+                    type: 'content',
+                    content: {
+                      type: 'text',
+                      text: lines(30, `hit:${t}:${k}:`),
+                    },
+                  },
+                ]
+              : kind === 'execute'
+                ? [{ type: 'terminal', terminalId: `term-${t}-${k}` }]
+                : [
+                    {
+                      type: 'content',
+                      content: { type: 'text', text: lines(20, `file:${t}:${k}:`) },
+                    },
+                  ],
+        },
+      });
+    }
+    for (let e = 0; e < shape.editsPerTurn; e += 1) {
+      const id = `t${t}-edit-${e}`;
+      const oldText = lines(shape.editLines, `old${t}${e}:`);
+      const newText = lines(shape.editLines, `new${t}${e}:`);
+      events.push({
+        type: 'tool-call',
+        toolCall: {
+          toolCallId: id,
+          title: `Edit src/${t}/${e}.ts`,
+          kind: 'edit',
+          status: 'completed',
+          content: [{ type: 'diff', path: `src/${t}/${e}.ts`, oldText, newText }],
+          locations: [{ path: `src/${t}/${e}.ts` }],
+        },
+      });
+    }
+    const messageId = `asst-${t}`;
+    events.push(textChunk(messageId, `Summary of turn ${t}.\n`));
+    events.push(textChunk(messageId, lines(8, `detail-${t}-`)));
+  }
+  return events;
+}
+
+function streamTail(shape: LoadShape): AgentEvent[] {
+  const messageId = 'asst-streaming';
+  const events: AgentEvent[] = [textChunk(messageId, 'Streaming reply:\n')];
+  const piece = 'x'.repeat(shape.chunkChars);
+  for (let i = 0; i < shape.streamChunks; i += 1) {
+    events.push(textChunk(messageId, `${piece} `));
+  }
+  return events;
+}
+
+function foldAll(events: readonly AgentEvent[]): void {
+  const builder = createConversationBuilder();
+  for (const event of events) builder.advance(event);
+  builder.snapshot();
+}
+
+function foldStreamingCost(shape: LoadShape): void {
+  const history = seedHistory(shape);
+  const builder = createConversationBuilder();
+  for (const event of history) builder.advance(event);
+  for (const event of streamTail(shape)) {
+    builder.advance(event);
+    // Each live chunk invalidates the cache and forces a fresh items shallow-copy.
+    builder.snapshot();
+  }
+}
+
+function bufferClient(buffer: EventBuffer): LinkCodeClient {
+  return {
+    eventSeq: (id: SessionId) => buffer.eventSeq(id),
+    eventsSnapshot: (id: SessionId) => buffer.snapshot(id),
+    subscribe: (id: SessionId, cb: () => void) => buffer.subscribe(id, () => cb()),
+  } as LinkCodeClient;
+}
+
+function storeStreamingCost(shape: LoadShape): void {
+  const sessionId = 'sess-perf' as SessionId;
+  const history = seedHistory(shape);
+  const buffer = new EventBuffer();
+  for (const event of history) buffer.ingest(sessionId, event);
+
+  // createConversationStore only needs the event surface used by sync().
+  const store = createConversationStore(bufferClient(buffer), sessionId);
+  // Seed fold via first getSnapshot.
+  store.getSnapshot();
+
+  for (const event of streamTail(shape)) {
+    buffer.ingest(sessionId, event);
+    store.getSnapshot();
+  }
+}
+
+function eventBufferSnapshotCost(shape: LoadShape): void {
+  const sessionId = 'sess-buf' as SessionId;
+  const buffer = new EventBuffer();
+  for (const event of seedHistory(shape)) buffer.ingest(sessionId, event);
+  for (const event of streamTail(shape)) buffer.ingest(sessionId, event);
+  // snapshot copies the full buffer array when the cache is cold; force cold each time.
+  buffer.ingest(sessionId, textChunk('force', '.'));
+  buffer.snapshot(sessionId);
+}
+
+describe('conversation fold — small (~20 turns)', () => {
+  const history = seedHistory(SMALL);
+  bench('fold history once', () => {
+    foldAll(history);
+  });
+  bench('stream 100 chunks + snapshot each (on seeded history)', () => {
+    foldStreamingCost(SMALL);
+  });
+  bench('store stream 100 chunks (EventBuffer + ConversationStore)', () => {
+    storeStreamingCost(SMALL);
+  });
+});
+
+describe('conversation fold — large (~80 turns)', () => {
+  const history = seedHistory(LARGE);
+  bench('fold history once', () => {
+    foldAll(history);
+  });
+  bench('stream 200 chunks + snapshot each (on seeded history)', () => {
+    foldStreamingCost(LARGE);
+  });
+  bench('store stream 200 chunks (EventBuffer + ConversationStore)', () => {
+    storeStreamingCost(LARGE);
+  });
+  bench('EventBuffer cold snapshot after full load', () => {
+    eventBufferSnapshotCost(LARGE);
+  });
+});

--- a/packages/client-core/src/__tests__/conversation-perf.report.test.ts
+++ b/packages/client-core/src/__tests__/conversation-perf.report.test.ts
@@ -1,0 +1,226 @@
+/**
+ * One-shot timing report for the conversation fold path.
+ *
+ *   pnpm test packages/client-core/src/__tests__/conversation-perf.report.test.ts
+ *
+ * Always prints a table (not a flaky timing assertion). Pair with the *.bench.ts files
+ * for statistical runs via `pnpm exec vitest bench …`.
+ */
+
+import type { AgentEvent, MessageId, SessionId } from '@linkcode/schema';
+import { describe, expect, it } from 'vitest';
+import type { LinkCodeClient } from '../client';
+import { EventBuffer } from '../client/event-buffer';
+import type { Conversation } from '../conversation';
+import { createConversationBuilder } from '../conversation';
+import { createConversationStore } from '../conversation-store';
+
+interface LoadShape {
+  label: string;
+  turns: number;
+  toolsPerTurn: number;
+  editsPerTurn: number;
+  editLines: number;
+  streamChunks: number;
+  chunkChars: number;
+}
+
+const SHAPES: LoadShape[] = [
+  {
+    label: 'small (~20 turns)',
+    turns: 20,
+    toolsPerTurn: 4,
+    editsPerTurn: 1,
+    editLines: 40,
+    streamChunks: 100,
+    chunkChars: 24,
+  },
+  {
+    label: 'large (~80 turns)',
+    turns: 80,
+    toolsPerTurn: 8,
+    editsPerTurn: 2,
+    editLines: 120,
+    streamChunks: 200,
+    chunkChars: 32,
+  },
+];
+
+function lines(count: number, prefix: string): string {
+  const parts: string[] = [];
+  for (let i = 0; i < count; i += 1) parts.push(prefix + String(i));
+  return parts.join('\n') + '\n';
+}
+
+function textChunk(messageId: string, text: string): AgentEvent {
+  return {
+    type: 'agent-message-chunk',
+    messageId: messageId as MessageId,
+    content: { type: 'text', text },
+  };
+}
+
+function seedHistory(shape: LoadShape): AgentEvent[] {
+  const events: AgentEvent[] = [{ type: 'status', status: 'running' }];
+  for (let t = 0; t < shape.turns; t += 1) {
+    events.push({
+      type: 'user-message',
+      content: [{ type: 'text', text: 'Please work on task ' + String(t) }],
+    });
+    for (let k = 0; k < shape.toolsPerTurn; k += 1) {
+      const kind = k % 3 === 0 ? 'read' : k % 3 === 1 ? 'search' : 'execute';
+      const id = 't' + String(t) + '-tool-' + String(k);
+      events.push({
+        type: 'tool-call',
+        toolCall: {
+          toolCallId: id,
+          title: kind + ' ' + id,
+          kind,
+          status: 'completed',
+          content:
+            kind === 'search'
+              ? [
+                  {
+                    type: 'content',
+                    content: { type: 'text', text: lines(30, 'hit:' + String(t) + ':') },
+                  },
+                ]
+              : [],
+        },
+      });
+    }
+    for (let e = 0; e < shape.editsPerTurn; e += 1) {
+      const id = 't' + String(t) + '-edit-' + String(e);
+      events.push({
+        type: 'tool-call',
+        toolCall: {
+          toolCallId: id,
+          title: 'Edit src/' + String(t) + '/' + String(e) + '.ts',
+          kind: 'edit',
+          status: 'completed',
+          content: [
+            {
+              type: 'diff',
+              path: 'src/' + String(t) + '/' + String(e) + '.ts',
+              oldText: lines(shape.editLines, 'old' + String(t) + String(e) + ':'),
+              newText: lines(shape.editLines, 'new' + String(t) + String(e) + ':'),
+            },
+          ],
+        },
+      });
+    }
+    const messageId = 'asst-' + String(t);
+    events.push(textChunk(messageId, 'Summary of turn ' + String(t) + '.\n'));
+    events.push(textChunk(messageId, lines(8, 'detail-' + String(t) + '-')));
+  }
+  return events;
+}
+
+function streamTail(shape: LoadShape): AgentEvent[] {
+  const messageId = 'asst-streaming';
+  const events: AgentEvent[] = [textChunk(messageId, 'Streaming reply:\n')];
+  const piece = 'x'.repeat(shape.chunkChars);
+  for (let i = 0; i < shape.streamChunks; i += 1) {
+    events.push(textChunk(messageId, piece + ' '));
+  }
+  return events;
+}
+
+function median(samples: number[]): number {
+  const sorted = [...samples].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid];
+}
+
+function measure(fn: () => void, iterations: number, warmup = 2): number {
+  for (let i = 0; i < warmup; i += 1) fn();
+  const samples: number[] = [];
+  for (let i = 0; i < iterations; i += 1) {
+    const a = performance.now();
+    fn();
+    samples.push(performance.now() - a);
+  }
+  return median(samples);
+}
+
+function fmt(ms: number): string {
+  if (ms < 1) return (ms * 1000).toFixed(0) + 'µs';
+  if (ms < 10) return ms.toFixed(2) + 'ms';
+  return ms.toFixed(1) + 'ms';
+}
+
+function foldHistory(history: readonly AgentEvent[]): Conversation {
+  const builder = createConversationBuilder();
+  for (const event of history) builder.advance(event);
+  return builder.snapshot();
+}
+
+/** Minimal EventBuffer-backed client surface for createConversationStore. */
+function bufferClient(buffer: EventBuffer): LinkCodeClient {
+  return {
+    eventSeq: (id: SessionId) => buffer.eventSeq(id),
+    eventsSnapshot: (id: SessionId) => buffer.snapshot(id),
+    subscribe: (id: SessionId, cb: () => void) => buffer.subscribe(id, () => cb()),
+  } as LinkCodeClient;
+}
+
+function reportShape(shape: LoadShape): string {
+  const history = seedHistory(shape);
+  const stream = streamTail(shape);
+  const folded = foldHistory(history);
+
+  const foldOnce = measure(() => {
+    foldHistory(history);
+  }, 8);
+
+  const streamFold = measure(() => {
+    const builder = createConversationBuilder();
+    for (const event of history) builder.advance(event);
+    for (const event of stream) {
+      builder.advance(event);
+      builder.snapshot();
+    }
+  }, 4);
+
+  const storeStream = measure(() => {
+    const sessionId = 'sess-perf' as SessionId;
+    const buffer = new EventBuffer();
+    for (const event of history) buffer.ingest(sessionId, event);
+    const store = createConversationStore(bufferClient(buffer), sessionId);
+    store.getSnapshot();
+    for (const event of stream) {
+      buffer.ingest(sessionId, event);
+      store.getSnapshot();
+    }
+  }, 4);
+
+  expect(folded.items.length).toBeGreaterThan(shape.turns * 2);
+
+  return [
+    '## ' + shape.label,
+    'seed: ' + String(history.length) + ' events → ' + String(folded.items.length) + ' items',
+    'fold history once (median):              ' + fmt(foldOnce),
+    'stream ' +
+      String(shape.streamChunks) +
+      ' chunks + snapshot each:   ' +
+      fmt(streamFold) +
+      '  (≈ ' +
+      fmt(streamFold / shape.streamChunks) +
+      '/chunk)',
+    'store stream ' +
+      String(shape.streamChunks) +
+      ' chunks:            ' +
+      fmt(storeStream) +
+      '  (≈ ' +
+      fmt(storeStream / shape.streamChunks) +
+      '/chunk)',
+  ].join('\n');
+}
+
+describe('conversation perf report (fold / store)', () => {
+  it('prints fold-path timings for small and large synthetic sessions', () => {
+    const body = SHAPES.map((shape) => reportShape(shape)).join('\n\n');
+    // eslint-disable-next-line no-console -- intentional profiling report output
+    console.log(['', 'LinkCode conversation fold — performance report', '', body, ''].join('\n'));
+  });
+});

--- a/packages/ui/src/__tests__/conversation-view-perf.bench.ts
+++ b/packages/ui/src/__tests__/conversation-view-perf.bench.ts
@@ -1,0 +1,328 @@
+/**
+ * Microbenchmarks for the ConversationView pure pipeline (everything the component does
+ * before React commit) plus the expensive diff-stats helpers tool headers re-run.
+ *
+ *   pnpm exec vitest bench packages/ui/src/__tests__/conversation-view-perf.bench.ts
+ */
+import type { ToolCall } from '@linkcode/schema';
+import { bench, describe } from 'vitest';
+import { groupTimeline } from '../chat/activity-groups';
+import {
+  conversationFlowItems,
+  declinedToolCallIds,
+  selectPendingPromptItems,
+} from '../chat/conversation-prompts';
+import { assistantTurnText } from '../chat/conversation-text';
+import { toolCallDiffStats } from '../chat/diff-utils';
+import { partitionSubagentItems } from '../chat/subagents';
+import { splitTurnSegments, turnFileEdits } from '../chat/turn-edits';
+import type { ConversationItem, ConversationViewModel } from '../chat/types';
+
+interface LoadShape {
+  turns: number;
+  toolsPerTurn: number;
+  editsPerTurn: number;
+  editLines: number;
+  assistantParagraphs: number;
+}
+
+const SMALL: LoadShape = {
+  turns: 20,
+  toolsPerTurn: 4,
+  editsPerTurn: 1,
+  editLines: 40,
+  assistantParagraphs: 3,
+};
+
+const LARGE: LoadShape = {
+  turns: 80,
+  toolsPerTurn: 8,
+  editsPerTurn: 2,
+  editLines: 120,
+  assistantParagraphs: 6,
+};
+
+function lines(count: number, prefix: string): string {
+  let out = '';
+  for (let i = 0; i < count; i += 1) out += `${prefix}${i}\n`;
+  return out;
+}
+
+function toolItem(
+  turnId: string,
+  id: string,
+  kind: ToolCall['kind'],
+  content: ToolCall['content'] = [],
+): ConversationItem {
+  return {
+    kind: 'tool',
+    id,
+    turnId,
+    toolCall: {
+      toolCallId: id,
+      title: `${kind} ${id}`,
+      kind,
+      status: 'completed',
+      content,
+    },
+  };
+}
+
+function buildConversation(shape: LoadShape): ConversationViewModel {
+  const items: ConversationItem[] = [];
+  for (let t = 0; t < shape.turns; t += 1) {
+    const turnId = `turn-${t}`;
+    items.push({
+      kind: 'message',
+      id: `user-${t}`,
+      turnId,
+      role: 'user',
+      blocks: [{ type: 'text', text: `Please work on task ${t}` }],
+      isStreaming: false,
+    });
+    for (let k = 0; k < shape.toolsPerTurn; k += 1) {
+      const kind = k % 3 === 0 ? 'read' : k % 3 === 1 ? 'search' : 'execute';
+      items.push(
+        toolItem(
+          turnId,
+          `t${t}-tool-${k}`,
+          kind,
+          kind === 'search'
+            ? [{ type: 'content', content: { type: 'text', text: lines(30, `hit:${t}:`) } }]
+            : [],
+        ),
+      );
+    }
+    for (let e = 0; e < shape.editsPerTurn; e += 1) {
+      items.push(
+        toolItem(turnId, `t${t}-edit-${e}`, 'edit', [
+          {
+            type: 'diff',
+            path: `src/${t}/${e}.ts`,
+            oldText: lines(shape.editLines, `old${t}${e}:`),
+            newText: lines(shape.editLines, `new${t}${e}:`),
+          },
+        ]),
+      );
+    }
+    // One task + nested children so partitionSubagentItems does real work.
+    if (t % 4 === 0) {
+      const taskId = `t${t}-task`;
+      items.push(toolItem(turnId, taskId, 'task'));
+      items.push({
+        kind: 'message',
+        id: `sub-${t}`,
+        turnId,
+        role: 'assistant',
+        blocks: [{ type: 'text', text: `subagent note ${t}` }],
+        isStreaming: false,
+        parentToolCallId: taskId,
+      });
+      const nested = toolItem(turnId, `t${t}-sub-read`, 'read');
+      if (nested.kind === 'tool') {
+        items.push({
+          ...nested,
+          toolCall: { ...nested.toolCall, parentToolCallId: taskId },
+        });
+      }
+    }
+    const paragraphs: string[] = [];
+    for (let p = 0; p < shape.assistantParagraphs; p += 1) {
+      paragraphs.push(`## Turn ${t} section ${p}\n\n${lines(12, `p${t}${p}:`)}`);
+    }
+    items.push({
+      kind: 'message',
+      id: `asst-${t}`,
+      turnId,
+      role: 'assistant',
+      blocks: [{ type: 'text', text: paragraphs.join('\n') }],
+      isStreaming: t === shape.turns - 1,
+      model: 'bench-model',
+      receivedAt: 1_700_000_000_000 + t,
+    });
+  }
+
+  return {
+    items,
+    status: 'running',
+    usage: null,
+    currentModeId: null,
+    approvalPolicy: null,
+    currentModel: 'bench-model',
+    currentEffort: null,
+    availableCommands: null,
+    availableModels: null,
+    capabilities: null,
+    stopReason: null,
+    pendingPermissionIds: [],
+    pendingQuestionIds: [],
+  };
+}
+
+/**
+ * Mirrors ConversationView's pre-commit work: every agent.event that lands triggers this
+ * over the full timeline — not just the streaming tail. Historical turns re-run turnFileEdits
+ * (LCS) on every tick while the session is running.
+ */
+function conversationViewPipeline(conversation: ConversationViewModel): number {
+  const { items } = conversation;
+  const isThinking = conversation.status === 'running' || conversation.status === 'starting';
+  const declined = declinedToolCallIds(items);
+  const snapshottedToolIds = new Set(
+    items.flatMap((item) => (item.kind === 'tool' ? [item.toolCall.toolCallId] : [])),
+  );
+  const awaitingApproval = new Set(
+    selectPendingPromptItems(conversation).flatMap((item) =>
+      item.kind === 'approval' ? [item.toolCall.toolCallId] : [],
+    ),
+  );
+  const segments = splitTurnSegments(conversationFlowItems(items));
+  const subagentTasks = items.filter(
+    (item): item is Extract<ConversationItem, { kind: 'tool' }> =>
+      item.kind === 'tool' && item.toolCall.kind === 'task',
+  );
+  const allSubagentChildren = partitionSubagentItems(items).childrenByParent;
+
+  let entryCount = 0;
+  for (let index = 0; index < segments.length; index += 1) {
+    const segment = segments[index];
+    const ended = index < segments.length - 1 || !isThinking;
+    const { topLevel } = partitionSubagentItems(segment.items);
+    const edits = ended ? turnFileEdits(segment.items) : null;
+    const replyText = ended ? assistantTurnText(topLevel) : '';
+    const entries = groupTimeline(topLevel);
+    entryCount += entries.length + (edits ? edits.files.length : 0) + (replyText ? 1 : 0);
+  }
+
+  // Keep the compiler from DCE-ing side work under aggressive opts.
+  return (
+    entryCount +
+    declined.size +
+    snapshottedToolIds.size +
+    awaitingApproval.size +
+    subagentTasks.length +
+    allSubagentChildren.size
+  );
+}
+
+/** Sum toolCallDiffStats across every edit tool — ActivityGroup headers do this on re-render. */
+function allEditDiffStats(conversation: ConversationViewModel): number {
+  let total = 0;
+  for (const item of conversation.items) {
+    if (item.kind !== 'tool' || item.toolCall.kind !== 'edit') continue;
+    const stats = toolCallDiffStats(item.toolCall);
+    total += stats.additions + stats.deletions;
+  }
+  return total;
+}
+
+function simulateStreamTicks(conversation: ConversationViewModel, ticks: number): number {
+  // Identity-stable history + mutating tail message text, like a streaming chunk each tick.
+  let acc = 0;
+  const base = conversation.items.slice(0, -1);
+  const last = conversation.items.at(-1);
+  if (last?.kind !== 'message') return conversationViewPipeline(conversation);
+
+  let text = last.blocks[0]?.type === 'text' ? last.blocks[0].text : '';
+  for (let i = 0; i < ticks; i += 1) {
+    text += ` token${i}`;
+    const next: ConversationViewModel = {
+      ...conversation,
+      items: [
+        ...base,
+        {
+          ...last,
+          blocks: [{ type: 'text', text }],
+          isStreaming: true,
+        },
+      ],
+    };
+    acc += conversationViewPipeline(next);
+  }
+  return acc;
+}
+
+describe('ConversationView pure pipeline — small (~20 turns)', () => {
+  const conversation = buildConversation(SMALL);
+  bench(`pipeline once (${conversation.items.length} items)`, () => {
+    conversationViewPipeline(conversation);
+  });
+  bench('all edit toolCallDiffStats once', () => {
+    allEditDiffStats(conversation);
+  });
+  bench('simulate 50 stream ticks (full pipeline each)', () => {
+    simulateStreamTicks(conversation, 50);
+  });
+});
+
+describe('ConversationView pure pipeline — large (~80 turns)', () => {
+  const conversation = buildConversation(LARGE);
+  bench(`pipeline once (${conversation.items.length} items)`, () => {
+    conversationViewPipeline(conversation);
+  });
+  bench('all edit toolCallDiffStats once', () => {
+    allEditDiffStats(conversation);
+  });
+  bench('simulate 100 stream ticks (full pipeline each)', () => {
+    simulateStreamTicks(conversation, 100);
+  });
+  bench('turnFileEdits over whole timeline once', () => {
+    turnFileEdits(conversation.items);
+  });
+});
+
+describe('diffLines / toolCallDiffStats isolated', () => {
+  const mid = {
+    toolCallId: 'd1',
+    title: 'Edit',
+    kind: 'edit' as const,
+    status: 'completed' as const,
+    content: [
+      {
+        type: 'diff' as const,
+        path: 'mid.ts',
+        oldText: lines(200, 'o:'),
+        newText: lines(200, 'n:'),
+      },
+    ],
+  };
+  const nearCap = {
+    toolCallId: 'd2',
+    title: 'Edit',
+    kind: 'edit' as const,
+    status: 'completed' as const,
+    content: [
+      {
+        type: 'diff' as const,
+        path: 'big.ts',
+        // 500×500 = 250k cells — just under the fallback gate
+        oldText: lines(500, 'o:'),
+        newText: lines(500, 'n:'),
+      },
+    ],
+  };
+  const overCap = {
+    toolCallId: 'd3',
+    title: 'Edit',
+    kind: 'edit' as const,
+    status: 'completed' as const,
+    content: [
+      {
+        type: 'diff' as const,
+        path: 'huge.ts',
+        oldText: lines(600, 'o:'),
+        newText: lines(600, 'n:'),
+      },
+    ],
+  };
+
+  bench('toolCallDiffStats 200×200 lines', () => {
+    toolCallDiffStats(mid);
+  });
+  bench('toolCallDiffStats 500×500 lines (near LCS cap)', () => {
+    toolCallDiffStats(nearCap);
+  });
+  bench('toolCallDiffStats 600×600 lines (fallback path)', () => {
+    toolCallDiffStats(overCap);
+  });
+});

--- a/packages/ui/src/__tests__/conversation-view-perf.report.test.ts
+++ b/packages/ui/src/__tests__/conversation-view-perf.report.test.ts
@@ -1,0 +1,340 @@
+/**
+ * One-shot timing report for ConversationView's pure pre-commit pipeline.
+ *
+ *   pnpm test packages/ui/src/__tests__/conversation-view-perf.report.test.ts
+ */
+
+import type { ToolCall } from '@linkcode/schema';
+import { describe, expect, it } from 'vitest';
+import { groupTimeline } from '../chat/activity-groups';
+import {
+  conversationFlowItems,
+  declinedToolCallIds,
+  selectPendingPromptItems,
+} from '../chat/conversation-prompts';
+import { assistantTurnText } from '../chat/conversation-text';
+import { toolCallDiffStats } from '../chat/diff-utils';
+import { partitionSubagentItems } from '../chat/subagents';
+import { splitTurnSegments, turnFileEdits } from '../chat/turn-edits';
+import type { ConversationItem, ConversationViewModel } from '../chat/types';
+
+interface LoadShape {
+  label: string;
+  turns: number;
+  toolsPerTurn: number;
+  editsPerTurn: number;
+  editLines: number;
+  streamTicks: number;
+}
+
+const SHAPES: LoadShape[] = [
+  {
+    label: 'small (~20 turns)',
+    turns: 20,
+    toolsPerTurn: 4,
+    editsPerTurn: 1,
+    editLines: 40,
+    streamTicks: 50,
+  },
+  {
+    label: 'large (~80 turns)',
+    turns: 80,
+    toolsPerTurn: 8,
+    editsPerTurn: 2,
+    editLines: 120,
+    streamTicks: 100,
+  },
+];
+
+function lines(count: number, prefix: string): string {
+  const parts: string[] = [];
+  for (let i = 0; i < count; i += 1) parts.push(prefix + String(i));
+  return parts.join('\n') + '\n';
+}
+
+function toolItem(
+  turnId: string,
+  id: string,
+  kind: ToolCall['kind'],
+  content: ToolCall['content'] = [],
+): ConversationItem {
+  return {
+    kind: 'tool',
+    id,
+    turnId,
+    toolCall: {
+      toolCallId: id,
+      title: kind + ' ' + id,
+      kind,
+      status: 'completed',
+      content,
+    },
+  };
+}
+
+function buildConversation(shape: LoadShape): ConversationViewModel {
+  const items: ConversationItem[] = [];
+  for (let t = 0; t < shape.turns; t += 1) {
+    const turnId = 'turn-' + String(t);
+    items.push({
+      kind: 'message',
+      id: 'user-' + String(t),
+      turnId,
+      role: 'user',
+      blocks: [{ type: 'text', text: 'Please work on task ' + String(t) }],
+      isStreaming: false,
+    });
+    for (let k = 0; k < shape.toolsPerTurn; k += 1) {
+      const kind = k % 3 === 0 ? 'read' : k % 3 === 1 ? 'search' : 'execute';
+      items.push(
+        toolItem(
+          turnId,
+          't' + String(t) + '-tool-' + String(k),
+          kind,
+          kind === 'search'
+            ? [
+                {
+                  type: 'content',
+                  content: { type: 'text', text: lines(30, 'hit:' + String(t) + ':') },
+                },
+              ]
+            : [],
+        ),
+      );
+    }
+    for (let e = 0; e < shape.editsPerTurn; e += 1) {
+      items.push(
+        toolItem(turnId, 't' + String(t) + '-edit-' + String(e), 'edit', [
+          {
+            type: 'diff',
+            path: 'src/' + String(t) + '/' + String(e) + '.ts',
+            oldText: lines(shape.editLines, 'old' + String(t) + String(e) + ':'),
+            newText: lines(shape.editLines, 'new' + String(t) + String(e) + ':'),
+          },
+        ]),
+      );
+    }
+    if (t % 4 === 0) {
+      const taskId = 't' + String(t) + '-task';
+      items.push(toolItem(turnId, taskId, 'task'));
+      items.push({
+        kind: 'message',
+        id: 'sub-' + String(t),
+        turnId,
+        role: 'assistant',
+        blocks: [{ type: 'text', text: 'subagent note ' + String(t) }],
+        isStreaming: false,
+        parentToolCallId: taskId,
+      });
+      const nested = toolItem(turnId, 't' + String(t) + '-sub-read', 'read');
+      if (nested.kind === 'tool') {
+        items.push({
+          ...nested,
+          toolCall: { ...nested.toolCall, parentToolCallId: taskId },
+        });
+      }
+    }
+    items.push({
+      kind: 'message',
+      id: 'asst-' + String(t),
+      turnId,
+      role: 'assistant',
+      blocks: [{ type: 'text', text: lines(36, 'asst-' + String(t) + ':') }],
+      isStreaming: t === shape.turns - 1,
+      model: 'bench-model',
+      receivedAt: 1_700_000_000_000 + t,
+    });
+  }
+
+  return {
+    items,
+    status: 'running',
+    usage: null,
+    currentModeId: null,
+    approvalPolicy: null,
+    currentModel: 'bench-model',
+    currentEffort: null,
+    availableCommands: null,
+    availableModels: null,
+    capabilities: null,
+    stopReason: null,
+    pendingPermissionIds: [],
+    pendingQuestionIds: [],
+  };
+}
+
+/**
+ * Full pre-commit work ConversationView does on every conversation snapshot.
+ * Matches conversation-view.tsx: trailers only for ended turns — while status is running,
+ * every historical turn still re-runs LCS; only the in-flight turn skips.
+ */
+function conversationViewPipeline(conversation: ConversationViewModel): number {
+  const { items } = conversation;
+  const isThinking = conversation.status === 'running' || conversation.status === 'starting';
+  const declined = declinedToolCallIds(items);
+  const snapshottedToolIds = new Set(
+    items.flatMap((item) => (item.kind === 'tool' ? [item.toolCall.toolCallId] : [])),
+  );
+  const awaitingApproval = new Set(
+    selectPendingPromptItems(conversation).flatMap((item) =>
+      item.kind === 'approval' ? [item.toolCall.toolCallId] : [],
+    ),
+  );
+  const segments = splitTurnSegments(conversationFlowItems(items));
+  let entryCount = 0;
+  for (let index = 0; index < segments.length; index += 1) {
+    const segment = segments[index];
+    const ended = index < segments.length - 1 || !isThinking;
+    const { topLevel } = partitionSubagentItems(segment.items);
+    const edits = ended ? turnFileEdits(segment.items) : null;
+    const replyText = ended ? assistantTurnText(topLevel) : '';
+    entryCount += groupTimeline(topLevel).length + (edits ? 1 : 0) + (replyText ? 1 : 0);
+  }
+  return entryCount + declined.size + snapshottedToolIds.size + awaitingApproval.size;
+}
+
+/** Pipeline without turnFileEdits — isolates grouping/partition from LCS cost. */
+function conversationViewPipelineNoEdits(conversation: ConversationViewModel): number {
+  const { items } = conversation;
+  declinedToolCallIds(items);
+  const segments = splitTurnSegments(conversationFlowItems(items));
+  let entryCount = 0;
+  for (const segment of segments) {
+    const { topLevel } = partitionSubagentItems(segment.items);
+    entryCount += groupTimeline(topLevel).length + (assistantTurnText(topLevel) ? 1 : 0);
+  }
+  return entryCount;
+}
+
+function allEditDiffStats(conversation: ConversationViewModel): number {
+  let total = 0;
+  for (const item of conversation.items) {
+    if (item.kind !== 'tool' || item.toolCall.kind !== 'edit') continue;
+    const stats = toolCallDiffStats(item.toolCall);
+    total += stats.additions + stats.deletions;
+  }
+  return total;
+}
+
+function median(samples: number[]): number {
+  const sorted = [...samples].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid];
+}
+
+function measure(fn: () => void, iterations: number, warmup = 2): number {
+  for (let i = 0; i < warmup; i += 1) fn();
+  const samples: number[] = [];
+  for (let i = 0; i < iterations; i += 1) {
+    const a = performance.now();
+    fn();
+    samples.push(performance.now() - a);
+  }
+  return median(samples);
+}
+
+function fmt(ms: number): string {
+  if (ms < 1) return (ms * 1000).toFixed(0) + 'µs';
+  if (ms < 10) return ms.toFixed(2) + 'ms';
+  return ms.toFixed(1) + 'ms';
+}
+
+function reportShape(shape: LoadShape): string {
+  const conversation = buildConversation(shape);
+  const iters = shape.turns >= 80 ? 6 : 30;
+
+  const pipelineOnce = measure(() => {
+    conversationViewPipeline(conversation);
+  }, iters);
+
+  const pipelineNoEdits = measure(() => {
+    conversationViewPipelineNoEdits(conversation);
+  }, iters);
+
+  const streamPipeline = measure(
+    () => {
+      const base = conversation.items.slice(0, -1);
+      const last = conversation.items.at(-1);
+      if (last?.kind !== 'message') return;
+      let text = last.blocks[0]?.type === 'text' ? last.blocks[0].text : '';
+      for (let i = 0; i < shape.streamTicks; i += 1) {
+        text += ' token' + String(i);
+        conversationViewPipeline({
+          ...conversation,
+          items: [...base, { ...last, blocks: [{ type: 'text', text }], isStreaming: true }],
+        });
+      }
+    },
+    shape.turns >= 80 ? 2 : 4,
+  );
+
+  const diffs = measure(() => {
+    allEditDiffStats(conversation);
+  }, iters);
+
+  const turnEdits = measure(() => {
+    turnFileEdits(conversation.items);
+  }, iters);
+
+  expect(conversationViewPipeline(conversation)).toBeGreaterThan(0);
+
+  return [
+    '## ' + shape.label,
+    'items: ' + String(conversation.items.length),
+    'pipeline once (median):                     ' + fmt(pipelineOnce),
+    'pipeline without turnFileEdits (median):    ' + fmt(pipelineNoEdits),
+    'pipeline × ' +
+      String(shape.streamTicks) +
+      ' stream ticks:            ' +
+      fmt(streamPipeline) +
+      '  (≈ ' +
+      fmt(streamPipeline / shape.streamTicks) +
+      '/tick)',
+    'all edit toolCallDiffStats once:            ' + fmt(diffs),
+    'turnFileEdits(whole timeline) once:         ' + fmt(turnEdits),
+  ].join('\n');
+}
+
+function reportIsolatedDiffs(): string {
+  const cases: Array<{ label: string; n: number }> = [
+    { label: '200×200 lines', n: 200 },
+    { label: '500×500 lines (near LCS cap)', n: 500 },
+    { label: '600×600 lines (fallback)', n: 600 },
+  ];
+  return [
+    '## isolated toolCallDiffStats',
+    ...cases.map((c) => {
+      const tool = {
+        content: [
+          {
+            type: 'diff' as const,
+            path: 'f.ts',
+            oldText: lines(c.n, 'o:'),
+            newText: lines(c.n, 'n:'),
+          },
+        ],
+      };
+      const m = measure(() => {
+        toolCallDiffStats(tool);
+      }, 12);
+      return c.label.padEnd(36) + fmt(m);
+    }),
+  ].join('\n');
+}
+
+describe('conversation perf report (ConversationView pipeline)', () => {
+  it('prints pure-pipeline and diff-stats timings', () => {
+    const body = [...SHAPES.map((shape) => reportShape(shape)), reportIsolatedDiffs()].join('\n\n');
+    // eslint-disable-next-line no-console -- intentional profiling report output
+    console.log(
+      [
+        '',
+        'LinkCode ConversationView pure pipeline — performance report',
+        'Note: pure JS only (no React commit / Streamdown / layout). Each stream tick ≈ one agent.event recompute.',
+        '',
+        body,
+        '',
+      ].join('\n'),
+    );
+  }, 60000);
+});


### PR DESCRIPTION
## Summary

Adds a reproducible microbenchmark / one-shot timing harness for the conversation hot path so we can measure fold/store and `ConversationView` pure-pipeline cost without spinning up a full UI session.

- **Fold / store** (`packages/client-core`): synthetic multi-turn histories + stream-chunk workloads over `createConversationBuilder`, `EventBuffer`, and `ConversationStore`
- **View pipeline** (`packages/ui`): mirrors `ConversationView` pre-commit work (`groupTimeline`, `partitionSubagentItems`, `turnFileEdits`, …) and isolates `toolCallDiffStats` / LCS

### How to run

```bash
pnpm test packages/client-core/src/__tests__/conversation-perf.report.test.ts \
          packages/ui/src/__tests__/conversation-view-perf.report.test.ts

pnpm exec vitest bench \
  packages/client-core/src/__tests__/conversation-perf.bench.ts \
  packages/ui/src/__tests__/conversation-view-perf.bench.ts
```

### Baseline findings (darwin arm64, pure JS)

| Path | Small (~20 turns) | Large (~80 turns / ~1k items) |
| --- | --- | --- |
| Fold / store stream | ~µs–100µs | ~70–320µs |
| View pipeline once | ~0.4ms | **~14ms** |
| Pipeline **without** `turnFileEdits` | ~17µs | **~42µs** (~340× cheaper) |
| 100 stream ticks (full pipeline) | — | **~1.4s** (≈14ms/tick) |

**Takeaway:** data-plane fold is cheap; the dominant cost is re-running `turnFileEdits` / LCS over historical turns on every `agent.event` while the session is streaming. That alone approaches a 16ms frame budget before React commit / Streamdown / layout.

This PR is harness-only — no product behavior change. Follow-up work can cache edit trailers (or compute them once per settled turn) and re-run the same report.

## Test plan

- [x] `pnpm test packages/client-core/src/__tests__/conversation-perf.report.test.ts packages/ui/src/__tests__/conversation-view-perf.report.test.ts` prints tables and passes
- [x] Pre-commit format / lint / typecheck green on the harness files
- [ ] Optional: `pnpm exec vitest bench` on the two `*.bench.ts` files for statistical numbers on your machine