### PR TITLE
feat(ui,workbench): collapse the error banner into a title-side badge, card-style conversation errors, clear on navigation (CODE-239)

### DIFF
--- a/apps/desktop/src/renderer/src/shell/desktop-shell.tsx
+++ b/apps/desktop/src/renderer/src/shell/desktop-shell.tsx
@@ -3,6 +3,7 @@ import type { ComposerAttachment } from '@linkcode/ui';
 import {
   AgentIcon,
   ConversationSurface,
+  ErrorBadge,
   ErrorBanner,
   HostFooter,
   NewSessionSurface,
@@ -359,7 +360,6 @@ export function DesktopShell({
           TerminalBlockComponent={TerminalBlockComponent}
           disabled={!active || active.status === 'stopped'}
           isRunning={isRunning}
-          topContent={<ErrorBanner errorMessage={errorMessage} onDismissError={onDismissError} />}
           mentionItems={mentionItems}
           onMentionQueryChange={onMentionQueryChange}
           onSendPrompt={onSendPrompt}
@@ -554,6 +554,11 @@ export function DesktopShell({
                 onOpenDiff={() => openRightPanelSection('diff')}
               />
             ) : undefined}
+            <ErrorBadge
+              errorMessage={errorMessage}
+              onDismissError={onDismissError}
+              className="pointer-events-auto [-webkit-app-region:no-drag]"
+            />
           </>
         }
         onShowSidebar={() => updateSidebarOpen(true)}

--- a/apps/desktop/src/renderer/src/shell/desktop-shell.tsx
+++ b/apps/desktop/src/renderer/src/shell/desktop-shell.tsx
@@ -535,7 +535,20 @@ export function DesktopShell({
         sidebarShortcut={sidebarShortcut}
         rightPanelShortcut={rightPanelShortcut}
         bottomPanelShortcut={bottomPanelShortcut}
-        titleContent={hideMainTitle ? null : undefined}
+        titleContent={
+          hideMainTitle ? (
+            // An untitled conversation hides the title area, which would also hide the error
+            // badge with no banner fallback; keep the badge alone. The draft page stays bare —
+            // it reports errors through its own in-page banner.
+            draft === null ? (
+              <ErrorBadge
+                errorMessage={errorMessage}
+                onDismissError={onDismissError}
+                className="pointer-events-auto [-webkit-app-region:no-drag]"
+              />
+            ) : null
+          ) : undefined
+        }
         titleIcon={
           titledSession ? (
             <AgentIcon className="text-foreground" kind={titledSession.kind} variant="ghost" />

--- a/apps/webview/src/shell/web-workbench-shell.tsx
+++ b/apps/webview/src/shell/web-workbench-shell.tsx
@@ -1,4 +1,4 @@
-import { ShellFrame, ShellIconButton, TitleStrip } from '@linkcode/ui';
+import { ErrorBadge, ShellFrame, ShellIconButton, TitleStrip } from '@linkcode/ui';
 import type { WorkbenchShellProps } from '@linkcode/workbench';
 import { WorkspaceServicesMenu } from '@linkcode/workbench';
 import { Button } from 'coss-ui/components/button';
@@ -44,6 +44,11 @@ export function WebWorkbenchShell({
               <div className="truncate text-muted-foreground text-xs">{header.subtitle}</div>
             )}
           </div>
+          {/* The draft page reports errors through its own banner. */}
+          <ErrorBadge
+            errorMessage={props.draft ? null : props.errorMessage}
+            onDismissError={props.onDismissError}
+          />
           <div className="ml-auto flex items-center gap-2">
             {/* No in-app browser in the web client: preview links always open a new tab. */}
             <WorkspaceServicesMenu cwd={props.activeSession?.cwd} />

--- a/packages/i18n/src/locales/en.ts
+++ b/packages/i18n/src/locales/en.ts
@@ -115,6 +115,10 @@ export const en = {
         'Unable to connect to the daemon ({url}). It starts automatically with the app — retry, and restart the app if this keeps failing.',
       retry: 'Retry',
     },
+    errors: {
+      actionFailed: 'Action failed',
+      dismiss: 'Dismiss error',
+    },
     conversation: {
       emptyTitle: 'Start the conversation',
       emptyHint: 'Type a message below — {agent} will get to work in {cwd}.',

--- a/packages/i18n/src/locales/zh-cn.ts
+++ b/packages/i18n/src/locales/zh-cn.ts
@@ -112,6 +112,10 @@ export const zhCN = {
         '无法连接到 daemon（{url}）。它会随应用自动启动——请重试，若持续失败请重启应用。',
       retry: '重试',
     },
+    errors: {
+      actionFailed: '操作失败',
+      dismiss: '清除错误',
+    },
     conversation: {
       emptyTitle: '开始对话',
       emptyHint: '在下方输入消息，{agent} 会在 {cwd} 中开始工作。',

--- a/packages/ui/src/__tests__/error-text.test.ts
+++ b/packages/ui/src/__tests__/error-text.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeErrorMessage } from '../lib/error-text';
+
+describe('normalizeErrorMessage', () => {
+  it('collapses stacked Error: prefixes to one', () => {
+    expect(normalizeErrorMessage('Error: Error: No API key found')).toBe('Error: No API key found');
+    expect(normalizeErrorMessage('Error:  Error:\tError: boom')).toBe('Error: boom');
+  });
+
+  it('keeps a single prefix as-is', () => {
+    expect(normalizeErrorMessage('Error: boom')).toBe('Error: boom');
+  });
+
+  it('leaves unprefixed messages untouched', () => {
+    expect(normalizeErrorMessage('Session is busy: s-1')).toBe('Session is busy: s-1');
+    expect(normalizeErrorMessage('TypeError: x is not a function')).toBe(
+      'TypeError: x is not a function',
+    );
+  });
+
+  it('does not touch Error: appearing mid-message', () => {
+    expect(normalizeErrorMessage('send failed — Error: boom')).toBe('send failed — Error: boom');
+  });
+});

--- a/packages/ui/src/chat/error-message.tsx
+++ b/packages/ui/src/chat/error-message.tsx
@@ -1,7 +1,9 @@
-import { Alert, AlertTitle } from 'coss-ui/components/alert';
 import { TriangleAlertIcon } from 'lucide-react';
 import { cn } from '../lib/cn';
+import { normalizeErrorMessage } from '../lib/error-text';
+import { Message, MessageContent } from './message';
 
+/** An agent error event, rendered as a message-shaped card in red mono type (CODE-239). */
 export function ErrorMessage({
   message,
   code,
@@ -12,15 +14,21 @@ export function ErrorMessage({
   recoverable: boolean;
 }): React.ReactNode {
   return (
-    <Alert
-      className={cn('my-1', !recoverable && 'border-destructive/48 bg-destructive/8')}
-      variant="error"
-    >
-      <TriangleAlertIcon />
-      <AlertTitle className="break-words font-normal">
-        {message}
-        {code ? <span className="ml-2 text-muted-foreground">({code})</span> : null}
-      </AlertTitle>
-    </Alert>
+    <Message from="assistant">
+      <MessageContent>
+        <div
+          className={cn(
+            'flex items-start gap-2.5 rounded-2xl rounded-bl border border-destructive/24 bg-destructive/4 px-3.5 py-2.5',
+            !recoverable && 'border-destructive/48 bg-destructive/8',
+          )}
+        >
+          <TriangleAlertIcon className="mt-0.5 size-4 shrink-0 text-destructive-foreground" />
+          <div className="min-w-0 whitespace-pre-wrap break-words font-mono text-destructive-foreground text-xs leading-relaxed">
+            {normalizeErrorMessage(message)}
+            {code ? <span className="ml-2 opacity-64">({code})</span> : null}
+          </div>
+        </div>
+      </MessageContent>
+    </Message>
   );
 }

--- a/packages/ui/src/lib/error-text.ts
+++ b/packages/ui/src/lib/error-text.ts
@@ -1,0 +1,17 @@
+/** Matches one leading `Error: ` token (the `Error` name prefix added by error stringification). */
+const ERROR_PREFIX = /^Error:\s+/;
+
+/**
+ * Collapse stacked `Error: Error: …` prefixes down to one. Wire error messages often already
+ * carry the provider CLI's own `Error: ` prefix, and every client-side stringification pass
+ * (e.g. `extractErrorMessage`'s name prefix) stacks another on top.
+ */
+export function normalizeErrorMessage(message: string): string {
+  let rest = message;
+  let prefixed = false;
+  while (ERROR_PREFIX.test(rest)) {
+    prefixed = true;
+    rest = rest.replace(ERROR_PREFIX, '');
+  }
+  return prefixed ? `Error: ${rest}` : rest;
+}

--- a/packages/ui/src/shell/conversation-surface.tsx
+++ b/packages/ui/src/shell/conversation-surface.tsx
@@ -36,7 +36,6 @@ export interface ConversationSurfaceProps {
   onCancelLogin?: (kind: AgentKind) => void;
   disabled?: boolean;
   isRunning: boolean;
-  topContent?: React.ReactNode;
   className?: string;
   conversationClassName?: string;
   TerminalBlockComponent?: React.ComponentType<{ terminalId: string }>;
@@ -85,7 +84,6 @@ export function ConversationSurface({
   onCancelLogin,
   disabled = false,
   isRunning,
-  topContent,
   className,
   conversationClassName,
   TerminalBlockComponent,
@@ -125,7 +123,6 @@ export function ConversationSurface({
 
   return (
     <div className={cn('flex h-full min-h-0 min-w-0 flex-col bg-background', className)}>
-      {topContent}
       <div className={cn('min-h-0 flex-1', conversationClassName)}>
         <ArtifactHostActionsProvider actions={artifactActions}>
           <ConversationView

--- a/packages/ui/src/shell/error-badge.tsx
+++ b/packages/ui/src/shell/error-badge.tsx
@@ -1,0 +1,62 @@
+import { Badge } from 'coss-ui/components/badge';
+import { Button } from 'coss-ui/components/button';
+import { HoverCard, HoverCardContent, HoverCardTrigger } from 'coss-ui/components/preview-card';
+import { CircleAlertIcon, XIcon } from 'lucide-react';
+import { useTranslations } from 'use-intl';
+import { cn } from '../lib/cn';
+import { normalizeErrorMessage } from '../lib/error-text';
+
+/**
+ * Title-side surface for the last failed action (CODE-239): a compact badge whose full error
+ * message only shows in a hover card, replacing the old always-on banner. Renders nothing
+ * without an error.
+ */
+export function ErrorBadge({
+  errorMessage,
+  onDismissError,
+  className,
+}: {
+  errorMessage?: string | null;
+  onDismissError?: () => void;
+  className?: string;
+}): React.ReactNode {
+  const t = useTranslations('workbench.errors');
+  if (!errorMessage) return null;
+
+  return (
+    <HoverCard>
+      <HoverCardTrigger
+        delay={300}
+        render={
+          <Badge
+            variant="error"
+            className={cn('shrink-0 border-destructive/32 px-1.5', className)}
+          />
+        }
+      >
+        <CircleAlertIcon />
+        {t('actionFailed')}
+      </HoverCardTrigger>
+      <HoverCardContent align="start" className="w-96 max-w-[min(24rem,90vw)] flex-col gap-2 p-3">
+        <div className="flex items-center justify-between gap-2">
+          <span className="font-medium text-destructive-foreground text-sm">
+            {t('actionFailed')}
+          </span>
+          {onDismissError && (
+            <Button
+              size="icon-xs"
+              variant="ghost"
+              aria-label={t('dismiss')}
+              onClick={onDismissError}
+            >
+              <XIcon />
+            </Button>
+          )}
+        </div>
+        <div className="max-h-64 overflow-y-auto whitespace-pre-wrap break-words font-mono text-xs leading-relaxed">
+          {normalizeErrorMessage(errorMessage)}
+        </div>
+      </HoverCardContent>
+    </HoverCard>
+  );
+}

--- a/packages/ui/src/shell/error-banner.tsx
+++ b/packages/ui/src/shell/error-banner.tsx
@@ -1,7 +1,11 @@
 import { Alert, AlertAction, AlertDescription, AlertTitle } from 'coss-ui/components/alert';
 import { Button } from 'coss-ui/components/button';
 import { XIcon } from 'lucide-react';
+import { useTranslations } from 'use-intl';
+import { normalizeErrorMessage } from '../lib/error-text';
 
+/** Full-width banner for surfaces without a title strip (the new-session page); conversation
+ * surfaces show the compact `ErrorBadge` beside the title instead (CODE-239). */
 export function ErrorBanner({
   errorMessage,
   onDismissError,
@@ -9,13 +13,14 @@ export function ErrorBanner({
   errorMessage?: string | null;
   onDismissError?: () => void;
 }): React.ReactNode {
+  const t = useTranslations('workbench.errors');
   if (!errorMessage) return null;
 
   return (
     <div className="border-border border-b px-4 py-2">
       <Alert variant="error" className="rounded-md py-2">
-        <AlertTitle>Action failed</AlertTitle>
-        <AlertDescription>{errorMessage}</AlertDescription>
+        <AlertTitle>{t('actionFailed')}</AlertTitle>
+        <AlertDescription>{normalizeErrorMessage(errorMessage)}</AlertDescription>
         {onDismissError && (
           <AlertAction>
             <Button size="icon-xs" variant="ghost" aria-label="Dismiss" onClick={onDismissError}>

--- a/packages/ui/src/shell/index.ts
+++ b/packages/ui/src/shell/index.ts
@@ -6,6 +6,7 @@ export * from './command-palette';
 export * from './composer';
 export * from './composer-attachments';
 export * from './conversation-surface';
+export * from './error-badge';
 export * from './error-banner';
 export * from './general-settings-panel';
 export * from './history/history-browser';

--- a/packages/ui/src/shell/shell-frame.tsx
+++ b/packages/ui/src/shell/shell-frame.tsx
@@ -191,12 +191,12 @@ export function ShellFrame({
       </div>
       <main className="flex min-w-0 flex-1 flex-col">
         {header}
-        <ErrorBanner errorMessage={errorMessage} onDismissError={onDismissError} />
         {draft ? (
           // Keyed per entry point so opening from another group resets the page's picks.
           <NewSessionSurface
             key={draft.initialWorkspaceId ?? 'default'}
             className="min-h-0 flex-1"
+            topContent={<ErrorBanner errorMessage={errorMessage} onDismissError={onDismissError} />}
             draft={draft}
             workspaces={workspaces}
             chatWorkspace={chatWorkspace}

--- a/packages/workbench/src/surface/shell.tsx
+++ b/packages/workbench/src/surface/shell.tsx
@@ -1,6 +1,6 @@
 import type { TokenUsage } from '@linkcode/schema';
 import type { ComposerAttachment, ShellFrameProps } from '@linkcode/ui';
-import { ShellFrame, TitleStrip } from '@linkcode/ui';
+import { ErrorBadge, ShellFrame, TitleStrip } from '@linkcode/ui';
 
 export interface WorkbenchShellHeader {
   title: string;
@@ -35,10 +35,30 @@ export function DefaultWorkbenchShell({
   onReadAttachmentFile,
   ...props
 }: WorkbenchShellProps): React.ReactNode {
-  return <ShellFrame {...props} header={<DefaultTitleStrip header={header} />} />;
+  return (
+    <ShellFrame
+      {...props}
+      header={
+        <DefaultTitleStrip
+          header={header}
+          // The draft page reports errors through its own banner (it has no meaningful title).
+          errorMessage={props.draft ? null : props.errorMessage}
+          onDismissError={props.onDismissError}
+        />
+      }
+    />
+  );
 }
 
-function DefaultTitleStrip({ header }: { header: WorkbenchShellHeader }): React.ReactNode {
+function DefaultTitleStrip({
+  header,
+  errorMessage,
+  onDismissError,
+}: {
+  header: WorkbenchShellHeader;
+  errorMessage?: string | null;
+  onDismissError?: () => void;
+}): React.ReactNode {
   const hasUsage =
     header.usage != null && (header.usage.inputTokens != null || header.usage.outputTokens != null);
 
@@ -50,6 +70,7 @@ function DefaultTitleStrip({ header }: { header: WorkbenchShellHeader }): React.
           <div className="truncate text-muted-foreground text-xs">{header.subtitle}</div>
         )}
       </div>
+      <ErrorBadge errorMessage={errorMessage} onDismissError={onDismissError} />
       {hasUsage && (
         <span className="ml-auto font-mono text-muted-foreground text-xs">
           {header.usage?.inputTokens ?? 0} in / {header.usage?.outputTokens ?? 0} out

--- a/packages/workbench/src/surface/workbench.tsx
+++ b/packages/workbench/src/surface/workbench.tsx
@@ -88,7 +88,32 @@ export function Workbench({
     setErrorMessage(extractErrorMessage(err));
   }
 
-  const sessions = useWorkbenchSessions(handleError);
+  const rawSessions = useWorkbenchSessions(handleError);
+  // Leaving the current surface drops its error state: a stale failure must not follow the user
+  // to another thread or the new-thread page (CODE-239). `create` clears at submit time instead.
+  const sessions: WorkbenchSessions = {
+    ...rawSessions,
+    select(id) {
+      setErrorMessage(null);
+      rawSessions.select(id);
+    },
+    startDraft(workspaceId) {
+      setErrorMessage(null);
+      rawSessions.startDraft(workspaceId);
+    },
+    goBack() {
+      setErrorMessage(null);
+      rawSessions.goBack();
+    },
+    goForward() {
+      setErrorMessage(null);
+      rawSessions.goForward();
+    },
+    close(id) {
+      setErrorMessage(null);
+      rawSessions.close(id);
+    },
+  };
   useWorkbenchKeyboardShortcuts(rootRef, sessions);
   const conversation = useSeededConversation(sessions.active, handleError);
 


### PR DESCRIPTION
Closes CODE-239.

## What

1. **Banner → title-side badge.** The always-on "Action failed" banner over the conversation is replaced by a compact `ErrorBadge` beside the title (shared `packages/ui` component: coss-ui `Badge` + base-ui `PreviewCard`); the full error message shows only in a hover card, with a dismiss button inside. Wired into the desktop chrome `titleChip` (pointer-events/no-drag like `DiffStatChip`), the webview `TitleStrip`, and the default shell.
2. **Conversation error events render as a message-shaped card** — red mono type, rounded bubble, keeping the `(code)` suffix and the stronger tint for non-recoverable errors.
3. **Error state clears on navigation.** Root cause of the residue: `Workbench`'s `errorMessage` was a `useState` nothing ever cleared. Every navigation entry point (`select` / `startDraft` / `goBack` / `goForward` / `close`) now drops it first.
4. **`Error: Error:` de-dup.** Wire messages already carry the provider CLI's `Error: ` prefix and `extractErrorMessage` stacks the error name on top; a new unit-tested `normalizeErrorMessage` collapses repeated prefixes at every display surface.

Design note: the new-session (home) page keeps the banner — it has no title strip to host a badge, and a failed session create must be visible in place. Since errors clear on navigation, that banner can only ever show errors raised on the page itself.

## Verification

- `pnpm check:ci` green; full `pnpm test` (1257 tests) green, including new `error-text` unit tests.
- Drove both renderers with Playwright against the mock host (`dev:mock`, `fail` prompt → error event + `request.failed`): badge appears beside the title, hover opens the detail card, dismiss inside the card clears the badge, navigating home / switching threads clears the error, and the timeline card renders in the new red-mono style. Verified on webview (Chrome) and the desktop app (CDP attach), matching the issue mocks.