### PR TITLE
fix(daemon,agent-adapter,engine,assets): hide win32 console windows on daemon child spawns (CODE-236)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@ Each of these breaks the product, a release, or the build with **no loud error**
 3. **Native deps must be allow-listed.** pnpm blocks install scripts by default; a native dep (e.g. `better-sqlite3`) missing from `allowBuilds:` in `pnpm-workspace.yaml` installs fine but fails at `require()` time with missing bindings.
 4. **CI does not run `pnpm test`.** The vitest suite (~57 test files, node-env pure logic) is absent from `check:ci` and from every workflow — CI gates only format/lint/typecheck plus the Rust job. A green PR does not mean the tests pass; run `pnpm test` yourself before every commit.
 5. **A release is a version+tag pair.** Bump `apps/desktop/package.json` `version`, then push a `v*.*.*` tag; CI fails unless `v${version}` equals the tag. Never hand-tag or hand-edit workspace versions ([`docs/RELEASE.md`](docs/RELEASE.md)).
+6. **Every daemon-side child process sets `windowsHide: true`.** Node defaults it to `false`, and the daemon runs console-less (Electron `utilityProcess`), so a console-subsystem child spawned without it — agent CLI, git, sidecar, bsdtar — pops a visible console window on packaged Windows only; silent everywhere else, dev included. Applies to every `spawn`/`exec*`/cross-spawn call in `apps/daemon` and `packages/{engine,agent-adapter,assets}` (CODE-236 swept all sites 2026-07 — keep new ones consistent). SDK-internal spawns are out of reach: claude's SDK hides its own, opencode's `createOpencodeServer` does not.
 
 ## Routing — touching X, read Y first
 

--- a/apps/daemon/src/ai-gateway.ts
+++ b/apps/daemon/src/ai-gateway.ts
@@ -154,5 +154,5 @@ function tomlString(value: string): string {
 }
 
 function defaultSpawn(command: string, args: string[]): SidecarChildProcess {
-  return nodeSpawn(command, args, { stdio: ['ignore', 'pipe', 'pipe'] });
+  return nodeSpawn(command, args, { stdio: ['ignore', 'pipe', 'pipe'], windowsHide: true });
 }

--- a/apps/daemon/src/pty/sidecar.ts
+++ b/apps/daemon/src/pty/sidecar.ts
@@ -119,7 +119,12 @@ export class SidecarPtyBackend implements PtyBackend {
 
   private ensureChild(): SidecarChild {
     if (this.child) return this.child;
-    const child = spawn(this.binaryPath, [], { stdio: ['pipe', 'pipe', 'inherit'] });
+    // windowsHide: the daemon runs console-less (Electron utilityProcess), so spawning a
+    // console-subsystem binary without CREATE_NO_WINDOW pops a visible console on Windows.
+    const child = spawn(this.binaryPath, [], {
+      stdio: ['pipe', 'pipe', 'inherit'],
+      windowsHide: true,
+    });
     this.child = child;
     child.stdout.on('data', (chunk: Buffer) => {
       try {

--- a/packages/agent-adapter/src/login.ts
+++ b/packages/agent-adapter/src/login.ts
@@ -100,7 +100,7 @@ export function startClaudeLogin(
 
 function defaultSpawn(command: string, args: string[]): LoginChildProcess {
   // No `env` override: inherit the daemon's environment so credentials land where the SDK reads them.
-  return nodeSpawn(command, args, { stdio: ['pipe', 'pipe', 'pipe'] });
+  return nodeSpawn(command, args, { stdio: ['pipe', 'pipe', 'pipe'], windowsHide: true });
 }
 
 /** Agent kinds whose CLI login LinkCode can drive headlessly; the engine rejects the rest. */

--- a/packages/agent-adapter/src/native/codex/app-server.ts
+++ b/packages/agent-adapter/src/native/codex/app-server.ts
@@ -136,6 +136,7 @@ export class CodexAppServer {
     const child = spawn(opts.binaryPath, ['app-server'], {
       stdio: ['pipe', 'pipe', 'pipe'],
       env: { ...processEnv, ...opts.env },
+      windowsHide: true,
     });
     const server = new CodexAppServer(child, opts);
     try {

--- a/packages/agent-adapter/src/native/grok-build/process.ts
+++ b/packages/agent-adapter/src/native/grok-build/process.ts
@@ -61,6 +61,7 @@ export function runGrokHeadless(opts: GrokHeadlessRunOptions): GrokHeadlessRun {
       GROK_DISABLE_AUTOUPDATER: '1',
       ...opts.env,
     },
+    windowsHide: true,
   });
 
   return attachGrokHeadlessChild(child, opts.onEvent);

--- a/packages/agent-adapter/src/native/opencode/history-server.ts
+++ b/packages/agent-adapter/src/native/opencode/history-server.ts
@@ -273,6 +273,7 @@ function defaultSpawnServer(args: { port: number; cwd: string }): HistoryServerP
   return crossSpawn('opencode', ['serve', '--hostname=127.0.0.1', `--port=${args.port}`], {
     cwd: args.cwd,
     stdio: ['ignore', 'pipe', 'pipe'],
+    windowsHide: true,
   });
 }
 

--- a/packages/agent-adapter/src/probe/base.ts
+++ b/packages/agent-adapter/src/probe/base.ts
@@ -134,7 +134,10 @@ export abstract class AgentCliProbe {
     if (!existsSync(file)) return undefined;
     try {
       // 10s: Windows Defender's first-touch scan can stall a binary's first exec past 5s.
-      const { stdout } = await execFileAsync(file, ['--version'], { timeout: 10_000 });
+      const { stdout } = await execFileAsync(file, ['--version'], {
+        timeout: 10_000,
+        windowsHide: true,
+      });
       const version = this.parseVersion(stdout);
       return version ? { path: file, version } : undefined;
     } catch {

--- a/packages/agent-adapter/src/probe/claude-code.ts
+++ b/packages/agent-adapter/src/probe/claude-code.ts
@@ -31,7 +31,10 @@ export class ClaudeCodeProbe extends AgentCliProbe {
   override async probeAuth(file: string): Promise<AgentAuthStatus | undefined> {
     let stdout = '';
     try {
-      ({ stdout } = await execFileAsync(file, ['auth', 'status', '--json'], { timeout: 5000 }));
+      ({ stdout } = await execFileAsync(file, ['auth', 'status', '--json'], {
+        timeout: 5000,
+        windowsHide: true,
+      }));
     } catch (err) {
       const captured = (err as { stdout?: unknown }).stdout;
       if (typeof captured === 'string') stdout = captured;

--- a/packages/agent-adapter/src/probe/codex.ts
+++ b/packages/agent-adapter/src/probe/codex.ts
@@ -42,7 +42,10 @@ export class CodexProbe extends AgentCliProbe {
   override async probeAuth(file: string): Promise<AgentAuthStatus | undefined> {
     let output = '';
     try {
-      const { stdout, stderr } = await execFileAsync(file, ['login', 'status'], { timeout: 5000 });
+      const { stdout, stderr } = await execFileAsync(file, ['login', 'status'], {
+        timeout: 5000,
+        windowsHide: true,
+      });
       output = `${stdout}\n${stderr}`;
     } catch (err) {
       const { stdout, stderr } = err as { stdout?: unknown; stderr?: unknown };

--- a/packages/assets/src/extract.ts
+++ b/packages/assets/src/extract.ts
@@ -46,7 +46,9 @@ export async function extractMember(
     }
   } else {
     try {
-      await execFileAsync(zipTarBinary(), ['-xf', archive, '-C', workDir, member]);
+      await execFileAsync(zipTarBinary(), ['-xf', archive, '-C', workDir, member], {
+        windowsHide: true,
+      });
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
         throw new UnsupportedPlatformError('system tar is unavailable for zip extraction', {

--- a/packages/engine/src/automation/shell-exec.ts
+++ b/packages/engine/src/automation/shell-exec.ts
@@ -31,7 +31,12 @@ export interface ShellCheckOptions {
  */
 export function runShellCheck(command: string, opts: ShellCheckOptions): Promise<ShellCheckResult> {
   return new Promise<ShellCheckResult>((resolve) => {
-    const child = spawn(command, { cwd: opts.cwd, env: process.env, shell: true });
+    const child = spawn(command, {
+      cwd: opts.cwd,
+      env: process.env,
+      shell: true,
+      windowsHide: true,
+    });
 
     let output = '';
     let timedOut = false;

--- a/packages/engine/src/git/exec.ts
+++ b/packages/engine/src/git/exec.ts
@@ -33,6 +33,7 @@ export function runCommand(
       env: { ...process.env, ...options.env },
       shell: false,
       stdio: ['ignore', 'pipe', 'pipe'],
+      windowsHide: true,
     });
 
     const maxOutputBytes = options.maxOutputBytes ?? DEFAULT_MAX_OUTPUT_BYTES;


### PR DESCRIPTION
## Problem

On packaged Windows builds, opening the embedded terminal pops a visible system console window (Windows Terminal / conhost). Root cause: the daemon runs console-less inside Electron's `utilityProcess`, and the PTY sidecar (`linkcode-pty.exe`, a console-subsystem Rust binary) was spawned without `windowsHide: true`, so Windows allocates a fresh visible console (`CREATE_NO_WINDOW` missing).

## Change

Sweep of every daemon-side child-process call — all now pass `windowsHide: true` (12 sites):

- **daemon**: PTY sidecar (the reported popup), aigateway sidecar
- **engine**: `runCommand` (every git call), loop verify-check shell runner
- **agent-adapter**: probe `--version` / claude `auth status` / codex `login status`, claude login, codex app-server, grok headless, opencode history server (cross-spawn)
- **assets**: win32 zip extraction via System32 bsdtar

Also records the rule as root `AGENTS.md` invariant #6 (silent, Windows-only failure mode).

Out of scope (node_modules): claude SDK already hides its own CLI spawns (verified in sdk.mjs); opencode SDK's `createOpencodeServer` does not — noted on the Linear issue.

## Verification

- `pnpm check:ci` clean; targeted vitest run over the touched modules (82 passed; sidecar integration test skipped — needs the built Rust binary)
- **Outstanding**: packaged-Windows manual check (open terminal / codex session / git refresh → no console window) — tracked on CODE-236

https://linear.app/arcbox/issue/CODE-236