### PR TITLE
fix(workbench): let long viewer lines scroll instead of clipping at the Files panel edge (CODE-263)

### DIFF
--- a/apps/desktop/e2e/file-tree.e2e.mts
+++ b/apps/desktop/e2e/file-tree.e2e.mts
@@ -107,6 +107,41 @@ async function run(win: Page): Promise<void> {
     fail('clicking the tree row did not open the file viewer with its content');
   }
   console.log('viewer opened with file content after tree click');
+
+  // Long unwrapped lines must scroll inside the viewer, not clip at the window edge
+  // (regression: the viewer flex column lacked min-w-0 and grew to its content width).
+  await win.evaluate(() => {
+    const host = document.querySelector('file-tree-container');
+    const row = host?.shadowRoot?.querySelector<HTMLElement>(
+      'button[data-type="item"][aria-label="long-line.txt"]',
+    );
+    if (!row) throw new Error('no tree row for long-line.txt');
+    row.click();
+  });
+  await win.waitForTimeout(2000);
+
+  const viewer = await win.evaluate(() => {
+    const pre = [...document.querySelectorAll('pre')].find((el) =>
+      el.textContent?.includes('end-of-long-line'),
+    );
+    if (!pre) return null;
+    const rect = pre.getBoundingClientRect();
+    return {
+      right: rect.right,
+      innerWidth: window.innerWidth,
+      scrollWidth: pre.scrollWidth,
+      clientWidth: pre.clientWidth,
+    };
+  });
+  console.log('long-line viewer metrics:', JSON.stringify(viewer));
+  if (!viewer) fail('long-line.txt did not open in the plain-text viewer');
+  if (viewer.right > viewer.innerWidth + 1) {
+    fail('viewer overflows the window instead of scrolling (missing min-w-0)');
+  }
+  if (viewer.scrollWidth <= viewer.clientWidth) {
+    fail('long line is not horizontally scrollable inside the viewer');
+  }
+  console.log('long-line content scrolls inside the viewer');
 }
 
 async function main(): Promise<void> {
@@ -126,6 +161,7 @@ async function main(): Promise<void> {
   mkdirSync(join(chatRoot, 'docs'), { recursive: true });
   mkdirSync(join(chatRoot, '.hidden'), { recursive: true });
   writeFileSync(join(chatRoot, 'fixture-readme.md'), '# Tree fixture readme content\n');
+  writeFileSync(join(chatRoot, 'long-line.txt'), `${'x'.repeat(2000)} end-of-long-line\n`);
   writeFileSync(join(chatRoot, 'docs', 'notes.md'), '# Notes\n');
   writeFileSync(join(chatRoot, '.hidden', 'secret.txt'), 'nope\n');
 

--- a/packages/workbench/src/files/panel.tsx
+++ b/packages/workbench/src/files/panel.tsx
@@ -51,7 +51,9 @@ export function FilesPanel({
           <WorkspaceFileTree key={cwd} paths={treeFiles} onFileOpen={onOpenFile} />
         )}
       </div>
-      <div className="flex h-full min-h-0 flex-1 flex-col">
+      {/* min-w-0: without it this flex item's min-width tracks the viewer's widest line and
+          long unwrapped content clips at the panel edge instead of scrolling inside the pre. */}
+      <div className="flex h-full min-h-0 min-w-0 flex-1 flex-col">
         {tabs.length === 0 ? (
           <div className="flex h-full items-center justify-center p-6 text-center text-muted-foreground text-sm">
             {t('empty')}


### PR DESCRIPTION
Follow-up to #172: the tree sidebar turned the Files viewer column into a flex row item, and without `min-w-0` its min-width tracked the widest unwrapped line — the `pre` never got a horizontal scrollbar and long content clipped at the window edge (screenshot repro on real device).

One-line layout fix plus an E2E regression assertion: the committed `e2e:file-tree` now opens a 2000-char single-line `.txt` from the tree and asserts the viewer stays inside the window (`rect.right <= innerWidth`) while scrolling internally (`scrollWidth > clientWidth`). Verified against the real daemon + built app: `right:1180 == innerWidth:1180`, `scrollWidth:15160 > clientWidth:215`. `pnpm check:ci` + `pnpm test` green.

Refs CODE-263.