### PR TITLE
feat(settings): fold Connection into a Developer tab with a caution notice (CODE-238)

### DIFF
--- a/apps/desktop/src/renderer/src/settings/developer-tab.tsx
+++ b/apps/desktop/src/renderer/src/settings/developer-tab.tsx
@@ -1,10 +1,12 @@
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useWorkbenchRuntimeEndpoint } from '@linkcode/workbench';
 import { rhfErrorsToFormErrors } from '@linkcode/workbench/form';
+import { Alert, AlertDescription } from 'coss-ui/components/alert';
 import { Button } from 'coss-ui/components/button';
 import { Field, FieldDescription, FieldError, FieldLabel } from 'coss-ui/components/field';
 import { Form } from 'coss-ui/components/form';
 import { Input } from 'coss-ui/components/input';
+import { TriangleAlertIcon } from 'lucide-react';
 import { useForm } from 'react-hook-form';
 import { useTranslations } from 'use-intl';
 import { z } from 'zod';
@@ -19,7 +21,21 @@ const connectionSchema = z.object({
 });
 type ConnectionForm = z.infer<typeof connectionSchema>;
 
-export function ConnectionTab(): React.ReactNode {
+export function DeveloperTab(): React.ReactNode {
+  const t = useTranslations('settings.developer');
+
+  return (
+    <div className="flex flex-col gap-6">
+      <Alert variant="warning">
+        <TriangleAlertIcon />
+        <AlertDescription>{t('warning')}</AlertDescription>
+      </Alert>
+      <ConnectionSection />
+    </div>
+  );
+}
+
+function ConnectionSection(): React.ReactNode {
   const t = useTranslations('settings.connection');
   const daemonUrl = useWorkbenchRuntimeEndpoint();
   const daemonUrlOverride = useDesktopSettingsStore((state) => state.daemonUrlOverride);

--- a/apps/desktop/src/renderer/src/settings/settings-view.tsx
+++ b/apps/desktop/src/renderer/src/settings/settings-view.tsx
@@ -16,6 +16,7 @@ import { noop } from 'foxact/noop';
 import {
   BellIcon,
   BotIcon,
+  CodeXmlIcon,
   HistoryIcon,
   InfoIcon,
   KeyRoundIcon,
@@ -23,7 +24,6 @@ import {
   SettingsIcon,
   SunMoonIcon,
   TerminalIcon,
-  WifiIcon,
 } from 'lucide-react';
 import { useRef, useState } from 'react';
 import { useTranslations } from 'use-intl';
@@ -35,7 +35,7 @@ import { DEFAULT_LAYOUT } from '../shell/store/model';
 import { AboutTab } from './about-tab';
 import { AgentsTab } from './agents-tab';
 import { AppearanceTab } from './appearance-tab';
-import { ConnectionTab } from './connection-tab';
+import { DeveloperTab } from './developer-tab';
 import { GeneralTab } from './general-tab';
 import { HistoryImportTab } from './history-import-tab';
 import { ImChannelTab } from './im-channel-tab';
@@ -187,12 +187,12 @@ export function SettingsView(): React.ReactNode {
       label: t('groups.system'),
       items: [
         {
-          key: 'connection',
-          icon: <WifiIcon className="size-4" />,
-          label: t('tabs.connection'),
-          keywords: searchKeywords.connection,
-          active: category === 'connection',
-          onClick: () => setCategory('connection'),
+          key: 'developer',
+          icon: <CodeXmlIcon className="size-4" />,
+          label: t('tabs.developer'),
+          keywords: searchKeywords.developer,
+          active: category === 'developer',
+          onClick: () => setCategory('developer'),
         },
         {
           key: 'about',
@@ -297,8 +297,8 @@ function renderSettingsPanel(
       return <AppearanceTab />;
     case 'terminal':
       return <TerminalTab />;
-    case 'connection':
-      return <ConnectionTab />;
+    case 'developer':
+      return <DeveloperTab />;
     case 'notifications':
       return <NotificationsTab />;
     case 'about':

--- a/apps/desktop/src/renderer/src/settings/store.ts
+++ b/apps/desktop/src/renderer/src/settings/store.ts
@@ -8,7 +8,7 @@ export type SettingsCategory =
   | 'general'
   | 'appearance'
   | 'terminal'
-  | 'connection'
+  | 'developer'
   | 'notifications'
   | 'about'
   | 'providers'

--- a/apps/webview/src/router.tsx
+++ b/apps/webview/src/router.tsx
@@ -2,7 +2,7 @@ import { AutomationsRoute } from '@webview/routes/automations';
 import { RootLayout } from '@webview/routes/root-layout';
 import { AgentsSettings } from '@webview/routes/settings/agents';
 import { AppearanceSettings } from '@webview/routes/settings/appearance';
-import { ConnectionSettings } from '@webview/routes/settings/connection';
+import { DeveloperSettings } from '@webview/routes/settings/developer';
 import { GeneralSettings } from '@webview/routes/settings/general';
 import { MessagingSettings } from '@webview/routes/settings/messaging';
 import { NotificationsSettings } from '@webview/routes/settings/notifications';
@@ -25,7 +25,7 @@ export const router = createBrowserRouter([
           { index: true, element: <GeneralSettings /> },
           { path: 'appearance', element: <AppearanceSettings /> },
           { path: 'terminal', element: <TerminalSettings /> },
-          { path: 'connection', element: <ConnectionSettings /> },
+          { path: 'developer', element: <DeveloperSettings /> },
           { path: 'notifications', element: <NotificationsSettings /> },
           { path: 'providers', element: <ProvidersSettings /> },
           { path: 'agents', element: <AgentsSettings /> },

--- a/apps/webview/src/routes/settings/developer.tsx
+++ b/apps/webview/src/routes/settings/developer.tsx
@@ -2,10 +2,12 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { rhfErrorsToFormErrors } from '@linkcode/workbench/form';
 import { usePageTitle } from '@webview/hooks/use-page-title';
 import { useSettingsStore } from '@webview/settings/store';
+import { Alert, AlertDescription } from 'coss-ui/components/alert';
 import { Button } from 'coss-ui/components/button';
 import { Field, FieldDescription, FieldError, FieldLabel } from 'coss-ui/components/field';
 import { Form } from 'coss-ui/components/form';
 import { Input } from 'coss-ui/components/input';
+import { TriangleAlertIcon } from 'lucide-react';
 import { useForm } from 'react-hook-form';
 import { useTranslations } from 'use-intl';
 import { z } from 'zod';
@@ -13,10 +15,24 @@ import { z } from 'zod';
 const connectionSchema = z.object({ daemonUrl: z.url() });
 type ConnectionForm = z.infer<typeof connectionSchema>;
 
-export function ConnectionSettings(): React.ReactNode {
-  const t = useTranslations('settings.connection');
+export function DeveloperSettings(): React.ReactNode {
+  const t = useTranslations('settings.developer');
   const tTabs = useTranslations('settings.tabs');
-  usePageTitle(tTabs('connection'));
+  usePageTitle(tTabs('developer'));
+
+  return (
+    <div className="flex flex-col gap-6">
+      <Alert variant="warning">
+        <TriangleAlertIcon />
+        <AlertDescription>{t('warning')}</AlertDescription>
+      </Alert>
+      <ConnectionSection />
+    </div>
+  );
+}
+
+function ConnectionSection(): React.ReactNode {
+  const t = useTranslations('settings.connection');
   const daemonUrl = useSettingsStore((state) => state.daemonUrl);
   const setDaemonUrl = useSettingsStore((state) => state.setDaemonUrl);
 

--- a/apps/webview/src/routes/settings/settings-layout.tsx
+++ b/apps/webview/src/routes/settings/settings-layout.tsx
@@ -3,12 +3,12 @@ import { filterSettingsNavGroups, useSettingsSearchKeywords } from '@linkcode/wo
 import {
   BellIcon,
   BotIcon,
+  CodeXmlIcon,
   KeyRoundIcon,
   SendIcon,
   SettingsIcon,
   SunMoonIcon,
   TerminalIcon,
-  WifiIcon,
 } from 'lucide-react';
 import { useState } from 'react';
 import { Link, Outlet, useLocation, useNavigate } from 'react-router';
@@ -22,7 +22,7 @@ const SETTINGS_ROUTES: Record<string, string> = {
   agents: '/settings/agents',
   providers: '/settings/providers',
   messaging: '/settings/messaging',
-  connection: '/settings/connection',
+  developer: '/settings/developer',
 };
 
 export function SettingsLayout(): React.ReactNode {
@@ -106,12 +106,12 @@ export function SettingsLayout(): React.ReactNode {
       label: t('groups.system'),
       items: [
         {
-          key: 'connection',
-          icon: <WifiIcon className="size-4" />,
-          label: t('tabs.connection'),
-          keywords: searchKeywords.connection,
-          active: isActive(pathname, 'connection'),
-          render: <Link to="/settings/connection" />,
+          key: 'developer',
+          icon: <CodeXmlIcon className="size-4" />,
+          label: t('tabs.developer'),
+          keywords: searchKeywords.developer,
+          active: isActive(pathname, 'developer'),
+          render: <Link to="/settings/developer" />,
         },
       ],
     },
@@ -161,7 +161,7 @@ function isActive(
     | ''
     | 'appearance'
     | 'terminal'
-    | 'connection'
+    | 'developer'
     | 'notifications'
     | 'providers'
     | 'agents'

--- a/packages/i18n/src/locales/en.ts
+++ b/packages/i18n/src/locales/en.ts
@@ -539,7 +539,7 @@ export const en = {
       general: 'General',
       appearance: 'Appearance',
       terminal: 'Terminal',
-      connection: 'Connection',
+      developer: 'Developer',
       notifications: 'Notifications',
       about: 'About',
       providers: 'Providers',
@@ -604,6 +604,9 @@ export const en = {
       colorScheme: 'Color scheme',
       colorSchemeHint: 'Terminal colors. "Follow theme" tracks the app light/dark mode.',
       colorSchemeAuto: 'Follow theme',
+    },
+    developer: {
+      warning: 'Do not change these settings unless necessary.',
     },
     connection: {
       title: 'Daemon',

--- a/packages/i18n/src/locales/zh-cn.ts
+++ b/packages/i18n/src/locales/zh-cn.ts
@@ -529,7 +529,7 @@ export const zhCN = {
       general: '通用',
       appearance: '外观',
       terminal: '终端',
-      connection: '连接',
+      developer: '开发者设置',
       notifications: '通知',
       about: '关于',
       providers: 'Providers',
@@ -592,6 +592,9 @@ export const zhCN = {
       colorScheme: '配色方案',
       colorSchemeHint: '终端配色。「跟随主题」随应用浅色 / 深色切换。',
       colorSchemeAuto: '跟随主题',
+    },
+    developer: {
+      warning: '非必要情况下，请不要修改这里的设置。',
     },
     connection: {
       title: 'Daemon',

--- a/packages/workbench/src/settings/search.ts
+++ b/packages/workbench/src/settings/search.ts
@@ -22,7 +22,7 @@ export interface SettingsSearchKeywords {
   appearance: readonly string[];
   terminal: readonly string[];
   notifications: readonly string[];
-  connection: readonly string[];
+  developer: readonly string[];
   about: readonly string[];
   agents: readonly string[];
   providers: readonly string[];
@@ -70,7 +70,7 @@ export function useSettingsSearchKeywords(): SettingsSearchKeywords {
       t('notifications.awaitingApproval'),
       t('notifications.error'),
     ],
-    connection: [t('connection.title'), t('connection.url')],
+    developer: [t('connection.title'), t('connection.url')],
     about: [t('about.version'), t('about.checkForUpdates')],
     agents: [
       t('agents.title'),


### PR DESCRIPTION
## Summary

- Replace the Settings sidebar's "Connection" tab (System group) with a **Developer** tab (「开发者设置」) on both desktop and webview; the Daemon URL form now lives inside it as a section.
- The tab leads with a warning alert — 「非必要情况下，请不要修改这里的设置。」 / "Do not change these settings unless necessary." — per the user feedback that a bare Connection entry is a dangerous, meaningless knob for normal users.
- i18n: `settings.tabs.connection` → `settings.tabs.developer` + new `settings.developer.warning`; `settings.connection.*` section keys unchanged. Settings search keywords follow (searching "Daemon" still lands on the tab).

## Verification

- `pnpm check:ci` and `pnpm test` (1260 tests) green.
- Webview driven via Playwright in zh-CN and en-US: System group shows only 开发者设置/Developer, page renders warning + Daemon form, no console errors.
- Built desktop app driven via `_electron.launch` (isolated HOME/profile): Connection absent from the sidebar, Developer tab renders warning + Daemon form, screenshot inspected.

Closes CODE-238