### PR TITLE
feat(ui,workbench,desktop): syntax-highlight the Files viewer via @pierre/diffs File (CODE-269)

### DIFF
--- a/apps/desktop/e2e/file-tree.e2e.mts
+++ b/apps/desktop/e2e/file-tree.e2e.mts
@@ -120,21 +120,29 @@ async function run(win: Page): Promise<void> {
   });
   await win.waitForTimeout(2000);
 
+  // The code view renders inside @pierre/diffs' `diffs-container` shadow root.
   const viewer = await win.evaluate(() => {
-    const pre = [...document.querySelectorAll('pre')].find((el) =>
-      el.textContent?.includes('end-of-long-line'),
-    );
-    if (!pre) return null;
-    const rect = pre.getBoundingClientRect();
-    return {
-      right: rect.right,
-      innerWidth: window.innerWidth,
-      scrollWidth: pre.scrollWidth,
-      clientWidth: pre.clientWidth,
-    };
+    for (const host of document.querySelectorAll('diffs-container')) {
+      const pre = [...(host.shadowRoot?.querySelectorAll('pre') ?? [])].find((el) =>
+        el.textContent?.includes('end-of-long-line'),
+      );
+      if (!pre) continue;
+      const scroller =
+        pre.scrollWidth > pre.clientWidth
+          ? pre
+          : [pre, ...pre.querySelectorAll('*'), host].find((el) => el.scrollWidth > el.clientWidth);
+      const rect = host.getBoundingClientRect();
+      return {
+        right: rect.right,
+        innerWidth: window.innerWidth,
+        scrollWidth: scroller?.scrollWidth ?? 0,
+        clientWidth: scroller?.clientWidth ?? 0,
+      };
+    }
+    return null;
   });
   console.log('long-line viewer metrics:', JSON.stringify(viewer));
-  if (!viewer) fail('long-line.txt did not open in the plain-text viewer');
+  if (!viewer) fail('long-line.txt did not open in the code viewer');
   if (viewer.right > viewer.innerWidth + 1) {
     fail('viewer overflows the window instead of scrolling (missing min-w-0)');
   }
@@ -142,6 +150,34 @@ async function run(win: Page): Promise<void> {
     fail('long line is not horizontally scrollable inside the viewer');
   }
   console.log('long-line content scrolls inside the viewer');
+
+  // Syntax highlighting: a JSON file must render colored shiki tokens (CODE-269).
+  await win.evaluate(() => {
+    const host = document.querySelector('file-tree-container');
+    const row = host?.shadowRoot?.querySelector<HTMLElement>(
+      'button[data-type="item"][aria-label="app-config.json"]',
+    );
+    if (!row) throw new Error('no tree row for app-config.json');
+    row.click();
+  });
+  await win.waitForTimeout(2500);
+
+  const highlight = await win.evaluate(() => {
+    for (const host of document.querySelectorAll('diffs-container')) {
+      const shadow = host.shadowRoot;
+      if (!shadow?.textContent?.includes('tree-fixture-config')) continue;
+      const html = shadow.innerHTML;
+      return {
+        tokens: /color:\s*#|--shiki/.test(html),
+        sample: html.slice(html.indexOf('tree-fixture-config') - 200, 300),
+      };
+    }
+    return null;
+  });
+  console.log('highlight probe:', JSON.stringify(highlight)?.slice(0, 400));
+  if (!highlight) fail('app-config.json did not open in the code viewer');
+  if (!highlight.tokens) fail('JSON file rendered without shiki color tokens');
+  console.log('code viewer renders highlighted tokens');
 }
 
 async function main(): Promise<void> {
@@ -162,6 +198,7 @@ async function main(): Promise<void> {
   mkdirSync(join(chatRoot, '.hidden'), { recursive: true });
   writeFileSync(join(chatRoot, 'fixture-readme.md'), '# Tree fixture readme content\n');
   writeFileSync(join(chatRoot, 'long-line.txt'), `${'x'.repeat(2000)} end-of-long-line\n`);
+  writeFileSync(join(chatRoot, 'app-config.json'), '{"name":"tree-fixture-config","count":42}\n');
   writeFileSync(join(chatRoot, 'docs', 'notes.md'), '# Notes\n');
   writeFileSync(join(chatRoot, '.hidden', 'secret.txt'), 'nope\n');
 

--- a/apps/desktop/src/renderer/src/shell/layout/right-panel-region.tsx
+++ b/apps/desktop/src/renderer/src/shell/layout/right-panel-region.tsx
@@ -65,6 +65,7 @@ export function DesktopRightPanelRegion({
             cwd={cwd}
             tabs={panel.files.tabs}
             activeTabId={panel.files.activeTabId}
+            themeType={themeType}
             onSelectTab={onSelectFileTab}
             onCloseTab={onCloseFileTab}
             onOpenFile={onOpenFileTab}

--- a/packages/ui/src/shell/files/file-viewer.tsx
+++ b/packages/ui/src/shell/files/file-viewer.tsx
@@ -1,5 +1,8 @@
 import type { WorkspaceFile } from '@linkcode/schema';
+import type { FileContents, FileOptions, ThemeTypes } from '@pierre/diffs';
+import { File as PierreFile } from '@pierre/diffs/react';
 import { extractErrorMessage } from 'foxts/extract-error-message';
+import { useMemo } from 'react';
 import { useTranslations } from 'use-intl';
 import { artifactKindForPath } from '../../chat/artifacts';
 import { Markdown } from '../../chat/markdown';
@@ -11,6 +14,8 @@ export interface FileViewerProps {
   file: WorkspaceFile | undefined;
   isLoading: boolean;
   error?: unknown;
+  /** Shiki theme pairing for the code view — same axis as the Diff section. */
+  themeType?: ThemeTypes;
   className?: string;
 }
 
@@ -21,12 +26,14 @@ function dataUrl(file: WorkspaceFile): string {
 }
 
 /** Renders one workspace file by artifact kind: markdown through the chat pipeline,
- * images/PDF natively, utf8 text as-is; anything else degrades to a notice. */
+ * images/PDF natively, utf8 text through the `@pierre/diffs` highlighted code view;
+ * anything else degrades to a notice. */
 export function FileViewer({
   path,
   file,
   isLoading,
   error,
+  themeType = 'system',
   className,
 }: FileViewerProps): React.ReactNode {
   const t = useTranslations('workbench.files');
@@ -72,16 +79,7 @@ export function FileViewer({
     case 'pdf':
       return <PdfView file={file} className={className} />;
     case 'text':
-      return (
-        <pre
-          className={cn(
-            'h-full overflow-auto p-4 font-mono text-[12.5px] leading-relaxed',
-            className,
-          )}
-        >
-          {file.content}
-        </pre>
-      );
+      return <CodeFileView file={file} themeType={themeType} className={className} />;
     default:
       return (
         <FileViewerNotice className={className} title={t('unsupported')}>
@@ -89,6 +87,38 @@ export function FileViewer({
         </FileViewerNotice>
       );
   }
+}
+
+/** Shiki-highlighted read-only code view (`@pierre/diffs` `File`, same library and theme
+ * axis as the Diff section). Language is inferred from the filename; unknown types fall
+ * back to plain rendering inside the same component. */
+function CodeFileView({
+  file,
+  themeType,
+  className,
+}: {
+  file: WorkspaceFile;
+  themeType: ThemeTypes;
+  className?: string;
+}): React.ReactNode {
+  const contents = useMemo<FileContents>(
+    () => ({
+      name: file.path,
+      contents: file.content,
+      // Highlight-cache key: same path re-read after an edit must re-render.
+      cacheKey: `${file.path}:${file.mtimeMs}`,
+    }),
+    [file],
+  );
+  const options = useMemo<FileOptions<undefined>>(
+    () => ({ themeType, disableFileHeader: true }),
+    [themeType],
+  );
+  return (
+    <div className={cn('h-full overflow-y-auto', className)}>
+      <PierreFile file={contents} options={options} />
+    </div>
+  );
 }
 
 /** Blob URLs keyed by the SWR-cached file object: idempotent per file (safe to call in

--- a/packages/workbench/src/files/panel.tsx
+++ b/packages/workbench/src/files/panel.tsx
@@ -14,6 +14,8 @@ export interface FilesPanelProps {
   cwd: string | undefined;
   tabs: FileTab[];
   activeTabId: string | null;
+  /** Shiki theme pairing for the code viewer — same axis the Diff section receives. */
+  themeType?: 'system' | 'light' | 'dark';
   onSelectTab: (id: string) => void;
   onCloseTab: (id: string) => void;
   /** Open a workspace file (cwd-relative path) as a viewer tab — tree clicks land here. */
@@ -25,6 +27,7 @@ export function FilesPanel({
   cwd,
   tabs,
   activeTabId,
+  themeType,
   onSelectTab,
   onCloseTab,
   onOpenFile,
@@ -68,7 +71,13 @@ export function FilesPanel({
             />
             <div className="min-h-0 flex-1">
               {active ? (
-                <FileViewer path={active.path} file={data} isLoading={isLoading} error={error} />
+                <FileViewer
+                  path={active.path}
+                  file={data}
+                  isLoading={isLoading}
+                  error={error}
+                  themeType={themeType}
+                />
               ) : null}
             </div>
           </>


### PR DESCRIPTION
## Summary

The Files viewer's text branch was a bare `<pre>` ("utf8 text as-is") — fine when the viewer only served artifact outputs, glaring once the CODE-263 tree made arbitrary source files one click away.

Replaced with **`@pierre/diffs`' `File` component** — zero new dependency (same library as the Diff section):

- language inferred from the filename, shiki-highlighted, worker-pool rendering with a `path:mtimeMs` cache key so a re-read after an edit re-renders;
- `disableFileHeader` (the tab strip already names the file);
- theme follows the Diff section's axis: `themeType` threaded `right-panel-region` → `FilesPanel` → `FileViewer` (deliberately not the chat-fence code-theme preference from CODE-199 — theme names aren't portable across libraries, right-panel internal consistency wins);
- markdown/image/PDF branches untouched; unknown text falls back to plain rendering inside the same component.

## Verification

Real E2E (`e2e:file-tree`) extended and green against the built app + isolated daemon:
- JSON fixture renders **colored shiki tokens** inside `diffs-container`'s shadow root (`tokens:true`);
- the min-w-0 long-line regression guard still passes under the new DOM (`right:1180 == innerWidth:1180`, `scrollWidth:15784 > clientWidth:294`);
- worker-pool highlighting works under the desktop CSP unchanged.

`pnpm check:ci` + `pnpm test` green (1258 passed).

Closes CODE-269.