### PR TITLE
feat(ui): group opencode models by provider in the model picker (CODE-270)

### DIFF
--- a/packages/ui/src/__tests__/agent-models.test.ts
+++ b/packages/ui/src/__tests__/agent-models.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { AGENT_MODEL_OPTIONS, resolveModel } from '../shell/agent-models';
+import { AGENT_MODEL_OPTIONS, groupModelsByProvider, resolveModel } from '../shell/agent-models';
 
 const claude = AGENT_MODEL_OPTIONS['claude-code'];
 const codex = AGENT_MODEL_OPTIONS.codex;
@@ -22,5 +22,40 @@ describe('resolveModel', () => {
     expect(resolveModel(claude, null)).toBeUndefined();
     expect(resolveModel(claude, 'not-a-model')).toBeUndefined();
     expect(resolveModel(undefined, 'claude-opus-4-8')).toBeUndefined();
+  });
+});
+
+describe('groupModelsByProvider', () => {
+  const multiProvider = [
+    { id: 'opencode/hy3', label: 'Hy3', description: 'OpenCode Zen' },
+    { id: 'openai/gpt-5.4', label: 'GPT-5.4', description: 'OpenAI' },
+    { id: 'opencode/big-pickle', label: 'Big Pickle', description: 'OpenCode Zen' },
+    { id: 'openai/gpt-5.6-sol', label: 'GPT-5.6 Sol', description: 'OpenAI' },
+  ];
+
+  it('groups by provider in first-appearance order, preserving catalog order within groups', () => {
+    expect(groupModelsByProvider(multiProvider)).toStrictEqual({
+      ungrouped: [],
+      groups: [
+        { label: 'OpenCode Zen', options: [multiProvider[0], multiProvider[2]] },
+        { label: 'OpenAI', options: [multiProvider[1], multiProvider[3]] },
+      ],
+    });
+  });
+
+  it('collects descriptionless options into ungrouped', () => {
+    const legacy = { id: 'legacy', label: 'Legacy' };
+    expect(groupModelsByProvider([legacy, ...multiProvider])?.ungrouped).toStrictEqual([legacy]);
+  });
+
+  it('returns null below two distinct providers so the flat list renders', () => {
+    expect(groupModelsByProvider(undefined)).toBeNull();
+    expect(groupModelsByProvider([])).toBeNull();
+    // Static tables carry no provider subtitle.
+    expect(groupModelsByProvider(claude)).toBeNull();
+    // Single-provider catalogs (e.g. opencode pinned to one credential) stay flat too.
+    expect(
+      groupModelsByProvider(multiProvider.filter((option) => option.description === 'OpenAI')),
+    ).toBeNull();
   });
 });

--- a/packages/ui/src/shell/agent-models.ts
+++ b/packages/ui/src/shell/agent-models.ts
@@ -8,6 +8,36 @@ export interface ModelOption {
   description?: string;
 }
 
+export interface ModelProviderGroups {
+  /** Options without a provider subtitle, rendered flat before the provider submenus. */
+  ungrouped: ModelOption[];
+  groups: { label: string; options: ModelOption[] }[];
+}
+
+/** Group a catalog by its provider subtitle (`description`, per the adapter convention above),
+ * preserving catalog order within groups and first-appearance order across them. Returns null
+ * below two distinct providers — a single-provider list reads better flat. */
+export function groupModelsByProvider(
+  options: readonly ModelOption[] | undefined,
+): ModelProviderGroups | null {
+  const ungrouped: ModelOption[] = [];
+  const byProvider = new Map<string, ModelOption[]>();
+  for (const option of options ?? []) {
+    if (option.description === undefined) {
+      ungrouped.push(option);
+      continue;
+    }
+    const group = byProvider.get(option.description);
+    if (group) group.push(option);
+    else byProvider.set(option.description, [option]);
+  }
+  if (byProvider.size < 2) return null;
+  return {
+    ungrouped,
+    groups: [...byProvider.entries()].map(([label, grouped]) => ({ label, options: grouped })),
+  };
+}
+
 /** Resolve a reflected model id (from `model-update`) to its catalog entry. The daemon emits the
  * *served* id, which may be a pinned snapshot of an alias (e.g. `claude-haiku-4-5-20251001`);
  * prefix-match only after an exact match fails so `gpt-5.4-mini` never mis-resolves to `gpt-5.4`. */

--- a/packages/ui/src/shell/composer-controls.tsx
+++ b/packages/ui/src/shell/composer-controls.tsx
@@ -26,7 +26,7 @@ import { useTranslations } from 'use-intl';
 import { AGENT_LABELS, AgentIcon } from '../chat/agent-icon';
 import type { EffortOption } from './agent-efforts';
 import type { ModelOption } from './agent-models';
-import { resolveModel } from './agent-models';
+import { groupModelsByProvider, resolveModel } from './agent-models';
 import type { AgentRuntimeCue, AgentRuntimeCues } from './agent-onboarding-card';
 
 // Linear lookup: the policy/effort lists are a handful of entries at most.
@@ -208,6 +208,7 @@ export function ModelSelectorMenu({
 }): React.ReactNode {
   const t = useTranslations('workbench.composer');
   const selectedModel = resolveModel(modelOptions, selectedModelId);
+  const providerGroups = groupModelsByProvider(modelOptions);
   const selectedEffort = optionById(effortOptions, selectedEffortId);
   const providers = selectableProviders ?? [];
   const hasEfforts = Boolean(effortOptions?.length);
@@ -258,18 +259,42 @@ export function ModelSelectorMenu({
                   value={selectedModel?.id ?? selectedModelId ?? ''}
                   onValueChange={(value) => onSelectModel(String(value))}
                 >
-                  {modelOptions?.map((option) => (
-                    <MenuRadioItem key={option.id} closeOnClick value={option.id}>
-                      <span className="flex min-w-0 flex-col">
-                        <span>{option.label}</span>
-                        {option.description ? (
-                          <span className="text-muted-foreground text-xs">
-                            {option.description}
-                          </span>
-                        ) : null}
-                      </span>
-                    </MenuRadioItem>
-                  ))}
+                  {providerGroups === null ? (
+                    modelOptions?.map((option) => (
+                      <MenuRadioItem key={option.id} closeOnClick value={option.id}>
+                        <span className="flex min-w-0 flex-col">
+                          <span>{option.label}</span>
+                          {option.description ? (
+                            <span className="text-muted-foreground text-xs">
+                              {option.description}
+                            </span>
+                          ) : null}
+                        </span>
+                      </MenuRadioItem>
+                    ))
+                  ) : (
+                    <>
+                      {providerGroups.ungrouped.map((option) => (
+                        <MenuRadioItem key={option.id} closeOnClick value={option.id}>
+                          {option.label}
+                        </MenuRadioItem>
+                      ))}
+                      {/* One submenu per provider; the trigger names the provider, so items drop
+                       * the subtitle the flat list needs for disambiguation. */}
+                      {providerGroups.groups.map((group) => (
+                        <MenuSub key={group.label}>
+                          <MenuSubTrigger>{group.label}</MenuSubTrigger>
+                          <MenuSubPopup className="w-56">
+                            {group.options.map((option) => (
+                              <MenuRadioItem key={option.id} closeOnClick value={option.id}>
+                                {option.label}
+                              </MenuRadioItem>
+                            ))}
+                          </MenuSubPopup>
+                        </MenuSub>
+                      ))}
+                    </>
+                  )}
                 </MenuRadioGroup>
               </MenuSubPopup>
             </MenuSub>

--- a/packages/workbench/src/mock/data/models.ts
+++ b/packages/workbench/src/mock/data/models.ts
@@ -1,0 +1,28 @@
+import type { AgentKind, AgentModelOption } from '@linkcode/schema';
+
+/** Canned catalogs for agents whose model set is adapter-advertised (`available-models-update`).
+ * Mirrors the opencode adapter's shape: `id` = `providerId/modelId`, `description` = provider
+ * display name — the composer groups the picker by that subtitle. */
+export const SEED_MODEL_CATALOGS: Partial<Record<AgentKind, AgentModelOption[]>> = {
+  opencode: [
+    { id: 'opencode/hy3-free', label: 'Hy3 Free', description: 'OpenCode Zen' },
+    { id: 'opencode/big-pickle', label: 'Big Pickle', description: 'OpenCode Zen' },
+    { id: 'opencode/mimo-v2.5-free', label: 'MiMo V2.5 Free', description: 'OpenCode Zen' },
+    {
+      id: 'opencode/deepseek-v4-flash-free',
+      label: 'DeepSeek V4 Flash Free',
+      description: 'OpenCode Zen',
+    },
+    { id: 'openai/gpt-5.4', label: 'GPT-5.4', description: 'OpenAI' },
+    { id: 'openai/gpt-5.4-mini', label: 'GPT-5.4 mini', description: 'OpenAI' },
+    { id: 'openai/gpt-5.6-terra', label: 'GPT-5.6 Terra', description: 'OpenAI' },
+    { id: 'openai/gpt-5.6-luna', label: 'GPT-5.6 Luna', description: 'OpenAI' },
+    { id: 'openai/gpt-5.6-sol', label: 'GPT-5.6 Sol', description: 'OpenAI' },
+    { id: 'anthropic/claude-fable-5', label: 'Claude Fable 5', description: 'Anthropic' },
+    { id: 'anthropic/claude-opus-4-8', label: 'Claude Opus 4.8', description: 'Anthropic' },
+    { id: 'anthropic/claude-sonnet-5', label: 'Claude Sonnet 5', description: 'Anthropic' },
+    { id: 'anthropic/claude-haiku-4-5', label: 'Claude Haiku 4.5', description: 'Anthropic' },
+    { id: 'google/gemini-3.2-pro', label: 'Gemini 3.2 Pro', description: 'Google' },
+    { id: 'google/gemini-3.2-flash', label: 'Gemini 3.2 Flash', description: 'Google' },
+  ],
+};

--- a/packages/workbench/src/mock/dev-mock-host.ts
+++ b/packages/workbench/src/mock/dev-mock-host.ts
@@ -32,6 +32,7 @@ import { wait } from 'foxts/wait';
 import { MOCK_WORKSPACE_FILES, mockFileFixture } from './data/files';
 import { gitFixtureFor } from './data/git';
 import { SEED_HISTORY } from './data/history';
+import { SEED_MODEL_CATALOGS } from './data/models';
 import {
   CHUNK_LATENCY_MS,
   CONTROL_LATENCY_MS,
@@ -577,10 +578,14 @@ export class DevMockHost {
     const { sessionId } = session;
     this.emit(sessionId, { type: 'status', status: 'starting' });
     this.emit(sessionId, { type: 'current-mode-update', currentModeId: 'mock' });
+    const catalog = SEED_MODEL_CATALOGS[kind];
+    if (catalog) {
+      this.emit(sessionId, { type: 'available-models-update', models: catalog });
+    }
     // Reflect a concrete model/effort like a real adapter, so the composer shows them not placeholders.
     this.emit(sessionId, {
       type: 'model-update',
-      model: model ?? (kind === 'codex' ? 'gpt-5.5' : 'claude-opus-4-8'),
+      model: model ?? catalog?.[0]?.id ?? (kind === 'codex' ? 'gpt-5.5' : 'claude-opus-4-8'),
     });
     this.emit(sessionId, { type: 'effort-update', effort: 'high' });
     this.emit(sessionId, { type: 'status', status: 'idle' });
@@ -746,6 +751,11 @@ export class DevMockHost {
       return;
     }
     session.status = 'idle';
+    // Parity with the engine's replay-on-attach: a resumed session re-advertises its catalog.
+    const catalog = SEED_MODEL_CATALOGS[session.kind];
+    if (catalog) {
+      this.emit(sessionId, { type: 'available-models-update', models: catalog });
+    }
     this.emit(sessionId, { type: 'status', status: 'idle' });
     this.send({ kind: 'session.started', replyTo, sessionId });
   }


### PR DESCRIPTION
## Problem

CODE-226 made opencode's dynamic model catalog reachable from the composer, but the adapter flattens provider×model into one list — with several providers connected the model submenu renders ~50 two-line rows, taller than the viewport.

## Fix

UI-only, per-provider submenus. The grouping key already rides on the wire: `description` carries the provider display name (adapter convention, documented on `ModelOption`). No schema/wire change, no adapter change.

- `agent-models.ts`: pure `groupModelsByProvider()` — groups by `description` in first-appearance order; returns `null` below two distinct providers, so static tables (claude-code/codex/grok) and single-provider opencode keep the flat list.
- `composer-controls.tsx`: the model `MenuSubPopup` renders one `MenuSub` per provider; items inside drop the now-redundant provider subtitle (single-line rows). One `MenuRadioGroup` spans all submenus — base-ui's radio context flows through the nested portals (verified: checked state renders and follows selection).
- Mock parity: canned multi-provider opencode catalog (`mock/data/models.ts`) emitted as `available-models-update` on session start/resume, so the grouped picker is exercisable in `dev:mock` without opencode installed.
- Unit tests for the grouping helper.

## Verification

- `pnpm test` (1263 passed) and `pnpm check:ci` green.
- Live in webview `dev:mock`: opencode thread → model menu shows 4 provider rows (OpenCode Zen / OpenAI / Anthropic / Google), each opening its short model list; ✓ tracks the served model across groups; selecting a model round-trips `set-model` → `model-update` and updates the trigger label.
- Regression: claude-code/codex threads still render the flat static list.

Closes CODE-270.