### PR TITLE
fix(engine,common): resolve gh via PATH scan + fallback install locations (CODE-271)

### DIFF
--- a/packages/agent-adapter/src/probe/base.ts
+++ b/packages/agent-adapter/src/probe/base.ts
@@ -1,10 +1,10 @@
 import { execFile } from 'node:child_process';
 import { existsSync } from 'node:fs';
 import { createRequire } from 'node:module';
-import { homedir } from 'node:os';
-import { delimiter, isAbsolute, join } from 'node:path';
+import { join } from 'node:path';
 import process from 'node:process';
 import { promisify } from 'node:util';
+import { executableSearchLocations } from '@linkcode/common/node';
 import type { AgentAuthStatus } from '@linkcode/schema';
 
 const execFileAsync = promisify(execFile);
@@ -17,55 +17,6 @@ export interface DetectedAgentRuntime {
 
 /** The agent kinds that spawn an external CLI (pi is in-process; opencode is PATH-based until CODE-76). */
 export type ProbeableKind = 'claude-code' | 'codex' | 'grok-build';
-
-/**
- * Candidate paths from the daemon's own PATH, searched ahead of the fallback locations
- * (CODE-220): PATH is the user's declared resolution order, and its order decides which of
- * several installs wins. Deriving candidates executes nothing — verification stays in
- * `probeAt`'s `--version` vendor marker — so only entries that don't denote a fixed location
- * are dropped: relative and empty segments (both resolve against the daemon's incidental cwd).
- * npm's Windows `.cmd` shims are skipped implicitly (only `<dir>/<binary>` with the platform
- * suffix is probed; `execFile` can't run a shim anyway) — those installs ride the managed tier.
- */
-function pathInstallLocations(binary: string): string[] {
-  const locations: string[] = [];
-  for (const entry of (process.env.PATH ?? '').split(delimiter)) {
-    // Windows PATH entries with spaces are conventionally double-quoted.
-    const dir = entry.replaceAll('"', '');
-    if (dir.length > 0 && isAbsolute(dir)) locations.push(join(dir, binary));
-  }
-  return locations;
-}
-
-/**
- * Fallback absolute install locations, probed after the PATH scan for daemons whose PATH was
- * stripped by a GUI launch (macOS launchd passes only `/usr/bin:/bin:/usr/sbin:/sbin`).
- * win32 has no entries: Windows GUI processes inherit the registry-composed user PATH, which
- * installers (winget Links, claude's `%USERPROFILE%\.local\bin`, scoop shims) join by design,
- * so the PATH scan already covers them.
- */
-function fallbackInstallLocations(binary: string): string[] {
-  const home = homedir();
-  switch (process.platform) {
-    case 'darwin':
-      // Official installers target ~/.local/bin; Homebrew is /opt/homebrew (arm) or /usr/local (intel).
-      return [
-        join(home, '.local', 'bin', binary),
-        join('/opt/homebrew/bin', binary),
-        join('/usr/local/bin', binary),
-      ];
-    case 'linux':
-      // /usr/bin is where distro packages land (e.g. Arch's codex).
-      return [
-        join(home, '.local', 'bin', binary),
-        join('/home/linuxbrew/.linuxbrew/bin', binary),
-        join('/usr/local/bin', binary),
-        join('/usr/bin', binary),
-      ];
-    default:
-      return [];
-  }
-}
 
 /**
  * One agent's CLI probe: where its user-installed binary may live and how to verify a candidate is
@@ -122,10 +73,12 @@ export abstract class AgentCliProbe {
     return process.platform === 'win32' ? `${this.binaryBase}.exe` : this.binaryBase;
   }
 
+  /** Deriving candidates executes nothing — verification stays in `probeAt`'s `--version`
+   * vendor marker. npm's Windows `.cmd` shims are skipped implicitly (only `<dir>/<binary>`
+   * with the platform suffix is probed; `execFile` can't run a shim anyway) — those installs
+   * ride the managed tier. */
   knownLocations(): string[] {
-    if (this.locations) return this.locations;
-    const binary = this.binaryName();
-    return [...new Set([...pathInstallLocations(binary), ...fallbackInstallLocations(binary)])];
+    return this.locations ?? executableSearchLocations(this.binaryName());
   }
 
   /** Version-probe one candidate binary. `undefined` means "not this one" (absent, not executable,

--- a/packages/common/src/node/__tests__/executable-locations.test.ts
+++ b/packages/common/src/node/__tests__/executable-locations.test.ts
@@ -1,0 +1,39 @@
+import { tmpdir } from 'node:os';
+import { delimiter, isAbsolute, join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { executableSearchLocations } from '../executable-locations';
+
+describe('executableSearchLocations', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('scans absolute PATH entries in order, ahead of the fallback locations', () => {
+    vi.stubEnv('PATH', '');
+    const fallback = executableSearchLocations('tool');
+
+    const dirA = join(tmpdir(), 'exec-path-a');
+    const dirB = join(tmpdir(), 'exec-path-b');
+    // Relative, empty, and duplicate entries must be dropped; quotes stripped.
+    vi.stubEnv('PATH', [dirA, 'relative/bin', '', `"${dirB}"`, dirA].join(delimiter));
+    expect(executableSearchLocations('tool')).toEqual([
+      join(dirA, 'tool'),
+      join(dirB, 'tool'),
+      ...fallback,
+    ]);
+  });
+
+  it('dedupes duplicates across PATH and the fallback locations', () => {
+    vi.stubEnv('PATH', ['/usr/local/bin', '/usr/local/bin'].join(delimiter));
+    const locations = executableSearchLocations('tool');
+    expect(locations[0]).toBe(join('/usr/local/bin', 'tool'));
+    expect(new Set(locations).size).toBe(locations.length);
+  });
+
+  it('yields only absolute candidate paths', () => {
+    vi.stubEnv('PATH', ['relative/bin', ''].join(delimiter));
+    for (const location of executableSearchLocations('tool')) {
+      expect(isAbsolute(location)).toBe(true);
+    }
+  });
+});

--- a/packages/common/src/node/executable-locations.ts
+++ b/packages/common/src/node/executable-locations.ts
@@ -1,0 +1,63 @@
+import { homedir } from 'node:os';
+import { delimiter, isAbsolute, join } from 'node:path';
+
+/**
+ * Where a user-installed CLI may live, for daemons that cannot trust their inherited PATH.
+ * Extracted from the agent runtime probe (CODE-220) so non-agent CLIs (e.g. `gh`, CODE-271)
+ * resolve with the same semantics. `binary` is the exact filename including any platform
+ * suffix (`.exe` on win32) — spawning by absolute path bypasses PATHEXT.
+ */
+
+/**
+ * Candidate paths from the process's own PATH, searched ahead of the fallback locations
+ * (CODE-220): PATH is the user's declared resolution order, and its order decides which of
+ * several installs wins. Deriving candidates executes nothing, so only entries that don't
+ * denote a fixed location are dropped: relative and empty segments (both resolve against
+ * the process's incidental cwd).
+ */
+function pathInstallLocations(binary: string): string[] {
+  const locations: string[] = [];
+  for (const entry of (process.env.PATH ?? '').split(delimiter)) {
+    // Windows PATH entries with spaces are conventionally double-quoted.
+    const dir = entry.replaceAll('"', '');
+    if (dir.length > 0 && isAbsolute(dir)) locations.push(join(dir, binary));
+  }
+  return locations;
+}
+
+/**
+ * Fallback absolute install locations, probed after the PATH scan for daemons whose PATH was
+ * stripped by a GUI launch (macOS launchd passes only `/usr/bin:/bin:/usr/sbin:/sbin`).
+ * win32 has no entries: Windows GUI processes inherit the registry-composed user PATH, which
+ * installers (winget Links, claude's `%USERPROFILE%\.local\bin`, scoop shims) join by design,
+ * so the PATH scan already covers them.
+ */
+function fallbackInstallLocations(binary: string): string[] {
+  const home = homedir();
+  switch (process.platform) {
+    case 'darwin':
+      // Official installers target ~/.local/bin; Homebrew is /opt/homebrew (arm) or /usr/local (intel).
+      return [
+        join(home, '.local', 'bin', binary),
+        join('/opt/homebrew/bin', binary),
+        join('/usr/local/bin', binary),
+      ];
+    case 'linux':
+      // /usr/bin is where distro packages land (e.g. Arch's codex).
+      return [
+        join(home, '.local', 'bin', binary),
+        join('/home/linuxbrew/.linuxbrew/bin', binary),
+        join('/usr/local/bin', binary),
+        join('/usr/bin', binary),
+      ];
+    default:
+      return [];
+  }
+}
+
+/** Deduped candidate paths for `binary`: PATH scan first (user-declared precedence), then the
+ * per-platform fallback install locations. Existence is the caller's check — deriving the list
+ * stats nothing and executes nothing. */
+export function executableSearchLocations(binary: string): string[] {
+  return [...new Set([...pathInstallLocations(binary), ...fallbackInstallLocations(binary)])];
+}

--- a/packages/common/src/node/index.ts
+++ b/packages/common/src/node/index.ts
@@ -10,6 +10,8 @@ import { daemonRuntimeFileSegments } from '@linkcode/schema/daemon-runtime-const
  * bundles. The tsconfig base sets `types: []` — the reference above opts in the Node globals.
  */
 
+export { executableSearchLocations } from './executable-locations';
+
 /** Parse a JSON file, or `null` when it is missing, unreadable, or malformed. */
 export function readJsonFileSync(path: string): unknown {
   try {

--- a/packages/engine/src/git/github.ts
+++ b/packages/engine/src/git/github.ts
@@ -1,3 +1,5 @@
+import { existsSync } from 'node:fs';
+import { executableSearchLocations } from '@linkcode/common/node';
 import type {
   GitChecksState,
   GitPullRequestStatus,
@@ -92,6 +94,16 @@ function firstLine(text: string): string {
   return text.split('\n', 1)[0]?.trim() ?? '';
 }
 
+/** Absolute path of the user's `gh`, resolved like the agent runtime probe (PATH scan, then
+ * per-platform fallback install dirs — CODE-271): a GUI-launched daemon inherits launchd's bare
+ * PATH, where a bare `spawn('gh')` misses a Homebrew install. Falls back to the bare name so an
+ * absent gh still reports through the ENOENT → `cli_not_installed` path. Re-resolved per call —
+ * a handful of stats against a 20s API call — so a gh installed mid-session is picked up. */
+function resolveGhBinary(): string {
+  const binary = process.platform === 'win32' ? 'gh.exe' : 'gh';
+  return executableSearchLocations(binary).find((path) => existsSync(path)) ?? 'gh';
+}
+
 /** GitHub via the user's local `gh` CLI — auth is fully delegated to `gh auth login`; the daemon
  * never sees or stores a token. A token-backed client (LinkCode GitHub App) can later implement
  * the same {@link GitProviderClient} seam without touching the wire contract. */
@@ -102,7 +114,7 @@ export class GhCliGitHubClient implements GitProviderClient {
     let result;
     try {
       // `gh pr view` resolves the PR for the checked-out branch (cwd-derived), open or merged.
-      result = await runCommand('gh', ['pr', 'view', '--json', GH_PR_JSON_FIELDS], {
+      result = await runCommand(resolveGhBinary(), ['pr', 'view', '--json', GH_PR_JSON_FIELDS], {
         cwd: query.cwd,
         env: GH_ENV,
         timeoutMs: GH_TIMEOUT_MS,


### PR DESCRIPTION
## Problem

In the packaged app the Git panel reports "GitHub CLI not installed" even with gh installed (CODE-229 part 1 / CODE-271). `GhCliGitHubClient` spawned `gh` by bare name against the daemon's inherited PATH; a Finder/Dock launch inherits launchd's bare `PATH` (`/usr/bin:/bin:/usr/sbin:/sbin`), which lacks `/opt/homebrew/bin` and other user install dirs, so the spawn ENOENTs into `cli_not_installed`. Terminal-launched dev builds inherit the full shell PATH, which is why the bug only shows in releases.

## Fix

Reuse the CODE-220 resolution semantics (the agent runtime probe was already immune):

- The location-derivation logic (PATH scan of absolute entries in order, then per-platform fallback install dirs; deduped) moves from `probe/base.ts` into `@linkcode/common/node` as `executableSearchLocations` — a generic executable lookup engine shouldn't reach into agent-adapter for.
- `AgentCliProbe.knownLocations` consumes the shared helper; behavior unchanged.
- `GhCliGitHubClient` resolves `gh` (`gh.exe` on win32) to the first existing candidate and spawns the absolute path, re-resolved per call so a gh installed mid-session is picked up. When nothing is found it falls back to the bare name, preserving the ENOENT → `cli_not_installed` reporting.

Daemon-wide PATH augmentation was considered and rejected for this fix — rationale in CODE-271.

## Verification

- A/B under launchd's bare PATH driving `GhCliGitHubClient.getPullRequestStatus` directly: pre-fix `{"status":"unavailable","reason":"cli_not_installed"}`, post-fix `{"status":"ok","pullRequest":null}` (gh at `/opt/homebrew/bin/gh` found and executed).
- New unit tests for `executableSearchLocations` (PATH order, relative/empty/duplicate entry handling, quote stripping, dedupe); existing probe tests cover the refactored `knownLocations` unchanged.
- `pnpm check:ci` and `pnpm test` (164 files, 1263 tests) green.
- Not re-verified end-to-end from a packaged Finder launch — worth a smoke check on the next release build.