### PR TITLE
feat(ui,desktop): auto-seed a terminal session when the Terminal section opens + strip inset alignment (CODE-230)

### DIFF
--- a/apps/desktop/src/renderer/src/__tests__/shell-state.test.ts
+++ b/apps/desktop/src/renderer/src/__tests__/shell-state.test.ts
@@ -13,8 +13,10 @@ import {
   parsePersistedDesktopShellState,
   RIGHT_PANEL_MAX_SIZE,
   RIGHT_PANEL_MIN_SIZE,
+  revealSectionState,
   SIDEBAR_MAX_SIZE,
   SIDEBAR_MIN_SIZE,
+  seedTerminalSection,
   serializeDesktopShellState,
 } from '@renderer/shell/store/model';
 import { describe, expect, it } from 'vitest';
@@ -118,6 +120,57 @@ describe('desktop shell state persistence', () => {
     expect(state.rightPanel.activeSection).toBe('terminal');
     expect(state.rightPanel.terminal.tabs).toHaveLength(3);
     expect(state.rightPanel.terminal.activeTabId).toBe(state.rightPanel.terminal.tabs[2].id);
+  });
+
+  it('seeds a first terminal tab when restoring an open panel showing an empty terminal section', () => {
+    const state = parsePersistedDesktopShellState({
+      version: 2,
+      sidebarOpen: true,
+      layout: DEFAULT_LAYOUT,
+      expansionStack: [],
+      rightPanel: {
+        open: true,
+        activeSection: 'terminal',
+        terminalTabCount: 0,
+        activeTerminalTabIndex: 0,
+      },
+      bottomPanel: { open: false, tabs: ['terminal'], activeTabIndex: 0 },
+    });
+
+    expect(state.rightPanel.terminal.tabs).toHaveLength(1);
+    expect(state.rightPanel.terminal.activeTabId).toBe(state.rightPanel.terminal.tabs[0].id);
+  });
+
+  it('does not seed a terminal tab when the restored panel is closed or on another section', () => {
+    const closed = parsePersistedDesktopShellState({
+      version: 2,
+      sidebarOpen: true,
+      layout: DEFAULT_LAYOUT,
+      expansionStack: [],
+      rightPanel: {
+        open: false,
+        activeSection: 'terminal',
+        terminalTabCount: 0,
+        activeTerminalTabIndex: 0,
+      },
+      bottomPanel: { open: false, tabs: ['terminal'], activeTabIndex: 0 },
+    });
+    expect(closed.rightPanel.terminal.tabs).toEqual([]);
+
+    const otherSection = parsePersistedDesktopShellState({
+      version: 2,
+      sidebarOpen: true,
+      layout: DEFAULT_LAYOUT,
+      expansionStack: [],
+      rightPanel: {
+        open: true,
+        activeSection: 'diff',
+        terminalTabCount: 0,
+        activeTerminalTabIndex: 0,
+      },
+      bottomPanel: { open: false, tabs: ['terminal'], activeTabIndex: 0 },
+    });
+    expect(otherSection.rightPanel.terminal.tabs).toEqual([]);
   });
 
   it('rejects an invalid right panel section and falls back to diff', () => {
@@ -267,6 +320,43 @@ describe('closeSectionTabState', () => {
     const terminal = { tabs: [a], activeTabId: a.id };
 
     expect(closeSectionTabState(terminal, 'missing')).toBe(terminal);
+  });
+});
+
+describe('seedTerminalSection', () => {
+  it('seeds and focuses a first tab when the section is empty', () => {
+    const seeded = seedTerminalSection({ tabs: [], activeTabId: null });
+
+    expect(seeded.tabs).toHaveLength(1);
+    expect(seeded.activeTabId).toBe(seeded.tabs[0].id);
+  });
+
+  it('is a no-op when tabs already exist', () => {
+    const a = createRightTerminalTab();
+    const terminal = { tabs: [a], activeTabId: a.id };
+
+    expect(seedTerminalSection(terminal)).toBe(terminal);
+  });
+});
+
+describe('revealSectionState', () => {
+  it('seeds the terminal section when it comes forward on an open panel', () => {
+    const panel = { ...createDefaultRightPanelState(), open: true };
+
+    const revealed = revealSectionState(panel, 'terminal', true);
+
+    expect(revealed.activeSection).toBe('terminal');
+    expect(revealed.terminal.tabs).toHaveLength(1);
+    expect(revealed.terminal.activeTabId).toBe(revealed.terminal.tabs[0].id);
+  });
+
+  it('leaves the terminal section untouched when revealing another section', () => {
+    const panel = { ...createDefaultRightPanelState(), open: true };
+
+    const revealed = revealSectionState(panel, 'files', true);
+
+    expect(revealed.activeSection).toBe('files');
+    expect(revealed.terminal.tabs).toEqual([]);
   });
 });
 

--- a/apps/desktop/src/renderer/src/shell/store/model.ts
+++ b/apps/desktop/src/renderer/src/shell/store/model.ts
@@ -186,6 +186,27 @@ export function createRightTerminalTab(): PanelSectionTab {
   return { id: `right-terminal-${tabSequence}` };
 }
 
+/** The terminal section never comes forward empty: seed a first PTY tab (same as pressing +). */
+export function seedTerminalSection(terminal: RightPanelTerminalState): RightPanelTerminalState {
+  if (terminal.tabs.length > 0) return terminal;
+  const tab = createRightTerminalTab();
+  return { tabs: [tab], activeTabId: tab.id };
+}
+
+/** Brings `section` forward, seeding the terminal section's first tab when it becomes visible. */
+export function revealSectionState(
+  panel: RightPanelState,
+  section: PanelSection,
+  open: boolean,
+): RightPanelState {
+  return {
+    ...panel,
+    open,
+    activeSection: section,
+    terminal: open && section === 'terminal' ? seedTerminalSection(panel.terminal) : panel.terminal,
+  };
+}
+
 export function createRightFileTab(path: string): FileSectionTab {
   tabSequence += 1;
   return { id: `right-file-${tabSequence}`, path };
@@ -399,14 +420,15 @@ function createPersistedRightPanelSchema(): z.ZodType<RightPanelState> {
           .map((path) => createRightFileTab(path));
         const activeFileIndex =
           fileTabs.length > 0 ? clamp(activeFileTabIndex, 0, fileTabs.length - 1) : 0;
+        const terminal = {
+          tabs,
+          activeTabId: tabs.length > 0 ? tabs[activeIndex].id : null,
+        };
 
         return {
           open,
           activeSection,
-          terminal: {
-            tabs,
-            activeTabId: tabs.length > 0 ? tabs[activeIndex].id : null,
-          },
+          terminal: open && activeSection === 'terminal' ? seedTerminalSection(terminal) : terminal,
           files: {
             tabs: fileTabs,
             activeTabId: fileTabs.length > 0 ? fileTabs[activeFileIndex].id : null,

--- a/apps/desktop/src/renderer/src/shell/store/store.ts
+++ b/apps/desktop/src/renderer/src/shell/store/store.ts
@@ -22,6 +22,8 @@ import {
   PersistedDesktopShellStateSchema,
   pushExpandedPanel,
   removeExpandedPanel,
+  revealSectionState,
+  seedTerminalSection,
   serializeDesktopShellState,
 } from './model';
 
@@ -102,7 +104,14 @@ export const useDesktopShellStore = create<DesktopShellStore>()(
                 expansionStack: open
                   ? current.expansionStack
                   : removeExpandedPanel(current.expansionStack, side),
-                rightPanel: { ...current.rightPanel, open },
+                rightPanel: {
+                  ...current.rightPanel,
+                  open,
+                  terminal:
+                    open && current.rightPanel.activeSection === 'terminal'
+                      ? seedTerminalSection(current.rightPanel.terminal)
+                      : current.rightPanel.terminal,
+                },
               };
             }
 
@@ -201,14 +210,14 @@ export const useDesktopShellStore = create<DesktopShellStore>()(
         setActiveSection(section) {
           updateShellState((current) => ({
             ...current,
-            rightPanel: { ...current.rightPanel, activeSection: section },
+            rightPanel: revealSectionState(current.rightPanel, section, current.rightPanel.open),
           }));
         },
 
         openRightPanelSection(section) {
           updateShellState((current) => ({
             ...current,
-            rightPanel: { ...current.rightPanel, open: true, activeSection: section },
+            rightPanel: revealSectionState(current.rightPanel, section, true),
           }));
         },
 

--- a/packages/ui/src/shell/files/file-tabs.tsx
+++ b/packages/ui/src/shell/files/file-tabs.tsx
@@ -28,7 +28,7 @@ export function FileTabStrip({
   return (
     <div
       className={cn(
-        'flex h-8 shrink-0 items-center gap-1 border-border border-b bg-background/60 px-2',
+        'flex h-9 shrink-0 items-center gap-1 border-border border-b bg-background/60 px-1',
         className,
       )}
     >

--- a/packages/ui/src/shell/panels/section-terminal-tabs.tsx
+++ b/packages/ui/src/shell/panels/section-terminal-tabs.tsx
@@ -28,7 +28,7 @@ export function SectionTerminalTabStrip({
   return (
     <div
       className={cn(
-        'flex h-8 shrink-0 items-center gap-1 border-border border-b bg-background/60 px-2',
+        'flex h-9 shrink-0 items-center gap-1 border-border border-b bg-background/60 px-1',
         className,
       )}
     >


### PR DESCRIPTION
Closes CODE-230.

User feedback (Mac, packaged build): switching the right panel to the Terminal section showed an empty pane — you had to press `+` manually — and the sub-tab strip's left inset (8px) didn't match its bottom inset (2px).

## Changes

- **Auto-seed**: the terminal section never comes forward empty. A first PTY tab (equivalent to pressing `+`) is seeded at every reveal point: section click (`setActiveSection`), programmatic reveal (`openRightPanelSection`), panel toggle landing on the terminal section, and persisted-state rehydrate (open panel restored on an empty terminal section). Closing the last tab deliberately does **not** respawn in place — a fresh session seeds on the next reveal instead.
- **Strip insets**: the terminal/files sub-tab strips go `h-8 px-2` → `h-9 px-1`, so the tab's left inset equals its bottom inset (4px, matching the 4px inter-tab gap).

## Verification

- Unit tests for `seedTerminalSection` / `revealSectionState` / rehydrate seeding in `shell-state.test.ts`; `pnpm check:ci` + full `pnpm test` green.
- E2E against the built desktop app + isolated daemon (fresh profile): switching to Terminal seeds exactly one tab and the PTY comes up live; measured insets left=4 / bottom=4.5 (the 0.5 is the strip's own bottom border); close-last → leave → re-enter re-seeds.