### PR TITLE
fix(client-core): keep live events a mid-turn transcript reseed does not cover (CODE-272)

### DIFF
--- a/packages/client-core/src/__tests__/conversation-store.test.ts
+++ b/packages/client-core/src/__tests__/conversation-store.test.ts
@@ -1,4 +1,4 @@
-import type { AgentEvent, SessionId } from '@linkcode/schema';
+import type { AgentEvent, MessageId, SessionId } from '@linkcode/schema';
 import { createWireMessage } from '@linkcode/transport';
 import { describe, expect, it } from 'vitest';
 import { createConversationStore } from '../conversation-store';
@@ -106,6 +106,61 @@ describe('createConversationStore', () => {
     // No duplicates either: the seedable prompt/announce inside the cut fold only from the seed.
     expect(conversation.items.filter((i) => i.kind === 'message')).toHaveLength(1);
     expect(conversation.items.filter((i) => i.kind === 'tool')).toHaveLength(1);
+    close();
+  });
+
+  // CODE-272: mid-turn, the transcript lags the live stream — the in-flight reply has no
+  // transcript row yet, so a reseed (focus/reconnect revalidation) must keep its live chunks
+  // even though they fall inside the cut, or the rendered answer collapses to a suffix.
+  it('keeps live chunks of a streaming message the snapshot has not flushed yet', async () => {
+    const { client, send, close } = await harness();
+    const chunk = (text: string): AgentEvent => ({
+      type: 'agent-message-chunk',
+      messageId: 'm1' as MessageId,
+      content: { type: 'text', text },
+    });
+    send(userText('tell a story'));
+    send({ type: 'status', status: 'running' });
+    send(chunk('Once upon '));
+    send(chunk('a time'));
+    await tick();
+
+    // Read resolved mid-turn: the snapshot has the prompt, not the streaming reply.
+    const store = createConversationStore(client, sessionId, {
+      events: [{ event: userText('tell a story') }],
+      uptoSeq: 4,
+    });
+    send(chunk(', the end.'));
+    await tick();
+
+    const messages = store.getSnapshot().items.filter((i) => i.kind === 'message');
+    expect(messages).toHaveLength(2);
+    expect(messages[1].blocks).toEqual([{ type: 'text', text: 'Once upon a time, the end.' }]);
+    close();
+  });
+
+  it('keeps an in-flight tool call the snapshot has not flushed yet', async () => {
+    const { client, send, close } = await harness();
+    const announce: AgentEvent = {
+      type: 'tool-call',
+      toolCall: {
+        toolCallId: 't1',
+        title: 'Bash',
+        kind: 'execute',
+        status: 'in_progress',
+        content: [],
+      },
+    };
+    send(userText('run echo'));
+    send(announce);
+    await tick();
+
+    const store = createConversationStore(client, sessionId, {
+      events: [{ event: userText('run echo') }],
+      uptoSeq: 2,
+    });
+    const items = store.getSnapshot().items;
+    expect(items.filter((i) => i.kind === 'tool')).toHaveLength(1);
     close();
   });
 

--- a/packages/client-core/src/conversation-store.ts
+++ b/packages/client-core/src/conversation-store.ts
@@ -30,22 +30,39 @@ const EMPTY_CONVERSATION: Conversation = {
 };
 
 /**
- * Event types a provider-transcript read can reproduce — the only ones the `uptoSeq` cut may drop
- * as "already in the snapshot". Everything else (interactive requests and resolutions, status,
- * stop, errors, usage …) is ephemeral: it never appears in `history.read`, so cutting it would erase
- * it outright — a pending permission-request would vanish and strand the turn (CODE-35).
+ * Whether the seed's transcript snapshot can be assumed to contain this event — the only license
+ * the `uptoSeq` cut has to drop it as "already in the snapshot". Providers flush transcripts by
+ * whole item, so coverage is checked per identity: a chunk of a message the snapshot never saw
+ * (the in-flight reply — claude-code writes the row only when the message completes) must survive
+ * a mid-turn reseed, or the streamed text vanishes at a chunk boundary (CODE-272). Everything
+ * outside the switch (interactive requests and resolutions, status, stop, errors, usage …) is
+ * ephemeral: it never appears in `history.read`, so cutting it would erase it outright — a pending
+ * permission-request would vanish and strand the turn (CODE-35).
  */
-const SEEDABLE_EVENT_TYPES = new Set<AgentEvent['type']>([
-  'user-message',
-  'agent-message-chunk',
-  'agent-thought-chunk',
-  'tool-call',
-]);
+function coveredBySeed(
+  event: AgentEvent,
+  seedMessageIds: ReadonlySet<string>,
+  seedToolIds: ReadonlySet<string>,
+): boolean {
+  switch (event.type) {
+    case 'agent-message-chunk':
+    case 'agent-thought-chunk':
+      return seedMessageIds.has(event.messageId);
+    case 'tool-call':
+      return seedToolIds.has(event.toolCall.toolCallId);
+    case 'user-message':
+      // No reliable cross-source id; providers flush the prompt row at accept, and the
+      // fresh-session race is handled by the adapters' session-ref deferral.
+      return true;
+    default:
+      return false;
+  }
+}
 
 /**
  * Project a session's conversation from a transcript seed plus the live event buffer: the seed
- * folds once, then `getSnapshot` lazily advances by unconsumed events, skipping seedable events
- * inside the `uptoSeq` cut. The sync is idempotent and monotone with a stable snapshot identity
+ * folds once, then `getSnapshot` lazily advances by unconsumed events, skipping events inside the
+ * `uptoSeq` cut that the snapshot verifiably covers (see {@link coveredBySeed}). The sync is idempotent and monotone with a stable snapshot identity
  * between events — the `useSyncExternalStore` getSnapshot contract. A store is bound to one
  * (session, seed) pair; create a fresh one when either changes.
  */
@@ -60,8 +77,20 @@ export function createConversationStore(
 
   const builder = createConversationBuilder();
   const uptoSeq = seed?.uptoSeq ?? 0;
+  // Identities the snapshot actually holds, for the per-event coverage check of the cut.
+  const seedMessageIds = new Set<string>();
+  const seedToolIds = new Set<string>();
+  if (seed) {
+    for (const { event } of seed.events) {
+      if (event.type === 'agent-message-chunk' || event.type === 'agent-thought-chunk') {
+        seedMessageIds.add(event.messageId);
+      } else if (event.type === 'tool-call') {
+        seedToolIds.add(event.toolCall.toolCallId);
+      }
+    }
+  }
   let seeded = false;
-  /** Highest receive seq already examined (not necessarily folded — seedable ones may be cut). */
+  /** Highest receive seq already examined (not necessarily folded — covered ones may be cut). */
   let consumedSeq = 0;
 
   const sync = (): void => {
@@ -73,7 +102,7 @@ export function createConversationStore(
     const events = client.eventsSnapshot(sessionId);
     for (let i = firstIndexAfter(events, consumedSeq); i < events.length; i += 1) {
       const { event, seq, receivedAt } = events[i];
-      if (seq > uptoSeq || !SEEDABLE_EVENT_TYPES.has(event.type)) {
+      if (seq > uptoSeq || !coveredBySeed(event, seedMessageIds, seedToolIds)) {
         builder.advance(event, receivedAt);
       }
     }

--- a/packages/client-core/src/conversation.ts
+++ b/packages/client-core/src/conversation.ts
@@ -570,7 +570,9 @@ export interface ConversationSeedEvent {
 
 /** A point-in-time transcript snapshot: past events read from provider history, plus the live
  * stream's receive counter sampled when the read resolved (see `LinkCodeClient.eventSeq`). The
- * conversation store folds the seed first, then only the live events past the `uptoSeq` cut. */
+ * conversation store folds the seed first, then the live events past the `uptoSeq` cut — and,
+ * because a mid-turn transcript lags the stream, pre-cut events whose identity the snapshot
+ * doesn't cover (an in-flight message's chunks, an unflushed tool call; CODE-272). */
 export interface ConversationSeed {
   events: ConversationSeedEvent[];
   /** The snapshot covers every live event with seq ≤ this; 0 = supersedes nothing. */

--- a/packages/ui/src/__tests__/agent-models.test.ts
+++ b/packages/ui/src/__tests__/agent-models.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { AGENT_MODEL_OPTIONS, resolveModel } from '../shell/agent-models';
+import { AGENT_MODEL_OPTIONS, groupModelsByProvider, resolveModel } from '../shell/agent-models';
 
 const claude = AGENT_MODEL_OPTIONS['claude-code'];
 const codex = AGENT_MODEL_OPTIONS.codex;
@@ -22,5 +22,40 @@ describe('resolveModel', () => {
     expect(resolveModel(claude, null)).toBeUndefined();
     expect(resolveModel(claude, 'not-a-model')).toBeUndefined();
     expect(resolveModel(undefined, 'claude-opus-4-8')).toBeUndefined();
+  });
+});
+
+describe('groupModelsByProvider', () => {
+  const multiProvider = [
+    { id: 'opencode/hy3', label: 'Hy3', description: 'OpenCode Zen' },
+    { id: 'openai/gpt-5.4', label: 'GPT-5.4', description: 'OpenAI' },
+    { id: 'opencode/big-pickle', label: 'Big Pickle', description: 'OpenCode Zen' },
+    { id: 'openai/gpt-5.6-sol', label: 'GPT-5.6 Sol', description: 'OpenAI' },
+  ];
+
+  it('groups by provider in first-appearance order, preserving catalog order within groups', () => {
+    expect(groupModelsByProvider(multiProvider)).toStrictEqual({
+      ungrouped: [],
+      groups: [
+        { label: 'OpenCode Zen', options: [multiProvider[0], multiProvider[2]] },
+        { label: 'OpenAI', options: [multiProvider[1], multiProvider[3]] },
+      ],
+    });
+  });
+
+  it('collects descriptionless options into ungrouped', () => {
+    const legacy = { id: 'legacy', label: 'Legacy' };
+    expect(groupModelsByProvider([legacy, ...multiProvider])?.ungrouped).toStrictEqual([legacy]);
+  });
+
+  it('returns null below two distinct providers so the flat list renders', () => {
+    expect(groupModelsByProvider(undefined)).toBeNull();
+    expect(groupModelsByProvider([])).toBeNull();
+    // Static tables carry no provider subtitle.
+    expect(groupModelsByProvider(claude)).toBeNull();
+    // Single-provider catalogs (e.g. opencode pinned to one credential) stay flat too.
+    expect(
+      groupModelsByProvider(multiProvider.filter((option) => option.description === 'OpenAI')),
+    ).toBeNull();
   });
 });

--- a/packages/ui/src/shell/agent-models.ts
+++ b/packages/ui/src/shell/agent-models.ts
@@ -8,6 +8,36 @@ export interface ModelOption {
   description?: string;
 }
 
+export interface ModelProviderGroups {
+  /** Options without a provider subtitle, rendered flat before the provider submenus. */
+  ungrouped: ModelOption[];
+  groups: { label: string; options: ModelOption[] }[];
+}
+
+/** Group a catalog by its provider subtitle (`description`, per the adapter convention above),
+ * preserving catalog order within groups and first-appearance order across them. Returns null
+ * below two distinct providers — a single-provider list reads better flat. */
+export function groupModelsByProvider(
+  options: readonly ModelOption[] | undefined,
+): ModelProviderGroups | null {
+  const ungrouped: ModelOption[] = [];
+  const byProvider = new Map<string, ModelOption[]>();
+  for (const option of options ?? []) {
+    if (option.description === undefined) {
+      ungrouped.push(option);
+      continue;
+    }
+    const group = byProvider.get(option.description);
+    if (group) group.push(option);
+    else byProvider.set(option.description, [option]);
+  }
+  if (byProvider.size < 2) return null;
+  return {
+    ungrouped,
+    groups: [...byProvider.entries()].map(([label, grouped]) => ({ label, options: grouped })),
+  };
+}
+
 /** Resolve a reflected model id (from `model-update`) to its catalog entry. The daemon emits the
  * *served* id, which may be a pinned snapshot of an alias (e.g. `claude-haiku-4-5-20251001`);
  * prefix-match only after an exact match fails so `gpt-5.4-mini` never mis-resolves to `gpt-5.4`. */

--- a/packages/ui/src/shell/composer-controls.tsx
+++ b/packages/ui/src/shell/composer-controls.tsx
@@ -26,7 +26,7 @@ import { useTranslations } from 'use-intl';
 import { AGENT_LABELS, AgentIcon } from '../chat/agent-icon';
 import type { EffortOption } from './agent-efforts';
 import type { ModelOption } from './agent-models';
-import { resolveModel } from './agent-models';
+import { groupModelsByProvider, resolveModel } from './agent-models';
 import type { AgentRuntimeCue, AgentRuntimeCues } from './agent-onboarding-card';
 
 // Linear lookup: the policy/effort lists are a handful of entries at most.
@@ -208,6 +208,7 @@ export function ModelSelectorMenu({
 }): React.ReactNode {
   const t = useTranslations('workbench.composer');
   const selectedModel = resolveModel(modelOptions, selectedModelId);
+  const providerGroups = groupModelsByProvider(modelOptions);
   const selectedEffort = optionById(effortOptions, selectedEffortId);
   const providers = selectableProviders ?? [];
   const hasEfforts = Boolean(effortOptions?.length);
@@ -258,18 +259,42 @@ export function ModelSelectorMenu({
                   value={selectedModel?.id ?? selectedModelId ?? ''}
                   onValueChange={(value) => onSelectModel(String(value))}
                 >
-                  {modelOptions?.map((option) => (
-                    <MenuRadioItem key={option.id} closeOnClick value={option.id}>
-                      <span className="flex min-w-0 flex-col">
-                        <span>{option.label}</span>
-                        {option.description ? (
-                          <span className="text-muted-foreground text-xs">
-                            {option.description}
-                          </span>
-                        ) : null}
-                      </span>
-                    </MenuRadioItem>
-                  ))}
+                  {providerGroups === null ? (
+                    modelOptions?.map((option) => (
+                      <MenuRadioItem key={option.id} closeOnClick value={option.id}>
+                        <span className="flex min-w-0 flex-col">
+                          <span>{option.label}</span>
+                          {option.description ? (
+                            <span className="text-muted-foreground text-xs">
+                              {option.description}
+                            </span>
+                          ) : null}
+                        </span>
+                      </MenuRadioItem>
+                    ))
+                  ) : (
+                    <>
+                      {providerGroups.ungrouped.map((option) => (
+                        <MenuRadioItem key={option.id} closeOnClick value={option.id}>
+                          {option.label}
+                        </MenuRadioItem>
+                      ))}
+                      {/* One submenu per provider; the trigger names the provider, so items drop
+                       * the subtitle the flat list needs for disambiguation. */}
+                      {providerGroups.groups.map((group) => (
+                        <MenuSub key={group.label}>
+                          <MenuSubTrigger>{group.label}</MenuSubTrigger>
+                          <MenuSubPopup className="w-56">
+                            {group.options.map((option) => (
+                              <MenuRadioItem key={option.id} closeOnClick value={option.id}>
+                                {option.label}
+                              </MenuRadioItem>
+                            ))}
+                          </MenuSubPopup>
+                        </MenuSub>
+                      ))}
+                    </>
+                  )}
                 </MenuRadioGroup>
               </MenuSubPopup>
             </MenuSub>

--- a/packages/workbench/src/mock/data/models.ts
+++ b/packages/workbench/src/mock/data/models.ts
@@ -1,0 +1,28 @@
+import type { AgentKind, AgentModelOption } from '@linkcode/schema';
+
+/** Canned catalogs for agents whose model set is adapter-advertised (`available-models-update`).
+ * Mirrors the opencode adapter's shape: `id` = `providerId/modelId`, `description` = provider
+ * display name — the composer groups the picker by that subtitle. */
+export const SEED_MODEL_CATALOGS: Partial<Record<AgentKind, AgentModelOption[]>> = {
+  opencode: [
+    { id: 'opencode/hy3-free', label: 'Hy3 Free', description: 'OpenCode Zen' },
+    { id: 'opencode/big-pickle', label: 'Big Pickle', description: 'OpenCode Zen' },
+    { id: 'opencode/mimo-v2.5-free', label: 'MiMo V2.5 Free', description: 'OpenCode Zen' },
+    {
+      id: 'opencode/deepseek-v4-flash-free',
+      label: 'DeepSeek V4 Flash Free',
+      description: 'OpenCode Zen',
+    },
+    { id: 'openai/gpt-5.4', label: 'GPT-5.4', description: 'OpenAI' },
+    { id: 'openai/gpt-5.4-mini', label: 'GPT-5.4 mini', description: 'OpenAI' },
+    { id: 'openai/gpt-5.6-terra', label: 'GPT-5.6 Terra', description: 'OpenAI' },
+    { id: 'openai/gpt-5.6-luna', label: 'GPT-5.6 Luna', description: 'OpenAI' },
+    { id: 'openai/gpt-5.6-sol', label: 'GPT-5.6 Sol', description: 'OpenAI' },
+    { id: 'anthropic/claude-fable-5', label: 'Claude Fable 5', description: 'Anthropic' },
+    { id: 'anthropic/claude-opus-4-8', label: 'Claude Opus 4.8', description: 'Anthropic' },
+    { id: 'anthropic/claude-sonnet-5', label: 'Claude Sonnet 5', description: 'Anthropic' },
+    { id: 'anthropic/claude-haiku-4-5', label: 'Claude Haiku 4.5', description: 'Anthropic' },
+    { id: 'google/gemini-3.2-pro', label: 'Gemini 3.2 Pro', description: 'Google' },
+    { id: 'google/gemini-3.2-flash', label: 'Gemini 3.2 Flash', description: 'Google' },
+  ],
+};

--- a/packages/workbench/src/mock/dev-mock-host.ts
+++ b/packages/workbench/src/mock/dev-mock-host.ts
@@ -32,6 +32,7 @@ import { wait } from 'foxts/wait';
 import { MOCK_WORKSPACE_FILES, mockFileFixture } from './data/files';
 import { gitFixtureFor } from './data/git';
 import { SEED_HISTORY } from './data/history';
+import { SEED_MODEL_CATALOGS } from './data/models';
 import {
   CHUNK_LATENCY_MS,
   CONTROL_LATENCY_MS,
@@ -577,10 +578,14 @@ export class DevMockHost {
     const { sessionId } = session;
     this.emit(sessionId, { type: 'status', status: 'starting' });
     this.emit(sessionId, { type: 'current-mode-update', currentModeId: 'mock' });
+    const catalog = SEED_MODEL_CATALOGS[kind];
+    if (catalog) {
+      this.emit(sessionId, { type: 'available-models-update', models: catalog });
+    }
     // Reflect a concrete model/effort like a real adapter, so the composer shows them not placeholders.
     this.emit(sessionId, {
       type: 'model-update',
-      model: model ?? (kind === 'codex' ? 'gpt-5.5' : 'claude-opus-4-8'),
+      model: model ?? catalog?.[0]?.id ?? (kind === 'codex' ? 'gpt-5.5' : 'claude-opus-4-8'),
     });
     this.emit(sessionId, { type: 'effort-update', effort: 'high' });
     this.emit(sessionId, { type: 'status', status: 'idle' });
@@ -746,6 +751,11 @@ export class DevMockHost {
       return;
     }
     session.status = 'idle';
+    // Parity with the engine's replay-on-attach: a resumed session re-advertises its catalog.
+    const catalog = SEED_MODEL_CATALOGS[session.kind];
+    if (catalog) {
+      this.emit(sessionId, { type: 'available-models-update', models: catalog });
+    }
     this.emit(sessionId, { type: 'status', status: 'idle' });
     this.send({ kind: 'session.started', replyTo, sessionId });
   }


### PR DESCRIPTION
Stacked on #179 — base is `ruocheng/code-270`; retarget to `master` once that merges.

## Problem

Scrolling while an answer streams could make the already-rendered part of the reply vanish: it re-renders as a mid-sentence suffix, cut exactly at a streaming-chunk boundary, previous turns intact (reported on desktop with claude-code). Scrolling is incidental — the trigger is any SWR revalidation of the transcript seed while a turn streams: window focus (cmd-tab back, returning from the interactive-screenshot UI; `revalidateOnFocus` is SWR's default and `WorkbenchSWRConfig` doesn't disable it), a connection generation becoming ready (`ReadyRevalidator`'s `mutate(trueFn)`), or browser `online`.

A revalidated seed makes `useConversation` build a fresh conversation store, whose `uptoSeq` cut drops every live seedable event (`user-message` / `agent-message-chunk` / `agent-thought-chunk` / `tool-call`) as "already in the snapshot". Mid-turn that assumption is false: claude-code flushes an assistant transcript row only when the message **completes**, so the in-flight reply isn't in `history.read` at all — its already-received chunks are erased, and only chunks received after the refetch survive. In-flight thought rows and tool-call announces are swallowed the same way. Same failure class as CODE-35 (ephemeral events must survive the cut) and the codex/opencode session-ref deferrals ("the seed's uptoSeq cut swallows the first prompt").

## Fix

Id-verify the cut in `createConversationStore` (`coveredBySeed`): a pre-cut live event is dropped only when the seed actually contains its identity —

- `agent-message-chunk` / `agent-thought-chunk`: drop iff the seed has that `messageId` (live and history ids converge by adapter contract);
- `tool-call`: drop iff the seed has that `toolCallId` (events are full snapshots, so this is exact);
- `user-message`: blanket drop unchanged (no reliable cross-source id; providers flush the prompt row at accept, and the fresh-session race stays handled by the adapters' session-ref deferral);
- everything else keeps CODE-35 semantics (ephemeral events always fold).

A mid-turn reseed now rebuilds the identical timeline (seed + live-only events), so every revalidation trigger is harmless. Client-core only; no wire/schema change.

## Verification

- Two new regression tests in `conversation-store.test.ts`: a mid-turn reseed whose snapshot lacks the streaming message keeps the full text, and an in-flight tool-call announce inside the cut survives. Both fail on the unfixed store (the message collapses to the post-cut suffix — the reported symptom) and pass with the fix; the existing no-duplicate assertions stay green.
- `pnpm test` (163 files / 1265 tests) and `pnpm check:ci` green.
- Not reproducible in `dev:mock` (the mock host doesn't implement `history.read`, so no seed ever exists there). Desktop smoke: start a long answer, cmd-tab away and back mid-stream, scroll — the reply stays whole.

Closes CODE-272.