### PR TITLE
fix(transport): avoid zod double parse

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -212,9 +212,12 @@ Every message is a **versioned envelope** (version, id, timestamp) wrapping a pa
 The payload is a discriminated union keyed by `kind` (`session.start` / `session.started`,
 `session.list` / `session.listed`, `history.list` / `history.listed`, `agent.event`, and
 so on). Local direct connections and remote tunnels share the identical format, and every
-receiving end validates with zod at its trust boundary before delivery; senders trust typed
-construction and do not re-validate (the per-frame send parse was hot on the terminal wire,
-CODE-231 — `LocalTransport` alone keeps a send-side parse to catch schema drift in tests).
+receiving end validates with zod at its trust boundary before delivery. Senders do not
+re-validate (the per-frame send parse was hot on the terminal wire, CODE-231): `send()` takes
+the branded `ValidatedWireMessage`, minted only by `createWireMessage` (typed construction)
+and `parseWireMessage` (boundary validation), so an unchecked object cannot reach a send path
+without an explicit cast. `LocalTransport` alone keeps a send-side parse so tests and the
+dev-mock host catch schema drift behind the brand.
 Any change to the payload union bumps `WIRE_PROTOCOL_VERSION`; the version is a validated
 literal, so a stale peer rejects every message — after a bump, restart the daemon and all
 clients together.
@@ -252,8 +255,8 @@ interface AgentAdapter {
 // @linkcode/transport — the carrier-agnostic message pipe + its listener
 interface Transport {
   connect(): Promise<void>;
-  send(msg: WireMessage): void | Promise<void>;              // trusted from typed construction
-  onMessage(cb: (msg: WireMessage) => void): Unsubscribe;    // zod-validated on receive
+  send(msg: ValidatedWireMessage): void | Promise<void>;     // brand minted by createWireMessage / parseWireMessage
+  onMessage(cb: (msg: ValidatedWireMessage) => void): Unsubscribe; // zod-validated on receive
   onClose(cb: () => void): Unsubscribe;
   close(): void | Promise<void>;
 }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -211,8 +211,10 @@ other clients of that host.
 Every message is a **versioned envelope** (version, id, timestamp) wrapping a payload.
 The payload is a discriminated union keyed by `kind` (`session.start` / `session.started`,
 `session.list` / `session.listed`, `history.list` / `history.listed`, `agent.event`, and
-so on). Local direct connections and remote tunnels share the identical format, and both
-ends validate with zod at the trust boundary — before sending and after receiving.
+so on). Local direct connections and remote tunnels share the identical format, and every
+receiving end validates with zod at its trust boundary before delivery; senders trust typed
+construction and do not re-validate (the per-frame send parse was hot on the terminal wire,
+CODE-231 — `LocalTransport` alone keeps a send-side parse to catch schema drift in tests).
 Any change to the payload union bumps `WIRE_PROTOCOL_VERSION`; the version is a validated
 literal, so a stale peer rejects every message — after a bump, restart the daemon and all
 clients together.
@@ -250,7 +252,7 @@ interface AgentAdapter {
 // @linkcode/transport — the carrier-agnostic message pipe + its listener
 interface Transport {
   connect(): Promise<void>;
-  send(msg: WireMessage): void | Promise<void>;              // zod-validated before send
+  send(msg: WireMessage): void | Promise<void>;              // trusted from typed construction
   onMessage(cb: (msg: WireMessage) => void): Unsubscribe;    // zod-validated on receive
   onClose(cb: () => void): Unsubscribe;
   close(): void | Promise<void>;

--- a/packages/client-core/src/__tests__/connection.test.ts
+++ b/packages/client-core/src/__tests__/connection.test.ts
@@ -1,4 +1,4 @@
-import type { WireMessage, WirePayload } from '@linkcode/schema';
+import type { ValidatedWireMessage, WirePayload } from '@linkcode/schema';
 import type { Transport, Unsubscribe } from '@linkcode/transport';
 import { createWireMessage } from '@linkcode/transport';
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -8,7 +8,7 @@ class ControlledTransport implements Transport {
   readonly sent: WirePayload[] = [];
   readonly connectError?: Error;
   closeCalls = 0;
-  private readonly messages = new Set<(message: WireMessage) => void>();
+  private readonly messages = new Set<(message: ValidatedWireMessage) => void>();
   private readonly closes = new Set<() => void>();
 
   constructor(options: { connectError?: Error } = {}) {
@@ -19,11 +19,11 @@ class ControlledTransport implements Transport {
     return this.connectError ? Promise.reject(this.connectError) : Promise.resolve();
   }
 
-  send(message: WireMessage): void {
+  send(message: ValidatedWireMessage): void {
     this.sent.push(message.payload);
   }
 
-  onMessage(cb: (message: WireMessage) => void): Unsubscribe {
+  onMessage(cb: (message: ValidatedWireMessage) => void): Unsubscribe {
     this.messages.add(cb);
     return () => this.messages.delete(cb);
   }

--- a/packages/client-core/src/__tests__/terminal-client.test.ts
+++ b/packages/client-core/src/__tests__/terminal-client.test.ts
@@ -1,7 +1,7 @@
 import type {
   TerminalMetadata,
   TerminalReplayEvent,
-  WireMessage,
+  ValidatedWireMessage,
   WirePayload,
 } from '@linkcode/schema';
 import type { Transport } from '@linkcode/transport';
@@ -13,7 +13,7 @@ import { createConnectedLocalClient } from './local-client';
 
 /** A transport whose every `send` rejects, so terminal frames always fail to leave. */
 function terminalFrameFailingTransport(err: Error): Transport {
-  let onMessage: (message: WireMessage) => void = noop;
+  let onMessage: (message: ValidatedWireMessage) => void = noop;
   return {
     connect() {
       return Promise.resolve();

--- a/packages/engine/src/__tests__/engine-agent-runtimes.test.ts
+++ b/packages/engine/src/__tests__/engine-agent-runtimes.test.ts
@@ -1,4 +1,4 @@
-import type { AgentRuntimes, WireMessage, WirePayload } from '@linkcode/schema';
+import type { AgentRuntimes, ValidatedWireMessage, WirePayload } from '@linkcode/schema';
 import type { Transport } from '@linkcode/transport';
 import { createWireMessage } from '@linkcode/transport';
 import { nullthrow } from 'foxts/guard';
@@ -13,10 +13,10 @@ function harness(
   agentRuntimesReady?: Promise<AgentRuntimes>,
 ) {
   const sent: WirePayload[] = [];
-  let handler: ((msg: WireMessage) => void) | null = null;
+  let handler: ((msg: ValidatedWireMessage) => void) | null = null;
   const transport: Transport = {
     connect: () => Promise.resolve(),
-    send(msg: WireMessage) {
+    send(msg: ValidatedWireMessage) {
       sent.push(msg.payload);
     },
     onMessage(cb) {

--- a/packages/engine/src/__tests__/engine-assets.test.ts
+++ b/packages/engine/src/__tests__/engine-assets.test.ts
@@ -3,7 +3,7 @@ import type {
   AssetInstallEvent,
   InstalledAsset,
   ManagedAssetStatus,
-  WireMessage,
+  ValidatedWireMessage,
   WirePayload,
 } from '@linkcode/schema';
 import type { Transport } from '@linkcode/transport';
@@ -40,10 +40,10 @@ function fakeAssets(overrides: Partial<AssetService> = {}) {
 
 function harness(deps: EngineDeps = {}) {
   const sent: WirePayload[] = [];
-  let handler: ((msg: WireMessage) => void) | null = null;
+  let handler: ((msg: ValidatedWireMessage) => void) | null = null;
   const transport: Transport = {
     connect: () => Promise.resolve(),
-    send(msg: WireMessage) {
+    send(msg: ValidatedWireMessage) {
       sent.push(msg.payload);
     },
     onMessage(cb) {

--- a/packages/engine/src/__tests__/engine-file-suggest.test.ts
+++ b/packages/engine/src/__tests__/engine-file-suggest.test.ts
@@ -3,7 +3,7 @@ import { mkdtemp } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import type { AgentAdapter } from '@linkcode/agent-adapter';
-import type { SessionId, WireMessage, WirePayload } from '@linkcode/schema';
+import type { SessionId, ValidatedWireMessage, WirePayload } from '@linkcode/schema';
 import type { Transport } from '@linkcode/transport';
 import { createWireMessage } from '@linkcode/transport';
 import { nullthrow } from 'foxts/guard';
@@ -37,10 +37,10 @@ function fakeAdapter(): AgentAdapter {
 
 function harness(store: SessionStore = new InMemorySessionStore()) {
   const sent: WirePayload[] = [];
-  let handler: ((msg: WireMessage) => void) | null = null;
+  let handler: ((msg: ValidatedWireMessage) => void) | null = null;
   const transport: Transport = {
     connect: () => Promise.resolve(),
-    send(msg: WireMessage) {
+    send(msg: ValidatedWireMessage) {
       sent.push(msg.payload);
     },
     onMessage(cb) {

--- a/packages/engine/src/__tests__/engine-loop.test.ts
+++ b/packages/engine/src/__tests__/engine-loop.test.ts
@@ -11,7 +11,7 @@ import type {
   AgentInput,
   LoopSpec,
   MessageId,
-  WireMessage,
+  ValidatedWireMessage,
   WirePayload,
 } from '@linkcode/schema';
 import { textBlock } from '@linkcode/schema';
@@ -89,10 +89,10 @@ function pick<K extends WirePayload['kind']>(
 
 function harness() {
   const sent: WirePayload[] = [];
-  let handler: ((msg: WireMessage) => void) | null = null;
+  let handler: ((msg: ValidatedWireMessage) => void) | null = null;
   const transport: Transport = {
     connect: () => Promise.resolve(),
-    send(msg: WireMessage) {
+    send(msg: ValidatedWireMessage) {
       sent.push(msg.payload);
     },
     onMessage(cb) {

--- a/packages/engine/src/__tests__/engine-schedule.test.ts
+++ b/packages/engine/src/__tests__/engine-schedule.test.ts
@@ -8,7 +8,7 @@ import type {
   AgentInput,
   MessageId,
   Schedule,
-  WireMessage,
+  ValidatedWireMessage,
   WirePayload,
 } from '@linkcode/schema';
 import { textBlock } from '@linkcode/schema';
@@ -86,10 +86,10 @@ function pick<K extends WirePayload['kind']>(
 
 function harness() {
   const sent: WirePayload[] = [];
-  let handler: ((msg: WireMessage) => void) | null = null;
+  let handler: ((msg: ValidatedWireMessage) => void) | null = null;
   const transport: Transport = {
     connect: () => Promise.resolve(),
-    send(msg: WireMessage) {
+    send(msg: ValidatedWireMessage) {
       sent.push(msg.payload);
     },
     onMessage(cb) {

--- a/packages/engine/src/__tests__/engine-sessions.test.ts
+++ b/packages/engine/src/__tests__/engine-sessions.test.ts
@@ -13,7 +13,7 @@ import type {
   MessageId,
   SessionId,
   StartOptions,
-  WireMessage,
+  ValidatedWireMessage,
   WirePayload,
 } from '@linkcode/schema';
 import { textBlock } from '@linkcode/schema';
@@ -168,10 +168,10 @@ function harness(
   agentRuntimesReady?: Promise<AgentRuntimes>,
 ) {
   const sent: WirePayload[] = [];
-  let handler: ((msg: WireMessage) => void) | null = null;
+  let handler: ((msg: ValidatedWireMessage) => void) | null = null;
   const transport: Transport = {
     connect: () => Promise.resolve(),
-    send(msg: WireMessage) {
+    send(msg: ValidatedWireMessage) {
       sent.push(msg.payload);
     },
     onMessage(cb) {

--- a/packages/engine/src/__tests__/terminal-takeover.test.ts
+++ b/packages/engine/src/__tests__/terminal-takeover.test.ts
@@ -1,4 +1,4 @@
-import type { WireMessage } from '@linkcode/schema';
+import type { ValidatedWireMessage } from '@linkcode/schema';
 import type { Transport, Unsubscribe } from '@linkcode/transport';
 import { createWireMessage, Listeners } from '@linkcode/transport';
 import { Hub } from '@linkcode/transport/server';
@@ -8,18 +8,18 @@ import { Engine } from '../engine';
 import type { PtyBackend, PtyOpenOptions, PtyProcess } from '../pty-backend';
 
 class PeerTransport implements Transport {
-  readonly sent: WireMessage[] = [];
-  private readonly inbound = new Listeners<WireMessage>();
+  readonly sent: ValidatedWireMessage[] = [];
+  private readonly inbound = new Listeners<ValidatedWireMessage>();
 
   connect(): Promise<void> {
     return Promise.resolve();
   }
 
-  send(message: WireMessage): void {
+  send(message: ValidatedWireMessage): void {
     this.sent.push(message);
   }
 
-  onMessage(cb: (message: WireMessage) => void): Unsubscribe {
+  onMessage(cb: (message: ValidatedWireMessage) => void): Unsubscribe {
     return this.inbound.add(cb);
   }
 
@@ -29,7 +29,7 @@ class PeerTransport implements Transport {
 
   close = noop;
 
-  emit(message: WireMessage): void {
+  emit(message: ValidatedWireMessage): void {
     this.inbound.emit(message);
   }
 }

--- a/packages/schema/src/wire/index.ts
+++ b/packages/schema/src/wire/index.ts
@@ -74,7 +74,16 @@ export const WireMessageSchema = z.object({
 });
 export type WireMessage = z.infer<typeof WireMessageSchema>;
 
-/** Parse + validate an inbound message; on failure returns the zod SafeParse result. */
-export function parseWireMessage(input: unknown): ReturnType<typeof WireMessageSchema.safeParse> {
-  return WireMessageSchema.safeParse(input);
+declare const wireMessageValidated: unique symbol;
+/**
+ * A WireMessage a transport accepts for send. Minted in exactly two places: here by
+ * {@link parseWireMessage} (zod at the receive trust boundary) and by the transport package's
+ * `createWireMessage` (typed local construction). The brand keeps raw, unvalidated objects out
+ * of the send path without paying a per-frame parse there.
+ */
+export type ValidatedWireMessage = WireMessage & { readonly [wireMessageValidated]: true };
+
+/** Parse + validate an inbound message; success mints the {@link ValidatedWireMessage} brand. */
+export function parseWireMessage(input: unknown): z.ZodSafeParseResult<ValidatedWireMessage> {
+  return WireMessageSchema.safeParse(input) as z.ZodSafeParseResult<ValidatedWireMessage>;
 }

--- a/packages/transport/src/__tests__/hub.test.ts
+++ b/packages/transport/src/__tests__/hub.test.ts
@@ -1,4 +1,4 @@
-import type { SessionId, WireMessage } from '@linkcode/schema';
+import type { SessionId, ValidatedWireMessage } from '@linkcode/schema';
 import { noop } from 'foxts/noop';
 import { describe, expect, it } from 'vitest';
 import { Hub } from '../hub';
@@ -6,18 +6,18 @@ import type { Transport, Unsubscribe } from '../transport';
 import { createWireMessage, Listeners } from '../transport';
 
 class FakeConn implements Transport {
-  readonly sent: WireMessage[] = [];
-  private readonly inbound = new Listeners<WireMessage>();
+  readonly sent: ValidatedWireMessage[] = [];
+  private readonly inbound = new Listeners<ValidatedWireMessage>();
 
   connect(): Promise<void> {
     return Promise.resolve();
   }
 
-  send(msg: WireMessage): void {
+  send(msg: ValidatedWireMessage): void {
     this.sent.push(msg);
   }
 
-  onMessage(cb: (msg: WireMessage) => void): Unsubscribe {
+  onMessage(cb: (msg: ValidatedWireMessage) => void): Unsubscribe {
     return this.inbound.add(cb);
   }
 
@@ -28,7 +28,7 @@ class FakeConn implements Transport {
   close = noop;
 
   /** Simulate the client sending a message into the hub. */
-  emit(msg: WireMessage): void {
+  emit(msg: ValidatedWireMessage): void {
     this.inbound.emit(msg);
   }
 }
@@ -36,7 +36,7 @@ class FakeConn implements Transport {
 const S1 = 's1' as SessionId;
 const S2 = 's2' as SessionId;
 
-function agentEvent(sessionId: SessionId): WireMessage {
+function agentEvent(sessionId: SessionId): ValidatedWireMessage {
   return createWireMessage({
     kind: 'agent.event',
     sessionId,
@@ -97,7 +97,7 @@ describe('Hub subscriptions', () => {
     const hub = new Hub();
     const conn = new FakeConn();
     hub.addConnection(conn);
-    const forwarded: WireMessage[] = [];
+    const forwarded: ValidatedWireMessage[] = [];
     hub.onMessage((msg) => forwarded.push(msg));
 
     conn.emit(createWireMessage({ kind: 'subscription.set', clientReqId: 'r9', mode: 'all' }));
@@ -127,7 +127,7 @@ describe('Hub subscriptions', () => {
   it('answers ping on its connection without forwarding it to the host', () => {
     const hub = new Hub();
     const conn = new FakeConn();
-    const forwarded: WireMessage[] = [];
+    const forwarded: ValidatedWireMessage[] = [];
     hub.addConnection(conn);
     hub.onMessage((msg) => forwarded.push(msg));
 
@@ -226,7 +226,7 @@ describe('Hub terminal routing', () => {
   it('detaches every attachment when its connection closes', () => {
     const hub = new Hub();
     const conn = new FakeConn();
-    const forwarded: WireMessage[] = [];
+    const forwarded: ValidatedWireMessage[] = [];
     hub.addConnection(conn);
     hub.onMessage((msg) => forwarded.push(msg));
     conn.emit(
@@ -264,7 +264,7 @@ describe('Hub terminal routing', () => {
     const hub = new Hub();
     const conn = new FakeConn();
     const replacement = new FakeConn();
-    const forwarded: WireMessage[] = [];
+    const forwarded: ValidatedWireMessage[] = [];
     hub.addConnection(conn);
     hub.onMessage((msg) => forwarded.push(msg));
     conn.emit(

--- a/packages/transport/src/hub.ts
+++ b/packages/transport/src/hub.ts
@@ -3,7 +3,7 @@ import type {
   TerminalAttachmentCredentials,
   TerminalAttachmentId,
   TerminalId,
-  WireMessage,
+  ValidatedWireMessage,
 } from '@linkcode/schema';
 import { noop } from 'foxts/noop';
 import type { Transport, Unsubscribe } from './transport';
@@ -38,7 +38,7 @@ export class Hub implements Transport {
   /** Kept through origin disconnect so a late host reply cannot collide with a reused request id. */
   private readonly pendingReplies = new Map<string, Transport>();
   private readonly pendingTerminals = new Map<string, PendingTerminalRequest>();
-  private readonly inbound = new Listeners<WireMessage>();
+  private readonly inbound = new Listeners<ValidatedWireMessage>();
   private readonly closed = new Listeners<void>();
 
   /** Register a client connection; its inbound messages are forwarded to the Host. */
@@ -83,7 +83,7 @@ export class Hub implements Transport {
     return Promise.resolve();
   }
 
-  private route(conn: Transport, msg: WireMessage): void {
+  private route(conn: Transport, msg: ValidatedWireMessage): void {
     const p = msg.payload;
     const subscription = this.subscriptions.get(conn);
     if ('clientReqId' in p && this.pendingReplies.has(p.clientReqId)) {
@@ -134,7 +134,7 @@ export class Hub implements Transport {
   }
 
   /** Route one host frame; one failing connection never blocks the others. */
-  send(msg: WireMessage): void {
+  send(msg: ValidatedWireMessage): void {
     const p = msg.payload;
     if ('replyTo' in p) {
       const conn = this.pendingReplies.get(p.replyTo);
@@ -203,7 +203,7 @@ export class Hub implements Transport {
     attachments.set(attachment.attachmentId, attachment.attachmentSecret);
   }
 
-  onMessage(cb: (msg: WireMessage) => void): Unsubscribe {
+  onMessage(cb: (msg: ValidatedWireMessage) => void): Unsubscribe {
     return this.inbound.add(cb);
   }
 

--- a/packages/transport/src/local.ts
+++ b/packages/transport/src/local.ts
@@ -1,4 +1,4 @@
-import type { WireMessage } from '@linkcode/schema';
+import type { ValidatedWireMessage } from '@linkcode/schema';
 import { parseWireMessage } from '@linkcode/schema';
 import { invariant } from 'foxts/guard';
 import type { Transport, Unsubscribe } from './transport';
@@ -7,7 +7,7 @@ import { Listeners } from './transport';
 /** Local direct-connection (in-process / over IPC) Transport. Use `createLocalTransportPair()`
  * to obtain a pair of endpoints that loop back to each other. */
 export class LocalTransport implements Transport {
-  private readonly inbound = new Listeners<WireMessage>();
+  private readonly inbound = new Listeners<ValidatedWireMessage>();
   private readonly closed = new Listeners<void>();
   private peer: LocalTransport | null = null;
   private connected = false;
@@ -22,10 +22,11 @@ export class LocalTransport implements Transport {
     return Promise.resolve();
   }
 
-  send(msg: WireMessage): void {
+  send(msg: ValidatedWireMessage): void {
     if (!this.connected) throw new Error('LocalTransport: send before connect()');
     invariant(this.peer, 'LocalTransport: not linked to a peer');
-    // Trust-boundary validation: validate against the contract even for local direct connections, to catch schema drift in the implementation layer.
+    // The one transport that still parses on send: tests and the dev-mock host run on
+    // LocalTransport, so schema drift behind the ValidatedWireMessage brand fails loudly here.
     const parsed = parseWireMessage(msg);
     if (!parsed.success) {
       throw new Error(`LocalTransport: invalid WireMessage: ${parsed.error.message}`);
@@ -35,7 +36,7 @@ export class LocalTransport implements Transport {
     queueMicrotask(() => this.peer?.inbound.emit(data));
   }
 
-  onMessage(cb: (msg: WireMessage) => void): Unsubscribe {
+  onMessage(cb: (msg: ValidatedWireMessage) => void): Unsubscribe {
     return this.inbound.add(cb);
   }
 

--- a/packages/transport/src/socket-io-server.ts
+++ b/packages/transport/src/socket-io-server.ts
@@ -32,7 +32,7 @@ export interface SocketIoServer extends TransportServer {
 
 class SocketIoServerConnection extends WireConnection {
   constructor(private readonly socket: Socket) {
-    super('SocketIoServer');
+    super();
     // The Socket.IO connection is already live when handed to us, so emitClosed is armed up front.
     this.armClosedListener();
 

--- a/packages/transport/src/socket-io.ts
+++ b/packages/transport/src/socket-io.ts
@@ -27,7 +27,7 @@ export class SocketIoTransport extends WireConnection {
   private rejectConnecting: ((error: Error) => void) | null = null;
 
   constructor(private readonly opts: SocketIoTransportOptions) {
-    super('SocketIoTransport');
+    super();
   }
 
   override connect(): Promise<void> {

--- a/packages/transport/src/transport.ts
+++ b/packages/transport/src/transport.ts
@@ -1,4 +1,4 @@
-import type { WireMessage, WirePayload } from '@linkcode/schema';
+import type { ValidatedWireMessage, WireMessage, WirePayload } from '@linkcode/schema';
 import { WIRE_PROTOCOL_VERSION } from '@linkcode/schema';
 import { noop } from 'foxts/noop';
 import { once } from 'foxts/once';
@@ -13,10 +13,10 @@ export type Unsubscribe = () => void;
  */
 export interface Transport {
   connect(): Promise<void>;
-  /** Send a wire message. Outbound frames are trusted from typed construction; the receiving peer validates at its own trust boundary. */
-  send(msg: WireMessage): void | Promise<void>;
+  /** Send a wire message. The {@link ValidatedWireMessage} brand is the proof of validity; no parse runs on the send path. */
+  send(msg: ValidatedWireMessage): void | Promise<void>;
   /** Subscribe to inbound messages (implementations must run zod validation before delivery). */
-  onMessage(cb: (msg: WireMessage) => void): Unsubscribe;
+  onMessage(cb: (msg: ValidatedWireMessage) => void): Unsubscribe;
   /** Subscribe to connection close. */
   onClose(cb: () => void): Unsubscribe;
   close(): void | Promise<void>;
@@ -31,15 +31,15 @@ export interface TransportServer {
 
 let __seq = 0;
 
-/** Build a wire message with a version / id / timestamp envelope. */
-export function createWireMessage(payload: WirePayload): WireMessage {
+/** Build a wire message with a version / id / timestamp envelope. Typed construction is the second mint of the {@link ValidatedWireMessage} brand (the first is `parseWireMessage`). */
+export function createWireMessage(payload: WirePayload): ValidatedWireMessage {
   __seq += 1;
   return {
     v: WIRE_PROTOCOL_VERSION,
     id: `${Date.now().toString(36)}-${__seq.toString(36)}` as WireMessage['id'],
     ts: Date.now(),
     payload,
-  };
+  } as ValidatedWireMessage;
 }
 
 /** A simple set of listeners, reused across transport implementations. */
@@ -71,7 +71,7 @@ export class Listeners<T> {
  * constructor and keep the inherited default `connect()`.
  */
 export abstract class WireConnection implements Transport {
-  protected readonly inbound = new Listeners<WireMessage>();
+  protected readonly inbound = new Listeners<ValidatedWireMessage>();
   protected readonly closed = new Listeners<void>();
   /** No-op until `armClosedListener()` runs; closing before that point is a safe no-op. */
   protected emitClosed: () => void = noop;
@@ -84,16 +84,16 @@ export abstract class WireConnection implements Transport {
   abstract close(): void | Promise<void>;
 
   /** Push the message onto the underlying socket (or drop it if it isn't ready). */
-  protected abstract sendBytes(msg: WireMessage): void;
+  protected abstract sendBytes(msg: ValidatedWireMessage): void;
 
-  // No zod parse on send: outbound frames come from typed local construction and every receiving
-  // end validates at its own trust boundary, so the per-frame parse only added hot-path cost
+  // No zod parse on send: the ValidatedWireMessage brand is the proof (minted only by
+  // createWireMessage / parseWireMessage), so a per-frame parse here would only re-check it
   // (CODE-231). LocalTransport keeps its send-side parse to catch schema drift in tests.
-  send(msg: WireMessage): void {
+  send(msg: ValidatedWireMessage): void {
     this.sendBytes(msg);
   }
 
-  onMessage(cb: (msg: WireMessage) => void): Unsubscribe {
+  onMessage(cb: (msg: ValidatedWireMessage) => void): Unsubscribe {
     return this.inbound.add(cb);
   }
 

--- a/packages/transport/src/transport.ts
+++ b/packages/transport/src/transport.ts
@@ -1,5 +1,5 @@
 import type { WireMessage, WirePayload } from '@linkcode/schema';
-import { parseWireMessage, WIRE_PROTOCOL_VERSION } from '@linkcode/schema';
+import { WIRE_PROTOCOL_VERSION } from '@linkcode/schema';
 import { noop } from 'foxts/noop';
 import { once } from 'foxts/once';
 
@@ -13,9 +13,9 @@ export type Unsubscribe = () => void;
  */
 export interface Transport {
   connect(): Promise<void>;
-  /** Send a wire message (implementations should run zod validation before sending). */
+  /** Send a wire message. Outbound frames are trusted from typed construction; the receiving peer validates at its own trust boundary. */
   send(msg: WireMessage): void | Promise<void>;
-  /** Subscribe to inbound messages (implementations should run zod validation before delivery). */
+  /** Subscribe to inbound messages (implementations must run zod validation before delivery). */
   onMessage(cb: (msg: WireMessage) => void): Unsubscribe;
   /** Subscribe to connection close. */
   onClose(cb: () => void): Unsubscribe;
@@ -64,8 +64,8 @@ export class Listeners<T> {
 
 /**
  * Base for the four wire-carried `Transport` implementations (ws / ws-server / socket-io /
- * socket-io-server): factors out the listener bookkeeping, the deferred `emitClosed` arming, and
- * the parse-or-throw `send()` gate they all repeat. Binding timing is the load-bearing difference:
+ * socket-io-server): factors out the listener bookkeeping and the deferred `emitClosed` arming
+ * they all repeat. Binding timing is the load-bearing difference:
  * client transports create their socket in an overridden `connect()` and arm `emitClosed` there;
  * server-side connections already hold a live socket at construction, so they arm it in their
  * constructor and keep the inherited default `connect()`.
@@ -76,11 +76,6 @@ export abstract class WireConnection implements Transport {
   /** No-op until `armClosedListener()` runs; closing before that point is a safe no-op. */
   protected emitClosed: () => void = noop;
 
-  protected constructor(
-    /** Used to prefix thrown/error messages, e.g. `WsTransport: invalid WireMessage: ...`. */
-    private readonly label: string,
-  ) {}
-
   /** Default: the socket is already open when handed to us. Client transports override this. */
   connect(): Promise<void> {
     return Promise.resolve();
@@ -88,15 +83,14 @@ export abstract class WireConnection implements Transport {
 
   abstract close(): void | Promise<void>;
 
-  /** Push already-validated bytes onto the underlying socket (or drop them if it isn't ready). */
+  /** Push the message onto the underlying socket (or drop it if it isn't ready). */
   protected abstract sendBytes(msg: WireMessage): void;
 
+  // No zod parse on send: outbound frames come from typed local construction and every receiving
+  // end validates at its own trust boundary, so the per-frame parse only added hot-path cost
+  // (CODE-231). LocalTransport keeps its send-side parse to catch schema drift in tests.
   send(msg: WireMessage): void {
-    const parsed = parseWireMessage(msg);
-    if (!parsed.success) {
-      throw new Error(`${this.label}: invalid WireMessage: ${parsed.error.message}`);
-    }
-    this.sendBytes(parsed.data);
+    this.sendBytes(msg);
   }
 
   onMessage(cb: (msg: WireMessage) => void): Unsubscribe {

--- a/packages/transport/src/tunnel.ts
+++ b/packages/transport/src/tunnel.ts
@@ -49,11 +49,7 @@ export class TunnelTransport implements Transport {
   }
 
   send(msg: WireMessage): void {
-    const parsed = parseWireMessage(msg);
-    if (!parsed.success) {
-      throw new Error(`TunnelTransport: invalid WireMessage: ${parsed.error.message}`);
-    }
-    this.client.send(JSON.stringify(parsed.data));
+    this.client.send(JSON.stringify(msg));
   }
 
   onMessage(cb: (msg: WireMessage) => void): Unsubscribe {
@@ -93,11 +89,7 @@ class TunnelPeerTransport implements Transport {
   }
 
   send(msg: WireMessage): void {
-    const parsed = parseWireMessage(msg);
-    if (!parsed.success) {
-      throw new Error(`TunnelPeerTransport: invalid WireMessage: ${parsed.error.message}`);
-    }
-    this.peer.send(JSON.stringify(parsed.data));
+    this.peer.send(JSON.stringify(msg));
   }
 
   onMessage(cb: (msg: WireMessage) => void): Unsubscribe {

--- a/packages/transport/src/tunnel.ts
+++ b/packages/transport/src/tunnel.ts
@@ -1,4 +1,4 @@
-import type { WireMessage } from '@linkcode/schema';
+import type { ValidatedWireMessage } from '@linkcode/schema';
 import { parseWireMessage } from '@linkcode/schema';
 import type { Transport, TransportServer, Unsubscribe } from './transport';
 import { Listeners } from './transport';
@@ -17,7 +17,7 @@ export type TunnelTransportServerOptions = Omit<TunnelClientOptions, 'role'>;
  */
 export class TunnelTransport implements Transport {
   private readonly client: TunnelClient;
-  private readonly inbound = new Listeners<WireMessage>();
+  private readonly inbound = new Listeners<ValidatedWireMessage>();
 
   constructor(opts: TunnelTransportOptions) {
     this.client = new TunnelClient(opts);
@@ -48,11 +48,11 @@ export class TunnelTransport implements Transport {
     return this.client.connect();
   }
 
-  send(msg: WireMessage): void {
+  send(msg: ValidatedWireMessage): void {
     this.client.send(JSON.stringify(msg));
   }
 
-  onMessage(cb: (msg: WireMessage) => void): Unsubscribe {
+  onMessage(cb: (msg: ValidatedWireMessage) => void): Unsubscribe {
     return this.inbound.add(cb);
   }
 
@@ -66,7 +66,7 @@ export class TunnelTransport implements Transport {
 }
 
 class TunnelPeerTransport implements Transport {
-  private readonly inbound = new Listeners<WireMessage>();
+  private readonly inbound = new Listeners<ValidatedWireMessage>();
   private readonly closed = new Listeners<void>();
   private ended = false;
 
@@ -88,11 +88,11 @@ class TunnelPeerTransport implements Transport {
     return Promise.resolve();
   }
 
-  send(msg: WireMessage): void {
+  send(msg: ValidatedWireMessage): void {
     this.peer.send(JSON.stringify(msg));
   }
 
-  onMessage(cb: (msg: WireMessage) => void): Unsubscribe {
+  onMessage(cb: (msg: ValidatedWireMessage) => void): Unsubscribe {
     return this.inbound.add(cb);
   }
 

--- a/packages/transport/src/ws-server.ts
+++ b/packages/transport/src/ws-server.ts
@@ -37,7 +37,7 @@ const textDecoder = new TextDecoder();
 
 class WsServerConnection extends WireConnection {
   constructor(private readonly ws: WebSocket) {
-    super('WsServer');
+    super();
     // The socket is already live when handed to us, so emitClosed is armed up front.
     this.armClosedListener();
 

--- a/packages/transport/src/ws.ts
+++ b/packages/transport/src/ws.ts
@@ -56,7 +56,7 @@ export class WsTransport extends WireConnection {
   private readonly reconnectOpts: Required<WsReconnectOptions> | null;
 
   constructor(private readonly opts: WsTransportOptions) {
-    super('WsTransport');
+    super();
     const overrides = opts.reconnect === true ? {} : opts.reconnect;
     this.reconnectOpts = overrides ? { ...RECONNECT_DEFAULTS, ...overrides } : null;
     this.armClosedListener();


### PR DESCRIPTION
Related: CODE-231

Note that this is not the real fix for CODE-231. The real problem behind CODE-231 is that we don't have any flow control/back pressure here; when a DoS like `yes` happens, we just jam the entire transport, causing terminals to be unresponsive.

The PR, however, focused on another potential bottleneck: double zod parsing/validation. By making a new brand `ValidatedWireMessage` we ensure the payload does not get parsed by zod again.