### PR TITLE
feat(ui): animate the in-progress compaction row (spinner + shimmer + elapsed) (CODE-280)

### DIFF
--- a/packages/ui/src/chat/__tests__/compaction-marker.test.tsx
+++ b/packages/ui/src/chat/__tests__/compaction-marker.test.tsx
@@ -4,6 +4,7 @@ import { cleanup, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { CompactionMarker } from '../compaction-marker';
+import { formatElapsed } from '../use-elapsed';
 
 vi.mock('use-intl', () => ({
   useTranslations: () => (key: string) => key,
@@ -15,8 +16,14 @@ describe('CompactionMarker', () => {
   it('renders the live compacting row while in progress, with no divider state', () => {
     render(<CompactionMarker inProgress preTokens={1000} postTokens={20} />);
     expect(screen.getByText('compacting')).toBeTruthy();
+    expect(screen.getByLabelText('Loading')).toBeTruthy(); // animated spinner, not the static icon
     expect(screen.queryByText('compacted')).toBeNull();
     expect(screen.queryByText('compactedTokens')).toBeNull();
+  });
+
+  it('shows a live elapsed counter when a start time is known', () => {
+    render(<CompactionMarker inProgress startedAt={Date.now() - 3000} />);
+    expect(screen.getByText(/·\s*\d+s/)).toBeTruthy();
   });
 
   it('renders the divider with token detail once completed', () => {
@@ -32,5 +39,22 @@ describe('CompactionMarker', () => {
     expect(screen.queryByText('what happened so far')).toBeNull();
     await user.click(screen.getByText('compacted'));
     expect(screen.getByText('what happened so far')).toBeTruthy();
+  });
+});
+
+describe('formatElapsed', () => {
+  it('formats seconds, minutes, and hours like codex fmt_elapsed_compact', () => {
+    expect(formatElapsed(0)).toBe('0s');
+    expect(formatElapsed(999)).toBe('0s');
+    expect(formatElapsed(59_000)).toBe('59s');
+    expect(formatElapsed(60_000)).toBe('1m 00s');
+    expect(formatElapsed(61_000)).toBe('1m 01s');
+    expect(formatElapsed((59 * 60 + 59) * 1000)).toBe('59m 59s');
+    expect(formatElapsed(3_600_000)).toBe('1h 00m 00s');
+    expect(formatElapsed((3600 + 60 + 1) * 1000)).toBe('1h 01m 01s');
+  });
+
+  it('clamps negatives to 0s', () => {
+    expect(formatElapsed(-5000)).toBe('0s');
   });
 });

--- a/packages/ui/src/chat/compaction-marker.tsx
+++ b/packages/ui/src/chat/compaction-marker.tsx
@@ -4,20 +4,40 @@ import {
   CollapsibleTrigger,
 } from 'coss-ui/components/collapsible';
 import { Separator } from 'coss-ui/components/separator';
+import { Spinner } from 'coss-ui/components/spinner';
 import { ChevronRightIcon, FoldVerticalIcon } from 'lucide-react';
 import { useState } from 'react';
 import { useTranslations } from 'use-intl';
 import { cn } from '../lib/cn';
 import { Markdown } from './markdown';
 import { Shimmer } from './shimmer';
+import { formatElapsed, useNowEverySecond } from './use-elapsed';
 
 export interface CompactionMarkerProps {
   /** Live compaction still running: renders a shimmering "compacting…" row instead of the divider. */
   inProgress?: boolean;
+  /** When the compaction started (the item's `receivedAt`); drives the live elapsed counter. */
+  startedAt?: number;
   preTokens?: number;
   postTokens?: number;
   /** The summary the agent swapped in for the compacted turns; expandable when present. */
   summary?: string;
+}
+
+/** The live "compacting…" row: an animated spinner + shimmering label + elapsed counter, mirroring
+ * codex's in-progress status. Kept a separate component so the per-second clock is subscribed only
+ * while a compaction is actually running (this row is mounted only then). */
+function CompactingRow({ startedAt }: { startedAt?: number }): React.ReactNode {
+  const t = useTranslations('workbench.conversation');
+  const now = useNowEverySecond();
+  const elapsed = startedAt === undefined ? null : formatElapsed(now - startedAt);
+  return (
+    <div className="my-2 flex items-center gap-2 text-[13px] text-muted-foreground">
+      <Spinner className="size-3.5 shrink-0" />
+      <Shimmer className="font-medium">{t('compacting')}</Shimmer>
+      {elapsed ? <span className="text-muted-foreground/70">· {elapsed}</span> : null}
+    </div>
+  );
 }
 
 /** Compact token counts ("193437" → "193.4k", "1193437" → "1.2M") so the marker reads at a glance. */
@@ -30,6 +50,7 @@ function formatTokens(count: number): string {
  * from the swapped-in summary; the row expands to show the summary when present. */
 export function CompactionMarker({
   inProgress,
+  startedAt,
   preTokens,
   postTokens,
   summary,
@@ -42,12 +63,7 @@ export function CompactionMarker({
       : null;
 
   if (inProgress) {
-    return (
-      <div className="my-2 flex items-center gap-2 text-[13px] text-muted-foreground">
-        <FoldVerticalIcon className="size-3.5 shrink-0" />
-        <Shimmer className="font-medium">{t('compacting')}</Shimmer>
-      </div>
-    );
+    return <CompactingRow startedAt={startedAt} />;
   }
 
   const row = (

--- a/packages/ui/src/chat/turn-segment-view.tsx
+++ b/packages/ui/src/chat/turn-segment-view.tsx
@@ -132,6 +132,7 @@ export function TurnSegmentView({
           <CompactionMarker
             key={item.id}
             inProgress={item.status === 'in_progress'}
+            startedAt={item.receivedAt}
             preTokens={item.preTokens}
             postTokens={item.postTokens}
             summary={item.summary}

--- a/packages/ui/src/chat/use-elapsed.ts
+++ b/packages/ui/src/chat/use-elapsed.ts
@@ -1,0 +1,52 @@
+import { useSyncExternalStore } from 'react';
+
+const TICK_MS = 1000;
+
+/** Shared 1s clock: one `setInterval` while any live counter is subscribed (mirrors
+ * `shell/use-relative-time-label.ts`). Never read `Date.now()` in `getSnapshot` — the
+ * compiler-memoized render must see only this stored value. */
+let now = Date.now();
+let timer: ReturnType<typeof setInterval> | null = null;
+const listeners = new Set<() => void>();
+
+function tick(): void {
+  now = Date.now();
+  for (const listener of listeners) listener();
+}
+
+function subscribe(listener: () => void): () => void {
+  if (listeners.size === 0) {
+    now = Date.now();
+    timer = setInterval(tick, TICK_MS);
+  }
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+    if (listeners.size === 0 && timer !== null) {
+      clearInterval(timer);
+      timer = null;
+    }
+  };
+}
+
+function getSnapshot(): number {
+  return now;
+}
+
+/** Live wall-clock (ms) that re-renders once a second while subscribed. Only mount this in a
+ * component that is present exclusively while the counter is live, so the interval runs then. */
+export function useNowEverySecond(): number {
+  return useSyncExternalStore(subscribe, getSnapshot);
+}
+
+/** Compact elapsed label mirroring codex's `fmt_elapsed_compact`: `0s`, `59s`, `1m 00s`, `1h 00m 00s`. */
+export function formatElapsed(ms: number): string {
+  const secs = Math.max(0, Math.floor(ms / 1000));
+  if (secs < 60) return `${secs}s`;
+  const m = Math.floor(secs / 60);
+  const s = secs % 60;
+  if (secs < 3600) return `${m}m ${String(s).padStart(2, '0')}s`;
+  const h = Math.floor(secs / 3600);
+  const mm = Math.floor((secs % 3600) / 60);
+  return `${h}h ${String(mm).padStart(2, '0')}m ${String(s).padStart(2, '0')}s`;
+}


### PR DESCRIPTION
Closes CODE-280. Follow-up polish to CODE-142 (merged, #186).

## Why

The live "compacting…" row from CODE-142 paired a **static** `FoldVerticalIcon` with shimmering text. The user referenced Codex's own compacting indicator, which animates. I read the Codex TUI source (rust-v0.144.1, authoritative) to ground the change.

## What Codex actually does (source-verified)

Codex's compacting row is its shared `StatusIndicatorWidget` — the same widget as a running "Working" turn — composed of:
- a **shimmer sweep** over the header text (`shimmer.rs::shimmer_spans`: raised-cosine band, 2.0s period, redrawn every 32ms),
- an **animated leading bullet** (`motion.rs::activity_indicator`),
- an **elapsed timer** + interrupt hint,
- an explicit reduced-motion fallback.

We already had the shimmer (our `Shimmer`); the gap was the static icon and the missing timer.

## Change (pure `packages/ui`, no wire/schema touch)

- Swap the static `FoldVerticalIcon` for coss-ui `<Spinner>` in the in-progress state — matching Codex's spinner+shimmer **and** every other in-progress row in our own UI (tool / activity-group / subagent already use `<Spinner>`).
- Append a live elapsed counter (`· 3s`, Codex `fmt_elapsed_compact` style: `0s`/`59s`/`1m 00s`/`1h 00m 00s`), anchored on the item's `receivedAt`; hidden when unknown (history replay).
- Drive the seconds counter through a **shared 1s clock** (`use-elapsed.ts`, `useSyncExternalStore`) mirroring `shell/use-relative-time-label.ts` — one module interval, and it's scoped to a `CompactingRow` subcomponent that only mounts while a compaction is live, so the interval runs **only** during a compaction (no timer-per-row).

## Verification

- Unit: `formatElapsed` (s/m/h formatting + negative clamp), plus render tests (spinner present, elapsed counter shows when `startedAt` known). Full suite green (1293 passed).
- Visual, webview mock (`dev:mock`, headless Chrome): the row renders `◌ Compacting context… · 0s` and the counter advances to `· 1s` one second later; the spinner carries `animate-spin` and the still frame even caught the shimmer mid-sweep. `pnpm check:ci` green.