### PR TITLE
fix(schema): renumber wire protocol to 39 after parallel 38 bumps

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@
 
 Each of these breaks the product, a release, or the build with **no loud error**.
 
-1. **Wire-protocol versions are lockstep.** `WIRE_PROTOCOL_VERSION` (currently 38) is a `z.literal` in `packages/schema/src/wire`; any change to any wire variant must bump it. Mismatched peers still complete the socket ("connected") but every frame fails validation and is **silently discarded** — zero messages, a hang-like failure. Rebuild and restart the daemon and every client together.
+1. **Wire-protocol versions are lockstep.** `WIRE_PROTOCOL_VERSION` (currently 39) is a `z.literal` in `packages/schema/src/wire`; any change to any wire variant must bump it. Mismatched peers still complete the socket ("connected") but every frame fails validation and is **silently discarded** — zero messages, a hang-like failure. Rebuild and restart the daemon and every client together.
 2. **`foxts/once` prewarms by default.** `once(fn)` runs `fn` immediately at construction and caches the result; call-at-most-once semantics need `once(fn, false)`. The default has already shipped a daemon that ran its shutdown at boot and transports whose close-callback fired at construction. Read any foxts helper's `.d.ts`/source before adopting it — the lodash-alike name lies.
 3. **Native deps must be allow-listed.** pnpm blocks install scripts by default; a native dep (e.g. `better-sqlite3`) missing from `allowBuilds:` in `pnpm-workspace.yaml` installs fine but fails at `require()` time with missing bindings.
 4. **CI does not run `pnpm test`.** The vitest suite (~57 test files, node-env pure logic) is absent from `check:ci` and from every workflow — CI gates only format/lint/typecheck plus the Rust job. A green PR does not mean the tests pass; run `pnpm test` yourself before every commit.

--- a/packages/schema/src/wire/index.ts
+++ b/packages/schema/src/wire/index.ts
@@ -33,7 +33,10 @@ export {
  * so request/response control messages correlate via `clientReqId` → `replyTo`.
  */
 
-export const WIRE_PROTOCOL_VERSION = 38 as const;
+// 39 disambiguates a parallel double-bump: #186 (CODE-142) and #189 (CODE-219) both shipped as
+// "38" with different schemas, so a build from between their merges shares a number with a
+// schema it does not speak.
+export const WIRE_PROTOCOL_VERSION = 39 as const;
 
 /** Envelope payload: a discriminated union keyed by `kind`. */
 export const WirePayloadSchema = z.discriminatedUnion('kind', [


### PR DESCRIPTION
#186 (CODE-142) and #189 (CODE-219) merged 36 minutes apart, both bumping the wire literal 37→38 with different schemas — the exact silent-merge trap the invariant warns about. A daemon or client built from the window between the two merges claims 38 but lacks `agent:pi`, so against current master it fails validation only on the frames touching the changed variants (partial, mystery-shaped breakage instead of the clean full mismatch). Renumbering to 39 gives every post-#189 build a unique number; stale-38 peers now fail the literal check on every frame — the loud, documented "rebuild everything" behavior.