### PR TITLE
fix(pty,engine,client-core): end-to-end terminal output flow control (CODE-231)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@
 
 Each of these breaks the product, a release, or the build with **no loud error**.
 
-1. **Wire-protocol versions are lockstep.** `WIRE_PROTOCOL_VERSION` (currently 39) is a `z.literal` in `packages/schema/src/wire`; any change to any wire variant must bump it. Mismatched peers still complete the socket ("connected") but every frame fails validation and is **silently discarded** — zero messages, a hang-like failure. Rebuild and restart the daemon and every client together.
+1. **Wire-protocol versions are lockstep.** `WIRE_PROTOCOL_VERSION` (currently 40) is a `z.literal` in `packages/schema/src/wire`; any change to any wire variant must bump it. Mismatched peers still complete the socket ("connected") but every frame fails validation and is **silently discarded** — zero messages, a hang-like failure. Rebuild and restart the daemon and every client together.
 2. **`foxts/once` prewarms by default.** `once(fn)` runs `fn` immediately at construction and caches the result; call-at-most-once semantics need `once(fn, false)`. The default has already shipped a daemon that ran its shutdown at boot and transports whose close-callback fired at construction. Read any foxts helper's `.d.ts`/source before adopting it — the lodash-alike name lies.
 3. **Native deps must be allow-listed.** pnpm blocks install scripts by default; a native dep (e.g. `better-sqlite3`) missing from `allowBuilds:` in `pnpm-workspace.yaml` installs fine but fails at `require()` time with missing bindings.
 4. **CI does not run `pnpm test`.** The vitest suite (~57 test files, node-env pure logic) is absent from `check:ci` and from every workflow — CI gates only format/lint/typecheck plus the Rust job. A green PR does not mean the tests pass; run `pnpm test` yourself before every commit.

--- a/apps/daemon/src/__tests__/terminal-flood.integration.test.ts
+++ b/apps/daemon/src/__tests__/terminal-flood.integration.test.ts
@@ -1,0 +1,215 @@
+import { existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { Engine } from '@linkcode/engine';
+import type { WirePayload } from '@linkcode/schema';
+import type { Transport } from '@linkcode/transport';
+import { createWireMessage, SocketIoTransport } from '@linkcode/transport';
+import type { SocketIoServer } from '@linkcode/transport/server';
+import { createSocketIoServer, Hub } from '@linkcode/transport/server';
+import { noop } from 'foxts/noop';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { binaryName, SidecarPtyBackend } from '../pty/sidecar';
+
+/**
+ * CODE-231 regression: a terminal flooding at full PTY speed must not starve the control plane.
+ * Two raw wire clients against a real Engine + Hub + socket.io server + Rust sidecar: client A
+ * hosts a `yes`-style flood (acking like client-core does), while client B's requests, terminal
+ * open, and input echo must stay responsive. Before credit flow control, the flood ballooned the
+ * socket buffers and B's frames sat behind megabytes of output.
+ */
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..', '..');
+const BINARY =
+  [
+    process.env.LINKCODE_PTY_SIDECAR_PATH,
+    join(repoRoot, 'target', 'debug', binaryName()),
+    join(repoRoot, 'target', 'release', binaryName()),
+  ].find((path) => !!path && existsSync(path)) ?? '';
+
+const ACK_CHUNK = 64 * 1024;
+
+/** Raw wire client: no client-core (the daemon must not depend on it); acks are hand-rolled. */
+class RawWireClient {
+  readonly transport: SocketIoTransport;
+  private readonly waiters = new Set<(p: WirePayload) => void>();
+
+  constructor(url: string) {
+    this.transport = new SocketIoTransport({ url });
+  }
+
+  async connect(): Promise<void> {
+    await this.transport.connect();
+    this.transport.onMessage((message) => {
+      for (const waiter of this.waiters) waiter(message.payload);
+    });
+  }
+
+  send(payload: WirePayload): void {
+    this.transport.send(createWireMessage(payload));
+  }
+
+  /** Subscribe to every inbound payload; returns an unsubscribe. */
+  onPayload(cb: (p: WirePayload) => void): () => void {
+    this.waiters.add(cb);
+    return () => this.waiters.delete(cb);
+  }
+
+  waitFor<T>(pick: (p: WirePayload) => T | undefined, what: string, timeoutMs = 10000): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+      let unsubscribe: () => void = noop;
+      const timer = setTimeout(() => {
+        unsubscribe();
+        reject(new Error(`timed out waiting for ${what}`));
+      }, timeoutMs);
+      unsubscribe = this.onPayload((p) => {
+        const picked = pick(p);
+        if (picked === undefined) return;
+        clearTimeout(timer);
+        unsubscribe();
+        resolve(picked);
+      });
+    });
+  }
+
+  /** Open a terminal and return its id, mimicking client-core's open + credentials. */
+  async openTerminal(name: string): Promise<{ terminalId: string; ack: (n: number) => void }> {
+    const credentials = { attachmentId: `${name}-att`, attachmentSecret: 's'.repeat(32) };
+    const clientReqId = `${name}-open`;
+    const opened = this.waitFor(
+      (p) => (p.kind === 'terminal.opened' && p.replyTo === clientReqId ? p : undefined),
+      `terminal.opened for ${name}`,
+    );
+    this.send({
+      kind: 'terminal.open',
+      clientReqId,
+      opts: { cols: 80, rows: 24, shell: '/bin/sh' },
+      ...credentials,
+    });
+    const terminalId = (await opened).terminal.terminalId;
+    return {
+      terminalId,
+      ack: (acked: number) => {
+        this.send({ kind: 'terminal.ack', terminalId, acked, ...credentials });
+      },
+    };
+  }
+
+  input(terminalId: string, name: string, data: string): void {
+    this.send({
+      kind: 'terminal.input',
+      terminalId,
+      data,
+      attachmentId: `${name}-att`,
+      attachmentSecret: 's'.repeat(32),
+    });
+  }
+
+  close(): void {
+    this.transport.close();
+  }
+}
+
+describe.skipIf(!BINARY || process.platform === 'win32')(
+  'terminal flood does not starve the control plane',
+  () => {
+    let server: SocketIoServer;
+    let hub: Hub;
+    let engine: Engine;
+    let backend: SidecarPtyBackend;
+    let clientA: RawWireClient;
+    let clientB: RawWireClient;
+
+    beforeAll(async () => {
+      hub = new Hub();
+      backend = new SidecarPtyBackend(BINARY);
+      engine = new Engine(hub, { ptyBackend: backend });
+      await engine.start();
+      server = await createSocketIoServer({ port: 0, host: '127.0.0.1' });
+      server.onConnection((conn: Transport) => hub.addConnection(conn));
+      clientA = new RawWireClient(`http://127.0.0.1:${server.port}`);
+      clientB = new RawWireClient(`http://127.0.0.1:${server.port}`);
+      await clientA.connect();
+      await clientB.connect();
+    });
+
+    afterAll(async () => {
+      await engine.stop();
+      clientA.close();
+      clientB.close();
+      await server.close();
+    });
+
+    it('keeps client B responsive while client A hosts a full-speed flood', async () => {
+      // Client A: spawn the flood and ack like client-core (cumulative, every 64K chars).
+      const a = await clientA.openTerminal('flood');
+      let bytesA = 0;
+      let ackedA = 0;
+      clientA.onPayload((p) => {
+        if (p.kind !== 'terminal.output' || p.terminalId !== a.terminalId) return;
+        bytesA += p.data.length;
+        if (bytesA - ackedA >= ACK_CHUNK) {
+          ackedA = bytesA;
+          a.ack(ackedA);
+        }
+      });
+      clientA.input(a.terminalId, 'flood', 'while :; do echo linkcode-flood-line; done\n');
+
+      // The flood must sustain past one full credit window: proof that acks return PTY credit.
+      const floodDeadline = Date.now() + 15000;
+      while (bytesA < 2 * 1024 * 1024) {
+        if (Date.now() > floodDeadline) throw new Error(`flood stalled at ${bytesA} bytes`);
+        await new Promise((resolve) => {
+          const timer = setTimeout(resolve, 50);
+          timer.unref();
+        });
+      }
+
+      // Control-plane probe: correlated terminal.list round-trips mid-flood.
+      const rtts: number[] = [];
+      for (let i = 0; i < 5; i++) {
+        const clientReqId = `b-list-${i}`;
+        const started = Date.now();
+        const listed = clientB.waitFor(
+          (p) => (p.kind === 'terminal.listed' && p.replyTo === clientReqId ? p : undefined),
+          `terminal.listed ${i}`,
+          5000,
+        );
+        clientB.send({ kind: 'terminal.list', clientReqId });
+        await listed;
+        rtts.push(Date.now() - started);
+      }
+      const sorted = [...rtts].sort((x, y) => x - y);
+      expect(sorted[Math.floor(sorted.length / 2)]).toBeLessThan(500);
+      expect(sorted.at(-1)).toBeLessThan(2000);
+
+      // Opening a second terminal mid-flood must not time out ("Terminal failed to start").
+      const openStarted = Date.now();
+      const b = await clientB.openTerminal('second');
+      expect(Date.now() - openStarted).toBeLessThan(3000);
+
+      // And its echo round-trip stays interactive.
+      const echoed = clientB.waitFor(
+        (p) =>
+          p.kind === 'terminal.output' &&
+          p.terminalId === b.terminalId &&
+          p.data.includes('linkcode-echo-marker')
+            ? true
+            : undefined,
+        'echo round-trip on terminal B',
+        5000,
+      );
+      clientB.input(b.terminalId, 'second', 'echo linkcode-echo-marker\n');
+      const echoStarted = Date.now();
+      await echoed;
+      expect(Date.now() - echoStarted).toBeLessThan(2000);
+
+      // The flood is still alive behind the probes (flow control, not a stall).
+      const before = bytesA;
+      await new Promise((resolve) => {
+        const timer = setTimeout(resolve, 500);
+        timer.unref();
+      });
+      expect(bytesA).toBeGreaterThan(before);
+    }, 30000);
+  },
+);

--- a/apps/daemon/src/pty/__tests__/sidecar.integration.test.ts
+++ b/apps/daemon/src/pty/__tests__/sidecar.integration.test.ts
@@ -74,4 +74,43 @@ describe.skipIf(!BINARY)('SidecarPtyBackend against the real linkcode-pty binary
     proc.write('exit 7\n');
     await expect(code).resolves.toBe(7);
   });
+
+  it('parks a credited terminal at its budget and resumes on grantRead', async () => {
+    backend = new SidecarPtyBackend(BINARY);
+    const proc = await backend.open('term-1', {
+      cols: 80,
+      rows: 24,
+      shell: '/bin/sh',
+      args: ['-c', 'while :; do echo linkcode-flood-line; done'],
+      credit: 8192,
+    });
+
+    let received = 0;
+    proc.onData((data) => {
+      received += Buffer.byteLength(data);
+    });
+    // The flood must stall at (or before) the budget: wait for half a second of silence.
+    const settled = await new Promise<number>((resolve) => {
+      let last = -1;
+      const timer = setInterval(() => {
+        if (received === last) {
+          clearInterval(timer);
+          resolve(received);
+        }
+        last = received;
+      }, 500);
+    });
+    expect(settled).toBeGreaterThan(0);
+    expect(settled).toBeLessThanOrEqual(8192);
+
+    // Granting more budget resumes the flow.
+    proc.grantRead(8192);
+    await new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error('no output after grantRead')), TIMEOUT_MS);
+      proc.onData(() => {
+        clearTimeout(timer);
+        resolve();
+      });
+    });
+  }, 15000);
 });

--- a/apps/daemon/src/pty/codec.ts
+++ b/apps/daemon/src/pty/codec.ts
@@ -10,6 +10,7 @@ export const OPEN = 0x01;
 export const INPUT = 0x02;
 export const RESIZE = 0x03;
 export const CLOSE = 0x04;
+export const CREDIT = 0x05;
 // Sidecar → daemon.
 export const OPENED = 0x81;
 export const OUTPUT = 0x82;

--- a/apps/daemon/src/pty/sidecar.ts
+++ b/apps/daemon/src/pty/sidecar.ts
@@ -10,6 +10,7 @@ import { noop } from 'foxts/noop';
 import type { Frame } from './codec';
 import {
   CLOSE,
+  CREDIT,
   decodeDataFrame,
   ERROR,
   EXIT,
@@ -91,6 +92,7 @@ export class SidecarPtyBackend implements PtyBackend {
         // an unspecified shell belongs in the user's home, like a fresh terminal app tab.
         cwd: opts.cwd ?? homedir(),
         env: opts.env ?? {},
+        credit: opts.credit,
       }),
     );
     return new Promise<PtyProcess>((resolve, reject) => {
@@ -220,6 +222,7 @@ export class SidecarPtyBackend implements PtyBackend {
       write: (data) => this.send(INPUT, encodeDataFrame(terminalId, Buffer.from(data, 'utf8'))),
       resize: (cols, rows) =>
         this.send(RESIZE, Buffer.from(JSON.stringify({ terminalId, cols, rows }))),
+      grantRead: (bytes) => this.send(CREDIT, Buffer.from(JSON.stringify({ terminalId, bytes }))),
       kill: () => this.send(CLOSE, Buffer.from(JSON.stringify({ terminalId }))),
     };
   }

--- a/crates/linkcode-pty/PROTOCOL.md
+++ b/crates/linkcode-pty/PROTOCOL.md
@@ -35,6 +35,7 @@ Daemon to sidecar:
 | `0x02` | `INPUT` | binary [`DataFrame`](#data-frame-body) |
 | `0x03` | `RESIZE` | JSON [`ResizeParams`](#resize) |
 | `0x04` | `CLOSE` | JSON [`CloseParams`](#close) |
+| `0x05` | `CREDIT` | JSON [`CreditParams`](#credit) |
 
 Sidecar to daemon:
 
@@ -91,6 +92,7 @@ Fields:
 | `args` | string[] | no | Defaults to `[]`. |
 | `cwd` | string or null | no | Working directory. If omitted/null, the sidecar does not set one. |
 | `env` | object | no | Additional environment variables. Defaults to `{}`. |
+| `credit` | number or null | no | Initial [read-credit](#credit) budget in bytes (Rust `u64`). Omitted/null means unthrottled. |
 
 Behavior:
 
@@ -119,7 +121,18 @@ Behavior:
 }
 ```
 
-`CLOSE` requests termination. Cleanup is reported by the later `EXIT` frame from the reader thread when the PTY reaches EOF and the child has been reaped.
+`CLOSE` requests termination. Cleanup is reported by the later `EXIT` frame from the reader thread when the PTY reaches EOF and the child has been reaped. `CLOSE` also lifts the terminal's [read-credit](#credit) gate so a parked reader can drain to that EOF; the dying process is unthrottled from this point on.
+
+### `CREDIT`
+
+```json
+{
+  "terminalId": "term-mj7w5r-1",
+  "bytes": 65536
+}
+```
+
+Grants `bytes` of additional PTY read budget to one terminal (flow control). A terminal opened with a `credit` field reads at most its remaining budget from the PTY and parks once the budget hits zero — the kernel PTY buffer then fills and the shell's writes block, propagating backpressure into a flooding process. Terminals opened without `credit` ignore grants and stay unthrottled (compatibility with pre-credit daemons). `CREDIT` is best effort: an unknown or already-exited `terminalId` is ignored. Sidecar shutdown, like `CLOSE`, releases every gate so parked readers can reach EOF.
 
 ### `OPENED`
 

--- a/crates/linkcode-pty/src/credit.rs
+++ b/crates/linkcode-pty/src/credit.rs
@@ -1,0 +1,130 @@
+//! Per-terminal read-credit gate.
+//!
+//! The daemon grants byte budgets (`OPEN.credit`, then incremental `CREDIT` frames); the
+//! terminal's reader thread parks once the budget is exhausted. A parked reader stops draining
+//! the PTY, the kernel PTY buffer fills, and the child's writes block — restoring end-to-end
+//! backpressure all the way into the flooding process.
+
+use std::sync::{Condvar, Mutex};
+
+/// Byte budget for one terminal's PTY reads.
+///
+/// `None` means unthrottled: either the daemon never sent a credit (a pre-credit daemon) or the
+/// terminal is draining to EOF after close/shutdown. The reader thread is the only consumer;
+/// grants and releases may come from any thread.
+pub struct Credit {
+    remaining: Mutex<Option<u64>>,
+    granted: Condvar,
+}
+
+impl Credit {
+    /// A gate starting with `initial` bytes of budget, or unthrottled when `None`.
+    pub fn new(initial: Option<u64>) -> Self {
+        Self {
+            remaining: Mutex::new(initial),
+            granted: Condvar::new(),
+        }
+    }
+
+    /// Block until some budget is available, then return how much may be read (at most `max`,
+    /// never 0 for `max > 0`). Unthrottled gates return `max` immediately.
+    pub fn acquire(&self, max: usize) -> usize {
+        let mut remaining = self.remaining.lock().expect("credit mutex poisoned");
+        loop {
+            match *remaining {
+                None => return max,
+                Some(0) => {
+                    remaining = self.granted.wait(remaining).expect("credit mutex poisoned");
+                }
+                Some(budget) => return usize::try_from(budget).unwrap_or(usize::MAX).min(max),
+            }
+        }
+    }
+
+    /// Consume `n` bytes actually read. Saturating: a concurrent `release` may have lifted the
+    /// budget between `acquire` and here.
+    pub fn consume(&self, n: usize) {
+        let mut remaining = self.remaining.lock().expect("credit mutex poisoned");
+        if let Some(budget) = *remaining {
+            *remaining = Some(budget.saturating_sub(n as u64));
+        }
+    }
+
+    /// Add daemon-granted budget and wake a parked reader. No-op on an unthrottled gate.
+    pub fn grant(&self, bytes: u64) {
+        let mut remaining = self.remaining.lock().expect("credit mutex poisoned");
+        if let Some(budget) = *remaining {
+            *remaining = Some(budget.saturating_add(bytes));
+            self.granted.notify_all();
+        }
+    }
+
+    /// Lift throttling permanently (close/shutdown drain) and wake a parked reader.
+    pub fn release(&self) {
+        let mut remaining = self.remaining.lock().expect("credit mutex poisoned");
+        *remaining = None;
+        self.granted.notify_all();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::sync::mpsc::channel;
+    use std::thread;
+    use std::time::Duration;
+
+    use super::*;
+
+    #[test]
+    fn unthrottled_gates_pass_through() {
+        let credit = Credit::new(None);
+        assert_eq!(credit.acquire(4096), 4096);
+        credit.consume(4096);
+        assert_eq!(credit.acquire(4096), 4096);
+    }
+
+    #[test]
+    fn acquire_clamps_to_the_remaining_budget() {
+        let credit = Credit::new(Some(100));
+        assert_eq!(credit.acquire(4096), 100);
+        credit.consume(60);
+        assert_eq!(credit.acquire(4096), 40);
+        assert_eq!(credit.acquire(16), 16);
+    }
+
+    #[test]
+    fn grant_unparks_an_exhausted_reader() {
+        let credit = Arc::new(Credit::new(Some(10)));
+        credit.consume(10);
+
+        let (tx, rx) = channel();
+        let parked = Arc::clone(&credit);
+        thread::spawn(move || {
+            tx.send(parked.acquire(4096)).unwrap();
+        });
+        assert!(
+            rx.recv_timeout(Duration::from_millis(200)).is_err(),
+            "reader should park on an exhausted budget"
+        );
+
+        credit.grant(64);
+        assert_eq!(rx.recv_timeout(Duration::from_secs(5)).unwrap(), 64);
+    }
+
+    #[test]
+    fn release_unparks_to_unthrottled() {
+        let credit = Arc::new(Credit::new(Some(0)));
+        let (tx, rx) = channel();
+        let parked = Arc::clone(&credit);
+        thread::spawn(move || {
+            tx.send(parked.acquire(4096)).unwrap();
+        });
+
+        credit.release();
+        assert_eq!(rx.recv_timeout(Duration::from_secs(5)).unwrap(), 4096);
+        // Grants after release must not re-arm throttling.
+        credit.grant(1);
+        assert_eq!(credit.acquire(4096), 4096);
+    }
+}

--- a/crates/linkcode-pty/src/main.rs
+++ b/crates/linkcode-pty/src/main.rs
@@ -3,6 +3,7 @@
 //! One long-lived process the daemon spawns; it multiplexes many terminals over a framed stdio
 //! protocol (see [`proto`]). Control frames arrive on stdin; output and lifecycle frames go to stdout.
 
+mod credit;
 mod mux;
 mod proto;
 mod pty;
@@ -12,7 +13,7 @@ use std::io::{self, BufReader};
 use serde::Deserialize;
 
 use crate::mux::Mux;
-use crate::proto::{CLOSE, INPUT, OPEN, RESIZE, decode_data, read_frame};
+use crate::proto::{CLOSE, CREDIT, INPUT, OPEN, RESIZE, decode_data, read_frame};
 use crate::pty::OpenParams;
 
 #[derive(Deserialize)]
@@ -21,6 +22,13 @@ struct ResizeParams {
     terminal_id: String,
     cols: u16,
     rows: u16,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CreditParams {
+    terminal_id: String,
+    bytes: u64,
 }
 
 #[derive(Deserialize)]
@@ -81,6 +89,11 @@ fn main() {
             CLOSE => {
                 if let Ok(params) = serde_json::from_slice::<CloseParams>(&body) {
                     mux.close(&params.terminal_id);
+                }
+            }
+            CREDIT => {
+                if let Ok(params) = serde_json::from_slice::<CreditParams>(&body) {
+                    mux.credit(&params.terminal_id, params.bytes);
                 }
             }
             _ => {}

--- a/crates/linkcode-pty/src/mux.rs
+++ b/crates/linkcode-pty/src/mux.rs
@@ -10,6 +10,7 @@ use std::time::Duration;
 use portable_pty::{Child, MasterPty, PtySize};
 use serde_json::json;
 
+use crate::credit::Credit;
 use crate::proto::{ERROR, EXIT, OPENED, OUTPUT, encode_data, write_frame};
 use crate::pty::{OpenParams, SpawnedPty, spawn};
 
@@ -19,6 +20,8 @@ struct Terminal {
     /// `None` once the reader thread has reaped the child; guards `signal_group` from ever
     /// targeting a pid the OS may have recycled.
     child: Mutex<Option<Box<dyn Child + Send + Sync>>>,
+    /// Read-credit gate shared with this terminal's reader thread.
+    credit: Arc<Credit>,
 }
 
 /// How hard to tear a terminal's process group down.
@@ -140,17 +143,19 @@ impl Mux {
             }
         };
 
+        let credit = Arc::new(Credit::new(params.credit));
         self.lock_terminals().insert(
             terminal_id.clone(),
             Arc::new(Terminal {
                 master: Mutex::new(master),
                 writer: Mutex::new(writer),
                 child: Mutex::new(Some(child)),
+                credit: Arc::clone(&credit),
             }),
         );
         // Reply OPENED before starting the reader so it always precedes this terminal's output.
         self.send_json(OPENED, &json!({ "terminalId": terminal_id, "pid": pid }));
-        Arc::clone(self).spawn_reader(terminal_id, reader);
+        Arc::clone(self).spawn_reader(terminal_id, reader, credit);
     }
 
     /// Reply `ERROR` for a single terminal that could not be opened (e.g. a malformed OPEN frame),
@@ -190,10 +195,21 @@ impl Mux {
         }
     }
 
+    /// Grant additional read credit to a terminal. Best effort: an unknown id (already exited) is
+    /// ignored, matching the other per-terminal control frames.
+    pub fn credit(&self, terminal_id: &str, bytes: u64) {
+        if let Some(terminal) = self.terminal(terminal_id) {
+            terminal.credit.grant(bytes);
+        }
+    }
+
     /// Request termination; the `EXIT` frame and map removal follow from the reader hitting EOF.
     /// A terminal still alive after [`CLOSE_GRACE_PERIOD`] is escalated to `SIGKILL` on its group.
     pub fn close(self: &Arc<Self>, terminal_id: &str) {
         if let Some(terminal) = self.terminal(terminal_id) {
+            // Lift throttling first: a credit-parked reader would otherwise never see the EOF this
+            // teardown produces. The dying process drains unthrottled from here on.
+            terminal.credit.release();
             terminal.signal_group(Teardown::Hangup);
         } else {
             return;
@@ -215,6 +231,8 @@ impl Mux {
     pub fn shutdown(&self) {
         for terminal in self.lock_terminals().values() {
             terminal.signal_group(Teardown::Kill);
+            // Wake any credit-parked reader so it can drain to EOF; the joins below depend on it.
+            terminal.credit.release();
         }
         let readers = std::mem::take(&mut *self.readers.lock().expect("readers mutex poisoned"));
         for reader in readers {
@@ -226,18 +244,29 @@ impl Mux {
         }
     }
 
-    fn spawn_reader(self: Arc<Self>, terminal_id: String, mut reader: Box<dyn Read + Send>) {
+    fn spawn_reader(
+        self: Arc<Self>,
+        terminal_id: String,
+        mut reader: Box<dyn Read + Send>,
+        credit: Arc<Credit>,
+    ) {
         let handle = thread::spawn({
             let mux = Arc::clone(&self);
             move || {
                 let mut buf = [0u8; 4096];
                 loop {
-                    match reader.read(&mut buf) {
+                    // Parks while the budget is exhausted — the kernel PTY buffer then fills and
+                    // the child's writes block, which is the whole point of the credit gate.
+                    let allowance = credit.acquire(buf.len());
+                    match reader.read(&mut buf[..allowance]) {
                         Ok(0) | Err(_) => break,
-                        Ok(n) => match encode_data(&terminal_id, &buf[..n]) {
-                            Ok(body) => mux.send(OUTPUT, body),
-                            Err(_) => break,
-                        },
+                        Ok(n) => {
+                            credit.consume(n);
+                            match encode_data(&terminal_id, &buf[..n]) {
+                                Ok(body) => mux.send(OUTPUT, body),
+                                Err(_) => break,
+                            }
+                        }
                     }
                 }
                 let exit_code = mux.reap(&terminal_id);

--- a/crates/linkcode-pty/src/proto.rs
+++ b/crates/linkcode-pty/src/proto.rs
@@ -17,6 +17,7 @@ pub const OPEN: u8 = 0x01;
 pub const INPUT: u8 = 0x02;
 pub const RESIZE: u8 = 0x03;
 pub const CLOSE: u8 = 0x04;
+pub const CREDIT: u8 = 0x05;
 
 // Sidecar → daemon.
 pub const OPENED: u8 = 0x81;

--- a/crates/linkcode-pty/src/pty.rs
+++ b/crates/linkcode-pty/src/pty.rs
@@ -24,6 +24,9 @@ pub struct OpenParams {
     pub cwd: Option<String>,
     #[serde(default)]
     pub env: HashMap<String, String>,
+    /// Initial read-credit budget in bytes. Absent means unthrottled (a pre-credit daemon).
+    #[serde(default)]
+    pub credit: Option<u64>,
 }
 
 impl OpenParams {

--- a/crates/linkcode-pty/tests/smoke.rs
+++ b/crates/linkcode-pty/tests/smoke.rs
@@ -8,6 +8,7 @@ use std::time::{Duration, Instant};
 const OPEN: u8 = 0x01;
 const INPUT: u8 = 0x02;
 const CLOSE: u8 = 0x04;
+const CREDIT: u8 = 0x05;
 const OPENED: u8 = 0x81;
 const OUTPUT: u8 = 0x82;
 const EXIT: u8 = 0x83;
@@ -354,6 +355,134 @@ fn rejects_open_with_a_nonexistent_cwd() {
     assert!(
         rejected,
         "an OPEN with a nonexistent cwd should be rejected"
+    );
+
+    let _ = child.kill();
+    let _ = child.wait();
+}
+
+/// Run frame reads on a helper thread so tests can assert *silence* (a throttled reader) with
+/// `recv_timeout` instead of blocking forever on the pipe.
+fn spawn_frame_reader(mut stdout: ChildStdout) -> std::sync::mpsc::Receiver<(u8, Vec<u8>)> {
+    let (tx, rx) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
+        while let Some(frame) = read_frame(&mut stdout) {
+            if tx.send(frame).is_err() {
+                break;
+            }
+        }
+    });
+    rx
+}
+
+/// Drain OUTPUT bytes for `id` until the stream stays silent for `quiet`; returns the byte count.
+fn drain_output_until_quiet(
+    rx: &std::sync::mpsc::Receiver<(u8, Vec<u8>)>,
+    id: &str,
+    quiet: Duration,
+) -> usize {
+    let mut total = 0;
+    while let Ok((type_byte, body)) = rx.recv_timeout(quiet) {
+        if type_byte == OUTPUT {
+            let (frame_id, _) = split_data(&body);
+            if frame_id == id {
+                total += body.len() - 2 - id.len();
+            }
+        }
+    }
+    total
+}
+
+#[test]
+fn credited_open_throttles_output_until_more_credit_arrives() {
+    let (mut child, mut stdin, stdout) = spawn_sidecar();
+    let rx = spawn_frame_reader(stdout);
+
+    // A flooding shell with an 8 KiB initial budget: output must stop at (or before) the budget.
+    let id = "t-credit";
+    write_frame(
+        &mut stdin,
+        OPEN,
+        format!(
+            r#"{{"terminalId":"{id}","cols":80,"rows":24,"cmd":"/bin/sh","args":["-c","while :; do echo linkcode-flood-line; done"],"credit":8192}}"#
+        )
+        .as_bytes(),
+    );
+    let opened = rx
+        .recv_timeout(Duration::from_secs(10))
+        .expect("opened frame");
+    assert_eq!(opened.0, OPENED);
+
+    let first_burst = drain_output_until_quiet(&rx, id, Duration::from_secs(1));
+    assert!(
+        first_burst > 0,
+        "some output should arrive before the budget runs out"
+    );
+    assert!(
+        first_burst <= 8192,
+        "output must stop at the credited budget, got {first_burst} bytes"
+    );
+
+    // Granting more credit resumes the flow — and stops again at the enlarged budget.
+    write_frame(
+        &mut stdin,
+        CREDIT,
+        format!(r#"{{"terminalId":"{id}","bytes":8192}}"#).as_bytes(),
+    );
+    let second_burst = drain_output_until_quiet(&rx, id, Duration::from_secs(1));
+    assert!(second_burst > 0, "granted credit should resume output");
+    assert!(
+        second_burst <= 8192,
+        "resumed output must stop at the granted budget, got {second_burst} bytes"
+    );
+
+    let _ = child.kill();
+    let _ = child.wait();
+}
+
+#[test]
+fn close_drains_a_credit_parked_terminal_to_exit() {
+    let (mut child, mut stdin, stdout) = spawn_sidecar();
+    let rx = spawn_frame_reader(stdout);
+
+    // A tiny budget guarantees the reader is parked mid-flood when CLOSE arrives.
+    let id = "t-parked";
+    write_frame(
+        &mut stdin,
+        OPEN,
+        format!(
+            r#"{{"terminalId":"{id}","cols":80,"rows":24,"cmd":"/bin/sh","args":["-c","while :; do echo linkcode-flood-line; done"],"credit":512}}"#
+        )
+        .as_bytes(),
+    );
+    let opened = rx
+        .recv_timeout(Duration::from_secs(10))
+        .expect("opened frame");
+    assert_eq!(opened.0, OPENED);
+    drain_output_until_quiet(&rx, id, Duration::from_secs(1));
+
+    // CLOSE must lift the credit gate: a parked reader would otherwise never reach EOF or EXIT.
+    write_frame(
+        &mut stdin,
+        CLOSE,
+        format!(r#"{{"terminalId":"{id}"}}"#).as_bytes(),
+    );
+    let deadline = Instant::now() + Duration::from_secs(10);
+    let mut exited = false;
+    while Instant::now() < deadline {
+        match rx.recv_timeout(Duration::from_secs(1)) {
+            Ok((EXIT, body)) => {
+                assert!(String::from_utf8_lossy(&body).contains(id));
+                exited = true;
+                break;
+            }
+            Ok(_) => {}
+            Err(_) => {}
+        }
+    }
+    assert!(
+        exited,
+        "close should drain a credit-parked terminal to EXIT"
     );
 
     let _ = child.kill();

--- a/packages/client-core/src/__tests__/terminal-client.test.ts
+++ b/packages/client-core/src/__tests__/terminal-client.test.ts
@@ -7,7 +7,7 @@ import type {
 import type { Transport } from '@linkcode/transport';
 import { createWireMessage } from '@linkcode/transport';
 import { noop } from 'foxts/noop';
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { LinkCodeClient } from '../client';
 import { createConnectedLocalClient } from './local-client';
 
@@ -112,6 +112,10 @@ describe('LinkCodeClient terminal error channel', () => {
 });
 
 describe('LinkCodeClient terminal attachments', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it('ingests output captured before terminal.opened resolves', async () => {
     let uuidSeq = 0;
     const { client, serverTransport } = await createConnectedLocalClient({
@@ -374,6 +378,54 @@ describe('LinkCodeClient terminal attachments', () => {
     expect(exits).toEqual([7]);
 
     client.detachTerminal('term-finished');
+    client.dispose();
+    serverTransport.close();
+  });
+
+  it('acks ingested live output cumulatively, skipping replayed and deduped frames', async () => {
+    const { client, serverTransport } = await createConnectedLocalClient();
+    vi.useFakeTimers();
+    const received: WirePayload[] = [];
+    serverTransport.onMessage((message) => {
+      const p = message.payload;
+      received.push(p);
+      if (p.kind !== 'terminal.attach') return;
+      serverTransport.send(
+        createWireMessage({
+          kind: 'terminal.attached',
+          replyTo: p.clientReqId,
+          terminal: metadata(p.terminalId, null),
+          replay: [{ type: 'write', seq: 1, data: 'replayed-not-acked' }],
+          cutoffSeq: 1,
+          truncated: false,
+        }),
+      );
+    });
+
+    await client.attachTerminal('term-ack');
+    const output = (seq: number, data: string) =>
+      serverTransport.send(
+        createWireMessage({ kind: 'terminal.output', terminalId: 'term-ack', seq, data }),
+      );
+
+    // A big frame crosses the 64K chunk threshold: the ack goes out immediately, and counts only
+    // live chars — the replayed event and the duplicate (stale seq) frame stay out of the total.
+    output(2, 'x'.repeat(64 * 1024));
+    output(2, 'duplicate-not-acked');
+    await vi.advanceTimersByTimeAsync(0);
+    const acks = () => received.filter((p) => p.kind === 'terminal.ack');
+    expect(acks()).toHaveLength(1);
+    expect(acks()[0]).toMatchObject({ terminalId: 'term-ack', acked: 64 * 1024 });
+
+    // A small tail is acked by the trailing timer rather than immediately.
+    output(3, 'tail');
+    await vi.advanceTimersByTimeAsync(0);
+    expect(acks()).toHaveLength(1);
+    await vi.advanceTimersByTimeAsync(150);
+    expect(acks()).toHaveLength(2);
+    expect(acks()[1]).toMatchObject({ acked: 64 * 1024 + 4 });
+
+    client.detachTerminal('term-ack');
     client.dispose();
     serverTransport.close();
   });

--- a/packages/client-core/src/client/terminal-channel.ts
+++ b/packages/client-core/src/client/terminal-channel.ts
@@ -24,6 +24,11 @@ interface AttachmentState {
   credentials: TerminalAttachmentCredentials;
   retainCount: number;
   result: { terminal: TerminalMetadata; truncated: boolean } | null;
+  /** Cumulative live write chars ingested (`terminal.ack` payload); spans control upgrades. */
+  ackedChars: number;
+  /** Counted-but-unsent chars; flushed at the chunk threshold or by the trailing timer. */
+  unackedChars: number;
+  ackTimer?: ReturnType<typeof setTimeout>;
 }
 
 /** Client-side remount replay is only a cache; the daemon remains the authoritative replay source. */
@@ -42,6 +47,12 @@ function replayEventBytes(event: TerminalReplayEvent): number {
  * agent output would grow memory and per-chunk re-render cost without limit. */
 const TERMINAL_OUTPUT_CAP = 200000;
 
+/** Flow control (CODE-231): cumulative `terminal.ack`s tell the host what this client has actually
+ * ingested, and the host clamps delivery (ultimately the PTY read itself) to that pace. Acks are
+ * batched: one per this many chars, with a trailing timer so a quiet stream still settles. */
+const TERMINAL_ACK_CHUNK_CHARS = 64 * 1024;
+const TERMINAL_ACK_TRAILING_MS = 100;
+
 /** Trim buffered output to the cap on a line boundary — a raw slice can start mid-ANSI-escape and
  * render the tail as literal garbage. */
 function capOutput(text: string, cap: number): string {
@@ -53,6 +64,12 @@ function capOutput(text: string, cap: number): string {
 
 function toError(err: unknown): Error {
   return new Error(extractErrorMessage(err) ?? 'Unknown error');
+}
+
+function clearAckTimer(state: AttachmentState): void {
+  if (!state.ackTimer) return;
+  clearTimeout(state.ackTimer);
+  state.ackTimer = undefined;
 }
 
 /**
@@ -125,8 +142,16 @@ export class TerminalChannel {
         return true;
       }
       case 'terminal.output': {
-        if (this.attachments.get(p.terminalId)?.result) {
-          this.ingestEvent(p.terminalId, { type: 'write', seq: p.seq, data: p.data });
+        const state = this.attachments.get(p.terminalId);
+        if (state?.result) {
+          // Only accepted live frames count toward acks — replayed events were part of the attach
+          // snapshot and are not in the host's delivery accounting for this attachment.
+          const accepted = this.ingestEvent(p.terminalId, {
+            type: 'write',
+            seq: p.seq,
+            data: p.data,
+          });
+          if (accepted) this.recordAck(p.terminalId, state, p.data.length);
         }
         return true;
       }
@@ -169,6 +194,8 @@ export class TerminalChannel {
       credentials: this.newCredentials(),
       retainCount: 1,
       result: null,
+      ackedChars: 0,
+      unackedChars: 0,
     };
     let requestId = '';
     return sendCorrelated(this.transport, this.pending, 'terminalOpen', (clientReqId) => {
@@ -194,7 +221,13 @@ export class TerminalChannel {
       if (existing.result) return Promise.resolve(existing.result);
     }
 
-    const state = existing ?? { credentials: this.newCredentials(), retainCount: 1, result: null };
+    const state = existing ?? {
+      credentials: this.newCredentials(),
+      retainCount: 1,
+      result: null,
+      ackedChars: 0,
+      unackedChars: 0,
+    };
     this.attachments.set(terminalId, state);
     const promise = this.requestAttach(terminalId, state, 'view');
     this.viewAttachPromises.set(terminalId, promise);
@@ -370,6 +403,7 @@ export class TerminalChannel {
   }
 
   disposeAll(): void {
+    for (const state of this.attachments.values()) clearAckTimer(state);
     this.outputSubs.clear();
     this.eventSubs.clear();
     this.exitSubs.clear();
@@ -443,6 +477,7 @@ export class TerminalChannel {
   private releaseAttachment(terminalId: string): void {
     const state = this.attachments.get(terminalId);
     if (!state) return;
+    clearAckTimer(state);
     this.sendFrame(terminalId, {
       kind: 'terminal.detach',
       terminalId,
@@ -475,37 +510,67 @@ export class TerminalChannel {
     if (subs) for (const cb of subs) cb(canControl);
   }
 
-  private ingestEvent(terminalId: string, event: TerminalReplayEvent): void {
-    if (event.seq <= (this.lastSeq.get(terminalId) ?? 0)) return;
+  /** Returns whether the event was accepted (seq-deduped events return false). */
+  private ingestEvent(terminalId: string, event: TerminalReplayEvent): boolean {
+    if (event.seq <= (this.lastSeq.get(terminalId) ?? 0)) return false;
     this.lastSeq.set(terminalId, event.seq);
     this.appendReplayEvent(terminalId, event);
 
     const eventSubs = this.eventSubs.get(terminalId);
     if (eventSubs) for (const cb of eventSubs) cb(event);
-    if (event.type !== 'write') return;
+    if (event.type !== 'write') return true;
 
     const outputSubs = this.outputSubs.get(terminalId);
     if (outputSubs) for (const cb of outputSubs) cb(event.data);
     const previous = this.output.get(terminalId) ?? '';
     this.output.set(terminalId, capOutput(previous + event.data, TERMINAL_OUTPUT_CAP));
     this.notifySnapshotChange(terminalId);
+    return true;
+  }
+
+  /** Count an accepted live write toward this attachment's cumulative ack and flush at the chunk
+   * threshold — or by the trailing timer, so the last sub-chunk of a burst still gets acked. */
+  private recordAck(terminalId: string, state: AttachmentState, chars: number): void {
+    state.ackedChars += chars;
+    state.unackedChars += chars;
+    if (state.unackedChars >= TERMINAL_ACK_CHUNK_CHARS) {
+      this.flushAck(terminalId, state);
+    } else if (!state.ackTimer) {
+      state.ackTimer = setTimeout(() => {
+        state.ackTimer = undefined;
+        this.flushAck(terminalId, state);
+      }, TERMINAL_ACK_TRAILING_MS);
+    }
+  }
+
+  private flushAck(terminalId: string, state: AttachmentState): void {
+    clearAckTimer(state);
+    if (state.unackedChars === 0) return;
+    state.unackedChars = 0;
+    this.sendFrame(terminalId, {
+      kind: 'terminal.ack',
+      terminalId,
+      acked: state.ackedChars,
+      ...state.credentials,
+    });
   }
 
   private appendReplayEvent(terminalId: string, event: TerminalReplayEvent): void {
-    const replay = [...(this.replay.get(terminalId) ?? []), event];
+    let replay = this.replay.get(terminalId);
+    if (!replay) {
+      replay = [];
+      this.replay.set(terminalId, replay);
+    }
+    replay.push(event);
     let dataSize = (this.replayDataSize.get(terminalId) ?? 0) + replayEventBytes(event);
 
     let truncated = false;
-    while (
-      replay.length > 0 &&
-      (replay.length > TERMINAL_REPLAY_EVENT_CAP || dataSize > TERMINAL_REPLAY_DATA_CAP)
-    ) {
+    while (replay.length > TERMINAL_REPLAY_EVENT_CAP || dataSize > TERMINAL_REPLAY_DATA_CAP) {
       const removed = replay.shift();
       if (!removed) break;
       dataSize -= replayEventBytes(removed);
       truncated = true;
     }
-    this.replay.set(terminalId, replay);
     this.replayDataSize.set(terminalId, dataSize);
     if (truncated) this.markReplayTruncated(terminalId);
   }

--- a/packages/engine/src/__tests__/script-service.test.ts
+++ b/packages/engine/src/__tests__/script-service.test.ts
@@ -45,6 +45,9 @@ class FakePtyProcess implements PtyProcess {
   resize(): void {
     /* no observable effect */
   }
+  grantRead(): void {
+    /* unthrottled fake */
+  }
   kill(): void {
     this.killed = true;
     this.exit(0);

--- a/packages/engine/src/__tests__/terminal-flow.test.ts
+++ b/packages/engine/src/__tests__/terminal-flow.test.ts
@@ -1,0 +1,155 @@
+import type { TerminalReplayEvent } from '@linkcode/schema';
+import { describe, expect, it } from 'vitest';
+import { TerminalFlow } from '../terminal-flow';
+import { TerminalReplayJournal } from '../terminal-replay';
+
+interface Harness {
+  journal: TerminalReplayJournal;
+  flow: TerminalFlow;
+  delivered: TerminalReplayEvent[];
+  grants: number[];
+}
+
+function harness(opts?: { windowChars?: number; journalBytes?: number }): Harness {
+  const journal = new TerminalReplayJournal(opts?.journalBytes ?? 10 * 1024 * 1024);
+  const delivered: TerminalReplayEvent[] = [];
+  const grants: number[] = [];
+  const flow = new TerminalFlow(
+    journal,
+    {
+      deliver: (event) => delivered.push(event),
+      grantRead: (bytes) => grants.push(bytes),
+    },
+    opts?.windowChars ?? 100,
+  );
+  return { journal, flow, delivered, grants };
+}
+
+function writes(delivered: TerminalReplayEvent[]): string[] {
+  return delivered.flatMap((event) => (event.type === 'write' ? [event.data] : []));
+}
+
+describe('TerminalFlow', () => {
+  it('free-runs and grants immediately while unattached', () => {
+    const { journal, flow, delivered, grants } = harness();
+    journal.appendWrite('x'.repeat(500));
+    flow.pump();
+    journal.appendResize(90, 30);
+    flow.pump();
+
+    expect(writes(delivered)).toEqual(['x'.repeat(500)]);
+    expect(delivered.at(-1)).toMatchObject({ type: 'resize', cols: 90, rows: 30 });
+    expect(grants).toEqual([500]);
+    expect(flow.drained).toBe(true);
+  });
+
+  it('clamps delivery to the window and resumes on ack, granting consumed bytes', () => {
+    const { journal, flow, delivered, grants } = harness({ windowChars: 100 });
+    flow.attach('a');
+    journal.appendWrite('x'.repeat(120));
+    journal.appendWrite('tail');
+    flow.pump();
+
+    // The first event overshoots the window (whole events only); the second is held.
+    expect(writes(delivered)).toEqual(['x'.repeat(120)]);
+    expect(grants).toEqual([]);
+
+    flow.ack('a', 120);
+    expect(writes(delivered)).toEqual(['x'.repeat(120), 'tail']);
+    expect(grants).toEqual([120]);
+    expect(flow.drained).toBe(true);
+  });
+
+  it('gates on the slowest attachment and recovers when it detaches', () => {
+    const { journal, flow, delivered } = harness({ windowChars: 100 });
+    flow.attach('fast');
+    flow.attach('slow');
+    journal.appendWrite('x'.repeat(150));
+    journal.appendWrite('tail');
+    flow.pump();
+    expect(writes(delivered)).toEqual(['x'.repeat(150)]);
+
+    flow.ack('fast', 150);
+    expect(writes(delivered)).toEqual(['x'.repeat(150)]);
+
+    flow.detach('slow');
+    expect(writes(delivered)).toEqual(['x'.repeat(150), 'tail']);
+  });
+
+  it('a mid-stream attach only accounts for chars delivered after its baseline', () => {
+    const { journal, flow, delivered } = harness({ windowChars: 100 });
+    flow.attach('early');
+    journal.appendWrite('x'.repeat(90));
+    flow.pump();
+    const { replay, cutoffSeq } = flow.attach('late');
+
+    // The late attachment's snapshot carries the already-delivered event; its window starts empty,
+    // so the early attachment's 90 outstanding chars still gate the stream.
+    expect(replay.at(-1)).toMatchObject({ type: 'write', data: 'x'.repeat(90) });
+    journal.appendWrite('y'.repeat(20));
+    flow.pump();
+    expect(writes(delivered)).toEqual(['x'.repeat(90), 'y'.repeat(20)]);
+    journal.appendWrite('held');
+    flow.pump();
+    expect(writes(delivered)).toEqual(['x'.repeat(90), 'y'.repeat(20)]);
+
+    // Acking only the late attachment can't free the window; the early one is the slowest.
+    flow.ack('late', 20);
+    expect(writes(delivered)).toHaveLength(2);
+    flow.ack('early', 110);
+    expect(writes(delivered)).toEqual(['x'.repeat(90), 'y'.repeat(20), 'held']);
+    expect(cutoffSeq).toBe(1);
+  });
+
+  it('re-attach preserves the accounting epoch (view→control upgrade)', () => {
+    const { journal, flow, delivered, grants } = harness({ windowChars: 100 });
+    flow.attach('a');
+    journal.appendWrite('x'.repeat(80));
+    flow.pump();
+    flow.attach('a');
+    journal.appendWrite('x'.repeat(80));
+    journal.appendWrite('held');
+    flow.pump();
+    expect(writes(delivered)).toEqual(['x'.repeat(80), 'x'.repeat(80)]);
+
+    // The client's acks stay cumulative across the upgrade. A baseline reset at re-attach would
+    // credit both events on the first ack (one 160-byte grant) instead of one event per ack.
+    flow.ack('a', 80);
+    expect(writes(delivered)).toEqual(['x'.repeat(80), 'x'.repeat(80), 'held']);
+    expect(grants).toEqual([80]);
+    flow.ack('a', 160);
+    expect(grants).toEqual([80, 80]);
+  });
+
+  it('clamps a hostile over-ack to what was actually delivered', () => {
+    const { journal, flow, grants } = harness({ windowChars: 100 });
+    flow.attach('a');
+    journal.appendWrite('x'.repeat(50));
+    flow.pump();
+
+    flow.ack('a', 1_000_000);
+    expect(grants).toEqual([50]);
+    flow.ack('a', 2_000_000);
+    expect(grants).toEqual([50]);
+  });
+
+  it('substitutes a clear sequence for a journal-truncation gap', () => {
+    // A tiny journal with a stalled window: each oversized append evicts the one before it, so
+    // by the time the window reopens the cursor points into truncated history.
+    const { journal, flow, delivered } = harness({ windowChars: 10, journalBytes: 100 });
+    flow.attach('a');
+    journal.appendWrite('x'.repeat(60));
+    flow.pump();
+    expect(writes(delivered)).toEqual(['x'.repeat(60)]);
+
+    journal.appendWrite('a'.repeat(90));
+    journal.appendWrite('b'.repeat(90));
+    journal.appendWrite('c'.repeat(95));
+    flow.ack('a', 60);
+
+    const resumed = writes(delivered).slice(1);
+    expect(resumed).toHaveLength(1);
+    expect(resumed[0]).toBe(`\u001B[2J\u001B[3J\u001B[H${'c'.repeat(95)}`);
+    expect(flow.drained).toBe(true);
+  });
+});

--- a/packages/engine/src/__tests__/terminal-service.test.ts
+++ b/packages/engine/src/__tests__/terminal-service.test.ts
@@ -53,10 +53,12 @@ class FakePtyProcess implements PtyProcess {
 class FakePtyBackend implements PtyBackend {
   shutdownCalled = false;
   readonly opened: FakePtyProcess[] = [];
+  readonly openOpts: PtyOpenOptions[] = [];
 
-  open(_terminalId: string, _opts: PtyOpenOptions): Promise<PtyProcess> {
+  open(_terminalId: string, opts: PtyOpenOptions): Promise<PtyProcess> {
     const process = new FakePtyProcess();
     this.opened.push(process);
+    this.openOpts.push(opts);
     return Promise.resolve(process);
   }
   shutdown(): void {
@@ -390,6 +392,89 @@ describe('TerminalService', () => {
     service.input(id, desktop, 'x');
     await tick();
     expect(sent.filter((p) => p.kind === 'terminal.output')).toHaveLength(0);
+  });
+
+  it('spawns with an initial PTY read credit and returns acked bytes as grants', async () => {
+    const { transport, sent } = recordingTransport();
+    const backend = new FakePtyBackend();
+    const service = new TerminalService(backend, transport);
+
+    await service.open('req-open', opts, desktop);
+    const id = openedId(sent, 'req-open');
+    expect(backend.openOpts[0].credit).toBe(1024 * 1024);
+
+    // A flood past the client window (512K chars) is held at the first oversized event.
+    backend.opened[0].emitData('x'.repeat(600 * 1024));
+    await tick();
+    backend.opened[0].emitData('held-tail');
+    await tick();
+    const outputs = () => sent.filter((p) => p.kind === 'terminal.output');
+    expect(outputs()).toHaveLength(1);
+    expect(backend.opened[0].grants).toEqual([]);
+
+    // The ack frees the window: the tail flows and the consumed bytes come back as credit.
+    service.ack(id, desktop, 600 * 1024);
+    expect(outputs()).toHaveLength(2);
+    expect(outputs()[1]).toMatchObject({ data: 'held-tail' });
+    expect(backend.opened[0].grants).toEqual([600 * 1024]);
+  });
+
+  it('holds terminal.exit until the ack-clamped drain delivers the final output', async () => {
+    const { transport, sent } = recordingTransport();
+    const backend = new FakePtyBackend();
+    const service = new TerminalService(backend, transport);
+
+    await service.open('req-open', opts, desktop);
+    const id = openedId(sent, 'req-open');
+    backend.opened[0].emitData('x'.repeat(600 * 1024));
+    await tick();
+    backend.opened[0].emitData('final-tail');
+    backend.opened[0].emitExit(0);
+
+    // The tail is still journal-held by the window, so the exit must not have been announced.
+    expect(sent.some((p) => p.kind === 'terminal.exit')).toBe(false);
+
+    service.ack(id, desktop, 600 * 1024);
+    const kinds = sent.map((p) => p.kind);
+    const tailIndex = sent.findIndex(
+      (p) => p.kind === 'terminal.output' && p.data === 'final-tail',
+    );
+    expect(tailIndex).toBeGreaterThan(-1);
+    expect(kinds.indexOf('terminal.exit')).toBeGreaterThan(tailIndex);
+  });
+
+  it('lets a detach finish a windowed post-exit drain', async () => {
+    const { transport, sent } = recordingTransport();
+    const backend = new FakePtyBackend();
+    const service = new TerminalService(backend, transport);
+
+    await service.open('req-open', opts, desktop);
+    const id = openedId(sent, 'req-open');
+    backend.opened[0].emitData('x'.repeat(600 * 1024));
+    await tick();
+    backend.opened[0].emitData('final-tail');
+    backend.opened[0].emitExit(0);
+    expect(sent.some((p) => p.kind === 'terminal.exit')).toBe(false);
+
+    // Connection loss becomes a detach; with no attachments left the drain free-runs to exit.
+    service.detach(id, desktop);
+    expect(sent.some((p) => p.kind === 'terminal.output' && p.data === 'final-tail')).toBe(true);
+    expect(sent.some((p) => p.kind === 'terminal.exit')).toBe(true);
+  });
+
+  it('managed terminals free-run: output flows and credits return without any client ack', async () => {
+    const { transport, sent } = recordingTransport();
+    const backend = new FakePtyBackend();
+    const service = new TerminalService(backend, transport);
+
+    await service.openManaged(opts);
+    backend.opened[0].emitData('x'.repeat(600 * 1024));
+    await tick();
+    backend.opened[0].emitData('more');
+    await tick();
+
+    expect(sent.filter((p) => p.kind === 'terminal.output')).toHaveLength(2);
+    expect(backend.opened[0].grants).toEqual([600 * 1024, 4]);
   });
 
   it('killBySession reaps only terminals owned by that session', async () => {

--- a/packages/engine/src/__tests__/terminal-service.test.ts
+++ b/packages/engine/src/__tests__/terminal-service.test.ts
@@ -10,6 +10,7 @@ class FakePtyProcess implements PtyProcess {
   killed = false;
   readonly writes: string[] = [];
   readonly resizes: Array<{ cols: number; rows: number }> = [];
+  readonly grants: number[] = [];
   private dataCbs: Array<(d: string) => void> = [];
   private exitCbs: Array<(c: number | null) => void> = [];
 
@@ -31,6 +32,9 @@ class FakePtyProcess implements PtyProcess {
   }
   resize(cols: number, rows: number): void {
     this.resizes.push({ cols, rows });
+  }
+  grantRead(bytes: number): void {
+    this.grants.push(bytes);
   }
   kill(): void {
     this.killed = true;

--- a/packages/engine/src/__tests__/terminal-takeover.test.ts
+++ b/packages/engine/src/__tests__/terminal-takeover.test.ts
@@ -54,6 +54,7 @@ class EchoPty implements PtyProcess {
   }
 
   resize = noop;
+  grantRead = noop;
 
   kill(): void {
     if (this.killed) return;

--- a/packages/engine/src/engine.ts
+++ b/packages/engine/src/engine.ts
@@ -983,6 +983,14 @@ export class Engine {
         );
         break;
       }
+      case 'terminal.ack': {
+        this.terminals?.ack(
+          p.terminalId,
+          { attachmentId: p.attachmentId, attachmentSecret: p.attachmentSecret },
+          p.acked,
+        );
+        break;
+      }
       case 'terminal.resize': {
         this.terminals?.resize(
           p.terminalId,

--- a/packages/engine/src/pty-backend.ts
+++ b/packages/engine/src/pty-backend.ts
@@ -18,6 +18,8 @@ export interface PtyOpenOptions {
   args?: string[];
   /** Extra environment merged over the inherited one (engine-internal, e.g. the script env contract). */
   env?: Record<string, string>;
+  /** Initial PTY read-credit budget in bytes; unset spawns an unthrottled terminal. */
+  credit?: number;
 }
 
 /** A live PTY. Data crosses this boundary as UTF-8 strings — the backend owns the streaming
@@ -29,6 +31,9 @@ export interface PtyProcess {
   onExit(cb: (exitCode: number | null) => void): Unsubscribe;
   write(data: string): void;
   resize(cols: number, rows: number): void;
+  /** Grant additional read budget to a terminal opened with `credit` (no-op otherwise). A backend
+   * with no flow control may implement this as a no-op; output then flows unthrottled. */
+  grantRead(bytes: number): void;
   kill(): void;
 }
 

--- a/packages/engine/src/terminal-flow.ts
+++ b/packages/engine/src/terminal-flow.ts
@@ -1,0 +1,143 @@
+import type { TerminalReplayEvent } from '@linkcode/schema';
+import type { TerminalReplayJournal } from './terminal-replay';
+
+/**
+ * Per-terminal output flow control (CODE-231): the journal is the only buffer, a single cursor
+ * delivers it in order, and delivery is clamped to the slowest attachment's unacknowledged
+ * window. Consumed journal bytes are returned to the PTY backend as read credit, which is what
+ * ultimately blocks a flooding process inside the kernel instead of ballooning any queue.
+ *
+ * Chars vs bytes: clients acknowledge UTF-16 lengths of the `data` strings they ingest (what
+ * they can count), while PTY credits are raw bytes. The journal records each write's UTF-8 size,
+ * which matches the sidecar's raw byte count (the streaming decoder's carry skews it by ≤3 bytes,
+ * self-correcting on the next chunk), so consumption is mapped event-by-event, exactly.
+ */
+
+/** Max unacknowledged chars in flight per attachment; the slowest attachment gates delivery. */
+export const TERMINAL_CLIENT_WINDOW_CHARS = 512 * 1024;
+/** PTY read budget: initial credit at open, topped up as delivered bytes are consumed. */
+export const TERMINAL_SIDECAR_WINDOW_BYTES = 1024 * 1024;
+
+/** Clear screen + scrollback + home: substitutes a journal-truncation gap so the stream stays
+ * renderable — the viewer loses the dropped scrollback but never sees a torn escape sequence
+ * from mid-stream resumption without it. */
+const GAP_CLEAR = '\u001B[2J\u001B[3J\u001B[H';
+
+interface AttachmentFlow {
+  /** `deliveredChars` at attach-reply time; this attachment only accounts for chars after it. */
+  baseChars: number;
+  /** Cumulative chars the client acknowledged since its baseline. */
+  ackedChars: number;
+}
+
+export interface TerminalFlowDelegate {
+  /** Send one journal event to the wire; write data may carry a gap-recovery clear prefix. */
+  deliver(event: TerminalReplayEvent): void;
+  /** Return consumed journal bytes to the PTY as read credit. */
+  grantRead(bytes: number): void;
+}
+
+/** Delivered-but-unconsumed write events, in order: cumulative delivered-char end + journal bytes. */
+interface UnconsumedEvent {
+  endChars: number;
+  bytes: number;
+}
+
+export class TerminalFlow {
+  private cursorSeq: number;
+  private deliveredChars = 0;
+  private consumedChars = 0;
+  private pendingGapClear = false;
+  private readonly attachments = new Map<string, AttachmentFlow>();
+  private readonly unconsumed: UnconsumedEvent[] = [];
+
+  constructor(
+    private readonly journal: TerminalReplayJournal,
+    private readonly delegate: TerminalFlowDelegate,
+    private readonly windowChars = TERMINAL_CLIENT_WINDOW_CHARS,
+  ) {
+    // Everything already in the journal (the spawn resize) belongs to attach snapshots, not the
+    // live stream; the cursor starts at the current head.
+    this.cursorSeq = journal.cutoffSeq;
+  }
+
+  /** True once every retained journal event has been delivered. */
+  get drained(): boolean {
+    return this.journal.entryAfter(this.cursorSeq) === undefined;
+  }
+
+  /** Register an attachment and return its snapshot: the journal up to the cursor. Later events
+   * reach it as live frames, so snapshot + stream is complete and never overlaps its accounting.
+   * A re-attach of a known attachment (a view→control upgrade) keeps its accounting epoch — the
+   * client's cumulative ack counter spans its whole attachment lifetime, not the last upgrade. */
+  attach(attachmentId: string): { replay: TerminalReplayEvent[]; cutoffSeq: number } {
+    if (!this.attachments.has(attachmentId)) {
+      this.attachments.set(attachmentId, { baseChars: this.deliveredChars, ackedChars: 0 });
+    }
+    return { replay: this.journal.snapshotUpTo(this.cursorSeq), cutoffSeq: this.cursorSeq };
+  }
+
+  detach(attachmentId: string): void {
+    if (!this.attachments.delete(attachmentId)) return;
+    this.advanceConsumption();
+    this.pump();
+  }
+
+  /** Apply a client's cumulative ack. Clamped to what was actually delivered to it, so a hostile
+   * or confused client cannot inflate credits. Stale (non-increasing) acks are ignored. */
+  ack(attachmentId: string, ackedChars: number): void {
+    const attachment = this.attachments.get(attachmentId);
+    if (!attachment) return;
+    const clamped = Math.min(ackedChars, this.deliveredChars - attachment.baseChars);
+    if (clamped <= attachment.ackedChars) return;
+    attachment.ackedChars = clamped;
+    this.advanceConsumption();
+    this.pump();
+  }
+
+  /** Deliver journal events while the slowest attachment's window has room. Call after every
+   * journal append and whenever a window may have moved (ack/detach). */
+  pump(): void {
+    while (this.maxOutstanding() < this.windowChars) {
+      const step = this.journal.entryAfter(this.cursorSeq);
+      if (!step) return;
+      this.cursorSeq = step.event.seq;
+      if (step.gap) this.pendingGapClear = true;
+      if (step.event.type === 'write') {
+        const data = this.pendingGapClear ? GAP_CLEAR + step.event.data : step.event.data;
+        this.pendingGapClear = false;
+        this.deliveredChars += data.length;
+        this.unconsumed.push({ endChars: this.deliveredChars, bytes: step.bytes });
+        this.delegate.deliver({ ...step.event, data });
+      } else {
+        this.delegate.deliver(step.event);
+      }
+      this.advanceConsumption();
+    }
+  }
+
+  /** Slowest attachment's delivered-but-unacked chars; zero when unattached (free-running). */
+  private maxOutstanding(): number {
+    let slowest = this.deliveredChars;
+    for (const { baseChars, ackedChars } of this.attachments.values()) {
+      slowest = Math.min(slowest, baseChars + ackedChars);
+    }
+    return this.deliveredChars - slowest;
+  }
+
+  /** Advance the consumption watermark to the slowest attachment (or the cursor when unattached)
+   * and return the freed journal bytes to the PTY as credit. Whole events only — partial-event
+   * grants would drift the byte mapping. */
+  private advanceConsumption(): void {
+    const target = this.deliveredChars - this.maxOutstanding();
+    if (target <= this.consumedChars) return;
+    this.consumedChars = target;
+    let freed = 0;
+    while (this.unconsumed.length > 0 && this.unconsumed[0].endChars <= target) {
+      const event = this.unconsumed.shift();
+      if (!event) break;
+      freed += event.bytes;
+    }
+    if (freed > 0) this.delegate.grantRead(freed);
+  }
+}

--- a/packages/engine/src/terminal-replay.ts
+++ b/packages/engine/src/terminal-replay.ts
@@ -5,6 +5,15 @@ interface ReplayEntry {
   bytes: number;
 }
 
+/** One journal step for a delivery cursor (see {@link TerminalReplayJournal.entryAfter}). */
+export interface ReplayStep {
+  event: TerminalReplayEvent;
+  /** UTF-8 byte size the journal accounted for this event. */
+  bytes: number;
+  /** True when events between the cursor and this one were truncated away (cap overflow). */
+  gap: boolean;
+}
+
 const DEFAULT_REPLAY_CAP = 10 * 1024 * 1024;
 const DEFAULT_REPLAY_EVENT_CAP = 10000;
 const RESIZE_BYTES = 16;
@@ -32,6 +41,28 @@ export class TerminalReplayJournal {
 
   snapshot(): TerminalReplayEvent[] {
     return this.entries.map(({ event }) => event);
+  }
+
+  /** Retained events with seq ≤ `seq` — the attach snapshot for a delivery cursor at `seq`;
+   * everything after it reaches that attachment as ordinary live frames. */
+  snapshotUpTo(seq: number): TerminalReplayEvent[] {
+    const events: TerminalReplayEvent[] = [];
+    for (const { event } of this.entries) {
+      if (event.seq > seq) break;
+      events.push(event);
+    }
+    return events;
+  }
+
+  /** The first retained event after `seq`, or undefined when the cursor is at the head. O(1):
+   * seqs are contiguous, so the target sits at a computable index. `gap` means the cap dropped
+   * events between the cursor and the returned entry (only reachable with an unthrottled feed). */
+  entryAfter(seq: number): ReplayStep | undefined {
+    const first = this.entries[0];
+    if (!first) return undefined;
+    if (seq + 1 < first.event.seq) return { ...first, gap: true };
+    const entry = this.entries[seq + 1 - first.event.seq];
+    return entry ? { ...entry, gap: false } : undefined;
   }
 
   appendWrite(data: string): Extract<TerminalReplayEvent, { type: 'write' }> {

--- a/packages/engine/src/terminal-service.ts
+++ b/packages/engine/src/terminal-service.ts
@@ -13,6 +13,7 @@ import { createHeadlessTerminal } from 'restty/headless';
 import type { ResttyWasm } from 'restty/internal';
 import { loadResttyWasm } from 'restty/internal';
 import type { PtyBackend, PtyOpenOptions, PtyProcess } from './pty-backend';
+import { TERMINAL_SIDECAR_WINDOW_BYTES, TerminalFlow } from './terminal-flow';
 import { TerminalReplayJournal } from './terminal-replay';
 
 interface TerminalRecord {
@@ -24,6 +25,7 @@ interface TerminalEntry extends TerminalRecord {
   process: PtyProcess;
   headless: ResttyHeadlessTerminal;
   attachments: Map<string, string>;
+  flow: TerminalFlow;
   /** Flush PTY bytes queued for microtask coalescing before any ordered non-write event. */
   flushOutput: () => void;
   reapTimer?: ReturnType<typeof setTimeout>;
@@ -38,6 +40,11 @@ interface TerminalEntry extends TerminalRecord {
 
 interface ExitedTerminalEntry extends TerminalRecord {
   exitCode: number | null;
+  /** Live flow + attachments carry over so a windowed drain can finish after the PTY exits. */
+  flow: TerminalFlow;
+  attachments: Map<string, string>;
+  /** Announce `terminal.exit` once the drain (or the retention backstop, force=true) allows it. */
+  finishExit: (force: boolean) => void;
   expiryTimer?: ReturnType<typeof setTimeout>;
 }
 
@@ -54,7 +61,9 @@ const EXITED_TERMINAL_RETENTION_MS = 60000;
 /**
  * Owns the host's live terminals and short-lived exited replay tombstones, bridging a
  * {@link PtyBackend} to the `terminal.*` wire. Output is coalesced per microtask so a full-speed
- * PTY doesn't emit one Zod-validated wire message per tiny write.
+ * PTY doesn't emit one Zod-validated wire message per tiny write, journaled, and delivered through
+ * a per-terminal {@link TerminalFlow} window clamped by client `terminal.ack`s — consumed bytes
+ * flow back to the PTY as read credit, so a flooding process blocks in the kernel (CODE-231).
  */
 export class TerminalService {
   private readonly terminals = new Map<string, TerminalEntry>();
@@ -81,12 +90,15 @@ export class TerminalService {
     const record = entry ?? this.exitedTerminals.get(spawned.terminalId);
     if (!record) throw new Error(`terminal ${spawned.terminalId} disappeared while opening`);
     try {
+      // A live terminal replies with the flow snapshot (baseline for this attachment's acks); a
+      // terminal that already exited mid-open has no live stream, so it gets the full journal.
+      const attach = entry ? entry.flow.attach(attachment.attachmentId) : undefined;
       this.send({
         kind: 'terminal.opened',
         replyTo: clientReqId,
         terminal: this.metadata(record),
-        replay: record.replay.snapshot(),
-        cutoffSeq: record.replay.cutoffSeq,
+        replay: attach?.replay ?? record.replay.snapshot(),
+        cutoffSeq: attach?.cutoffSeq ?? record.replay.cutoffSeq,
         truncated: record.replay.truncated,
       });
       if (entry) this.sendController(entry);
@@ -135,19 +147,51 @@ export class TerminalService {
       mode === 'control' && entry.metadata.controllerAttachmentId !== attachment.attachmentId;
     if (mode === 'control') entry.metadata.controllerAttachmentId = attachment.attachmentId;
 
-    this.sendAttached(clientReqId, entry);
+    const flowAttach = entry.flow.attach(attachment.attachmentId);
+    this.send({
+      kind: 'terminal.attached',
+      replyTo: clientReqId,
+      terminal: this.metadata(entry),
+      replay: flowAttach.replay,
+      cutoffSeq: flowAttach.cutoffSeq,
+      truncated: entry.replay.truncated,
+    });
     if (controllerChanged) this.sendController(entry);
   }
 
   detach(terminalId: string, attachment: TerminalAttachmentCredentials): void {
     const entry = this.terminals.get(terminalId);
-    if (!entry || !this.hasAttachment(entry, attachment)) return;
-    entry.attachments.delete(attachment.attachmentId);
-    if (entry.metadata.controllerAttachmentId === attachment.attachmentId) {
-      entry.metadata.controllerAttachmentId = null;
-      this.sendController(entry);
+    if (entry) {
+      if (!this.hasAttachment(entry, attachment)) return;
+      entry.attachments.delete(attachment.attachmentId);
+      entry.flow.detach(attachment.attachmentId);
+      if (entry.metadata.controllerAttachmentId === attachment.attachmentId) {
+        entry.metadata.controllerAttachmentId = null;
+        this.sendController(entry);
+      }
+      this.scheduleReap(entry);
+      return;
     }
-    this.scheduleReap(entry);
+    // A detach during a windowed post-exit drain unblocks it (connection loss becomes detach).
+    const exited = this.exitedTerminals.get(terminalId);
+    if (!exited || !this.hasAttachment(exited, attachment)) return;
+    exited.attachments.delete(attachment.attachmentId);
+    exited.flow.detach(attachment.attachmentId);
+    exited.finishExit(false);
+  }
+
+  /** Apply a client's cumulative output ack: frees its delivery window, pumps held output, and
+   * returns consumed journal bytes to the PTY as read credit. */
+  ack(terminalId: string, attachment: TerminalAttachmentCredentials, acked: number): void {
+    const entry = this.terminals.get(terminalId);
+    if (entry) {
+      if (this.hasAttachment(entry, attachment)) entry.flow.ack(attachment.attachmentId, acked);
+      return;
+    }
+    const exited = this.exitedTerminals.get(terminalId);
+    if (!exited || !this.hasAttachment(exited, attachment)) return;
+    exited.flow.ack(attachment.attachmentId, acked);
+    exited.finishExit(false);
   }
 
   /** Spawn an engine-owned terminal (e.g. a workspace script): no `terminal.opened` reply, exempt
@@ -181,7 +225,10 @@ export class TerminalService {
     });
     let process: PtyProcess;
     try {
-      process = await this.backend.open(terminalId, opts);
+      process = await this.backend.open(terminalId, {
+        ...opts,
+        credit: TERMINAL_SIDECAR_WINDOW_BYTES,
+      });
     } catch (error) {
       headless.dispose();
       throw error;
@@ -201,9 +248,27 @@ export class TerminalService {
     }
     const replay = new TerminalReplayJournal();
     replay.appendResize(opts.cols, opts.rows);
+    const flow = new TerminalFlow(replay, {
+      deliver: (event) => {
+        if (event.type === 'write') {
+          this.send({ kind: 'terminal.output', terminalId, seq: event.seq, data: event.data });
+        } else {
+          this.send({
+            kind: 'terminal.resized',
+            terminalId,
+            seq: event.seq,
+            cols: event.cols,
+            rows: event.rows,
+          });
+        }
+      },
+      // Post-exit grants are harmless: the sidecar ignores credits for an unknown terminal.
+      grantRead: (bytes) => process.grantRead(bytes),
+    });
     const entry: TerminalEntry = {
       process,
       headless,
+      flow,
       metadata: {
         terminalId,
         cols: opts.cols,
@@ -233,8 +298,8 @@ export class TerminalService {
       if (pending.length === 0 || entry.disposed) return;
       const data = pending;
       pending = '';
-      const event = entry.replay.appendWrite(data);
-      this.send({ kind: 'terminal.output', terminalId, seq: event.seq, data });
+      entry.replay.appendWrite(data);
+      flow.pump();
     };
     entry.flushOutput = flush;
 
@@ -251,20 +316,24 @@ export class TerminalService {
       }
     });
     let released = false;
-    let pendingExit: { exitCode: number | null } | undefined;
     let exitAnnounced = false;
-    const announceExit = (exitCode: number | null): void => {
-      if (exitAnnounced) return;
+    let exitResult: { exitCode: number | null } | undefined;
+    // Exit is announced only after the open replied (`released`) AND the cursor drained the
+    // journal, preserving the output-before-exit wire ordering under a clamped window. Acks and
+    // detaches on the exited record re-invoke this; the retention expiry forces it.
+    const finishExit = (force: boolean): void => {
+      if (exitAnnounced || !exitResult || !released) return;
+      if (!force && !flow.drained) return;
       exitAnnounced = true;
-      this.send({ kind: 'terminal.exit', terminalId, exitCode });
-      owner.onExit?.(exitCode);
+      this.send({ kind: 'terminal.exit', terminalId, exitCode: exitResult.exitCode });
+      owner.onExit?.(exitResult.exitCode);
     };
     const unsubExit = process.onExit((exitCode) => {
       if (entry.disposed) return;
       flush();
-      this.retainExited(entry, exitCode);
-      if (released) announceExit(exitCode);
-      else pendingExit = { exitCode };
+      exitResult = { exitCode };
+      this.retainExited(entry, exitCode, finishExit);
+      finishExit(false);
     });
     if (entry.disposed) unsubExit();
     else entry.unsubExit = unsubExit;
@@ -272,9 +341,7 @@ export class TerminalService {
       terminalId,
       releaseExit() {
         released = true;
-        if (!pendingExit) return;
-        announceExit(pendingExit.exitCode);
-        pendingExit = undefined;
+        finishExit(false);
       },
     };
   }
@@ -296,8 +363,9 @@ export class TerminalService {
     entry.metadata.cols = cols;
     entry.metadata.rows = rows;
     entry.headless.resize(cols, rows);
-    const event = entry.replay.appendResize(cols, rows);
-    this.send({ kind: 'terminal.resized', terminalId, seq: event.seq, cols, rows });
+    entry.replay.appendResize(cols, rows);
+    // The resized broadcast rides the delivery cursor so viewers see it ordered with output.
+    entry.flow.pump();
     entry.process.resize(cols, rows);
   }
 
@@ -337,7 +405,11 @@ export class TerminalService {
     this.backend.shutdown();
   }
 
-  private retainExited(entry: TerminalEntry, exitCode: number | null): void {
+  private retainExited(
+    entry: TerminalEntry,
+    exitCode: number | null,
+    finishExit: (force: boolean) => void,
+  ): void {
     const terminalId = entry.metadata.terminalId;
     entry.disposed = true;
     this.cancelReap(entry);
@@ -348,11 +420,16 @@ export class TerminalService {
     const exited: ExitedTerminalEntry = {
       metadata: { ...entry.metadata, controllerAttachmentId: null },
       replay: entry.replay,
+      flow: entry.flow,
+      attachments: entry.attachments,
+      finishExit,
       exitCode,
     };
     exited.expiryTimer = setTimeout(() => {
       exited.expiryTimer = undefined;
       if (this.exitedTerminals.get(terminalId) === exited) {
+        // Retention over: tell any straggling viewer it exited even if its drain never finished.
+        exited.finishExit(true);
         this.exitedTerminals.delete(terminalId);
       }
     }, EXITED_TERMINAL_RETENTION_MS);
@@ -370,7 +447,10 @@ export class TerminalService {
       : undefined;
   }
 
-  private hasAttachment(entry: TerminalEntry, attachment: TerminalAttachmentCredentials): boolean {
+  private hasAttachment(
+    entry: { attachments: Map<string, string> },
+    attachment: TerminalAttachmentCredentials,
+  ): boolean {
     return entry.attachments.get(attachment.attachmentId) === attachment.attachmentSecret;
   }
 
@@ -378,6 +458,7 @@ export class TerminalService {
     return { ...entry.metadata };
   }
 
+  /** Attach reply for an exited terminal: no live stream follows, so it gets the full journal. */
   private sendAttached(clientReqId: string, entry: TerminalRecord): void {
     this.send({
       kind: 'terminal.attached',

--- a/packages/schema/src/wire/__tests__/terminal.test.ts
+++ b/packages/schema/src/wire/__tests__/terminal.test.ts
@@ -20,4 +20,21 @@ describe('terminal wire schema', () => {
     if (!parsed.success || parsed.data.payload.kind !== 'terminal.open') return;
     expect(parsed.data.payload.opts).not.toHaveProperty('sessionId');
   });
+
+  it('requires attachment credentials and a nonnegative cumulative count on terminal.ack', () => {
+    const ack = (payload: Record<string, unknown>) =>
+      parseWireMessage({ v: WIRE_PROTOCOL_VERSION, id: 'message-1', ts: 1, payload });
+    const valid = {
+      kind: 'terminal.ack',
+      terminalId: 'term-1',
+      acked: 4096,
+      attachmentId: 'attachment-1',
+      attachmentSecret: 's'.repeat(32),
+    };
+
+    expect(ack(valid).success).toBe(true);
+    expect(ack({ ...valid, acked: -1 }).success).toBe(false);
+    expect(ack({ ...valid, acked: 1.5 }).success).toBe(false);
+    expect(ack({ ...valid, attachmentSecret: undefined }).success).toBe(false);
+  });
 });

--- a/packages/schema/src/wire/index.ts
+++ b/packages/schema/src/wire/index.ts
@@ -36,7 +36,7 @@ export {
 // 39 disambiguates a parallel double-bump: #186 (CODE-142) and #189 (CODE-219) both shipped as
 // "38" with different schemas, so a build from between their merges shares a number with a
 // schema it does not speak.
-export const WIRE_PROTOCOL_VERSION = 39 as const;
+export const WIRE_PROTOCOL_VERSION = 40 as const;
 
 /** Envelope payload: a discriminated union keyed by `kind`. */
 export const WirePayloadSchema = z.discriminatedUnion('kind', [

--- a/packages/schema/src/wire/terminal.ts
+++ b/packages/schema/src/wire/terminal.ts
@@ -77,6 +77,15 @@ export const terminalWireVariants = [
     seq: z.number().int().positive(),
     data: z.string(),
   }),
+  // Flow control: cumulative UTF-16 length of live output this attachment has consumed since its
+  // attach baseline (replayed events don't count). The host clamps delivery to the slowest
+  // attachment's unacknowledged window and propagates the freed budget to the PTY as read credit.
+  z.object({
+    kind: z.literal('terminal.ack'),
+    terminalId: TerminalIdSchema,
+    acked: z.number().int().nonnegative(),
+    ...TerminalAttachmentCredentialsSchema.shape,
+  }),
   z.object({
     kind: z.literal('terminal.resized'),
     terminalId: TerminalIdSchema,


### PR DESCRIPTION
## Problem

A full-speed terminal flood (`yes`) saturated every stage of the PTY pipeline — kernel backpressure died inside the sidecar (unbounded reader→stdout channel), the daemon pushed unbounded frames into socket.io's write buffer, and the renderer choked on parse + O(n²) replay appends. Result: head-of-line blocking for the whole wire — the other terminal stopped echoing, new terminals hit the 10s sidecar `OPENED` timeout or the ~45s engine.io ping death ("Terminal failed to start").

## Fix — three-stage credit chain (wire 39)

- **client → engine**: new `terminal.ack` variant; `client-core` acks cumulative ingested chars (64 KB chunks + 100 ms trailing timer). Replayed/deduped frames don't count, so both sides' accounting stays exact.
- **engine**: `TerminalFlow` — the replay journal is the only buffer, a single cursor delivers it in order, clamped to the slowest attachment's unacked window (512 KB chars). Attach snapshots cut at the cursor (`snapshotUpTo`) so baselines line up; `terminal.exit` waits for the drain; managed/unattached terminals free-run. Journal truncation past the cursor (pre-credit sidecar only) resumes behind a clear-screen instead of a torn escape sequence.
- **engine → sidecar**: `OPEN.credit` + `CREDIT (0x05)` grants (PROTOCOL.md updated). The Rust reader thread parks at zero budget → kernel PTY buffer fills → **`yes` itself blocks**. Acked journal bytes flow back as grants. `CLOSE`/shutdown release parked readers so drains and joins can't hang. Both directions degrade gracefully across old/new pairs (no `credit` ⇒ unthrottled, unknown frames ignored).

## Verification

- New tests: Rust `Credit` unit + 2 smoke tests (throttle-at-budget, close-drains-parked); TS sidecar integration (park + `grantRead` resume against the real binary); 7 `TerminalFlow` unit tests (window, slowest-governs, baselines, over-ack clamp, gap-clear); 4 service tests (credit passthrough, ack resume, exit-after-drain, managed free-run); client ack cadence test.
- **`terminal-flood.integration.test.ts`**: real Engine + Hub + socket.io + Rust sidecar, two wire clients — client A floods (>2 MB sustained, proving credit replenishment) while client B's `terminal.list` p50 stays <500 ms, a second terminal opens <3 s, and its echo round-trips <2 s.
- `pnpm check:ci`, full `pnpm test` (169 files / 1307 tests), `cargo fmt/clippy/test` all green.

## Deliberate scope cuts (follow-ups)

- Multi-client v1 is slowest-attachment-governs; a dead-but-undetected conn can freeze a terminal until ping-timeout detach (~45 s) self-heals. Per-attachment cursors with drop/resync (mosh-style) are the follow-up before mobile-over-tunnel terminals GA.
- Outbound frames are still Zod-validated per connection; single-validate-per-broadcast left for later.
- Packaged-app verification on a real device (CODE-231 task 3) still pending.

Closes CODE-231.