### PR TITLE
feat(desktop): size first launch from the work area, persist window bounds, align pane defaults

### DIFF
--- a/apps/desktop/e2e/window-bounds.e2e.mts
+++ b/apps/desktop/e2e/window-bounds.e2e.mts
@@ -1,0 +1,127 @@
+/**
+ * Window geometry E2E (CODE-285): a first launch derives the window size from the primary work
+ * area (capped at 1560×980), closing persists bounds + maximized state, and a relaunch restores
+ * both. Run `pnpm -F @linkcode/desktop e2e:window-bounds` after `pnpm -F @linkcode/desktop build`;
+ * no daemon needed — the connection gate is enough surface.
+ */
+
+import { existsSync, readFileSync, rmSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { join, resolve } from 'node:path';
+import { noop } from 'foxts/noop';
+import { wait } from 'foxts/wait';
+import type { ElectronApplication } from 'playwright-core';
+import { _electron } from 'playwright-core';
+
+const require = createRequire(import.meta.url);
+const desktopDir = resolve(import.meta.dirname, '..');
+const electronBinary = require('electron') as unknown as string;
+
+const PROFILE = `e2e-window-bounds-${process.pid}`;
+
+function fail(message: string): never {
+  console.error(`FAIL: ${message}`);
+  process.exit(1);
+}
+
+async function launch(): Promise<ElectronApplication> {
+  return _electron.launch({
+    executablePath: electronBinary,
+    args: [desktopDir, '--use-mock-keychain'],
+    env: { ...process.env, LINKCODE_PROFILE: PROFILE },
+  });
+}
+
+interface Bounds {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+async function windowBounds(app: ElectronApplication): Promise<Bounds> {
+  return app.evaluate(({ BrowserWindow }) => BrowserWindow.getAllWindows()[0].getBounds());
+}
+
+async function main(): Promise<void> {
+  if (!existsSync(join(desktopDir, 'out/main/index.js'))) {
+    fail('apps/desktop/out is missing — run `pnpm -F @linkcode/desktop build` first');
+  }
+
+  let app: ElectronApplication | null = null;
+  let userData = '';
+  let passed = false;
+  try {
+    // First launch: no persisted state → the derived work-area default.
+    app = await launch();
+    await app.firstWindow();
+    userData = await app.evaluate(({ app: electronApp }) => electronApp.getPath('userData'));
+    const workArea = await app.evaluate(({ screen }) => screen.getPrimaryDisplay().workAreaSize);
+    // Mirrors deriveDefaultWindowSize in src/main/window-state.ts.
+    const expected = {
+      width: Math.max(940, Math.min(1560, Math.round(workArea.width * 0.9))),
+      height: Math.max(600, Math.min(980, Math.round(workArea.height * 0.92))),
+    };
+    const first = await windowBounds(app);
+    console.log(
+      `workArea=${JSON.stringify(workArea)} first-launch bounds=${JSON.stringify(first)}`,
+    );
+    if (first.width !== expected.width || first.height !== expected.height) {
+      fail(
+        `first-launch size ${first.width}x${first.height}, expected ${expected.width}x${expected.height}`,
+      );
+    }
+
+    // Resize + move, then close: the state file must capture the normal bounds.
+    const target = { x: 120, y: 140, width: 1180, height: 820 };
+    await app.evaluate(({ BrowserWindow }, bounds) => {
+      BrowserWindow.getAllWindows()[0].setBounds(bounds);
+    }, target);
+    await wait(500);
+    await app.close();
+    app = null;
+    const stateFile = join(userData, 'window-state.json');
+    if (!existsSync(stateFile)) fail('window-state.json was not written on close');
+    console.log(`persisted: ${readFileSync(stateFile, 'utf8').trim().replaceAll('\n', ' ')}`);
+
+    // Relaunch: the saved bounds come back verbatim.
+    app = await launch();
+    await app.firstWindow();
+    const restored = await windowBounds(app);
+    console.log(`restored bounds=${JSON.stringify(restored)}`);
+    if (
+      restored.x !== target.x ||
+      restored.y !== target.y ||
+      restored.width !== target.width ||
+      restored.height !== target.height
+    ) {
+      fail(`restored ${JSON.stringify(restored)}, expected ${JSON.stringify(target)}`);
+    }
+
+    // Maximize, close, relaunch: the maximized flag survives while normal bounds stay intact.
+    await app.evaluate(({ BrowserWindow }) => BrowserWindow.getAllWindows()[0].maximize());
+    await wait(500);
+    await app.close();
+    app = null;
+    app = await launch();
+    await app.firstWindow();
+    await wait(1000);
+    const maximized = await app.evaluate(({ BrowserWindow }) =>
+      BrowserWindow.getAllWindows()[0].isMaximized(),
+    );
+    if (!maximized) fail('maximized state did not survive the relaunch');
+    console.log('maximized state restored');
+
+    passed = true;
+    console.log('PASS');
+  } finally {
+    await app?.close().catch(noop);
+    if (userData && passed) rmSync(userData, { recursive: true, force: true });
+    if (!passed) {
+      if (userData) console.error(`kept for debugging: userData=${userData}`);
+      process.exitCode = 1;
+    }
+  }
+}
+
+void main();

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -16,6 +16,7 @@
     "package:devshell": "pnpm run stage:host-runtime && node scripts/build.mts --mode devshell && node scripts/package-app.mts --devshell",
     "e2e:notifications": "node e2e/notifications.e2e.mts",
     "e2e:file-tree": "node e2e/file-tree.e2e.mts",
+    "e2e:window-bounds": "node e2e/window-bounds.e2e.mts",
     "lint": "pnpm --dir ../.. exec eslint --format=sukka apps/desktop"
   },
   "author": "ArcBox Labs <team@arcbox.dev>",

--- a/apps/desktop/src/main/__tests__/window-state.test.ts
+++ b/apps/desktop/src/main/__tests__/window-state.test.ts
@@ -81,6 +81,13 @@ describe('readWindowState', () => {
     writeState({ ...VALID_STATE, bounds: { ...VALID_STATE.bounds, x: 4000 } });
     expect(readWindowState()).toBeNull();
   });
+
+  it('discards bounds when only the bottom of the window remains visible', async () => {
+    const { readWindowState } = await import('../window-state');
+    mocks.displays = [{ workArea: { x: 0, y: 0, width: 1728, height: 1079 } }];
+    writeState({ ...VALID_STATE, bounds: { ...VALID_STATE.bounds, y: -752 } });
+    expect(readWindowState()).toBeNull();
+  });
 });
 
 describe('persistWindowStateOnClose', () => {

--- a/apps/desktop/src/main/__tests__/window-state.test.ts
+++ b/apps/desktop/src/main/__tests__/window-state.test.ts
@@ -1,0 +1,101 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  userData: '',
+  workAreaSize: { width: 1728, height: 1079 },
+  displays: [] as Array<{ workArea: { x: number; y: number; width: number; height: number } }>,
+}));
+
+vi.mock('electron', () => ({
+  app: { getPath: () => mocks.userData },
+  screen: {
+    getPrimaryDisplay: () => ({ workAreaSize: mocks.workAreaSize }),
+    getAllDisplays: () => mocks.displays,
+  },
+}));
+
+let root: string;
+
+beforeEach(() => {
+  vi.resetModules();
+  root = mkdtempSync(join(tmpdir(), 'linkcode-window-state-'));
+  mocks.userData = join(root, 'user-data');
+  mkdirSync(mocks.userData, { recursive: true });
+  mocks.workAreaSize = { width: 1728, height: 1079 };
+  mocks.displays = [{ workArea: { x: 0, y: 38, width: 1728, height: 1079 } }];
+});
+
+afterEach(() => {
+  rmSync(root, { force: true, recursive: true });
+});
+
+const VALID_STATE = {
+  bounds: { x: 80, y: 90, width: 1200, height: 800 },
+  maximized: false,
+  fullScreen: false,
+};
+
+function writeState(value: unknown): void {
+  writeFileSync(join(mocks.userData, 'window-state.json'), JSON.stringify(value));
+}
+
+describe('deriveDefaultWindowSize', () => {
+  it('takes a work-area fraction capped at the full-layout width', async () => {
+    const { deriveDefaultWindowSize } = await import('../window-state');
+    // 16" MBP work area: width lands on the 90% fraction, height hits the 980 cap.
+    expect(deriveDefaultWindowSize()).toEqual({ width: 1555, height: 980 });
+  });
+
+  it('scales down on small work areas but never below the window minimum', async () => {
+    const { deriveDefaultWindowSize } = await import('../window-state');
+    mocks.workAreaSize = { width: 1470, height: 920 };
+    expect(deriveDefaultWindowSize()).toEqual({ width: 1323, height: 846 });
+    mocks.workAreaSize = { width: 800, height: 560 };
+    expect(deriveDefaultWindowSize()).toEqual({ width: 940, height: 600 });
+  });
+});
+
+describe('readWindowState', () => {
+  it('returns null for a missing, malformed, or sub-minimum state file', async () => {
+    const { readWindowState } = await import('../window-state');
+    expect(readWindowState()).toBeNull();
+    writeFileSync(join(mocks.userData, 'window-state.json'), 'not json');
+    expect(readWindowState()).toBeNull();
+    writeState({ ...VALID_STATE, bounds: { ...VALID_STATE.bounds, width: 100 } });
+    expect(readWindowState()).toBeNull();
+  });
+
+  it('restores a state whose bounds still land on a connected display', async () => {
+    const { readWindowState } = await import('../window-state');
+    writeState(VALID_STATE);
+    expect(readWindowState()).toEqual(VALID_STATE);
+  });
+
+  it('keeps a grabbable sliver but discards bounds fully off every display', async () => {
+    const { readWindowState } = await import('../window-state');
+    writeState({ ...VALID_STATE, bounds: { ...VALID_STATE.bounds, x: 1608 } });
+    expect(readWindowState()).not.toBeNull();
+    writeState({ ...VALID_STATE, bounds: { ...VALID_STATE.bounds, x: 4000 } });
+    expect(readWindowState()).toBeNull();
+  });
+});
+
+describe('persistWindowStateOnClose', () => {
+  it('writes a restorable snapshot when the window closes', async () => {
+    const { persistWindowStateOnClose, readWindowState } = await import('../window-state');
+    let onClose: (() => void) | undefined;
+    persistWindowStateOnClose({
+      on(_event: 'close', cb: () => void) {
+        onClose = cb;
+      },
+      getNormalBounds: () => VALID_STATE.bounds,
+      isMaximized: () => true,
+      isFullScreen: () => false,
+    });
+    onClose?.();
+    expect(readWindowState()).toEqual({ ...VALID_STATE, maximized: true });
+  });
+});

--- a/apps/desktop/src/main/window-state.ts
+++ b/apps/desktop/src/main/window-state.ts
@@ -19,8 +19,8 @@ export const MIN_WINDOW_SIZE = { width: 940, height: 600 } as const;
 const MAX_DEFAULT_SIZE = { width: 1560, height: 980 } as const;
 const WORK_AREA_FRACTION = { width: 0.9, height: 0.92 } as const;
 
-/** Smallest saved-bounds sliver that still counts as on-display: enough chrome bar to grab. */
-const VISIBLE_MIN = { width: 100, height: 48 } as const;
+/** Smallest top-chrome area that must remain on-display so the window can be dragged. */
+const GRABBABLE_CHROME = { width: 100, height: 48 } as const;
 
 const WindowStateSchema = z.object({
   bounds: z.object({
@@ -56,7 +56,7 @@ export function deriveDefaultWindowSize(): { width: number; height: number } {
   };
 }
 
-/** Null unless a valid state exists AND its bounds still land on a connected display. */
+/** Null unless a valid state exists AND its top chrome remains grabbable on a display. */
 export function readWindowState(): PersistedWindowState | null {
   let state: PersistedWindowState;
   try {
@@ -72,10 +72,10 @@ function boundsOnSomeDisplay(bounds: Rectangle): boolean {
     const visibleWidth =
       Math.min(bounds.x + bounds.width, workArea.x + workArea.width) -
       Math.max(bounds.x, workArea.x);
-    const visibleHeight =
-      Math.min(bounds.y + bounds.height, workArea.y + workArea.height) -
+    const visibleChromeHeight =
+      Math.min(bounds.y + GRABBABLE_CHROME.height, workArea.y + workArea.height) -
       Math.max(bounds.y, workArea.y);
-    return visibleWidth >= VISIBLE_MIN.width && visibleHeight >= VISIBLE_MIN.height;
+    return visibleWidth >= GRABBABLE_CHROME.width && visibleChromeHeight >= GRABBABLE_CHROME.height;
   });
 }
 

--- a/apps/desktop/src/main/window-state.ts
+++ b/apps/desktop/src/main/window-state.ts
@@ -1,0 +1,112 @@
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import type { Rectangle } from 'electron';
+import { app, screen } from 'electron';
+import { clamp } from 'foxts/clamp';
+import { extractErrorMessage } from 'foxts/extract-error-message';
+import { z } from 'zod';
+
+/**
+ * Persisted window geometry (system plane, like settings.ts): JSON under `userData`, so the
+ * channel × profile identity isolates installs. Written once when the window closes; not part
+ * of the IPC settings surface.
+ */
+
+export const MIN_WINDOW_SIZE = { width: 940, height: 600 } as const;
+
+/* The first-launch cap is the full layout's natural width: sidebar 288 + chat column 824
+ * (max-w-3xl + px-7 gutters) + right panel 440 (renderer DEFAULT_LAYOUT). */
+const MAX_DEFAULT_SIZE = { width: 1560, height: 980 } as const;
+const WORK_AREA_FRACTION = { width: 0.9, height: 0.92 } as const;
+
+/** Smallest saved-bounds sliver that still counts as on-display: enough chrome bar to grab. */
+const VISIBLE_MIN = { width: 100, height: 48 } as const;
+
+const WindowStateSchema = z.object({
+  bounds: z.object({
+    x: z.number().int(),
+    y: z.number().int(),
+    width: z.number().int().min(MIN_WINDOW_SIZE.width),
+    height: z.number().int().min(MIN_WINDOW_SIZE.height),
+  }),
+  maximized: z.boolean(),
+  fullScreen: z.boolean(),
+});
+
+export type PersistedWindowState = z.infer<typeof WindowStateSchema>;
+
+function windowStatePath(): string {
+  return join(app.getPath('userData'), 'window-state.json');
+}
+
+/** First-launch size: a work-area fraction, capped at the full layout's natural width. */
+export function deriveDefaultWindowSize(): { width: number; height: number } {
+  const { width, height } = screen.getPrimaryDisplay().workAreaSize;
+  return {
+    width: clamp(
+      Math.round(width * WORK_AREA_FRACTION.width),
+      MIN_WINDOW_SIZE.width,
+      MAX_DEFAULT_SIZE.width,
+    ),
+    height: clamp(
+      Math.round(height * WORK_AREA_FRACTION.height),
+      MIN_WINDOW_SIZE.height,
+      MAX_DEFAULT_SIZE.height,
+    ),
+  };
+}
+
+/** Null unless a valid state exists AND its bounds still land on a connected display. */
+export function readWindowState(): PersistedWindowState | null {
+  let state: PersistedWindowState;
+  try {
+    state = WindowStateSchema.parse(JSON.parse(readFileSync(windowStatePath(), 'utf8')));
+  } catch {
+    return null;
+  }
+  return boundsOnSomeDisplay(state.bounds) ? state : null;
+}
+
+function boundsOnSomeDisplay(bounds: Rectangle): boolean {
+  return screen.getAllDisplays().some(({ workArea }) => {
+    const visibleWidth =
+      Math.min(bounds.x + bounds.width, workArea.x + workArea.width) -
+      Math.max(bounds.x, workArea.x);
+    const visibleHeight =
+      Math.min(bounds.y + bounds.height, workArea.y + workArea.height) -
+      Math.max(bounds.y, workArea.y);
+    return visibleWidth >= VISIBLE_MIN.width && visibleHeight >= VISIBLE_MIN.height;
+  });
+}
+
+/** The BrowserWindow slice the snapshot reads — lets tests pass a plain fake without casts. */
+interface SnapshotWindow {
+  on: (event: 'close', listener: () => void) => unknown;
+  getNormalBounds: () => Rectangle;
+  isMaximized: () => boolean;
+  isFullScreen: () => boolean;
+}
+
+/**
+ * Snapshots geometry on 'close'. getNormalBounds() reports the normal-state frame regardless of
+ * maximize/fullscreen/minimize, so no resize/move tracking (and none of its mid-transition races).
+ */
+export function persistWindowStateOnClose(win: SnapshotWindow): void {
+  win.on('close', () => {
+    const state: PersistedWindowState = {
+      bounds: win.getNormalBounds(),
+      maximized: win.isMaximized(),
+      fullScreen: win.isFullScreen(),
+    };
+    try {
+      const file = windowStatePath();
+      mkdirSync(dirname(file), { recursive: true });
+      writeFileSync(file, `${JSON.stringify(state, null, 2)}\n`);
+    } catch (err) {
+      // Best-effort: losing geometry must not turn quit into a crash.
+      process.stderr.write(
+        `[link-code/desktop] unable to persist window state: ${extractErrorMessage(err)}\n`,
+      );
+    }
+  });
+}

--- a/apps/desktop/src/main/window.ts
+++ b/apps/desktop/src/main/window.ts
@@ -14,6 +14,12 @@ import { APP_NAME } from './constants';
 import { watchDaemonRuntime } from './daemon-discovery';
 import { systemContextFor } from './system-context';
 import { onUpdaterStatus } from './updater';
+import {
+  deriveDefaultWindowSize,
+  MIN_WINDOW_SIZE,
+  persistWindowStateOnClose,
+  readWindowState,
+} from './window-state';
 
 export function createDesktopWindow(): BrowserWindow {
   const win = createWindow();
@@ -39,12 +45,11 @@ export function createDesktopWindow(): BrowserWindow {
 }
 
 function createWindow(): BrowserWindow {
+  const restored = readWindowState();
   const win = new BrowserWindow({
-    width: 1180,
-    height: 760,
-    minWidth: 940,
-    minHeight: 600,
-    center: true,
+    ...(restored ? restored.bounds : { ...deriveDefaultWindowSize(), center: true }),
+    minWidth: MIN_WINDOW_SIZE.width,
+    minHeight: MIN_WINDOW_SIZE.height,
     show: false,
     icon,
     title: APP_NAME,
@@ -76,10 +81,18 @@ function createWindow(): BrowserWindow {
     return { action: 'deny' };
   });
 
+  persistWindowStateOnClose(win);
+
   const updateBackgroundColor = (): void => {
     win.setBackgroundColor(desktopBackgroundColor());
   };
-  win.on('ready-to-show', () => win.show());
+  win.on('ready-to-show', () => {
+    // Display-state restore waits for first show: maximize() on a hidden window shows it early
+    // on Windows, and setFullScreen must not race the initial paint.
+    if (restored?.maximized) win.maximize();
+    if (restored?.fullScreen) win.setFullScreen(true);
+    win.show();
+  });
   nativeTheme.on('updated', updateBackgroundColor);
   win.on('closed', () => nativeTheme.off('updated', updateBackgroundColor));
   win.webContents.on('did-fail-load', (_event, errorCode, errorDescription, validatedURL) => {

--- a/apps/desktop/src/renderer/src/shell/connection-skeleton.tsx
+++ b/apps/desktop/src/renderer/src/shell/connection-skeleton.tsx
@@ -9,7 +9,7 @@ import { Skeleton } from 'coss-ui/components/skeleton';
 export function ConnectionSkeleton(): React.ReactNode {
   return (
     <div className="flex h-full min-h-0">
-      <aside className="flex w-[286px] shrink-0 flex-col gap-3 px-4 pt-12 pb-4">
+      <aside className="flex w-[288px] shrink-0 flex-col gap-3 px-4 pt-12 pb-4">
         <Skeleton className="h-5 w-28" />
         <Skeleton className="h-5 w-24" />
         <Skeleton className="h-5 w-32" />

--- a/apps/desktop/src/renderer/src/shell/store/model.ts
+++ b/apps/desktop/src/renderer/src/shell/store/model.ts
@@ -100,10 +100,12 @@ export const BOTTOM_PANEL_MIN_SIZE = 150;
 export const BOTTOM_PANEL_MAX_SIZE = 560;
 export const MIN_MAIN_SIZE = 360;
 
+/* 8px grid; sidebarW + the 824px chat column (max-w-3xl + px-7) + rightW is the first-launch
+ * window width cap (1560) in main/window-state.ts. */
 export const DEFAULT_LAYOUT: LayoutState = {
-  sidebarW: 286,
+  sidebarW: 288,
   rightW: 440,
-  bottomH: 230,
+  bottomH: 240,
 };
 
 export const PANEL_EXPANSION_TARGET: Record<PanelSide, PanelExpansionTarget> = {


### PR DESCRIPTION
## CODE-285

**Problem.** The 1180×760 default only budgets for sidebar + chat column — opening the right panel (diff/terminal/browser, the product's default working set) crushes the main pane to 454px. Window bounds were never persisted (every launch recentered at 1180×760), and pane defaults were not on a shared grid (sidebarW 286).

**Change.**
- First launch derives the window from the primary work area: `min(1560, 90% width) × min(980, 92% height)`, floor 940×600. The 1560 cap is the full layout's natural width: sidebar 288 + chat column 824 (max-w-3xl + px-7) + right panel 440.
- `window-state.json` (new `src/main/window-state.ts`, same store idiom as `settings.ts`) snapshots normal bounds + maximized/fullscreen on close via `getNormalBounds()`; restore validates the bounds still land on a connected display (≥100×48 grabbable sliver) and falls back to the derived default otherwise. Maximize/fullscreen restore is deferred to `ready-to-show` (hidden-window `maximize()` shows early on Windows).
- `DEFAULT_LAYOUT` aligned to the 8px grid: sidebarW 286→288, bottomH 230→240 (min/max bounds untouched, persisted shell-state shape unchanged — no version bump). Connection skeleton width follows.

**Verification.** Unit tests for derivation clamps, display-visibility validation, and the close-snapshot round-trip. New `pnpm -F @linkcode/desktop e2e:window-bounds` drives the built app: first-launch 1560×980 on a large work area, resize→close→relaunch restores bounds verbatim, maximized state survives relaunch — PASS locally. `pnpm check:ci` + `pnpm test` (1324) green.