### PR TITLE
feat(desktop): themed depth for the sidebar/content seam

### DIFF
--- a/apps/desktop/src/renderer/src/index.css
+++ b/apps/desktop/src/renderer/src/index.css
@@ -42,6 +42,31 @@
   --lc-shell-sidebar-divider: color-mix(in srgb, var(--foreground) 20%, var(--background));
 }
 
+/*
+ * Seam depth over the divider: the opaque content reads as slightly raised over the
+ * recessed translucent sidebar. Light casts a soft ambient shadow into the sidebar; dark
+ * lights the content's near edge instead, since a dark-on-dark shadow is invisible.
+ * `data-shell-seam` ties this to the sidebar border's lifecycle; inset so the cells'
+ * overflow-hidden can't clip it.
+ */
+.linkcode-desktop-shell {
+  --lc-shell-seam-shadow: color-mix(in srgb, var(--foreground) 10%, transparent);
+  --lc-shell-seam-highlight: transparent;
+}
+
+.dark .linkcode-desktop-shell {
+  --lc-shell-seam-shadow: transparent;
+  --lc-shell-seam-highlight: color-mix(in srgb, var(--foreground) 7%, transparent);
+}
+
+.linkcode-desktop-shell[data-shell-seam] [data-shell-pane="sidebar"] {
+  box-shadow: inset -10px 0 12px -10px var(--lc-shell-seam-shadow);
+}
+
+.linkcode-desktop-shell[data-shell-seam] [data-shell-pane="main"] {
+  box-shadow: inset 2px 0 2px -1px var(--lc-shell-seam-highlight);
+}
+
 .linkcode-chrome-grid,
 .linkcode-shell-grid {
   /* Keep in sync with the pane minima in shell/store/model.ts. A closed pane writes 0,

--- a/apps/desktop/src/renderer/src/shell/desktop-shell.tsx
+++ b/apps/desktop/src/renderer/src/shell/desktop-shell.tsx
@@ -522,6 +522,7 @@ export function DesktopShell({
       style={shellStyle}
       data-shell-horizontal-animating={horizontalAnimating ? '' : undefined}
       data-shell-vertical-animating={verticalAnimating ? '' : undefined}
+      data-shell-seam={sidebarTransition.paneVisible ? '' : undefined}
     >
       <DesktopChrome
         header={header}


### PR DESCRIPTION
## What

Adds themed depth to the sidebar/content seam. The 1px hairline stays the crisp contact edge; this only layers a restrained falloff so the opaque content reads as slightly raised over the recessed, translucent sidebar. No blur replaces the sharp edge.

## How

- Two theme-flipped tokens next to the existing divider colors in `index.css`. Light casts a soft ambient shadow into the sidebar (`inset -10px 0 12px -10px`); dark instead lights the content's near edge (`inset 2px 0 2px -1px`), since a dark-on-dark shadow is invisible.
- A `data-shell-seam` flag on the shell root (driven by `sidebarTransition.paneVisible`) gates the effect so it lives and dies with the sidebar's border — no residue when the sidebar is collapsed.
- `inset` so the cells' `overflow-hidden` can't clip it.

## Scope notes

- The titlebar band is deliberately left untouched: light's transparent titlebar sidebar segment lets the workspace layer show through (continuous), and dark's highlight is faint enough that the 40px it crosses reads seamless.
- Values are intentionally soft and are single-token knobs if we want more or less.

## Verification

- `check:ci` + `test` (1325) green.
- Geometry, per-theme flip, and the collapse gate verified against a faithful static reflow of the real DOM + tokens (before/after, light/dark).
- ⚠️ Screenshots can't capture native macOS/Windows vibrancy (window-level material sits below the web layer), so the final look over vibrancy — plus the collapse animation and small-screen resize — wants a real-device pass.
