### PR TITLE
feat(mobile): add legal and support links

### DIFF
--- a/apps/mobile/src/app/settings.tsx
+++ b/apps/mobile/src/app/settings.tsx
@@ -1,10 +1,15 @@
 import { AgentKindSchema, WIRE_PROTOCOL_VERSION } from '@linkcode/schema';
-import { MobileHome, ScreenScroll } from '@linkcode/ui/native';
+import { MobileHome, ScreenScroll, SectionLabel } from '@linkcode/ui/native';
 import { Stack, useRouter } from 'expo-router';
 import { Card, ListGroup, useThemeColor } from 'heroui-native';
 import { ChevronRightIcon } from 'lucide-react-native';
+import { Alert, Linking, View } from 'react-native';
 import { useTranslations } from 'use-intl';
 import { useCloudAccount } from '../runtime/cloud/account';
+
+const PRIVACY_POLICY_URL = 'https://linkcode.ai/privacy';
+const TERMS_OF_SERVICE_URL = 'https://linkcode.ai/terms';
+const SUPPORT_URL = 'https://linkcode.ai/support';
 
 /** App settings: account + host management entries plus the About/contract summary. */
 export default function SettingsScreen(): React.ReactNode {
@@ -14,6 +19,10 @@ export default function SettingsScreen(): React.ReactNode {
   const account = useCloudAccount();
   const muted = useThemeColor('muted');
   const chevron = <ChevronRightIcon size={16} color={muted} />;
+
+  function openExternalUrl(url: string): void {
+    void Linking.openURL(url).catch(() => Alert.alert(t('externalLinkError')));
+  }
 
   return (
     <>
@@ -49,6 +58,42 @@ export default function SettingsScreen(): React.ReactNode {
             <ListGroup.ItemSuffix>{chevron}</ListGroup.ItemSuffix>
           </ListGroup.Item>
         </ListGroup>
+
+        <View className="gap-2">
+          <SectionLabel>{t('legalAndSupport')}</SectionLabel>
+          <ListGroup>
+            <ListGroup.Item
+              accessibilityLabel={t('privacyPolicy')}
+              accessibilityRole="link"
+              onPress={() => openExternalUrl(PRIVACY_POLICY_URL)}
+            >
+              <ListGroup.ItemContent>
+                <ListGroup.ItemTitle>{t('privacyPolicy')}</ListGroup.ItemTitle>
+              </ListGroup.ItemContent>
+              <ListGroup.ItemSuffix>{chevron}</ListGroup.ItemSuffix>
+            </ListGroup.Item>
+            <ListGroup.Item
+              accessibilityLabel={t('termsOfService')}
+              accessibilityRole="link"
+              onPress={() => openExternalUrl(TERMS_OF_SERVICE_URL)}
+            >
+              <ListGroup.ItemContent>
+                <ListGroup.ItemTitle>{t('termsOfService')}</ListGroup.ItemTitle>
+              </ListGroup.ItemContent>
+              <ListGroup.ItemSuffix>{chevron}</ListGroup.ItemSuffix>
+            </ListGroup.Item>
+            <ListGroup.Item
+              accessibilityLabel={t('support')}
+              accessibilityRole="link"
+              onPress={() => openExternalUrl(SUPPORT_URL)}
+            >
+              <ListGroup.ItemContent>
+                <ListGroup.ItemTitle>{t('support')}</ListGroup.ItemTitle>
+              </ListGroup.ItemContent>
+              <ListGroup.ItemSuffix>{chevron}</ListGroup.ItemSuffix>
+            </ListGroup.Item>
+          </ListGroup>
+        </View>
 
         <Card>
           <Card.Header>

--- a/packages/i18n/src/locales/en.ts
+++ b/packages/i18n/src/locales/en.ts
@@ -945,6 +945,11 @@ export const en = {
       signIn: 'Sign in to LinkCode Cloud',
       manageHosts: 'Manage hosts',
       terminalAppearance: 'Terminal appearance',
+      legalAndSupport: 'Legal & Support',
+      privacyPolicy: 'Privacy Policy',
+      termsOfService: 'Terms of Service',
+      support: 'Support',
+      externalLinkError: 'Unable to open this link.',
       about: 'About',
     },
     terminalAppearance: {

--- a/packages/i18n/src/locales/zh-cn.ts
+++ b/packages/i18n/src/locales/zh-cn.ts
@@ -924,6 +924,11 @@ export const zhCN = {
       signIn: '登录 LinkCode Cloud',
       manageHosts: '管理 host',
       terminalAppearance: '终端外观',
+      legalAndSupport: '法律与支持',
+      privacyPolicy: '隐私政策',
+      termsOfService: '服务条款',
+      support: '支持',
+      externalLinkError: '无法打开此链接。',
       about: '关于',
     },
     terminalAppearance: {


### PR DESCRIPTION
## Summary

- add an always-visible Legal & Support section to Mobile Settings
- link Privacy Policy, Terms of Service, and Support through the platform browser
- add English and Simplified Chinese copy
- add explicit accessibility roles and labels plus localized link-open failure handling

## Verification

- `pnpm check:ci`
- `devenv shell -- pnpm test` — 1,325 tests passed
- compiled and launched the iOS development build on an iOS 26.5 simulator
- verified the new section while signed out

## Companion change

- [arcboxlabs/linkcodehq#8](https://github.com/arcboxlabs/linkcodehq/pull/8) publishes the `/support` destination

## Tracking

- [CODE-290](https://linear.app/arcbox/issue/CODE-290/featmobile-add-privacy-terms-and-support-links-in-app)