### PR TITLE
feat(schema,engine,workbench): fetch the endpoint's model list in the custom-account form (CODE-314)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@
 
 Each of these breaks the product, a release, or the build with **no loud error**.
 
-1. **Wire-protocol versions are lockstep.** `WIRE_PROTOCOL_VERSION` (currently 43) is a `z.literal` in `packages/schema/src/wire`; any change to any wire variant must bump it. Mismatched peers still complete the socket ("connected") but every frame fails validation and is **silently discarded** — zero messages, a hang-like failure. Rebuild and restart the daemon and every client together.
+1. **Wire-protocol versions are lockstep.** `WIRE_PROTOCOL_VERSION` (currently 44) is a `z.literal` in `packages/schema/src/wire`; any change to any wire variant must bump it. Mismatched peers still complete the socket ("connected") but every frame fails validation and is **silently discarded** — zero messages, a hang-like failure. Rebuild and restart the daemon and every client together.
 2. **`foxts/once` prewarms by default.** `once(fn)` runs `fn` immediately at construction and caches the result; call-at-most-once semantics need `once(fn, false)`. The default has already shipped a daemon that ran its shutdown at boot and transports whose close-callback fired at construction. Read any foxts helper's `.d.ts`/source before adopting it — the lodash-alike name lies.
 3. **Native deps must be allow-listed.** pnpm blocks install scripts by default; a native dep (e.g. `better-sqlite3`) missing from `allowBuilds:` in `pnpm-workspace.yaml` installs fine but fails at `require()` time with missing bindings.
 4. **CI does not run `pnpm test`.** The vitest suite (~57 test files, node-env pure logic) is absent from `check:ci` and from every workflow — CI gates only format/lint/typecheck plus the Rust job. A green PR does not mean the tests pass; run `pnpm test` yourself before every commit.

--- a/packages/client-core/src/client.ts
+++ b/packages/client-core/src/client.ts
@@ -1,4 +1,5 @@
 import type {
+  AccountProtocol,
   Accounts,
   AgentEvent,
   AgentHistoryId,
@@ -10,6 +11,7 @@ import type {
   AgentStartCatalog,
   ContentBlock,
   EffortLevel,
+  EndpointModel,
   FileSuggestion,
   GitDiff,
   GitDiffMode,
@@ -303,6 +305,9 @@ export class LinkCodeClient {
       case 'agent.cataloged':
         this.pending.resolve('agentCatalog', p.replyTo, p.catalog);
         break;
+      case 'endpoint.models-listed':
+        this.pending.resolve('endpointModels', p.replyTo, p.models);
+        break;
       case 'agent-runtime.changed':
         for (const cb of this.agentRuntimesChangedSubs) cb(p.runtimes);
         break;
@@ -570,6 +575,16 @@ export class LinkCodeClient {
   /** Pre-session picker data (models / approval tiers) for one agent kind. */
   getAgentCatalog(agentKind: AgentKind, cwd?: string): Promise<AgentStartCatalog> {
     return this.control.getAgentCatalog(agentKind, cwd);
+  }
+
+  /** Query an endpoint's model-listing API (daemon-proxied); rejects when it serves none. */
+  listEndpointModels(req: {
+    baseUrl: string;
+    protocol: AccountProtocol;
+    secret: string;
+    credentialType: 'api-key' | 'auth-token';
+  }): Promise<EndpointModel[]> {
+    return this.control.listEndpointModels(req);
   }
 
   listAssets(): Promise<ManagedAssetStatus[]> {

--- a/packages/client-core/src/client/control-channel.ts
+++ b/packages/client-core/src/client/control-channel.ts
@@ -1,4 +1,5 @@
 import type {
+  AccountProtocol,
   Accounts,
   AgentHistoryId,
   AgentHistoryListOptions,
@@ -11,6 +12,7 @@ import type {
   AgentStartCatalog,
   ContentBlock,
   EffortLevel,
+  EndpointModel,
   FileSuggestion,
   GitDiff,
   GitDiffMode,
@@ -334,6 +336,21 @@ export class ControlChannel {
       clientReqId,
       agentKind,
       cwd,
+    }));
+  }
+
+  /** Query an endpoint's model-listing API (daemon-proxied; the add-account form's fetch step).
+   * Rejects when the endpoint serves no listing — the form falls back to manual entry. */
+  listEndpointModels(req: {
+    baseUrl: string;
+    protocol: AccountProtocol;
+    secret: string;
+    credentialType: 'api-key' | 'auth-token';
+  }): Promise<EndpointModel[]> {
+    return this.sendCorrelated('endpointModels', (clientReqId) => ({
+      kind: 'endpoint.list-models',
+      clientReqId,
+      ...req,
     }));
   }
 

--- a/packages/client-core/src/client/pending-registry.ts
+++ b/packages/client-core/src/client/pending-registry.ts
@@ -4,6 +4,7 @@ import type {
   AgentHistoryReadResult,
   AgentRuntimes,
   AgentStartCatalog,
+  EndpointModel,
   FileSuggestion,
   GitDiff,
   GitPullRequestStatus,
@@ -65,6 +66,7 @@ export interface PendingValueMap {
   accountsGet: Accounts;
   agentRuntimeList: AgentRuntimes;
   agentCatalog: AgentStartCatalog;
+  endpointModels: EndpointModel[];
   assetList: ManagedAssetStatus[];
   assetEnsure: ManagedAssetStatus;
   gitStatus: GitStatus;
@@ -108,6 +110,7 @@ export class PendingRegistry {
     accountsGet: new Map(),
     agentRuntimeList: new Map(),
     agentCatalog: new Map(),
+    endpointModels: new Map(),
     assetList: new Map(),
     assetEnsure: new Map(),
     gitStatus: new Map(),

--- a/packages/engine/src/__tests__/endpoint-models.test.ts
+++ b/packages/engine/src/__tests__/endpoint-models.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it, vi } from 'vitest';
+import { listEndpointModels } from '../endpoint-models';
+
+function fetchStub(status: number, payload: unknown): typeof fetch {
+  return vi.fn(() => Promise.resolve(Response.json(payload, { status })));
+}
+
+describe('listEndpointModels', () => {
+  it('queries {baseUrl}/models with a bearer token for openai endpoints', async () => {
+    const fetchFn = fetchStub(200, { data: [{ id: 'gpt-x' }, { id: 'glm-y' }] });
+    const models = await listEndpointModels(
+      {
+        baseUrl: 'https://gw.test/v1/',
+        protocol: 'openai-chat',
+        secret: 'sk-1',
+        credentialType: 'api-key',
+      },
+      fetchFn,
+    );
+    expect(models).toEqual([{ id: 'gpt-x' }, { id: 'glm-y' }]);
+    expect(fetchFn).toHaveBeenCalledWith(
+      'https://gw.test/v1/models',
+      expect.objectContaining({ headers: { Authorization: 'Bearer sk-1' } }),
+    );
+  });
+
+  it('queries {baseUrl}/v1/models with x-api-key + version for anthropic api-key endpoints', async () => {
+    const fetchFn = fetchStub(200, { data: [{ id: 'claude-z' }] });
+    await listEndpointModels(
+      {
+        baseUrl: 'https://api.anthropic.com',
+        protocol: 'anthropic',
+        secret: 'sk-ant',
+        credentialType: 'api-key',
+      },
+      fetchFn,
+    );
+    expect(fetchFn).toHaveBeenCalledWith(
+      'https://api.anthropic.com/v1/models',
+      expect.objectContaining({
+        headers: { 'anthropic-version': '2023-06-01', 'x-api-key': 'sk-ant' },
+      }),
+    );
+  });
+
+  it('uses a bearer token for anthropic auth-token endpoints (gateway skins)', async () => {
+    const fetchFn = fetchStub(200, { data: [] });
+    await listEndpointModels(
+      {
+        baseUrl: 'https://openrouter.ai/api',
+        protocol: 'anthropic',
+        secret: 'sk-or',
+        credentialType: 'auth-token',
+      },
+      fetchFn,
+    );
+    expect(fetchFn).toHaveBeenCalledWith(
+      'https://openrouter.ai/api/v1/models',
+      expect.objectContaining({
+        headers: { 'anthropic-version': '2023-06-01', Authorization: 'Bearer sk-or' },
+      }),
+    );
+  });
+
+  it('captures OpenRouter context_length as contextWindow, skipping malformed entries', async () => {
+    const fetchFn = fetchStub(200, {
+      data: [
+        { id: 'a/b', context_length: 131072 },
+        { id: 'c', context_length: 'big' },
+        { noId: 1 },
+      ],
+    });
+    const models = await listEndpointModels(
+      {
+        baseUrl: 'https://openrouter.ai/api/v1',
+        protocol: 'openai-chat',
+        secret: 'sk',
+        credentialType: 'auth-token',
+      },
+      fetchFn,
+    );
+    expect(models).toEqual([{ id: 'a/b', contextWindow: 131072 }, { id: 'c' }]);
+  });
+
+  it('rejects on a non-2xx status with the status in the message', async () => {
+    await expect(
+      listEndpointModels(
+        {
+          baseUrl: 'https://ai.banned.test/v1',
+          protocol: 'openai-chat',
+          secret: 'k',
+          credentialType: 'api-key',
+        },
+        fetchStub(404, 'not found'),
+      ),
+    ).rejects.toThrow('404');
+  });
+
+  it('rejects on a shape without a data array', async () => {
+    await expect(
+      listEndpointModels(
+        {
+          baseUrl: 'https://x.test/v1',
+          protocol: 'openai-chat',
+          secret: 'k',
+          credentialType: 'api-key',
+        },
+        fetchStub(200, { models: [] }),
+      ),
+    ).rejects.toThrow('unexpected response shape');
+  });
+});

--- a/packages/engine/src/endpoint-models.ts
+++ b/packages/engine/src/endpoint-models.ts
@@ -1,0 +1,73 @@
+import type { AccountProtocol, EndpointModel } from '@linkcode/schema';
+
+/**
+ * The add-account form's "fetch model list" step: query an endpoint's model-listing API on the
+ * client's behalf (renderers cannot reach arbitrary user endpoints — desktop CSP, browser CORS).
+ * Listings are best-effort: many gateways serve none (404) — the caller surfaces the rejection
+ * and the form falls back to manual entry.
+ */
+
+export interface ListEndpointModelsRequest {
+  baseUrl: string;
+  protocol: AccountProtocol;
+  secret: string;
+  credentialType: 'api-key' | 'auth-token';
+}
+
+const TIMEOUT_MS = 10_000;
+
+/** OpenAI-shaped bases already end in a version segment (`…/v1`); Anthropic bases do not. */
+function listingUrl(baseUrl: string, protocol: AccountProtocol): string {
+  const base = baseUrl.replace(/\/+$/, '');
+  return protocol === 'anthropic' ? `${base}/v1/models` : `${base}/models`;
+}
+
+function listingHeaders(req: ListEndpointModelsRequest): Record<string, string> {
+  if (req.protocol === 'anthropic') {
+    return {
+      'anthropic-version': '2023-06-01',
+      ...(req.credentialType === 'api-key'
+        ? { 'x-api-key': req.secret }
+        : { Authorization: `Bearer ${req.secret}` }),
+    };
+  }
+  return { Authorization: `Bearer ${req.secret}` };
+}
+
+/** Both OpenAI- and Anthropic-shaped listings return `{data: [{id, …}]}`; OpenRouter adds
+ * `context_length`. Anything else is a shape error. */
+function parseListing(payload: unknown): EndpointModel[] {
+  if (typeof payload !== 'object' || payload === null || !('data' in payload)) {
+    throw new Error('unexpected response shape (no "data" array)');
+  }
+  const { data } = payload;
+  if (!Array.isArray(data)) throw new Error('unexpected response shape (no "data" array)');
+  const models: EndpointModel[] = [];
+  for (const entry of data) {
+    if (typeof entry !== 'object' || entry === null) continue;
+    const id = (entry as Record<string, unknown>).id;
+    if (typeof id !== 'string' || id.length === 0) continue;
+    const contextLength = (entry as Record<string, unknown>).context_length;
+    models.push({
+      id,
+      ...(typeof contextLength === 'number' &&
+        Number.isInteger(contextLength) &&
+        contextLength > 0 && { contextWindow: contextLength }),
+    });
+  }
+  return models;
+}
+
+export async function listEndpointModels(
+  req: ListEndpointModelsRequest,
+  fetchFn: typeof fetch = fetch,
+): Promise<EndpointModel[]> {
+  const response = await fetchFn(listingUrl(req.baseUrl, req.protocol), {
+    headers: listingHeaders(req),
+    signal: AbortSignal.timeout(TIMEOUT_MS),
+  });
+  if (!response.ok) {
+    throw new Error(`the endpoint answered ${response.status} — it may not serve a model listing`);
+  }
+  return parseListing(await response.json());
+}

--- a/packages/engine/src/engine.ts
+++ b/packages/engine/src/engine.ts
@@ -44,6 +44,7 @@ import {
   ScheduleService,
   watchTurn,
 } from './automation';
+import { listEndpointModels } from './endpoint-models';
 import { readWorkspaceFile } from './file-service';
 import { FileSuggestService } from './file-suggest-service';
 import { GitService } from './git/git-service';
@@ -570,6 +571,20 @@ export class Engine {
               : machineScoped;
           this.transport.send(
             createWireMessage({ kind: 'agent.cataloged', replyTo: p.clientReqId, catalog }),
+          );
+        });
+        break;
+      }
+      case 'endpoint.list-models': {
+        await this.tryReply(p.clientReqId, async () => {
+          const models = await listEndpointModels({
+            baseUrl: p.baseUrl,
+            protocol: p.protocol,
+            secret: p.secret,
+            credentialType: p.credentialType,
+          });
+          this.transport.send(
+            createWireMessage({ kind: 'endpoint.models-listed', replyTo: p.clientReqId, models }),
           );
         });
         break;

--- a/packages/i18n/src/locales/en.ts
+++ b/packages/i18n/src/locales/en.ts
@@ -742,6 +742,15 @@ export const en = {
       localProviders: {
         source: 'pi · models.json',
       },
+      fetchModels: {
+        button: 'Fetch model list',
+        loading: 'Fetching…',
+        needsEndpoint: 'Fill in the endpoint URL, protocol, and key to fetch automatically',
+        failed:
+          'Fetch failed ({message}) — the endpoint may not serve a listing; fill in models manually.',
+        empty: 'The endpoint returned an empty list; fill in models manually.',
+        addPicked: 'Add selected ({count})',
+      },
       import: {
         hint: 'Pick a pi models.json file; each custom provider becomes one account, with model definitions (cost and thinking-level map included) preserved in full. Plain JSON only (no comments).',
         parseError: 'Cannot parse: {message}',

--- a/packages/i18n/src/locales/zh-cn.ts
+++ b/packages/i18n/src/locales/zh-cn.ts
@@ -728,6 +728,14 @@ export const zhCN = {
       localProviders: {
         source: 'pi · models.json',
       },
+      fetchModels: {
+        button: '获取模型列表',
+        loading: '获取中…',
+        needsEndpoint: '填好端点 URL、协议和密钥后可自动获取',
+        failed: '获取失败({message})——该端点可能不提供列表接口,请手动填写模型。',
+        empty: '端点返回了空列表,请手动填写模型。',
+        addPicked: '添加所选({count})',
+      },
       import: {
         hint: '选择 pi 的 models.json 文件;每个自定义 provider 导入为一个账号,模型定义(含成本与思考等级映射)完整保留。仅支持纯 JSON(不支持注释)。',
         parseError: '无法解析:{message}',

--- a/packages/schema/src/account.ts
+++ b/packages/schema/src/account.ts
@@ -72,6 +72,15 @@ export const AccountCustomProviderSchema = z.object({
 });
 export type AccountCustomProvider = z.infer<typeof AccountCustomProviderSchema>;
 
+/** One model an endpoint's listing API reports (`endpoint.list-models`). Listings carry ids and,
+ * on some gateways (OpenRouter `context_length`), a context window — never cost or reasoning
+ * capability; form rows built from these fall back to defaults for the rest. */
+export const EndpointModelSchema = z.object({
+  id: z.string().min(1),
+  contextWindow: z.number().int().positive().optional(),
+});
+export type EndpointModel = z.infer<typeof EndpointModelSchema>;
+
 export const AccountSchema = z.object({
   /** Stable id referenced by `providers[kind].activeAccountId` and `StartOptions.config.accountId`. */
   id: z.string().min(1),

--- a/packages/schema/src/wire/config.ts
+++ b/packages/schema/src/wire/config.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { AccountsSchema } from '../account';
+import { AccountProtocolSchema, AccountsSchema, EndpointModelSchema } from '../account';
 import { ProvidersConfigSchema } from '../provider-config';
 
 /** Host configuration wire variants — per-agent provider settings (provider-config.ts) plus the
@@ -20,5 +20,22 @@ export const configWireVariants = [
     providers: ProvidersConfigSchema.optional(),
     /** The global account pool; omitted by a client editing only provider settings. */
     accounts: AccountsSchema.optional(),
+  }),
+  /** Ask the daemon to query an endpoint's model-listing API (the add-account form's fetch step).
+   * Daemon-proxied because renderers cannot reach arbitrary user endpoints (desktop CSP, browser
+   * CORS). Endpoints without a listing (404 etc.) reject the request — the form falls back to
+   * manual entry. */
+  z.object({
+    kind: z.literal('endpoint.list-models'),
+    clientReqId: z.string().min(1),
+    baseUrl: z.url(),
+    protocol: AccountProtocolSchema,
+    secret: z.string().min(1),
+    credentialType: z.enum(['api-key', 'auth-token']),
+  }),
+  z.object({
+    kind: z.literal('endpoint.models-listed'),
+    replyTo: z.string().min(1),
+    models: z.array(EndpointModelSchema),
   }),
 ] as const;

--- a/packages/schema/src/wire/index.ts
+++ b/packages/schema/src/wire/index.ts
@@ -37,7 +37,7 @@ export {
 // 39 disambiguates a parallel double-bump: #186 (CODE-142) and #189 (CODE-219) both shipped as
 // "38" with different schemas, so a build from between their merges shares a number with a
 // schema it does not speak.
-export const WIRE_PROTOCOL_VERSION = 43 as const;
+export const WIRE_PROTOCOL_VERSION = 44 as const;
 
 /** Envelope payload: a discriminated union keyed by `kind`. */
 export const WirePayloadSchema = z.discriminatedUnion('kind', [

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -6,6 +6,7 @@ import type {
 } from '@linkcode/client-core';
 import { LinkCodeClient } from '@linkcode/client-core';
 import type {
+  AccountProtocol,
   Accounts,
   AgentHistoryId,
   AgentHistoryListResult,
@@ -15,6 +16,7 @@ import type {
   AgentRuntimes,
   AgentStartCatalog,
   EffortLevel,
+  EndpointModel,
   FileSuggestion,
   GitDiff,
   GitDiffMode,
@@ -221,6 +223,16 @@ export class LinkCodeSdkClient {
   /** Pre-session picker data (models / approval tiers) for one agent kind. */
   getAgentCatalog(agentKind: AgentKind, cwd?: string): RequestResult<AgentStartCatalog> {
     return toResult(this.raw.getAgentCatalog(agentKind, cwd));
+  }
+
+  /** Query an endpoint's model-listing API (daemon-proxied); rejects when it serves none. */
+  listEndpointModels(req: {
+    baseUrl: string;
+    protocol: AccountProtocol;
+    secret: string;
+    credentialType: 'api-key' | 'auth-token';
+  }): RequestResult<EndpointModel[]> {
+    return toResult(this.raw.listEndpointModels(req));
   }
 
   /** Managed-asset store status: wanted versions and what is installed (CODE-111). */

--- a/packages/sdk/src/operations.ts
+++ b/packages/sdk/src/operations.ts
@@ -1,5 +1,6 @@
 import type { HistoryListClientOptions, HistoryReadClientOptions } from '@linkcode/client-core';
 import type {
+  AccountProtocol,
   Accounts,
   AgentHistoryId,
   AgentHistoryListResult,
@@ -9,6 +10,7 @@ import type {
   AgentRuntimes,
   AgentStartCatalog,
   EffortLevel,
+  EndpointModel,
   FileSuggestion,
   GitDiff,
   GitDiffMode,
@@ -186,6 +188,20 @@ export function getAgentCatalog(
   options: Options<{ agentKind: AgentKind; cwd?: string }>,
 ): RequestResult<AgentStartCatalog> {
   return resolveClient(options).getAgentCatalog(options.agentKind, options.cwd);
+}
+
+/** Query an endpoint's model-listing API (daemon-proxied; the add-account form's fetch step).
+ * Rejects when the endpoint serves no listing — the form falls back to manual entry. */
+export function listEndpointModels(
+  options: Options<{
+    baseUrl: string;
+    protocol: AccountProtocol;
+    secret: string;
+    credentialType: 'api-key' | 'auth-token';
+  }>,
+): RequestResult<EndpointModel[]> {
+  const { client: _client, ...req } = options;
+  return resolveClient(options).listEndpointModels(req);
 }
 
 /** Managed-asset store status: wanted versions and what is installed (CODE-111). */

--- a/packages/workbench/src/settings/providers/add-flow.tsx
+++ b/packages/workbench/src/settings/providers/add-flow.tsx
@@ -1,7 +1,9 @@
 import { zodResolver } from '@hookform/resolvers/zod';
-import type { Account, AccountProtocol, AgentRuntimes } from '@linkcode/schema';
+import type { Account, AccountProtocol, AgentRuntimes, EndpointModel } from '@linkcode/schema';
+import { listEndpointModels } from '@linkcode/sdk';
 import { ServiceIcon } from '@linkcode/ui';
 import { Button } from 'coss-ui/components/button';
+import { Checkbox } from 'coss-ui/components/checkbox';
 import { Field, FieldLabel } from 'coss-ui/components/field';
 import { Input } from 'coss-ui/components/input';
 import { RadioGroup, RadioGroupItem } from 'coss-ui/components/radio-group';
@@ -21,6 +23,7 @@ import type { Control, FieldValues, Path } from 'react-hook-form';
 import { Controller, useFieldArray, useForm, useWatch } from 'react-hook-form';
 import { useTranslations } from 'use-intl';
 import { z } from 'zod';
+import { useMutation } from '../../runtime/tayori';
 import type { ServiceDescriptor, ServiceGroup, ServiceVariant } from './catalog';
 import { fillTemplate, SERVICE_CATALOG, serviceById, templatePlaceholders } from './catalog';
 import type { ImportedProvider, ModelsJsonImport } from './import-models-json';
@@ -537,6 +540,50 @@ function CustomAccountForm({
   });
   const modelRows = useFieldArray({ control, name: 'models' });
 
+  // The "fetch model list" step: query the endpoint's listing API (daemon-proxied) and offer the
+  // ids as a checklist. Endpoints without a listing reject — the hint says to fill in manually.
+  const fetchModels = useMutation(listEndpointModels);
+  const [fetched, setFetched] = useState<EndpointModel[] | null>(null);
+  const [fetchError, setFetchError] = useState<string | null>(null);
+  const [picked, setPicked] = useState<ReadonlySet<string>>(() => new Set());
+  const [draftBaseUrl, draftProtocol, draftSecret, draftType] = useWatch({
+    control,
+    name: ['baseUrl', 'protocol', 'secret', 'type'],
+  });
+  const canFetch = draftBaseUrl.trim() !== '' && draftProtocol !== '' && draftSecret !== '';
+
+  const handleFetch = async (): Promise<void> => {
+    try {
+      const models = await fetchModels.trigger({
+        baseUrl: draftBaseUrl.trim(),
+        protocol: draftProtocol as AccountProtocol,
+        secret: draftSecret,
+        credentialType: draftType,
+      });
+      setFetched(models);
+      setPicked(new Set());
+      setFetchError(null);
+    } catch (err) {
+      setFetched(null);
+      setFetchError(extractErrorMessage(err));
+    }
+  };
+
+  const addPicked = (): void => {
+    for (const model of fetched ?? []) {
+      if (!picked.has(model.id)) continue;
+      modelRows.append({
+        id: model.id,
+        name: '',
+        reasoning: false,
+        contextWindow: model.contextWindow ?? 131072,
+        maxTokens: 8192,
+      });
+    }
+    setFetched(null);
+    setPicked(new Set());
+  };
+
   const typeItems = [
     { value: 'api-key', label: t('credentialApiKey') },
     { value: 'auth-token', label: t('credentialAuthToken') },
@@ -615,6 +662,56 @@ function CustomAccountForm({
           </Button>
         </div>
         <p className="text-muted-foreground text-xs">{t('form.customProviderHint')}</p>
+        <div className="flex items-center gap-2">
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            disabled={!canFetch || fetchModels.isMutating}
+            onClick={() => {
+              void handleFetch();
+            }}
+          >
+            {fetchModels.isMutating ? t('fetchModels.loading') : t('fetchModels.button')}
+          </Button>
+          {canFetch ? null : (
+            <span className="text-muted-foreground text-xs">{t('fetchModels.needsEndpoint')}</span>
+          )}
+        </div>
+        {fetchError === null ? null : (
+          <p className="text-muted-foreground text-xs">
+            {t('fetchModels.failed', { message: fetchError })}
+          </p>
+        )}
+        {fetched === null ? null : fetched.length === 0 ? (
+          <p className="text-muted-foreground text-xs">{t('fetchModels.empty')}</p>
+        ) : (
+          <div className="flex flex-col gap-2 rounded-lg border border-border p-2">
+            <div className="flex max-h-48 flex-col gap-1 overflow-y-auto">
+              {fetched.map((model) => (
+                <label key={model.id} className="flex items-center gap-2 text-sm">
+                  <Checkbox
+                    checked={picked.has(model.id)}
+                    onCheckedChange={(checked) => {
+                      setPicked((prev) => {
+                        const next = new Set(prev);
+                        if (checked) next.add(model.id);
+                        else next.delete(model.id);
+                        return next;
+                      });
+                    }}
+                  />
+                  <span className="min-w-0 truncate font-mono text-xs">{model.id}</span>
+                </label>
+              ))}
+            </div>
+            <div>
+              <Button type="button" size="sm" disabled={picked.size === 0} onClick={addPicked}>
+                {t('fetchModels.addPicked', { count: picked.size })}
+              </Button>
+            </div>
+          </div>
+        )}
         {modelRows.fields.length > 0 ? (
           <Field>
             <FieldLabel>{t('form.providerName')}</FieldLabel>


### PR DESCRIPTION
Closes CODE-314. Stacks on chenyu/code-313 (CODE-313).

## What

The custom-account form gains a **Fetch model list** step: with endpoint URL + protocol + secret filled in, one click queries the endpoint's model-listing API and offers the served ids as a checklist — selected entries become custom-provider model rows (context window prefilled when the listing carries it, defaults otherwise). The step is always offered; endpoints without a listing fail into an inline "fill manually" hint.

- **schema**: `endpoint.list-models` / `endpoint.models-listed` wire pair + `EndpointModelSchema`; wire v43 → v44.
- **engine**: `endpoint-models.ts` — daemon-proxied fetch (renderers can't reach arbitrary user endpoints: desktop CSP, browser CORS). URL/auth derive from the protocol (openai → `{base}/models` Bearer; anthropic → `{base}/v1/models` x-api-key/Bearer + anthropic-version); 10 s timeout; parses the standard `{data:[{id}]}` shape and captures OpenRouter's `context_length` as `contextWindow`.
- **client-core / sdk**: `listEndpointModels` plumbing.
- **workbench**: fetch button + scrollable checklist in the custom-provider section; i18n zh + en.

## Verification

- 6 engine unit tests (both protocol auth shapes, OpenRouter context_length, 404 and shape errors).
- Live end-to-end over the wire on an isolated daemon: OpenRouter listed **344 models** with contextWindow captured; the banned Cloudflare gateway rejected with a clear `404 — may not serve a model listing` message (the manual-entry path).
- `pnpm check:ci` + `pnpm test` green (1412 passed).