### PR TITLE
fix(ui): refresh imported history when switching agent tabs

### DIFF
--- a/packages/client/workbench/src/history/__tests__/use-provider-history.test.ts
+++ b/packages/client/workbench/src/history/__tests__/use-provider-history.test.ts
@@ -1,0 +1,130 @@
+// @vitest-environment jsdom
+
+import type { AgentHistoryListResult, AgentKind } from '@linkcode/schema';
+import { AgentHistoryIdSchema } from '@linkcode/schema';
+import { cleanup, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useProviderHistory } from '../use-provider-history';
+
+const { useDataMock, useMutationMock } = vi.hoisted(() => ({
+  useDataMock: vi.fn(),
+  useMutationMock: vi.fn(),
+}));
+
+vi.mock('../../runtime/tayori', () => ({
+  useData: useDataMock,
+  useMutation: useMutationMock,
+}));
+
+interface HistoryResponse {
+  data?: AgentHistoryListResult;
+  error?: unknown;
+}
+
+interface HistoryRequest {
+  agentKind: AgentKind;
+  opts: { limit: number };
+}
+
+interface HistoryDataOptions {
+  keepPreviousData?: boolean;
+}
+
+const responses = new Map<AgentKind, HistoryResponse>();
+const codexSessionId = AgentHistoryIdSchema.parse('codex-session');
+const claudeSessionId = AgentHistoryIdSchema.parse('claude-session');
+const lateCodexSessionId = AgentHistoryIdSchema.parse('late-codex-session');
+
+beforeEach(() => {
+  let previousData: AgentHistoryListResult | undefined;
+  let previousKind: AgentKind | undefined;
+
+  useDataMock.mockImplementation(
+    (_operation: unknown, request: HistoryRequest, options?: HistoryDataOptions) => {
+      const response = responses.get(request.agentKind) ?? {};
+      const changedProvider = previousKind !== undefined && previousKind !== request.agentKind;
+      const data =
+        response.data === undefined && changedProvider && options?.keepPreviousData !== false
+          ? previousData
+          : response.data;
+
+      if (response.data !== undefined) previousData = response.data;
+      previousKind = request.agentKind;
+
+      return {
+        data,
+        error: response.error,
+        isLoading: data === undefined && response.error === undefined,
+        mutate: vi.fn(),
+      };
+    },
+  );
+  useMutationMock.mockReturnValue({ trigger: vi.fn() });
+});
+
+afterEach(() => {
+  cleanup();
+  responses.clear();
+  useDataMock.mockReset();
+  useMutationMock.mockReset();
+});
+
+describe('useProviderHistory', () => {
+  it('does not retain an installed provider list when the next provider cannot be scanned', () => {
+    responses.set('codex', {
+      data: {
+        sessions: [{ historyId: codexSessionId, kind: 'codex', title: 'Codex chat' }],
+      },
+    });
+    const unavailable = new Error('pi: history list is not supported');
+    responses.set('pi', { error: unavailable });
+
+    const { result, rerender } = renderHook(
+      ({ kind }: { kind: AgentKind }) => useProviderHistory(kind),
+      { initialProps: { kind: 'codex' } },
+    );
+    expect(result.current.entries.map((entry) => entry.historyId)).toEqual([codexSessionId]);
+
+    rerender({ kind: 'pi' });
+
+    expect(result.current.entries).toEqual([]);
+    expect(result.current.loadError).toBe(unavailable);
+    expect(useDataMock.mock.lastCall?.[1]).toEqual({
+      agentKind: 'pi',
+      opts: { limit: 200 },
+    });
+    expect(useDataMock.mock.lastCall?.[2]).toEqual({ keepPreviousData: false });
+  });
+
+  it('keeps late results scoped to their provider during rapid switches and restores its cache', () => {
+    responses.set('claude-code', {
+      data: {
+        sessions: [{ historyId: claudeSessionId, kind: 'claude-code', title: 'Claude chat' }],
+      },
+    });
+
+    const { result, rerender } = renderHook(
+      ({ kind }: { kind: AgentKind }) => useProviderHistory(kind),
+      { initialProps: { kind: 'claude-code' } },
+    );
+    expect(result.current.entries.map((entry) => entry.historyId)).toEqual([claudeSessionId]);
+
+    rerender({ kind: 'codex' });
+    expect(result.current.entries).toEqual([]);
+    expect(result.current.isLoading).toBe(true);
+
+    rerender({ kind: 'opencode' });
+    expect(result.current.entries).toEqual([]);
+
+    responses.set('codex', {
+      data: {
+        sessions: [{ historyId: lateCodexSessionId, kind: 'codex', title: 'Codex chat' }],
+      },
+    });
+    rerender({ kind: 'opencode' });
+    expect(result.current.entries).toEqual([]);
+
+    rerender({ kind: 'codex' });
+    expect(result.current.entries.map((entry) => entry.historyId)).toEqual([lateCodexSessionId]);
+  });
+});

--- a/packages/client/workbench/src/history/use-provider-history.ts
+++ b/packages/client/workbench/src/history/use-provider-history.ts
@@ -25,10 +25,16 @@ export interface ProviderHistory {
 
 /** Global (cwd-less) provider history for one agent kind, plus the import mutation. */
 export function useProviderHistory(kind: AgentKind): ProviderHistory {
-  const { data, isLoading, error, mutate } = useData(listHistory, {
-    agentKind: kind,
-    opts: { limit: HISTORY_PAGE_LIMIT },
-  });
+  const { data, isLoading, error, mutate } = useData(
+    listHistory,
+    {
+      agentKind: kind,
+      opts: { limit: HISTORY_PAGE_LIMIT },
+    },
+    // Provider history is identity-scoped: retaining the previous key's rows would label one
+    // agent's sessions as another agent's while the next scan is pending or unavailable.
+    { keepPreviousData: false },
+  );
   const importMutation = useMutation(importSession);
   const [importingId, setImportingId] = useState<AgentHistoryId | null>(null);
   const [importError, setImportError] = useState<unknown>(null);


### PR DESCRIPTION
## Summary

- scope the existing tayori `listHistory` query to the selected agent without displaying another query key's previous data
- preserve SWR's per-agent cache and late-response isolation while showing the current agent's loading, empty, or error state
- add regression coverage for populated → unavailable switches, rapid tab changes with a late response, and switching back to the original agent

## Root cause

`listHistory` already included `agentKind` in its tayori/SWR key, but the workbench's global `keepPreviousData: true` setting exposed the previous key's rows while the newly selected CLI was scanning or could not be scanned. That made the old agent's conversations appear under the new agent tab.

The provider-history hook now opts out with `keepPreviousData: false`. This fixes the data source rather than clearing rows in the UI or adding a custom fetcher.

## Verification

- `pnpm check:ci` — passed
- `pnpm test packages/workbench/src/history/__tests__/use-provider-history.test.ts` — 2/2 passed
- desktop + daemon UI observation after rebasing onto current `origin/master`:
  - Pi and Grok Build show their unsupported-history error states
  - unavailable OpenCode shows its `ENOENT` scan error
  - Codex shows its own empty state after switching back
  - header and body remain aligned with the selected tab
- full `pnpm test` — 1485 passed, 2 unrelated orb-environment failures:
  - `git-status.test.ts` expects an SSH remote, but the orb's global Git config rewrites GitHub SSH URLs to HTTPS
  - `shell-exec.test.ts` runs `sleep 5` and reaches Vitest's 5-second timeout before its timeout assertion completes

Linear: CODE-346