### PR TITLE
feat(ui): keep terminal tabs in sync across panels

### DIFF
--- a/apps/desktop/src/renderer/src/__tests__/shell-state.test.ts
+++ b/apps/desktop/src/renderer/src/__tests__/shell-state.test.ts
@@ -8,6 +8,7 @@ import {
   createPanelState,
   createRightFileTab,
   DEFAULT_LAYOUT,
+  getTerminalPanelOwner,
   openFileTabState,
   parsePersistedDesktopShellState,
   RIGHT_PANEL_MAX_SIZE,
@@ -248,6 +249,20 @@ describe('revealSectionState', () => {
     const revealed = revealSectionState(panel, 'files', true);
 
     expect(revealed.activeSection).toBe('files');
+  });
+});
+
+describe('getTerminalPanelOwner', () => {
+  it('routes interaction to a maximized bottom terminal over an open right terminal', () => {
+    expect(getTerminalPanelOwner('bottom', true, 'terminal', true)).toBe('bottom');
+  });
+
+  it('keeps the right terminal as owner when no panel is maximized', () => {
+    expect(getTerminalPanelOwner(null, true, 'terminal', true)).toBe('right');
+  });
+
+  it('does not give a hidden bottom terminal ownership behind a maximized right panel', () => {
+    expect(getTerminalPanelOwner('right', true, 'diff', true)).toBeNull();
   });
 });
 

--- a/apps/desktop/src/renderer/src/__tests__/shell-state.test.ts
+++ b/apps/desktop/src/renderer/src/__tests__/shell-state.test.ts
@@ -7,7 +7,6 @@ import {
   createDefaultRightPanelState,
   createPanelState,
   createRightFileTab,
-  createRightTerminalTab,
   DEFAULT_LAYOUT,
   openFileTabState,
   parsePersistedDesktopShellState,
@@ -16,7 +15,6 @@ import {
   revealSectionState,
   SIDEBAR_MAX_SIZE,
   SIDEBAR_MIN_SIZE,
-  seedTerminalSection,
   serializeDesktopShellState,
 } from '@renderer/shell/store/model';
 import { describe, expect, it } from 'vitest';
@@ -37,7 +35,7 @@ describe('desktop shell state persistence', () => {
     expect(state.sidebarOpen).toBe(true);
     expect(state.expansionStack).toEqual([]);
     expect(state.rightPanel).toEqual(createDefaultRightPanelState());
-    expect(panelTypes(state.bottomPanel)).toEqual(['terminal']);
+    expect(panelTypes(state.bottomPanel)).toEqual([]);
   });
 
   it('falls back to defaults for a stale v1 payload instead of migrating it', () => {
@@ -53,12 +51,12 @@ describe('desktop shell state persistence', () => {
     expect(state.sidebarOpen).toBe(true);
     expect(state.expansionStack).toEqual([]);
     expect(state.rightPanel).toEqual(createDefaultRightPanelState());
-    expect(panelTypes(state.bottomPanel)).toEqual(['terminal']);
+    expect(panelTypes(state.bottomPanel)).toEqual([]);
   });
 
   it('clamps latest layout values', () => {
     const state = parsePersistedDesktopShellState({
-      version: 2,
+      version: 3,
       sidebarOpen: true,
       layout: { sidebarW: 10, rightW: 10000, bottomH: 1 },
       expansionStack: [],
@@ -80,7 +78,7 @@ describe('desktop shell state persistence', () => {
 
   it('rejects invalid bottom tabs and falls back when none remain', () => {
     const state = parsePersistedDesktopShellState({
-      version: 2,
+      version: 3,
       sidebarOpen: true,
       layout: {
         sidebarW: SIDEBAR_MAX_SIZE,
@@ -97,93 +95,19 @@ describe('desktop shell state persistence', () => {
       bottomPanel: { open: true, tabs: ['invalid'], activeTabIndex: 0 },
     });
 
-    expect(panelTypes(state.bottomPanel)).toEqual(['terminal']);
-    expect(activeBottomPanelType(state)).toBe('terminal');
-  });
-
-  it('restores the right panel section and terminal tab count, clamping the active index', () => {
-    const state = parsePersistedDesktopShellState({
-      version: 2,
-      sidebarOpen: true,
-      layout: DEFAULT_LAYOUT,
-      expansionStack: [],
-      rightPanel: {
-        open: true,
-        activeSection: 'terminal',
-        terminalTabCount: 3,
-        activeTerminalTabIndex: 99,
-      },
-      bottomPanel: { open: false, tabs: ['terminal'], activeTabIndex: 0 },
-    });
-
-    expect(state.rightPanel.open).toBe(true);
-    expect(state.rightPanel.activeSection).toBe('terminal');
-    expect(state.rightPanel.terminal.tabs).toHaveLength(3);
-    expect(state.rightPanel.terminal.activeTabId).toBe(state.rightPanel.terminal.tabs[2].id);
-  });
-
-  it('seeds a first terminal tab when restoring an open panel showing an empty terminal section', () => {
-    const state = parsePersistedDesktopShellState({
-      version: 2,
-      sidebarOpen: true,
-      layout: DEFAULT_LAYOUT,
-      expansionStack: [],
-      rightPanel: {
-        open: true,
-        activeSection: 'terminal',
-        terminalTabCount: 0,
-        activeTerminalTabIndex: 0,
-      },
-      bottomPanel: { open: false, tabs: ['terminal'], activeTabIndex: 0 },
-    });
-
-    expect(state.rightPanel.terminal.tabs).toHaveLength(1);
-    expect(state.rightPanel.terminal.activeTabId).toBe(state.rightPanel.terminal.tabs[0].id);
-  });
-
-  it('does not seed a terminal tab when the restored panel is closed or on another section', () => {
-    const closed = parsePersistedDesktopShellState({
-      version: 2,
-      sidebarOpen: true,
-      layout: DEFAULT_LAYOUT,
-      expansionStack: [],
-      rightPanel: {
-        open: false,
-        activeSection: 'terminal',
-        terminalTabCount: 0,
-        activeTerminalTabIndex: 0,
-      },
-      bottomPanel: { open: false, tabs: ['terminal'], activeTabIndex: 0 },
-    });
-    expect(closed.rightPanel.terminal.tabs).toEqual([]);
-
-    const otherSection = parsePersistedDesktopShellState({
-      version: 2,
-      sidebarOpen: true,
-      layout: DEFAULT_LAYOUT,
-      expansionStack: [],
-      rightPanel: {
-        open: true,
-        activeSection: 'diff',
-        terminalTabCount: 0,
-        activeTerminalTabIndex: 0,
-      },
-      bottomPanel: { open: false, tabs: ['terminal'], activeTabIndex: 0 },
-    });
-    expect(otherSection.rightPanel.terminal.tabs).toEqual([]);
+    expect(panelTypes(state.bottomPanel)).toEqual([]);
+    expect(activeBottomPanelType(state)).toBeUndefined();
   });
 
   it('rejects an invalid right panel section and falls back to diff', () => {
     const state = parsePersistedDesktopShellState({
-      version: 2,
+      version: 3,
       sidebarOpen: true,
       layout: DEFAULT_LAYOUT,
       expansionStack: [],
       rightPanel: {
         open: true,
         activeSection: 'invalid',
-        terminalTabCount: 0,
-        activeTerminalTabIndex: 0,
       },
       bottomPanel: { open: false, tabs: ['terminal'], activeTabIndex: 0 },
     });
@@ -191,35 +115,15 @@ describe('desktop shell state persistence', () => {
     expect(state.rightPanel.activeSection).toBe('diff');
   });
 
-  it('caps a corrupted terminal tab count', () => {
-    const state = parsePersistedDesktopShellState({
-      version: 2,
-      sidebarOpen: true,
-      layout: DEFAULT_LAYOUT,
-      expansionStack: [],
-      rightPanel: {
-        open: true,
-        activeSection: 'terminal',
-        terminalTabCount: 999,
-        activeTerminalTabIndex: 0,
-      },
-      bottomPanel: { open: false, tabs: ['terminal'], activeTabIndex: 0 },
-    });
-
-    expect(state.rightPanel.terminal.tabs.length).toBeLessThanOrEqual(20);
-  });
-
   it('filters expansion stack to open panels', () => {
     const state = parsePersistedDesktopShellState({
-      version: 2,
+      version: 3,
       sidebarOpen: true,
       layout: DEFAULT_LAYOUT,
       expansionStack: ['right', 'bottom', 'bottom', 'invalid'],
       rightPanel: {
         open: false,
         activeSection: 'diff',
-        terminalTabCount: 0,
-        activeTerminalTabIndex: 0,
       },
       bottomPanel: { open: true, tabs: ['terminal'], activeTabIndex: 0 },
     });
@@ -232,7 +136,6 @@ describe('desktop shell state persistence', () => {
     const rightPanel: RightPanelState = {
       open: true,
       activeSection: 'browser',
-      terminal: { tabs: [createRightTerminalTab(), createRightTerminalTab()], activeTabId: null },
       files: { tabs: [fileTab, createRightFileTab('/w/report.pdf')], activeTabId: fileTab.id },
       browser: { url: 'http://web--app-1a2b3c.localhost:19523' },
     };
@@ -240,10 +143,7 @@ describe('desktop shell state persistence', () => {
       sidebarOpen: false,
       layout: { sidebarW: 300, rightW: 500, bottomH: 260 },
       expansionStack: ['right', 'bottom'],
-      rightPanel: {
-        ...rightPanel,
-        terminal: { ...rightPanel.terminal, activeTabId: rightPanel.terminal.tabs[1].id },
-      },
+      rightPanel,
       bottomPanel: createPanelState(true, 'files'),
     };
 
@@ -253,7 +153,6 @@ describe('desktop shell state persistence', () => {
     expect(parsed.layout).toEqual(source.layout);
     expect(parsed.expansionStack).toEqual(['right', 'bottom']);
     expect(parsed.rightPanel.activeSection).toBe('browser');
-    expect(parsed.rightPanel.terminal.tabs).toHaveLength(2);
     expect(parsed.rightPanel.files.tabs.map((tab) => tab.path)).toEqual([
       '/w/PLAN.md',
       '/w/report.pdf',
@@ -261,6 +160,16 @@ describe('desktop shell state persistence', () => {
     expect(parsed.rightPanel.files.activeTabId).toBe(parsed.rightPanel.files.tabs[0].id);
     expect(parsed.rightPanel.browser.url).toBe('http://web--app-1a2b3c.localhost:19523');
     expect(panelTypes(parsed.bottomPanel)).toEqual(['files']);
+  });
+
+  it('round trips a shared terminal as the active bottom tab beside non-terminal tabs', () => {
+    const source = createDefaultDesktopShellState();
+    source.bottomPanel = { ...createPanelState(true, 'files'), activeTabId: null };
+
+    const parsed = parsePersistedDesktopShellState(serializeDesktopShellState(source));
+
+    expect(panelTypes(parsed.bottomPanel)).toEqual(['files']);
+    expect(parsed.bottomPanel.activeTabId).toBeNull();
   });
 
   it('drops renderer-scoped blob URLs from persisted browser state', () => {
@@ -283,71 +192,54 @@ describe('desktop shell state persistence', () => {
 
 describe('closeSectionTabState', () => {
   it('falls back the active tab to the neighbor that slides into its slot', () => {
-    const a = createRightTerminalTab();
-    const b = createRightTerminalTab();
-    const c = createRightTerminalTab();
-    const terminal = { tabs: [a, b, c], activeTabId: b.id };
+    const a = createRightFileTab('/a');
+    const b = createRightFileTab('/b');
+    const c = createRightFileTab('/c');
+    const files = { tabs: [a, b, c], activeTabId: b.id };
 
-    const next = closeSectionTabState(terminal, b.id);
+    const next = closeSectionTabState(files, b.id);
 
     expect(next.tabs.map((tab) => tab.id)).toEqual([a.id, c.id]);
     expect(next.activeTabId).toBe(c.id);
   });
 
   it('keeps the active tab untouched when closing an inactive tab', () => {
-    const a = createRightTerminalTab();
-    const b = createRightTerminalTab();
-    const terminal = { tabs: [a, b], activeTabId: a.id };
+    const a = createRightFileTab('/a');
+    const b = createRightFileTab('/b');
+    const files = { tabs: [a, b], activeTabId: a.id };
 
-    const next = closeSectionTabState(terminal, b.id);
+    const next = closeSectionTabState(files, b.id);
 
     expect(next.tabs.map((tab) => tab.id)).toEqual([a.id]);
     expect(next.activeTabId).toBe(a.id);
   });
 
   it('clears the active tab id once the last tab is closed', () => {
-    const a = createRightTerminalTab();
-    const terminal = { tabs: [a], activeTabId: a.id };
+    const a = createRightFileTab('/a');
+    const files = { tabs: [a], activeTabId: a.id };
 
-    const next = closeSectionTabState(terminal, a.id);
+    const next = closeSectionTabState(files, a.id);
 
     expect(next.tabs).toEqual([]);
     expect(next.activeTabId).toBeNull();
   });
 
   it('is a no-op when the tab is not found', () => {
-    const a = createRightTerminalTab();
-    const terminal = { tabs: [a], activeTabId: a.id };
+    const a = createRightFileTab('/a');
+    const files = { tabs: [a], activeTabId: a.id };
 
-    expect(closeSectionTabState(terminal, 'missing')).toBe(terminal);
-  });
-});
-
-describe('seedTerminalSection', () => {
-  it('seeds and focuses a first tab when the section is empty', () => {
-    const seeded = seedTerminalSection({ tabs: [], activeTabId: null });
-
-    expect(seeded.tabs).toHaveLength(1);
-    expect(seeded.activeTabId).toBe(seeded.tabs[0].id);
-  });
-
-  it('is a no-op when tabs already exist', () => {
-    const a = createRightTerminalTab();
-    const terminal = { tabs: [a], activeTabId: a.id };
-
-    expect(seedTerminalSection(terminal)).toBe(terminal);
+    expect(closeSectionTabState(files, 'missing')).toBe(files);
   });
 });
 
 describe('revealSectionState', () => {
-  it('seeds the terminal section when it comes forward on an open panel', () => {
+  it('brings the terminal section forward without owning its tabs', () => {
     const panel = { ...createDefaultRightPanelState(), open: true };
 
     const revealed = revealSectionState(panel, 'terminal', true);
 
     expect(revealed.activeSection).toBe('terminal');
-    expect(revealed.terminal.tabs).toHaveLength(1);
-    expect(revealed.terminal.activeTabId).toBe(revealed.terminal.tabs[0].id);
+    expect(revealed.open).toBe(true);
   });
 
   it('leaves the terminal section untouched when revealing another section', () => {
@@ -356,7 +248,6 @@ describe('revealSectionState', () => {
     const revealed = revealSectionState(panel, 'files', true);
 
     expect(revealed.activeSection).toBe('files');
-    expect(revealed.terminal.tabs).toEqual([]);
   });
 });
 

--- a/apps/desktop/src/renderer/src/shell/desktop-shell.tsx
+++ b/apps/desktop/src/renderer/src/shell/desktop-shell.tsx
@@ -460,6 +460,7 @@ export function DesktopShell({
       node: tab.id.startsWith('attach:') ? (
         <AttachedTerminalPanel
           terminalId={tab.id.slice('attach:'.length)}
+          onCloseTab={closeTab}
           interactive={rightOwnsTerminal}
           primary={rightOwnsTerminal}
           suspended={rightTransition.phase !== 'open' || shellAnimating}
@@ -468,6 +469,7 @@ export function DesktopShell({
         <TerminalPanel
           sessionKey={tab.id}
           cwd={active?.cwd}
+          onCloseTab={closeTab}
           interactive={rightOwnsTerminal}
           suspended={rightTransition.phase !== 'open' || shellAnimating}
         />
@@ -493,6 +495,7 @@ export function DesktopShell({
           tab.id.startsWith('attach:') ? (
             <AttachedTerminalPanel
               terminalId={tab.id.slice('attach:'.length)}
+              onCloseTab={closeTab}
               interactive={bottomOwnsTerminal}
               primary={bottomOwnsTerminal}
               suspended={bottomTransition.phase !== 'open' || shellAnimating}
@@ -501,6 +504,7 @@ export function DesktopShell({
             <TerminalPanel
               sessionKey={tab.id}
               cwd={active?.cwd}
+              onCloseTab={closeTab}
               interactive={bottomOwnsTerminal}
               suspended={bottomTransition.phase !== 'open' || shellAnimating}
             />

--- a/apps/desktop/src/renderer/src/shell/desktop-shell.tsx
+++ b/apps/desktop/src/renderer/src/shell/desktop-shell.tsx
@@ -23,6 +23,7 @@ import {
   TerminalPanel,
   useCloudHosts,
   useSelectedHostStore,
+  useTerminalTabsStore,
   WorkspaceServicesMenu,
 } from '@linkcode/workbench';
 import { useEffect as useAbortableEffect } from 'foxact/use-abortable-effect';
@@ -122,10 +123,10 @@ export function DesktopShell({
       bottomPanel: state.bottomPanel,
       updateSidebarOpen: state.updateSidebarOpen,
       updateLayout: state.updateLayout,
-      updatePanel: state.updatePanel,
       togglePanel: state.togglePanel,
       closePanel: state.closePanel,
       addWindow: state.addWindow,
+      setActiveBottomTab: state.setActiveBottomTab,
       closeTab: state.closeTab,
       toggleMaxPanel: state.toggleMaxPanel,
       setActiveSection: state.setActiveSection,
@@ -142,6 +143,9 @@ export function DesktopShell({
       resetRightPanelSize: state.resetRightPanelSize,
       resetBottomPanelSize: state.resetBottomPanelSize,
     })),
+  );
+  const terminalTabs = useTerminalTabsStore(
+    useShallow((state) => ({ tabs: state.tabs, activeTabId: state.activeTabId })),
   );
   const cloudAuth = useCloudAccount();
   const remoteHosts = useCloudHosts(cloudAuth.account?.email ?? null);
@@ -191,6 +195,17 @@ export function DesktopShell({
     setShellPaneCssSize(shellRootRef.current, '--lc-bottom-h', size);
   }, []);
   const { sidebarOpen, layout, expansionStack, rightPanel, bottomPanel } = shellState;
+  const rightPanelView = { ...rightPanel, terminal: terminalTabs };
+  const bottomPanelView = {
+    ...bottomPanel,
+    tabs: [
+      ...terminalTabs.tabs.map((tab) => ({ ...tab, type: 'terminal' as const })),
+      ...bottomPanel.tabs,
+    ],
+    activeTabId: bottomPanel.activeTabId ?? terminalTabs.activeTabId,
+  };
+  const rightOwnsTerminal = rightPanel.open && rightPanel.activeSection === 'terminal';
+  const bottomOwnsTerminal = bottomPanel.open && !rightOwnsTerminal;
   const sidebarTransition = usePaneTransition({
     open: sidebarOpen,
     size: layout.sidebarW,
@@ -241,10 +256,10 @@ export function DesktopShell({
   const {
     updateSidebarOpen,
     updateLayout,
-    updatePanel,
     togglePanel,
     closePanel,
     addWindow,
+    setActiveBottomTab,
     closeTab,
     toggleMaxPanel,
     setActiveSection,
@@ -390,7 +405,7 @@ export function DesktopShell({
   }): React.ReactNode {
     return (
       <DesktopRightPanelRegion
-        panel={rightPanel}
+        panel={rightPanelView}
         cwd={active?.cwd}
         themeType={themeType}
         maximized={options.maximized}
@@ -418,13 +433,13 @@ export function DesktopShell({
     return (
       <DesktopPanelRegion
         side="bottom"
-        panel={bottomPanel}
+        panel={bottomPanelView}
         maximized={options.maximized}
         chromeVisible={options.chromeVisible}
         contentHidden={options.contentHidden}
         chromeSurface={chromeSurface}
         contentTargetRef={setBottomContentTarget}
-        onSelectTab={(id) => updatePanel((current) => ({ ...current, activeTabId: id }))}
+        onSelectTab={setActiveBottomTab}
         onCloseTab={(id) => closeTab(id)}
         onAddWindow={(type) => addWindow(type)}
         onToggleMax={() => toggleMaxPanel('bottom')}
@@ -439,18 +454,21 @@ export function DesktopShell({
   // shell spawns for a never-shown panel; Diff/Browser content is stateless and stays inline.
   function renderRightPanelContents(host: HTMLDivElement): React.ReactNode {
     const activeIsTerminal = rightPanel.activeSection === 'terminal';
-    const items = rightPanel.terminal.tabs.map((tab) => ({
+    const items = terminalTabs.tabs.map((tab) => ({
       id: tab.id,
-      active: activeIsTerminal && tab.id === rightPanel.terminal.activeTabId,
+      active: activeIsTerminal && tab.id === terminalTabs.activeTabId,
       node: tab.id.startsWith('attach:') ? (
         <AttachedTerminalPanel
           terminalId={tab.id.slice('attach:'.length)}
+          interactive={rightOwnsTerminal}
+          primary={rightOwnsTerminal}
           suspended={rightTransition.phase !== 'open' || shellAnimating}
         />
       ) : (
         <TerminalPanel
           sessionKey={tab.id}
           cwd={active?.cwd}
+          interactive={rightOwnsTerminal}
           suspended={rightTransition.phase !== 'open' || shellAnimating}
         />
       ),
@@ -467,16 +485,26 @@ export function DesktopShell({
 
   // Same portal treatment for the bottom panel's flat tab strip.
   function renderBottomPanelContents(host: HTMLDivElement): React.ReactNode {
-    const items = bottomPanel.tabs.map((tab) => ({
+    const items = bottomPanelView.tabs.map((tab) => ({
       id: tab.id,
-      active: tab.id === bottomPanel.activeTabId,
+      active: tab.id === bottomPanelView.activeTabId,
       node:
         tab.type === 'terminal' ? (
-          <TerminalPanel
-            sessionKey={tab.id}
-            cwd={active?.cwd}
-            suspended={bottomTransition.phase !== 'open' || shellAnimating}
-          />
+          tab.id.startsWith('attach:') ? (
+            <AttachedTerminalPanel
+              terminalId={tab.id.slice('attach:'.length)}
+              interactive={bottomOwnsTerminal}
+              primary={bottomOwnsTerminal}
+              suspended={bottomTransition.phase !== 'open' || shellAnimating}
+            />
+          ) : (
+            <TerminalPanel
+              sessionKey={tab.id}
+              cwd={active?.cwd}
+              interactive={bottomOwnsTerminal}
+              suspended={bottomTransition.phase !== 'open' || shellAnimating}
+            />
+          )
         ) : (
           <PanelStubContent type={tab.type} />
         ),

--- a/apps/desktop/src/renderer/src/shell/desktop-shell.tsx
+++ b/apps/desktop/src/renderer/src/shell/desktop-shell.tsx
@@ -46,7 +46,7 @@ import type { DesktopShellStyle } from './layout/shell-style';
 import { createDesktopShellStyle, setShellPaneCssSize } from './layout/shell-style';
 import type { WorkspaceSide } from './layout/workspace';
 import { DesktopWorkspace } from './layout/workspace';
-import { getExpandedPanel } from './store/model';
+import { getExpandedPanel, getTerminalPanelOwner } from './store/model';
 import { useDesktopShellStore } from './store/store';
 import { useDesktopPaletteCommands } from './use-desktop-palette-commands';
 import { useDesktopShellShortcuts } from './use-desktop-shell-shortcuts';
@@ -195,6 +195,7 @@ export function DesktopShell({
     setShellPaneCssSize(shellRootRef.current, '--lc-bottom-h', size);
   }, []);
   const { sidebarOpen, layout, expansionStack, rightPanel, bottomPanel } = shellState;
+  const expandedPanel = getExpandedPanel(expansionStack, rightPanel.open, bottomPanel.open);
   const rightPanelView = { ...rightPanel, terminal: terminalTabs };
   const bottomPanelView = {
     ...bottomPanel,
@@ -204,8 +205,14 @@ export function DesktopShell({
     ],
     activeTabId: bottomPanel.activeTabId ?? terminalTabs.activeTabId,
   };
-  const rightOwnsTerminal = rightPanel.open && rightPanel.activeSection === 'terminal';
-  const bottomOwnsTerminal = bottomPanel.open && !rightOwnsTerminal;
+  const terminalPanelOwner = getTerminalPanelOwner(
+    expandedPanel,
+    rightPanel.open,
+    rightPanel.activeSection,
+    bottomPanel.open,
+  );
+  const rightOwnsTerminal = terminalPanelOwner === 'right';
+  const bottomOwnsTerminal = terminalPanelOwner === 'bottom';
   const sidebarTransition = usePaneTransition({
     open: sidebarOpen,
     size: layout.sidebarW,
@@ -236,7 +243,6 @@ export function DesktopShell({
   const showWindowControls = desktopPlatform !== 'darwin';
   // The workspace grid cell owns the animated divider, so the aside's own border is off.
   const sidebarClassName = hasNativeBackdrop ? 'border-r-0 bg-sidebar/25' : 'border-r-0 bg-sidebar';
-  const expandedPanel = getExpandedPanel(expansionStack, rightPanel.open, bottomPanel.open);
   const chromeSurface = getChromeSurface(expandedPanel);
 
   useAbortableEffect(

--- a/apps/desktop/src/renderer/src/shell/layout/right-panel-region.tsx
+++ b/apps/desktop/src/renderer/src/shell/layout/right-panel-region.tsx
@@ -1,6 +1,7 @@
 import type { ThemePreference } from '@linkcode/ipc';
 import type { ChromeSurface, PanelSection } from '@linkcode/ui/shell/panels';
 import { SectionPanelRegion } from '@linkcode/ui/shell/panels';
+import type { TerminalTabsState } from '@linkcode/workbench';
 import { FilesPanel, GitPanel } from '@linkcode/workbench';
 import { DesktopChromePortal } from '../chrome/chrome';
 import { DESKTOP_CHROME_SPACER_CLASS } from '../chrome/metrics';
@@ -30,7 +31,7 @@ export function DesktopRightPanelRegion({
   onOpenFileTab,
   onToggleMax,
 }: {
-  panel: RightPanelState;
+  panel: RightPanelState & { terminal: TerminalTabsState };
   cwd: string | undefined;
   themeType: ThemePreference;
   maximized: boolean;

--- a/apps/desktop/src/renderer/src/shell/store/model.ts
+++ b/apps/desktop/src/renderer/src/shell/store/model.ts
@@ -1,13 +1,6 @@
-import type {
-  PanelSection,
-  PanelSectionTab,
-  PanelSide,
-  PanelTab,
-  PanelWindowType,
-} from '@linkcode/ui/shell/panels';
+import type { PanelSection, PanelSide, PanelTab, PanelWindowType } from '@linkcode/ui/shell/panels';
 import { PANEL_SECTIONS, PANEL_WINDOW_TYPES } from '@linkcode/ui/shell/panels';
 import { clamp } from 'foxts/clamp';
-import { createFixedArray } from 'foxts/create-fixed-array';
 import { z } from 'zod';
 
 export type { PanelSide } from '@linkcode/ui/shell/panels';
@@ -19,14 +12,9 @@ export interface PanelState {
   activeTabId: string | null;
 }
 
-/** The right panel's terminal section: its own sub-tab strip of PTY instances. */
-export interface RightPanelTerminalState {
-  tabs: PanelSectionTab[];
-  activeTabId: string | null;
-}
-
 /** One open file in the right panel's files section. */
-export interface FileSectionTab extends PanelSectionTab {
+export interface FileSectionTab {
+  id: string;
   path: string;
 }
 
@@ -46,7 +34,6 @@ export interface RightPanelBrowserState {
 export interface RightPanelState {
   open: boolean;
   activeSection: PanelSection;
-  terminal: RightPanelTerminalState;
   files: RightPanelFilesState;
   browser: RightPanelBrowserState;
 }
@@ -66,7 +53,7 @@ export interface DesktopShellState {
 }
 
 export interface PersistedDesktopShellState {
-  version: 2;
+  version: 3;
   sidebarOpen: boolean;
   layout: LayoutState;
   expansionStack: PanelSide[];
@@ -77,8 +64,6 @@ export interface PersistedDesktopShellState {
 export interface PersistedRightPanelState {
   open: boolean;
   activeSection: PanelSection;
-  terminalTabCount: number;
-  activeTerminalTabIndex: number;
   fileTabPaths: string[];
   activeFileTabIndex: number;
   browserUrl: string | null;
@@ -90,7 +75,7 @@ export interface PersistedPanelState {
   activeTabIndex: number;
 }
 
-export const DESKTOP_SHELL_STORAGE_KEY = 'linkcode.desktop.shell-state:v2';
+export const DESKTOP_SHELL_STORAGE_KEY = 'linkcode.desktop.shell-state:v3';
 
 export const SIDEBAR_MIN_SIZE = 240;
 export const SIDEBAR_MAX_SIZE = 520;
@@ -113,12 +98,6 @@ export const PANEL_EXPANSION_TARGET: Record<PanelSide, PanelExpansionTarget> = {
   bottom: 'workbench',
 };
 
-/** The bottom panel's window type when it needs to seed a first tab. */
-const DEFAULT_BOTTOM_WINDOW_TYPE: PanelWindowType = 'terminal';
-
-/** Defensive cap on the terminal tab count restored from persisted state. */
-const MAX_PERSISTED_RIGHT_TERMINAL_TABS = 20;
-
 /** Defensive cap on the file tab count restored from persisted state. */
 const MAX_PERSISTED_RIGHT_FILE_TABS = 20;
 
@@ -127,6 +106,7 @@ let tabSequence = 0;
 const PanelSideSchema = z.enum(['right', 'bottom']);
 const PanelSectionSchema = z.enum(PANEL_SECTIONS);
 const PanelWindowTypeSchema = z.enum(PANEL_WINDOW_TYPES);
+const NonTerminalPanelWindowTypeSchema = PanelWindowTypeSchema.exclude(['terminal']);
 const FiniteNumberSchema = z.number();
 
 const PersistedLayoutSchema = z
@@ -154,7 +134,7 @@ export function createDefaultDesktopShellState(): DesktopShellState {
     layout: DEFAULT_LAYOUT,
     expansionStack: [],
     rightPanel: createDefaultRightPanelState(),
-    bottomPanel: createPanelState(false, DEFAULT_BOTTOM_WINDOW_TYPE),
+    bottomPanel: { open: false, tabs: [], activeTabId: null },
   };
 }
 
@@ -162,7 +142,6 @@ export function createDefaultRightPanelState(): RightPanelState {
   return {
     open: false,
     activeSection: 'diff',
-    terminal: { tabs: [], activeTabId: null },
     files: { tabs: [], activeTabId: null },
     browser: { url: null },
   };
@@ -182,20 +161,7 @@ export function createTab(type: PanelWindowType): PanelTab {
   return { id: `${type}-${tabSequence}`, type };
 }
 
-/** Prefixed so ids never collide with the bottom panel's tabs, which share the same PTY registry. */
-export function createRightTerminalTab(): PanelSectionTab {
-  tabSequence += 1;
-  return { id: `right-terminal-${tabSequence}` };
-}
-
-/** The terminal section never comes forward empty: seed a first PTY tab (same as pressing +). */
-export function seedTerminalSection(terminal: RightPanelTerminalState): RightPanelTerminalState {
-  if (terminal.tabs.length > 0) return terminal;
-  const tab = createRightTerminalTab();
-  return { tabs: [tab], activeTabId: tab.id };
-}
-
-/** Brings `section` forward, seeding the terminal section's first tab when it becomes visible. */
+/** Brings `section` forward. Terminal sessions are owned by the shared workbench store. */
 export function revealSectionState(
   panel: RightPanelState,
   section: PanelSection,
@@ -205,7 +171,6 @@ export function revealSectionState(
     ...panel,
     open,
     activeSection: section,
-    terminal: open && section === 'terminal' ? seedTerminalSection(panel.terminal) : panel.terminal,
   };
 }
 
@@ -215,7 +180,7 @@ export function createRightFileTab(path: string): FileSectionTab {
 }
 
 /** Removes a section sub-tab, falling back the active tab to a neighbor if it was the one closed. */
-export function closeSectionTabState<Tab extends PanelSectionTab>(
+export function closeSectionTabState<Tab extends { id: string }>(
   section: { tabs: Tab[]; activeTabId: string | null },
   id: string,
 ): { tabs: Tab[]; activeTabId: string | null } {
@@ -301,7 +266,7 @@ export function parsePersistedDesktopShellState(value: unknown): DesktopShellSta
 
 export function serializeDesktopShellState(state: DesktopShellState): PersistedDesktopShellState {
   return {
-    version: 2,
+    version: 3,
     sidebarOpen: state.sidebarOpen,
     layout: normalizeLayout(state.layout),
     expansionStack: normalizeExpansionStack(
@@ -321,11 +286,11 @@ function durableBrowserUrl(url: string | null): string | null {
 function createPersistedShellStateSchema(): z.ZodType<DesktopShellState> {
   const fallback = createDefaultDesktopShellState();
   const rightPanelSchema = createPersistedRightPanelSchema();
-  const bottomPanelSchema = createPersistedPanelSchema(DEFAULT_BOTTOM_WINDOW_TYPE, false);
+  const bottomPanelSchema = createPersistedPanelSchema(false);
 
   return z
     .object({
-      version: z.literal(2),
+      version: z.literal(3),
       sidebarOpen: z.boolean().catch(fallback.sidebarOpen),
       layout: PersistedLayoutSchema,
       expansionStack: PersistedExpansionStackSchema,
@@ -345,10 +310,7 @@ function createPersistedShellStateSchema(): z.ZodType<DesktopShellState> {
     }));
 }
 
-function createPersistedPanelSchema(
-  fallbackType: PanelWindowType,
-  fallbackOpen: boolean,
-): z.ZodType<PanelState> {
+function createPersistedPanelSchema(fallbackOpen: boolean): z.ZodType<PanelState> {
   return z
     .object({
       open: z.boolean().catch(fallbackOpen),
@@ -357,7 +319,7 @@ function createPersistedPanelSchema(
         .catch([])
         .transform((items) =>
           items.flatMap((item) => {
-            const parsed = PanelWindowTypeSchema.safeParse(item);
+            const parsed = NonTerminalPanelWindowTypeSchema.safeParse(item);
             return parsed.success ? [parsed.data] : [];
           }),
         ),
@@ -369,14 +331,13 @@ function createPersistedPanelSchema(
       activeTabIndex: 0,
     })
     .transform(({ open, tabs: parsedTypes, activeTabIndex }) => {
-      const types = parsedTypes.length > 0 ? parsedTypes : [fallbackType];
-      const tabs = types.map((type) => createTab(type));
+      const tabs = parsedTypes.map((type) => createTab(type));
       const activeIndex = clamp(activeTabIndex, 0, tabs.length - 1);
 
       return {
         open,
         tabs,
-        activeTabId: tabs[activeIndex].id,
+        activeTabId: activeTabIndex === -1 ? null : (tabs[activeIndex]?.id ?? null),
       };
     });
 }
@@ -388,9 +349,6 @@ function createPersistedRightPanelSchema(): z.ZodType<RightPanelState> {
     .object({
       open: z.boolean().catch(fallback.open),
       activeSection: PanelSectionSchema.catch(fallback.activeSection),
-      terminalTabCount: FiniteNumberSchema.int().nonnegative().catch(0),
-      activeTerminalTabIndex: FiniteNumberSchema.int().catch(0),
-      // Absent in pre-files persisted payloads; the catches make the section start empty.
       fileTabPaths: z.array(z.string().min(1)).catch([]),
       activeFileTabIndex: FiniteNumberSchema.int().catch(0),
       browserUrl: z.string().min(1).nullable().catch(null),
@@ -398,59 +356,32 @@ function createPersistedRightPanelSchema(): z.ZodType<RightPanelState> {
     .catch({
       open: fallback.open,
       activeSection: fallback.activeSection,
-      terminalTabCount: 0,
-      activeTerminalTabIndex: 0,
       fileTabPaths: [],
       activeFileTabIndex: 0,
       browserUrl: null,
     })
-    .transform(
-      ({
+    .transform(({ open, activeSection, fileTabPaths, activeFileTabIndex, browserUrl }) => {
+      const fileTabs = fileTabPaths
+        .slice(0, MAX_PERSISTED_RIGHT_FILE_TABS)
+        .map((path) => createRightFileTab(path));
+      const activeFileIndex =
+        fileTabs.length > 0 ? clamp(activeFileTabIndex, 0, fileTabs.length - 1) : 0;
+      return {
         open,
         activeSection,
-        terminalTabCount,
-        activeTerminalTabIndex,
-        fileTabPaths,
-        activeFileTabIndex,
-        browserUrl,
-      }) => {
-        const tabCount = clamp(terminalTabCount, 0, MAX_PERSISTED_RIGHT_TERMINAL_TABS);
-        const tabs = createFixedArray(tabCount).map(() => createRightTerminalTab());
-        const activeIndex = tabs.length > 0 ? clamp(activeTerminalTabIndex, 0, tabs.length - 1) : 0;
-        const fileTabs = fileTabPaths
-          .slice(0, MAX_PERSISTED_RIGHT_FILE_TABS)
-          .map((path) => createRightFileTab(path));
-        const activeFileIndex =
-          fileTabs.length > 0 ? clamp(activeFileTabIndex, 0, fileTabs.length - 1) : 0;
-        const terminal = {
-          tabs,
-          activeTabId: tabs.length > 0 ? tabs[activeIndex].id : null,
-        };
-
-        return {
-          open,
-          activeSection,
-          terminal: open && activeSection === 'terminal' ? seedTerminalSection(terminal) : terminal,
-          files: {
-            tabs: fileTabs,
-            activeTabId: fileTabs.length > 0 ? fileTabs[activeFileIndex].id : null,
-          },
-          browser: { url: durableBrowserUrl(browserUrl) },
-        };
-      },
-    );
+        files: {
+          tabs: fileTabs,
+          activeTabId: fileTabs.length > 0 ? fileTabs[activeFileIndex].id : null,
+        },
+        browser: { url: durableBrowserUrl(browserUrl) },
+      };
+    });
 }
 
 function serializeRightPanel(panel: RightPanelState): PersistedRightPanelState {
   return {
     open: panel.open,
     activeSection: panel.activeSection,
-    terminalTabCount: panel.terminal.tabs.length,
-    activeTerminalTabIndex: clamp(
-      panel.terminal.tabs.findIndex((tab) => tab.id === panel.terminal.activeTabId),
-      0,
-      Math.max(0, panel.terminal.tabs.length - 1),
-    ),
     fileTabPaths: panel.files.tabs.map((tab) => tab.path),
     activeFileTabIndex: clamp(
       panel.files.tabs.findIndex((tab) => tab.id === panel.files.activeTabId),
@@ -464,12 +395,15 @@ function serializeRightPanel(panel: RightPanelState): PersistedRightPanelState {
 function serializePanel(panel: PanelState): PersistedPanelState {
   return {
     open: panel.open,
-    tabs: panel.tabs.map((tab) => tab.type),
-    activeTabIndex: clamp(
-      panel.tabs.findIndex((tab) => tab.id === panel.activeTabId),
-      0,
-      Math.max(0, panel.tabs.length - 1),
-    ),
+    tabs: panel.tabs.flatMap((tab) => (tab.type === 'terminal' ? [] : [tab.type])),
+    activeTabIndex:
+      panel.activeTabId === null
+        ? -1
+        : clamp(
+            panel.tabs.findIndex((tab) => tab.id === panel.activeTabId),
+            0,
+            Math.max(0, panel.tabs.length - 1),
+          ),
   };
 }
 

--- a/apps/desktop/src/renderer/src/shell/store/model.ts
+++ b/apps/desktop/src/renderer/src/shell/store/model.ts
@@ -237,6 +237,22 @@ export function getExpandedPanel(
   return null;
 }
 
+/** Chooses the only terminal surface allowed to send PTY input/resize. A maximized panel owns
+ * interaction because the other panel is inert behind its overlay. */
+export function getTerminalPanelOwner(
+  expandedPanel: PanelSide | null,
+  rightPanelOpen: boolean,
+  rightPanelSection: PanelSection,
+  bottomPanelOpen: boolean,
+): PanelSide | null {
+  if (expandedPanel === 'bottom') return bottomPanelOpen ? 'bottom' : null;
+  if (expandedPanel === 'right') {
+    return rightPanelOpen && rightPanelSection === 'terminal' ? 'right' : null;
+  }
+  if (rightPanelOpen && rightPanelSection === 'terminal') return 'right';
+  return bottomPanelOpen ? 'bottom' : null;
+}
+
 export function getExpandedPanelForTarget(
   side: PanelSide | null,
   target: PanelExpansionTarget,

--- a/apps/desktop/src/renderer/src/shell/store/store.ts
+++ b/apps/desktop/src/renderer/src/shell/store/store.ts
@@ -1,18 +1,17 @@
 import { zodPersist } from '@linkcode/common/zustand';
 import type { PanelSection, PanelWindowType } from '@linkcode/ui/shell/panels';
+import { useTerminalTabsStore } from '@linkcode/workbench';
 import { clamp } from 'foxts/clamp';
 import { create } from 'zustand';
 import type {
   DesktopShellState,
   LayoutState,
   PanelSide,
-  PanelState,
   PersistedDesktopShellState,
 } from './model';
 import {
   closeSectionTabState,
   createDefaultDesktopShellState,
-  createRightTerminalTab,
   createTab,
   DEFAULT_LAYOUT,
   DESKTOP_SHELL_STORAGE_KEY,
@@ -23,21 +22,16 @@ import {
   pushExpandedPanel,
   removeExpandedPanel,
   revealSectionState,
-  seedTerminalSection,
   serializeDesktopShellState,
 } from './model';
-
-/** The bottom panel's window type when it needs to seed a first tab. */
-const DEFAULT_BOTTOM_WINDOW_TYPE: PanelWindowType = 'terminal';
 
 interface DesktopShellActions {
   updateSidebarOpen: (updater: boolean | ((current: boolean) => boolean)) => void;
   updateLayout: (updater: (current: LayoutState) => LayoutState) => void;
-  /** Bottom panel only — the right panel's tabs live under its terminal section instead. */
-  updatePanel: (updater: (panel: PanelState) => PanelState) => void;
   togglePanel: (side: PanelSide) => void;
   closePanel: (side: PanelSide) => void;
   addWindow: (type: PanelWindowType) => void;
+  setActiveBottomTab: (id: string) => void;
   closeTab: (id: string) => void;
   toggleMaxPanel: (side: PanelSide) => void;
   setActiveSection: (section: PanelSection) => void;
@@ -88,37 +82,25 @@ export const useDesktopShellStore = create<DesktopShellStore>()(
           }));
         },
 
-        updatePanel(updater) {
-          updateShellState((current) => ({
-            ...current,
-            bottomPanel: updater(current.bottomPanel),
-          }));
-        },
-
         togglePanel(side) {
           updateShellState((current) => {
             if (side === 'right') {
               const open = !current.rightPanel.open;
+              if (open && current.rightPanel.activeSection === 'terminal') {
+                useTerminalTabsStore.getState().ensureTab();
+              }
               return {
                 ...current,
                 expansionStack: open
                   ? current.expansionStack
                   : removeExpandedPanel(current.expansionStack, side),
-                rightPanel: {
-                  ...current.rightPanel,
-                  open,
-                  terminal:
-                    open && current.rightPanel.activeSection === 'terminal'
-                      ? seedTerminalSection(current.rightPanel.terminal)
-                      : current.rightPanel.terminal,
-                },
+                rightPanel: { ...current.rightPanel, open },
               };
             }
 
             const panel = current.bottomPanel;
             const open = !panel.open;
-            const tabs =
-              panel.tabs.length > 0 ? panel.tabs : [createTab(DEFAULT_BOTTOM_WINDOW_TYPE)];
+            if (open && panel.tabs.length === 0) useTerminalTabsStore.getState().ensureTab();
             return {
               ...current,
               expansionStack: open
@@ -127,8 +109,7 @@ export const useDesktopShellStore = create<DesktopShellStore>()(
               bottomPanel: {
                 ...panel,
                 open,
-                tabs,
-                activeTabId: open ? (panel.activeTabId ?? tabs[0].id) : panel.activeTabId,
+                activeTabId: open && panel.tabs.length === 0 ? null : panel.activeTabId,
               },
             };
           });
@@ -153,6 +134,14 @@ export const useDesktopShellStore = create<DesktopShellStore>()(
         },
 
         addWindow(type) {
+          if (type === 'terminal') {
+            useTerminalTabsStore.getState().addTab();
+            updateShellState((current) => ({
+              ...current,
+              bottomPanel: { ...current.bottomPanel, open: true, activeTabId: null },
+            }));
+            return;
+          }
           const tab = createTab(type);
           updateShellState((current) => ({
             ...current,
@@ -165,12 +154,57 @@ export const useDesktopShellStore = create<DesktopShellStore>()(
           }));
         },
 
+        setActiveBottomTab(id) {
+          const terminalTabs = useTerminalTabsStore.getState();
+          if (terminalTabs.tabs.some((tab) => tab.id === id)) {
+            terminalTabs.setActiveTab(id);
+            updateShellState((current) => ({
+              ...current,
+              bottomPanel: { ...current.bottomPanel, activeTabId: null },
+            }));
+            return;
+          }
+          updateShellState((current) => ({
+            ...current,
+            bottomPanel: { ...current.bottomPanel, activeTabId: id },
+          }));
+        },
+
         closeTab(id) {
+          const terminalTabs = useTerminalTabsStore.getState();
+          if (terminalTabs.tabs.some((tab) => tab.id === id)) {
+            terminalTabs.closeTab(id);
+            updateShellState((current) => {
+              if (useTerminalTabsStore.getState().tabs.length > 0) return current;
+              if (current.bottomPanel.tabs.length === 0) {
+                return {
+                  ...current,
+                  expansionStack: removeExpandedPanel(current.expansionStack, 'bottom'),
+                  bottomPanel: { ...current.bottomPanel, open: false, activeTabId: null },
+                };
+              }
+              const fallback = current.bottomPanel.tabs[0];
+              return {
+                ...current,
+                bottomPanel: {
+                  ...current.bottomPanel,
+                  activeTabId: current.bottomPanel.activeTabId ?? fallback.id,
+                },
+              };
+            });
+            return;
+          }
           updateShellState((current) => {
             const panel = current.bottomPanel;
             const index = panel.tabs.findIndex((tab) => tab.id === id);
             const tabs = panel.tabs.filter((tab) => tab.id !== id);
             if (tabs.length === 0) {
+              if (useTerminalTabsStore.getState().tabs.length > 0) {
+                return {
+                  ...current,
+                  bottomPanel: { ...panel, tabs, activeTabId: null },
+                };
+              }
               return {
                 ...current,
                 expansionStack: removeExpandedPanel(current.expansionStack, 'bottom'),
@@ -208,6 +242,9 @@ export const useDesktopShellStore = create<DesktopShellStore>()(
         },
 
         setActiveSection(section) {
+          if (section === 'terminal' && get().rightPanel.open) {
+            useTerminalTabsStore.getState().ensureTab();
+          }
           updateShellState((current) => ({
             ...current,
             rightPanel: revealSectionState(current.rightPanel, section, current.rightPanel.open),
@@ -215,6 +252,7 @@ export const useDesktopShellStore = create<DesktopShellStore>()(
         },
 
         openRightPanelSection(section) {
+          if (section === 'terminal') useTerminalTabsStore.getState().ensureTab();
           updateShellState((current) => ({
             ...current,
             rightPanel: revealSectionState(current.rightPanel, section, true),
@@ -222,36 +260,22 @@ export const useDesktopShellStore = create<DesktopShellStore>()(
         },
 
         addRightTerminalTab() {
-          const tab = createRightTerminalTab();
+          useTerminalTabsStore.getState().addTab();
           updateShellState((current) => ({
             ...current,
-            rightPanel: {
-              ...current.rightPanel,
-              terminal: {
-                tabs: [...current.rightPanel.terminal.tabs, tab],
-                activeTabId: tab.id,
-              },
-            },
+            bottomPanel: { ...current.bottomPanel, activeTabId: null },
           }));
         },
 
         closeRightTerminalTab(id) {
-          updateShellState((current) => ({
-            ...current,
-            rightPanel: {
-              ...current.rightPanel,
-              terminal: closeSectionTabState(current.rightPanel.terminal, id),
-            },
-          }));
+          get().closeTab(id);
         },
 
         setActiveRightTerminalTab(id) {
+          useTerminalTabsStore.getState().setActiveTab(id);
           updateShellState((current) => ({
             ...current,
-            rightPanel: {
-              ...current.rightPanel,
-              terminal: { ...current.rightPanel.terminal, activeTabId: id },
-            },
+            bottomPanel: { ...current.bottomPanel, activeTabId: null },
           }));
         },
 
@@ -307,22 +331,16 @@ export const useDesktopShellStore = create<DesktopShellStore>()(
         },
 
         openRightTerminalAttachTab(terminalId) {
-          const id = `attach:${terminalId}`;
-          updateShellState((current) => {
-            const terminal = current.rightPanel.terminal;
-            const tabs = terminal.tabs.some((tab) => tab.id === id)
-              ? terminal.tabs
-              : [...terminal.tabs, { id }];
-            return {
-              ...current,
-              rightPanel: {
-                ...current.rightPanel,
-                open: true,
-                activeSection: 'terminal',
-                terminal: { tabs, activeTabId: id },
-              },
-            };
-          });
+          useTerminalTabsStore.getState().openAttachedTab(terminalId);
+          updateShellState((current) => ({
+            ...current,
+            bottomPanel: { ...current.bottomPanel, activeTabId: null },
+            rightPanel: {
+              ...current.rightPanel,
+              open: true,
+              activeSection: 'terminal',
+            },
+          }));
         },
 
         resetSidebarSize() {
@@ -340,7 +358,7 @@ export const useDesktopShellStore = create<DesktopShellStore>()(
     },
     {
       name: DESKTOP_SHELL_STORAGE_KEY,
-      version: 2,
+      version: 3,
       schema: PersistedDesktopShellStateSchema,
       partialize: serializeDesktopShellState,
     },

--- a/packages/client/core/src/__tests__/terminal-client.test.ts
+++ b/packages/client/core/src/__tests__/terminal-client.test.ts
@@ -348,6 +348,50 @@ describe('LinkCodeClient terminal attachments', () => {
     serverTransport.close();
   });
 
+  it('releases an attachment whose final viewer detaches while attach is pending', async () => {
+    const { client, serverTransport } = await createConnectedLocalClient();
+    const received: WirePayload[] = [];
+    let replyAttached = noop;
+    serverTransport.onMessage((message) => {
+      const p = message.payload;
+      received.push(p);
+      if (p.kind !== 'terminal.attach') return;
+      replyAttached = () => {
+        serverTransport.send(
+          createWireMessage({
+            kind: 'terminal.attached',
+            replyTo: p.clientReqId,
+            terminal: metadata(p.terminalId, null),
+            replay: [],
+            cutoffSeq: 0,
+            truncated: false,
+          }),
+        );
+      };
+    });
+
+    const attached = client.attachTerminal('term-pending');
+    await flushMicrotasks();
+    const attachFrame = received.find((payload) => payload.kind === 'terminal.attach');
+    if (attachFrame?.kind !== 'terminal.attach') throw new Error('no terminal.attach frame');
+
+    client.detachTerminal('term-pending');
+    replyAttached();
+    await attached;
+    await flushMicrotasks();
+
+    expect(received.filter((payload) => payload.kind === 'terminal.detach')).toEqual([
+      {
+        kind: 'terminal.detach',
+        terminalId: 'term-pending',
+        attachmentId: attachFrame.attachmentId,
+        attachmentSecret: attachFrame.attachmentSecret,
+      },
+    ]);
+    client.dispose();
+    serverTransport.close();
+  });
+
   it('replays an exit that arrives immediately after a tombstone attachment', async () => {
     const { client, serverTransport } = await createConnectedLocalClient();
     serverTransport.onMessage((message) => {

--- a/packages/client/workbench/src/index.ts
+++ b/packages/client/workbench/src/index.ts
@@ -52,5 +52,6 @@ export * from './surface/workbench';
 export * from './terminal/attached-panel';
 export * from './terminal/block';
 export * from './terminal/panel';
+export * from './terminal/tabs-store';
 export * from './terminal/transport-session';
 export * from './workspace/hooks';

--- a/packages/client/workbench/src/terminal/__tests__/attached-panel.test.tsx
+++ b/packages/client/workbench/src/terminal/__tests__/attached-panel.test.tsx
@@ -25,10 +25,6 @@ vi.mock('@linkcode/ui/shell/terminal', () => ({
   LiveTerminal: () => null,
 }));
 
-vi.mock('../tabs-store', () => ({
-  useTerminalTabsStore: { getState: () => ({ closeTab }) },
-}));
-
 vi.mock('../../settings/terminal-prefs-store', () => ({
   useTerminalPrefsStore: selectTerminalPrefs,
 }));
@@ -66,7 +62,7 @@ describe('AttachedTerminalPanel', () => {
       resizeTerminal: noop,
       takeTerminalControl: () => Promise.resolve(),
     };
-    const view = render(<AttachedTerminalPanel terminalId="term-1" />);
+    const view = render(<AttachedTerminalPanel terminalId="term-1" onCloseTab={closeTab} />);
 
     expect(closeTab).toHaveBeenCalledOnce();
     expect(closeTab).toHaveBeenCalledWith('attach:term-1');
@@ -96,7 +92,9 @@ describe('AttachedTerminalPanel', () => {
       resizeTerminal: noop,
     };
 
-    const view = render(<AttachedTerminalPanel terminalId="term-1" primary={false} />);
+    const view = render(
+      <AttachedTerminalPanel terminalId="term-1" onCloseTab={closeTab} primary={false} />,
+    );
 
     expect(subscribeTerminalExit).not.toHaveBeenCalled();
     expect(closeTab).not.toHaveBeenCalled();

--- a/packages/client/workbench/src/terminal/__tests__/attached-panel.test.tsx
+++ b/packages/client/workbench/src/terminal/__tests__/attached-panel.test.tsx
@@ -1,0 +1,105 @@
+/** @vitest-environment jsdom */
+
+import type { TerminalAttachResult } from '@linkcode/client-core';
+import { act, render } from '@testing-library/react';
+import { noop } from 'foxts/noop';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { AttachedTerminalPanel } from '../attached-panel';
+
+const mocks = vi.hoisted<{ client: Record<string, unknown> }>(() => ({ client: {} }));
+const closeTab = vi.hoisted(() => vi.fn());
+
+function selectTerminalPrefs(select: (state: Record<string, unknown>) => unknown): unknown {
+  return select({ fontFamily: 'monospace', fontSize: 13, colorScheme: 'dark' });
+}
+
+function translate(key: string): string {
+  return key;
+}
+
+vi.mock('@linkcode/client-core', () => ({
+  useLinkCodeClient: () => mocks.client,
+}));
+
+vi.mock('@linkcode/ui/shell/terminal', () => ({
+  LiveTerminal: () => null,
+}));
+
+vi.mock('../tabs-store', () => ({
+  useTerminalTabsStore: { getState: () => ({ closeTab }) },
+}));
+
+vi.mock('../../settings/terminal-prefs-store', () => ({
+  useTerminalPrefsStore: selectTerminalPrefs,
+}));
+
+vi.mock('use-intl', () => ({
+  useTranslations: () => translate,
+}));
+
+describe('AttachedTerminalPanel', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    closeTab.mockReset();
+  });
+
+  it('closes once for a replayed exit and detaches once when the pending attach resolves', async () => {
+    let resolveAttach: (result: TerminalAttachResult) => void = noop;
+    const detachTerminal = vi.fn();
+    const unsubscribeExit = vi.fn();
+    mocks.client = {
+      attachTerminal: () =>
+        new Promise<TerminalAttachResult>((resolve) => {
+          resolveAttach = resolve;
+        }),
+      detachTerminal,
+      subscribeTerminalController: () => noop,
+      terminalCanControl: () => false,
+      subscribeTerminalExit(_terminalId: string, onExit: (code: number | null) => void) {
+        onExit(0);
+        return unsubscribeExit;
+      },
+      subscribeTerminalEvents: () => noop,
+      subscribeTerminalReplayTruncated: () => noop,
+      terminalReplayWasTruncated: () => false,
+      terminalInput: noop,
+      resizeTerminal: noop,
+      takeTerminalControl: () => Promise.resolve(),
+    };
+    const view = render(<AttachedTerminalPanel terminalId="term-1" />);
+
+    expect(closeTab).toHaveBeenCalledOnce();
+    expect(closeTab).toHaveBeenCalledWith('attach:term-1');
+
+    view.unmount();
+    expect(detachTerminal).toHaveBeenCalledOnce();
+    expect(detachTerminal).toHaveBeenCalledWith('term-1');
+    await act(async () => {
+      resolveAttach({} as TerminalAttachResult);
+      await Promise.resolve();
+    });
+
+    expect(detachTerminal).toHaveBeenCalledOnce();
+    expect(unsubscribeExit).toHaveBeenCalledOnce();
+  });
+
+  it('leaves exit ownership to the primary duplicate surface', () => {
+    const subscribeTerminalExit = vi.fn(() => noop);
+    mocks.client = {
+      subscribeTerminalController: () => noop,
+      terminalCanControl: () => false,
+      subscribeTerminalExit,
+      subscribeTerminalEvents: () => noop,
+      subscribeTerminalReplayTruncated: () => noop,
+      terminalReplayWasTruncated: () => false,
+      terminalInput: noop,
+      resizeTerminal: noop,
+    };
+
+    const view = render(<AttachedTerminalPanel terminalId="term-1" primary={false} />);
+
+    expect(subscribeTerminalExit).not.toHaveBeenCalled();
+    expect(closeTab).not.toHaveBeenCalled();
+    view.unmount();
+  });
+});

--- a/packages/client/workbench/src/terminal/__tests__/session-registry.test.ts
+++ b/packages/client/workbench/src/terminal/__tests__/session-registry.test.ts
@@ -7,6 +7,7 @@ interface FakeClient extends TerminalSessionClient {
   opened: string[];
   closed: string[];
   detached: string[];
+  detachAttempts: string[];
   attachments: Set<string>;
   controlled: Set<string>;
   exitCbs: Map<string, (code: number | null) => void>;
@@ -18,6 +19,7 @@ function createFakeClient(): FakeClient {
   const opened: string[] = [];
   const closed: string[] = [];
   const detached: string[] = [];
+  const detachAttempts: string[] = [];
   const exitCbs = new Map<string, (code: number | null) => void>();
   const controllerCbs = new Map<string, (canControl: boolean) => void>();
   const attached = new Set<string>();
@@ -27,6 +29,7 @@ function createFakeClient(): FakeClient {
     opened,
     closed,
     detached,
+    detachAttempts,
     attachments: attached,
     controlled,
     exitCbs,
@@ -40,6 +43,7 @@ function createFakeClient(): FakeClient {
       return Promise.resolve(id);
     },
     detachTerminal(terminalId) {
+      detachAttempts.push(terminalId);
       if (!attached.delete(terminalId)) return;
       detached.push(terminalId);
       controlled.delete(terminalId);
@@ -202,6 +206,119 @@ describe('terminal session registry', () => {
     await vi.advanceTimersByTimeAsync(1000);
   });
 
+  it('notifies the tab owner once when the terminal exits normally', async () => {
+    const client = createFakeClient();
+    const onExit = vi.fn();
+    const lease = acquireTerminalSession(client, 'tab-1', dims, onExit);
+    await vi.advanceTimersByTimeAsync(0);
+
+    client.exitCbs.get('term-1')?.(0);
+    client.exitCbs.get('term-1')?.(0);
+
+    expect(onExit).toHaveBeenCalledOnce();
+    expect(onExit).toHaveBeenCalledWith(0);
+    lease.release();
+    await vi.advanceTimersByTimeAsync(1000);
+  });
+
+  it('notifies the tab owner when the terminal is killed by a signal', async () => {
+    const client = createFakeClient();
+    const onExit = vi.fn();
+    const lease = acquireTerminalSession(client, 'tab-1', dims, onExit);
+    await vi.advanceTimersByTimeAsync(0);
+
+    client.exitCbs.get('term-1')?.(null);
+
+    expect(onExit).toHaveBeenCalledOnce();
+    expect(onExit).toHaveBeenCalledWith(null);
+    lease.release();
+    await vi.advanceTimersByTimeAsync(1000);
+  });
+
+  it('does not notify after the user releases the tab before a late exit', async () => {
+    const client = createFakeClient();
+    const onExit = vi.fn();
+    const lease = acquireTerminalSession(client, 'tab-1', dims, onExit);
+    await vi.advanceTimersByTimeAsync(0);
+    const lateExit = client.exitCbs.get('term-1');
+
+    lease.release();
+    lateExit?.(0);
+    await vi.advanceTimersByTimeAsync(1000);
+
+    expect(onExit).not.toHaveBeenCalled();
+    expect(client.closed).toEqual([]);
+    expect(client.detached).toEqual([]);
+    expect(client.detachAttempts).toEqual(['term-1']);
+  });
+
+  it('closes only the tab whose terminal exits', async () => {
+    const client = createFakeClient();
+    const onFirstExit = vi.fn();
+    const onSecondExit = vi.fn();
+    const first = acquireTerminalSession(client, 'tab-1', dims, onFirstExit);
+    const second = acquireTerminalSession(client, 'tab-2', dims, onSecondExit);
+    await vi.advanceTimersByTimeAsync(0);
+
+    client.exitCbs.get('term-1')?.(0);
+
+    expect(onFirstExit).toHaveBeenCalledOnce();
+    expect(onSecondExit).not.toHaveBeenCalled();
+    expect(second.getSnapshot().exit).toBeNull();
+    first.release();
+    second.release();
+    await vi.advanceTimersByTimeAsync(1000);
+  });
+
+  it('notifies only once while a tab lease is handed between panel mounts', async () => {
+    const client = createFakeClient();
+    const firstOwner = vi.fn();
+    const secondOwner = vi.fn();
+    const first = acquireTerminalSession(client, 'tab-1', dims, firstOwner);
+    await vi.advanceTimersByTimeAsync(0);
+    const second = acquireTerminalSession(client, 'tab-1', dims, secondOwner);
+
+    client.exitCbs.get('term-1')?.(0);
+
+    expect(firstOwner.mock.calls.length + secondOwner.mock.calls.length).toBe(1);
+    first.release();
+    second.release();
+    await vi.advanceTimersByTimeAsync(1000);
+  });
+
+  it('delivers an exit that arrives between releasing and reacquiring a handed-off tab', async () => {
+    const client = createFakeClient();
+    const staleOwner = vi.fn();
+    const nextOwner = vi.fn();
+    const first = acquireTerminalSession(client, 'tab-1', dims, staleOwner);
+    await vi.advanceTimersByTimeAsync(0);
+
+    first.release();
+    client.exitCbs.get('term-1')?.(0);
+    const second = acquireTerminalSession(client, 'tab-1', dims, nextOwner);
+
+    expect(staleOwner).not.toHaveBeenCalled();
+    expect(nextOwner).toHaveBeenCalledOnce();
+    expect(nextOwner).toHaveBeenCalledWith(0);
+    second.release();
+    await vi.advanceTimersByTimeAsync(1000);
+  });
+
+  it('keeps equal callbacks registered independently for concurrent leases', async () => {
+    const client = createFakeClient();
+    const onExit = vi.fn();
+    const first = acquireTerminalSession(client, 'tab-1', dims, onExit);
+    await vi.advanceTimersByTimeAsync(0);
+    const second = acquireTerminalSession(client, 'tab-1', dims, onExit);
+
+    first.release();
+    client.exitCbs.get('term-1')?.(0);
+
+    expect(onExit).toHaveBeenCalledOnce();
+    second.release();
+    await vi.advanceTimersByTimeAsync(1000);
+  });
+
   it('preserves a signal exit as distinct from a running terminal', async () => {
     const client = createFakeClient();
     const lease = acquireTerminalSession(client, 'tab-1', dims);
@@ -217,12 +334,13 @@ describe('terminal session registry', () => {
 
   it('preserves an exit delivered synchronously while the terminal opens', async () => {
     const client = createFakeClient();
+    const onExit = vi.fn();
     client.subscribeTerminalExit = (_terminalId, cb) => {
       cb(7);
       return noop;
     };
 
-    const lease = acquireTerminalSession(client, 'tab-1', dims);
+    const lease = acquireTerminalSession(client, 'tab-1', dims, onExit);
     await vi.advanceTimersByTimeAsync(0);
 
     expect(lease.getSnapshot()).toMatchObject({
@@ -231,6 +349,8 @@ describe('terminal session registry', () => {
       exit: { code: 7 },
       canControl: false,
     });
+    expect(onExit).toHaveBeenCalledOnce();
+    expect(onExit).toHaveBeenCalledWith(7);
     lease.release();
     await vi.advanceTimersByTimeAsync(1000);
   });

--- a/packages/client/workbench/src/terminal/__tests__/tabs-store.test.ts
+++ b/packages/client/workbench/src/terminal/__tests__/tabs-store.test.ts
@@ -1,0 +1,116 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, renderHook } from '@testing-library/react';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const stored = new Map<string, string>();
+const storage = {
+  getItem: (key: string) => stored.get(key) ?? null,
+  removeItem: (key: string) => stored.delete(key),
+  setItem: (key: string, value: string) => stored.set(key, value),
+};
+
+let createTerminalTab: typeof import('../tabs-store').createTerminalTab;
+let useTerminalTabsStore: typeof import('../tabs-store').useTerminalTabsStore;
+
+function useTerminalSurface() {
+  return useTerminalTabsStore();
+}
+
+describe('shared terminal tabs', () => {
+  beforeAll(() => vi.stubGlobal('localStorage', storage));
+  beforeEach(async () => {
+    stored.clear();
+    vi.resetModules();
+    ({ createTerminalTab, useTerminalTabsStore } = await import('../tabs-store'));
+    const tab = createTerminalTab();
+    useTerminalTabsStore.setState({ tabs: [tab], activeTabId: tab.id });
+  });
+
+  afterEach(cleanup);
+  afterAll(() => vi.unstubAllGlobals());
+
+  it('synchronizes create, activate, and close operations from both surfaces', () => {
+    const right = renderHook(useTerminalSurface);
+    const bottom = renderHook(useTerminalSurface);
+    const firstId = right.result.current.activeTabId;
+
+    let rightCreated = '';
+    act(() => {
+      rightCreated = right.result.current.addTab();
+    });
+    let bottomCreated = '';
+    act(() => {
+      bottomCreated = bottom.result.current.addTab();
+    });
+
+    expect(right.result.current.tabs.map((tab) => tab.id)).toEqual(
+      bottom.result.current.tabs.map((tab) => tab.id),
+    );
+    expect(right.result.current.activeTabId).toBe(bottomCreated);
+
+    act(() => bottom.result.current.setActiveTab(rightCreated));
+    expect(right.result.current.activeTabId).toBe(rightCreated);
+    expect(bottom.result.current.activeTabId).toBe(rightCreated);
+
+    act(() => right.result.current.closeTab(rightCreated));
+    expect(bottom.result.current.tabs.map((tab) => tab.id)).toEqual([firstId, bottomCreated]);
+    expect(bottom.result.current.activeTabId).toBe(bottomCreated);
+
+    act(() => bottom.result.current.closeTab(firstId!));
+    expect(right.result.current.tabs.map((tab) => tab.id)).toEqual([bottomCreated]);
+  });
+
+  it('represents the last-tab state once and can seed it again once', () => {
+    const right = renderHook(useTerminalSurface);
+    const bottom = renderHook(useTerminalSurface);
+    const onlyId = right.result.current.activeTabId!;
+
+    act(() => right.result.current.closeTab(onlyId));
+    expect(right.result.current.tabs).toEqual([]);
+    expect(bottom.result.current.tabs).toEqual([]);
+    expect(right.result.current.activeTabId).toBeNull();
+
+    let seededId = '';
+    act(() => {
+      seededId = bottom.result.current.ensureTab();
+    });
+    expect(right.result.current.tabs.map((tab) => tab.id)).toEqual([seededId]);
+    expect(bottom.result.current.activeTabId).toBe(seededId);
+  });
+
+  it('keeps sessions while either surface unmounts and exposes all independent terminals', () => {
+    const right = renderHook(useTerminalSurface);
+    const bottom = renderHook(useTerminalSurface);
+
+    let secondId = '';
+    let thirdId = '';
+    act(() => {
+      secondId = right.result.current.addTab();
+      thirdId = bottom.result.current.addTab();
+    });
+    const expectedIds = right.result.current.tabs.map((tab) => tab.id);
+    expect(new Set(expectedIds).size).toBe(3);
+
+    right.unmount();
+    act(() => bottom.result.current.setActiveTab(secondId));
+    expect(bottom.result.current.activeTabId).toBe(secondId);
+
+    const remountedRight = renderHook(useTerminalSurface);
+    expect(remountedRight.result.current.tabs.map((tab) => tab.id)).toEqual(expectedIds);
+    expect(remountedRight.result.current.activeTabId).toBe(secondId);
+
+    bottom.unmount();
+    act(() => remountedRight.result.current.closeTab(secondId));
+    expect(remountedRight.result.current.tabs.map((tab) => tab.id)).not.toContain(secondId);
+    expect(remountedRight.result.current.tabs.map((tab) => tab.id)).toContain(thirdId);
+  });
+
+  it('does not persist attached terminals as reopenable shells', () => {
+    const surface = renderHook(useTerminalSurface);
+    act(() => surface.result.current.openAttachedTab('script-log'));
+
+    const persisted = JSON.parse(stored.get('linkcode.workbench.terminal-tabs:v1')!);
+    expect(persisted.state.tabCount).toBe(1);
+  });
+});

--- a/packages/client/workbench/src/terminal/attached-panel.tsx
+++ b/packages/client/workbench/src/terminal/attached-panel.tsx
@@ -6,7 +6,6 @@ import { useEffect as useAbortableEffect } from 'foxact/use-abortable-effect';
 import { useCallback, useMemo, useState, useSyncExternalStore } from 'react';
 import { useTranslations } from 'use-intl';
 import { useTerminalPrefsStore } from '../settings/terminal-prefs-store';
-import { useTerminalTabsStore } from './tabs-store';
 import { createTransportTerminalSession } from './transport-session';
 
 /**
@@ -16,11 +15,14 @@ import { createTransportTerminalSession } from './transport-session';
  */
 export function AttachedTerminalPanel({
   terminalId,
+  onCloseTab,
   interactive,
   primary = true,
   suspended,
 }: {
   terminalId: string;
+  /** Close through the host action so panel selection/open state follows the shared tab store. */
+  onCloseTab: (id: string) => void;
   interactive?: boolean;
   /** Exactly one duplicate surface attaches/detaches the daemon capability. */
   primary?: boolean;
@@ -84,10 +86,10 @@ export function AttachedTerminalPanel({
     (signal) => {
       if (!primary) return;
       return client.subscribeTerminalExit(terminalId, () => {
-        if (!signal.aborted) useTerminalTabsStore.getState().closeTab(`attach:${terminalId}`);
+        if (!signal.aborted) onCloseTab(`attach:${terminalId}`);
       });
     },
-    [client, terminalId, primary],
+    [client, terminalId, onCloseTab, primary],
   );
 
   if (!primary) {

--- a/packages/client/workbench/src/terminal/attached-panel.tsx
+++ b/packages/client/workbench/src/terminal/attached-panel.tsx
@@ -15,9 +15,14 @@ import { createTransportTerminalSession } from './transport-session';
  */
 export function AttachedTerminalPanel({
   terminalId,
+  interactive,
+  primary = true,
   suspended,
 }: {
   terminalId: string;
+  interactive?: boolean;
+  /** Exactly one duplicate surface attaches/detaches the daemon capability. */
+  primary?: boolean;
   suspended?: boolean;
 }): React.ReactNode {
   const t = useTranslations('workbench.panel');
@@ -58,6 +63,7 @@ export function AttachedTerminalPanel({
 
   useAbortableEffect(
     (signal) => {
+      if (!primary) return;
       let attached = false;
       void client
         .attachTerminal(terminalId)
@@ -73,8 +79,22 @@ export function AttachedTerminalPanel({
         if (attached) client.detachTerminal(terminalId);
       };
     },
-    [client, terminalId],
+    [client, terminalId, primary],
   );
+
+  if (!primary) {
+    return (
+      <LiveTerminal
+        session={session}
+        interactive={false}
+        suspended={suspended}
+        fontFamily={fontFamily}
+        fontSize={fontSize}
+        colorScheme={colorScheme}
+        className="h-full w-full"
+      />
+    );
+  }
 
   const current = attachment?.terminalId === terminalId ? attachment : null;
   if (!current || 'failed' in current) {
@@ -96,6 +116,7 @@ export function AttachedTerminalPanel({
     <div className="relative h-full w-full">
       <LiveTerminal
         session={session}
+        interactive={interactive}
         suspended={suspended}
         fontFamily={fontFamily}
         fontSize={fontSize}

--- a/packages/client/workbench/src/terminal/attached-panel.tsx
+++ b/packages/client/workbench/src/terminal/attached-panel.tsx
@@ -6,6 +6,7 @@ import { useEffect as useAbortableEffect } from 'foxact/use-abortable-effect';
 import { useCallback, useMemo, useState, useSyncExternalStore } from 'react';
 import { useTranslations } from 'use-intl';
 import { useTerminalPrefsStore } from '../settings/terminal-prefs-store';
+import { useTerminalTabsStore } from './tabs-store';
 import { createTransportTerminalSession } from './transport-session';
 
 /**
@@ -64,20 +65,27 @@ export function AttachedTerminalPanel({
   useAbortableEffect(
     (signal) => {
       if (!primary) return;
-      let attached = false;
       void client
         .attachTerminal(terminalId)
         .then((result) => {
-          attached = true;
-          if (signal.aborted) client.detachTerminal(terminalId);
-          else setAttachment({ terminalId, result });
+          if (!signal.aborted) setAttachment({ terminalId, result });
         })
         .catch(() => {
           if (!signal.aborted) setAttachment({ terminalId, failed: true });
         });
-      return () => {
-        if (attached) client.detachTerminal(terminalId);
-      };
+      // Balance the retain immediately. If attach is still pending, client-core observes the
+      // zero retain count when the reply arrives and sends the terminal.detach frame then.
+      return () => client.detachTerminal(terminalId);
+    },
+    [client, terminalId, primary],
+  );
+
+  useAbortableEffect(
+    (signal) => {
+      if (!primary) return;
+      return client.subscribeTerminalExit(terminalId, () => {
+        if (!signal.aborted) useTerminalTabsStore.getState().closeTab(`attach:${terminalId}`);
+      });
     },
     [client, terminalId, primary],
   );

--- a/packages/client/workbench/src/terminal/panel.tsx
+++ b/packages/client/workbench/src/terminal/panel.tsx
@@ -7,6 +7,7 @@ import { useTranslations } from 'use-intl';
 import { useTerminalPrefsStore } from '../settings/terminal-prefs-store';
 import type { TerminalSessionLease } from './session-registry';
 import { acquireTerminalSession, peekTerminalSnapshot } from './session-registry';
+import { useTerminalTabsStore } from './tabs-store';
 
 const TERMINAL_INITIAL_SIZE = { cols: 80, rows: 24 };
 const INPUT_LOST_BANNER_MS = 4000;
@@ -39,7 +40,12 @@ export function TerminalPanel({
 
   const subscribe = useCallback(
     (onStoreChange: () => void) => {
-      const lease = acquireTerminalSession(client, sessionKey, { ...TERMINAL_INITIAL_SIZE, cwd });
+      const lease = acquireTerminalSession(
+        client,
+        sessionKey,
+        { ...TERMINAL_INITIAL_SIZE, cwd },
+        () => useTerminalTabsStore.getState().closeTab(sessionKey),
+      );
       leaseRef.current = lease;
       const unsubscribe = lease.subscribe(onStoreChange);
       return () => {

--- a/packages/client/workbench/src/terminal/panel.tsx
+++ b/packages/client/workbench/src/terminal/panel.tsx
@@ -7,7 +7,6 @@ import { useTranslations } from 'use-intl';
 import { useTerminalPrefsStore } from '../settings/terminal-prefs-store';
 import type { TerminalSessionLease } from './session-registry';
 import { acquireTerminalSession, peekTerminalSnapshot } from './session-registry';
-import { useTerminalTabsStore } from './tabs-store';
 
 const TERMINAL_INITIAL_SIZE = { cols: 80, rows: 24 };
 const INPUT_LOST_BANNER_MS = 4000;
@@ -20,12 +19,15 @@ const INPUT_LOST_BANNER_MS = 4000;
 export function TerminalPanel({
   sessionKey,
   cwd,
+  onCloseTab,
   interactive,
   suspended,
 }: {
   sessionKey: string;
   /** Working directory for the shell, captured when the terminal first opens (host home if omitted). */
   cwd?: string;
+  /** Close through the host action so panel selection/open state follows the shared tab store. */
+  onCloseTab: (id: string) => void;
   interactive?: boolean;
   /** Freeze the terminal's box while the host panel animates shut/open — see {@link LiveTerminal}. */
   suspended?: boolean;
@@ -44,7 +46,7 @@ export function TerminalPanel({
         client,
         sessionKey,
         { ...TERMINAL_INITIAL_SIZE, cwd },
-        () => useTerminalTabsStore.getState().closeTab(sessionKey),
+        () => onCloseTab(sessionKey),
       );
       leaseRef.current = lease;
       const unsubscribe = lease.subscribe(onStoreChange);
@@ -54,7 +56,7 @@ export function TerminalPanel({
         if (leaseRef.current === lease) leaseRef.current = null;
       };
     },
-    [client, sessionKey, cwd],
+    [client, sessionKey, cwd, onCloseTab],
   );
   const snapshot = useSyncExternalStore(subscribe, () => peekTerminalSnapshot(client, sessionKey));
 

--- a/packages/client/workbench/src/terminal/panel.tsx
+++ b/packages/client/workbench/src/terminal/panel.tsx
@@ -19,11 +19,13 @@ const INPUT_LOST_BANNER_MS = 4000;
 export function TerminalPanel({
   sessionKey,
   cwd,
+  interactive,
   suspended,
 }: {
   sessionKey: string;
   /** Working directory for the shell, captured when the terminal first opens (host home if omitted). */
   cwd?: string;
+  interactive?: boolean;
   /** Freeze the terminal's box while the host panel animates shut/open — see {@link LiveTerminal}. */
   suspended?: boolean;
 }): React.ReactNode {
@@ -99,6 +101,7 @@ export function TerminalPanel({
     <div className="relative h-full w-full">
       <LiveTerminal
         session={snapshot.session}
+        interactive={interactive}
         suspended={suspended}
         fontFamily={fontFamily}
         fontSize={fontSize}

--- a/packages/client/workbench/src/terminal/session-registry.ts
+++ b/packages/client/workbench/src/terminal/session-registry.ts
@@ -43,6 +43,8 @@ interface RegistryEntry {
   unsubController: (() => void) | null;
   snapshot: TerminalSnapshot;
   listeners: Set<() => void>;
+  exitListeners: Map<symbol, (exitCode: number | null) => void>;
+  exitDelivered: boolean;
 }
 
 /**
@@ -79,6 +81,15 @@ function notify(entry: RegistryEntry): void {
   for (const listener of entry.listeners) listener();
 }
 
+function deliverExit(entry: RegistryEntry): void {
+  if (entry.exitDelivered || entry.snapshot.exit === null) return;
+  let onExit: ((exitCode: number | null) => void) | undefined;
+  for (const listener of entry.exitListeners.values()) onExit = listener;
+  if (!onExit) return;
+  entry.exitDelivered = true;
+  onExit(entry.snapshot.exit.code);
+}
+
 function startOpen(
   client: TerminalSessionClient,
   registry: Map<string, RegistryEntry>,
@@ -87,6 +98,7 @@ function startOpen(
   opts: TerminalOpenOptions,
 ): void {
   entry.attempt += 1;
+  entry.exitDelivered = false;
   const attempt = entry.attempt;
   const isCurrent = (): boolean => registry.get(key) === entry && entry.attempt === attempt;
 
@@ -136,6 +148,7 @@ function startOpen(
           exit: { code: exitCode },
           canControl: false,
         };
+        deliverExit(entry);
         notify(entry);
       });
       notify(entry);
@@ -177,6 +190,7 @@ export function acquireTerminalSession(
   client: TerminalSessionClient,
   key: string,
   opts: TerminalOpenOptions,
+  onExit?: (exitCode: number | null) => void,
 ): TerminalSessionLease {
   const registry = getRegistry(client);
   let entry = registry.get(key);
@@ -197,6 +211,8 @@ export function acquireTerminalSession(
       unsubController: null,
       snapshot: OPENING_SNAPSHOT,
       listeners: new Set(),
+      exitListeners: new Map(),
+      exitDelivered: false,
     };
     registry.set(key, created);
     entry = created;
@@ -205,6 +221,11 @@ export function acquireTerminalSession(
 
   const leased = entry;
   let released = false;
+  const exitListenerId = Symbol('terminal-exit-listener');
+  if (onExit) {
+    leased.exitListeners.set(exitListenerId, onExit);
+    deliverExit(leased);
+  }
 
   return {
     getSnapshot: () => leased.snapshot,
@@ -222,6 +243,7 @@ export function acquireTerminalSession(
     release() {
       if (released) return;
       released = true;
+      leased.exitListeners.delete(exitListenerId);
       leased.refCount -= 1;
       if (leased.refCount > 0) return;
       leased.closeTimer = setTimeout(() => {

--- a/packages/client/workbench/src/terminal/tabs-store.ts
+++ b/packages/client/workbench/src/terminal/tabs-store.ts
@@ -1,0 +1,121 @@
+import { zodPersist } from '@linkcode/common/zustand';
+import { clamp } from 'foxts/clamp';
+import { createFixedArray } from 'foxts/create-fixed-array';
+import { z } from 'zod';
+import { create } from 'zustand';
+
+export interface TerminalTab {
+  id: string;
+}
+
+export interface TerminalTabsState {
+  tabs: TerminalTab[];
+  activeTabId: string | null;
+}
+
+interface TerminalTabsStore extends TerminalTabsState {
+  ensureTab: () => string;
+  addTab: () => string;
+  openAttachedTab: (terminalId: string) => string;
+  setActiveTab: (id: string) => void;
+  closeTab: (id: string) => void;
+}
+
+interface PersistedTerminalTabsState {
+  version: 1;
+  tabCount: number;
+  activeTabIndex: number;
+}
+
+const MAX_PERSISTED_TABS = 20;
+let tabSequence = 0;
+
+export function createTerminalTab(): TerminalTab {
+  tabSequence += 1;
+  return { id: `terminal-${tabSequence}` };
+}
+
+export function closeTerminalTabState(state: TerminalTabsState, id: string): TerminalTabsState {
+  const index = state.tabs.findIndex((tab) => tab.id === id);
+  if (index === -1) return state;
+  const tabs = state.tabs.filter((tab) => tab.id !== id);
+  const activeTabId =
+    state.activeTabId === id
+      ? (tabs[clamp(index, 0, tabs.length - 1)]?.id ?? null)
+      : state.activeTabId;
+  return { tabs, activeTabId };
+}
+
+export function createDefaultTerminalTabsState(): TerminalTabsState {
+  const tab = createTerminalTab();
+  return { tabs: [tab], activeTabId: tab.id };
+}
+
+const PersistedTerminalTabsStateSchema = z
+  .object({
+    version: z.literal(1),
+    tabCount: z.number().int().nonnegative().catch(1),
+    activeTabIndex: z.number().int().catch(0),
+  })
+  .transform(({ tabCount, activeTabIndex }): TerminalTabsState => {
+    const tabs = createFixedArray(clamp(tabCount, 0, MAX_PERSISTED_TABS)).map(createTerminalTab);
+    return {
+      tabs,
+      activeTabId: tabs[clamp(activeTabIndex, 0, tabs.length - 1)]?.id ?? null,
+    };
+  });
+
+export const useTerminalTabsStore = create<TerminalTabsStore>()(
+  zodPersist<TerminalTabsStore, [], [], PersistedTerminalTabsState, TerminalTabsState>(
+    (set, get) => ({
+      ...createDefaultTerminalTabsState(),
+      ensureTab() {
+        const current = get();
+        if (current.tabs.length > 0) {
+          const id = current.activeTabId ?? current.tabs[0].id;
+          if (current.activeTabId === null) set({ activeTabId: id });
+          return id;
+        }
+        return get().addTab();
+      },
+      addTab() {
+        const tab = createTerminalTab();
+        set((state) => ({ tabs: [...state.tabs, tab], activeTabId: tab.id }));
+        return tab.id;
+      },
+      openAttachedTab(terminalId) {
+        const id = `attach:${terminalId}`;
+        set((state) => ({
+          tabs: state.tabs.some((tab) => tab.id === id) ? state.tabs : [...state.tabs, { id }],
+          activeTabId: id,
+        }));
+        return id;
+      },
+      setActiveTab(id) {
+        if (get().tabs.some((tab) => tab.id === id)) set({ activeTabId: id });
+      },
+      closeTab(id) {
+        set((state) => closeTerminalTabState(state, id));
+      },
+    }),
+    {
+      name: 'linkcode.workbench.terminal-tabs:v1',
+      version: 1,
+      schema: PersistedTerminalTabsStateSchema,
+      partialize(state) {
+        // Attached terminals are owned by another runtime (for example a script log PTY) and
+        // cannot be recreated after a renderer restart. Persist only shell tabs we can reopen.
+        const tabs = state.tabs.filter((tab) => !tab.id.startsWith('attach:'));
+        return {
+          version: 1,
+          tabCount: tabs.length,
+          activeTabIndex: clamp(
+            tabs.findIndex((tab) => tab.id === state.activeTabId),
+            0,
+            Math.max(0, tabs.length - 1),
+          ),
+        };
+      },
+    },
+  ),
+);

--- a/packages/presentation/ui/src/shell/terminal/__tests__/live-terminal-transport.test.ts
+++ b/packages/presentation/ui/src/shell/terminal/__tests__/live-terminal-transport.test.ts
@@ -34,4 +34,22 @@ describe('createSessionPtyTransport', () => {
     expect(transport.isConnected()).toBe(false);
     expect(unsubscribe).toHaveBeenCalledOnce();
   });
+
+  it('prevents a secondary view from sending input or resize', () => {
+    const sendInput = vi.fn();
+    const resize = vi.fn();
+    const session = {
+      ...createSession(() => noop),
+      canControl: () => true,
+      sendInput,
+      resize,
+    };
+    const transport = createSessionPtyTransport(session, noop, false);
+
+    transport.sendInput('echo secondary');
+    transport.resize(120, 40);
+
+    expect(sendInput).not.toHaveBeenCalled();
+    expect(resize).not.toHaveBeenCalled();
+  });
 });

--- a/packages/presentation/ui/src/shell/terminal/live-terminal.tsx
+++ b/packages/presentation/ui/src/shell/terminal/live-terminal.tsx
@@ -52,6 +52,7 @@ function subscribeThemeChange(listener: () => void): () => void {
 export function createSessionPtyTransport(
   session: TerminalSession,
   applyHostResize: (cols: number, rows: number) => void,
+  interactive = true,
 ): PtyTransport {
   let unsubscribe: (() => void) | null = null;
   let connected = false;
@@ -95,11 +96,11 @@ export function createSessionPtyTransport(
     disconnect: close,
     destroy: close,
     sendInput(data) {
-      if (session.canControl()) session.sendInput(data);
+      if (interactive && session.canControl()) session.sendInput(data);
       return true;
     },
     resize(cols, rows) {
-      if (!applyingHostResize && session.canControl()) session.resize(cols, rows);
+      if (interactive && !applyingHostResize && session.canControl()) session.resize(cols, rows);
       return true;
     },
     isConnected: () => connected,
@@ -114,6 +115,7 @@ export function createSessionPtyTransport(
  */
 export function LiveTerminal({
   session,
+  interactive = true,
   suspended = false,
   className,
   fontFamily = DEFAULT_TERMINAL_FONT_FAMILY,
@@ -121,6 +123,8 @@ export function LiveTerminal({
   colorScheme = DEFAULT_TERMINAL_COLOR_SCHEME,
 }: {
   session: TerminalSession;
+  /** Whether this renderer owns local input and PTY resize when the same session has two views. */
+  interactive?: boolean;
   suspended?: boolean;
   className?: string;
   fontFamily?: string;
@@ -192,9 +196,11 @@ export function LiveTerminal({
             forwardTerminalReplies: false,
           },
           services: {
-            beforeInput: () => (session.canControl() ? undefined : null),
-            ptyTransport: createSessionPtyTransport(session, (cols, rows) =>
-              hostResize.apply(cols, rows),
+            beforeInput: () => (interactive && session.canControl() ? undefined : null),
+            ptyTransport: createSessionPtyTransport(
+              session,
+              (cols, rows) => hostResize.apply(cols, rows),
+              interactive,
             ),
           },
         });
@@ -212,14 +218,14 @@ export function LiveTerminal({
         applyTerminalTheme(restty, frame, colorScheme);
         restty.connectPty('session://terminal');
         const containerResize = new ResizeObserver(() => {
-          if (session.canControl()) restty.updateSize();
+          if (interactive && session.canControl()) restty.updateSize();
         });
         containerResize.observe(container);
         disconnectContainerResize = () => containerResize.disconnect();
         unsubscribeController = session.subscribeController((canControl) => {
-          if (canControl) restty.updateSize(true);
+          if (interactive && canControl) restty.updateSize(true);
         });
-        if (session.canControl()) restty.updateSize(true);
+        if (interactive && session.canControl()) restty.updateSize(true);
         // Reveal only once a themed frame can be painted, so the default black frames restty
         // draws while the WASM core boots are never shown.
         revealFrame = requestAnimationFrame(() => {
@@ -238,7 +244,7 @@ export function LiveTerminal({
     // fontFamily/fontSize/colorScheme only seed the initial config (live-synced by the effects
     // below); as deps they would tear the terminal down and rebuild it on every change.
     // eslint-disable-next-line react-hooks/exhaustive-deps -- intentional: initial seed only
-    [session],
+    [session, interactive],
   );
 
   // Live-apply appearance prefs without tearing the terminal down; on first mount resttyRef is


### PR DESCRIPTION
## Summary

- move terminal tab/session identity and the active terminal into one persisted workbench Zustand store
- render that same terminal set in the right Terminal section and bottom panel, routing create, activate, close, last-tab fallback, and attached-terminal operations through the shared model
- assign one visible surface as the PTY input/resize owner while the other remains an observational view, preventing duplicate resize/input races
- keep attached runtime terminals out of persisted reopenable shell state and preserve the bottom panel's terminal-active sentinel beside non-terminal tabs

PTY-exit-driven tab closure remains scoped to CODE-349; it can close the shared model exactly once.

Linear: CODE-351

## Verification

- `pnpm check:ci`
- `pnpm test packages/workbench/src/terminal packages/ui/src/shell/terminal apps/desktop/src/renderer/src/__tests__/shell-state.test.ts` — 32 tests passed
- real Electron UI: opened both surfaces, created a terminal from the right panel (both changed 1 → 2), switched/closed it (both changed 2 → 1), with no renderer page errors