### PR TITLE
feat(ui): import chat history by directory

### DIFF
--- a/apps/desktop/src/renderer/src/settings/history-import-tab.tsx
+++ b/apps/desktop/src/renderer/src/settings/history-import-tab.tsx
@@ -41,13 +41,17 @@ export function HistoryImportTab({ kind }: { kind: AgentKind }): React.ReactNode
       </DesktopChromePortal>
       <HistoryBrowserList
         entries={surface.entries}
-        groupByProject={sort === 'project'}
+        groupByProject
         truncated={surface.truncated}
         isLoading={surface.isLoading}
         loadError={surface.loadError}
-        importingId={surface.importingId}
-        importError={surface.importError}
+        importingIds={surface.importingIds}
+        importingCwds={surface.importingCwds}
+        importErrors={surface.importErrors}
+        groupImportFailures={surface.groupImportFailures}
+        actionError={surface.actionError}
         onImport={surface.importEntry}
+        onImportGroup={surface.importGroup}
         onOpen={surface.openEntry}
         onRefresh={surface.refresh}
       />

--- a/packages/client/workbench/src/history/__tests__/use-history-import-surface.test.ts
+++ b/packages/client/workbench/src/history/__tests__/use-history-import-surface.test.ts
@@ -1,0 +1,34 @@
+import type { AgentHistoryId } from '@linkcode/schema';
+import { describe, expect, it } from 'vitest';
+import { groupFailureAfterRetry } from '../use-history-import-surface';
+
+describe('groupFailureAfterRetry', () => {
+  it('removes only the successfully retried row from the directory failures', () => {
+    const key = 'claude-code\0/work/linkcode';
+    const failures = new Map([
+      [key, { total: 3, failedIds: new Set(['two', 'three'] as AgentHistoryId[]) }],
+    ]);
+
+    const updated = groupFailureAfterRetry(failures, key, 'two' as AgentHistoryId);
+    expect(updated).toEqual(new Map([[key, { total: 3, failedIds: new Set(['three']) }]]));
+    expect(groupFailureAfterRetry(updated, key, 'two' as AgentHistoryId)).toBe(updated);
+  });
+
+  it('clears the directory result after the final failed row succeeds', () => {
+    const key = 'claude-code\0/work/linkcode';
+    const failures = new Map([
+      [key, { total: 3, failedIds: new Set(['three'] as AgentHistoryId[]) }],
+    ]);
+
+    expect(groupFailureAfterRetry(failures, key, 'three' as AgentHistoryId)).toEqual(new Map());
+  });
+
+  it('ignores a success for a row that was not a group failure', () => {
+    const key = 'claude-code\0/work/linkcode';
+    const failures = new Map([
+      [key, { total: 2, failedIds: new Set(['two'] as AgentHistoryId[]) }],
+    ]);
+
+    expect(groupFailureAfterRetry(failures, key, 'one' as AgentHistoryId)).toBe(failures);
+  });
+});

--- a/packages/client/workbench/src/history/__tests__/use-provider-history.test.ts
+++ b/packages/client/workbench/src/history/__tests__/use-provider-history.test.ts
@@ -1,10 +1,17 @@
 // @vitest-environment jsdom
 
-import type { AgentHistoryListResult, AgentKind } from '@linkcode/schema';
+import type {
+  AgentHistoryId,
+  AgentHistoryListResult,
+  AgentHistorySession,
+  AgentKind,
+  SessionId,
+} from '@linkcode/schema';
 import { AgentHistoryIdSchema } from '@linkcode/schema';
 import { cleanup, renderHook } from '@testing-library/react';
+import { asyncNoop } from 'foxts/noop';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { useProviderHistory } from '../use-provider-history';
+import { importHistoryGroup, useProviderHistory } from '../use-provider-history';
 
 const { useDataMock, useMutationMock } = vi.hoisted(() => ({
   useDataMock: vi.fn(),
@@ -40,7 +47,8 @@ beforeEach(() => {
   let previousKind: AgentKind | undefined;
 
   useDataMock.mockImplementation(
-    (_operation: unknown, request: HistoryRequest, options?: HistoryDataOptions) => {
+    (_operation: unknown, request: HistoryRequest | object, options?: HistoryDataOptions) => {
+      if (!('agentKind' in request)) return { mutate: vi.fn() };
       const response = responses.get(request.agentKind) ?? {};
       const changedProvider = previousKind !== undefined && previousKind !== request.agentKind;
       const data =
@@ -89,11 +97,11 @@ describe('useProviderHistory', () => {
 
     expect(result.current.entries).toEqual([]);
     expect(result.current.loadError).toBe(unavailable);
-    expect(useDataMock.mock.lastCall?.[1]).toEqual({
-      agentKind: 'pi',
-      opts: { limit: 200 },
-    });
-    expect(useDataMock.mock.lastCall?.[2]).toEqual({ keepPreviousData: false });
+    expect(useDataMock).toHaveBeenCalledWith(
+      expect.anything(),
+      { agentKind: 'pi', opts: { limit: 200 } },
+      { keepPreviousData: false },
+    );
   });
 
   it('keeps late results scoped to their provider during rapid switches and restores its cache', () => {
@@ -126,5 +134,85 @@ describe('useProviderHistory', () => {
 
     rerender({ kind: 'codex' });
     expect(result.current.entries.map((entry) => entry.historyId)).toEqual([lateCodexSessionId]);
+  });
+});
+
+function entry(historyId: string): AgentHistorySession {
+  return {
+    historyId: historyId as AgentHistoryId,
+    kind: 'claude-code',
+    cwd: '/work/linkcode',
+  };
+}
+
+describe('importHistoryGroup', () => {
+  it('registers the directory and imports every conversation', async () => {
+    const register = vi.fn(asyncNoop);
+    const importEntry = vi.fn((item: AgentHistorySession) =>
+      Promise.resolve(`session-${item.historyId}` as SessionId),
+    );
+    const entries = [entry('one'), entry('two')];
+
+    await expect(
+      importHistoryGroup({
+        cwd: '/work/linkcode',
+        entries,
+        inFlight: new Set(),
+        register,
+        importEntry,
+      }),
+    ).resolves.toEqual({ imported: ['one', 'two'], failures: [] });
+    expect(register).toHaveBeenCalledOnce();
+    expect(register).toHaveBeenCalledWith('/work/linkcode');
+    expect(importEntry).toHaveBeenCalledTimes(2);
+  });
+
+  it('waits for all imports and reports partial failures against the failed entries', async () => {
+    const failure = new Error('history is unreadable');
+    const entries = [entry('one'), entry('two'), entry('three')];
+    const importEntry = vi.fn((item: AgentHistorySession) => {
+      if (item.historyId === 'two') return Promise.reject(failure);
+      return Promise.resolve(`session-${item.historyId}` as SessionId);
+    });
+
+    await expect(
+      importHistoryGroup({
+        cwd: '/work/linkcode',
+        entries,
+        inFlight: new Set(),
+        register: () => Promise.resolve(),
+        importEntry,
+      }),
+    ).resolves.toEqual({
+      imported: ['one', 'three'],
+      failures: [{ historyId: 'two', error: failure }],
+    });
+    expect(importEntry).toHaveBeenCalledTimes(3);
+  });
+
+  it('drops a repeated click while the same directory import is in flight', async () => {
+    let finishRegistration: (() => void) | undefined;
+    const registration = new Promise<void>((resolve) => {
+      finishRegistration = resolve;
+    });
+    const register = vi.fn(() => registration);
+    const importEntry = vi.fn(() => Promise.resolve('session-one' as SessionId));
+    const inFlight = new Set<string>();
+    const options = {
+      cwd: '/work/linkcode',
+      entries: [entry('one')],
+      inFlight,
+      register,
+      importEntry,
+    };
+
+    const first = importHistoryGroup(options);
+    await expect(importHistoryGroup(options)).resolves.toBeNull();
+    expect(register).toHaveBeenCalledOnce();
+    expect(importEntry).not.toHaveBeenCalled();
+
+    finishRegistration?.();
+    await expect(first).resolves.toEqual({ imported: ['one'], failures: [] });
+    expect(inFlight).toEqual(new Set());
   });
 });

--- a/packages/client/workbench/src/history/__tests__/use-provider-history.test.ts
+++ b/packages/client/workbench/src/history/__tests__/use-provider-history.test.ts
@@ -9,6 +9,7 @@ import type {
 } from '@linkcode/schema';
 import { AgentHistoryIdSchema } from '@linkcode/schema';
 import { cleanup, renderHook } from '@testing-library/react';
+import { createFixedArray } from 'foxts/create-fixed-array';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { importHistoryGroup, useProviderHistory } from '../use-provider-history';
 
@@ -182,6 +183,28 @@ describe('importHistoryGroup', () => {
       failures: [{ historyId: 'two', error: failure }],
     });
     expect(importEntry).toHaveBeenCalledTimes(3);
+  });
+
+  it('limits the number of concurrent imports in a directory', async () => {
+    let active = 0;
+    let maxActive = 0;
+    const importEntry = vi.fn(async (item: AgentHistorySession) => {
+      active += 1;
+      maxActive = Math.max(maxActive, active);
+      await Promise.resolve();
+      active -= 1;
+      return `session-${item.historyId}` as SessionId;
+    });
+
+    await importHistoryGroup({
+      cwd: '/work/linkcode',
+      entries: createFixedArray(10).map((index) => entry(`entry-${index}`)),
+      inFlight: new Set(),
+      importEntry,
+    });
+
+    expect(importEntry).toHaveBeenCalledTimes(10);
+    expect(maxActive).toBe(4);
   });
 
   it('drops a repeated click while the same directory import is in flight', async () => {

--- a/packages/client/workbench/src/history/__tests__/use-provider-history.test.ts
+++ b/packages/client/workbench/src/history/__tests__/use-provider-history.test.ts
@@ -9,7 +9,6 @@ import type {
 } from '@linkcode/schema';
 import { AgentHistoryIdSchema } from '@linkcode/schema';
 import { cleanup, renderHook } from '@testing-library/react';
-import { asyncNoop } from 'foxts/noop';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { importHistoryGroup, useProviderHistory } from '../use-provider-history';
 
@@ -146,8 +145,7 @@ function entry(historyId: string): AgentHistorySession {
 }
 
 describe('importHistoryGroup', () => {
-  it('registers the directory and imports every conversation', async () => {
-    const register = vi.fn(asyncNoop);
+  it('imports every conversation in the directory', async () => {
     const importEntry = vi.fn((item: AgentHistorySession) =>
       Promise.resolve(`session-${item.historyId}` as SessionId),
     );
@@ -158,12 +156,9 @@ describe('importHistoryGroup', () => {
         cwd: '/work/linkcode',
         entries,
         inFlight: new Set(),
-        register,
         importEntry,
       }),
     ).resolves.toEqual({ imported: ['one', 'two'], failures: [] });
-    expect(register).toHaveBeenCalledOnce();
-    expect(register).toHaveBeenCalledWith('/work/linkcode');
     expect(importEntry).toHaveBeenCalledTimes(2);
   });
 
@@ -180,7 +175,6 @@ describe('importHistoryGroup', () => {
         cwd: '/work/linkcode',
         entries,
         inFlight: new Set(),
-        register: () => Promise.resolve(),
         importEntry,
       }),
     ).resolves.toEqual({
@@ -191,27 +185,24 @@ describe('importHistoryGroup', () => {
   });
 
   it('drops a repeated click while the same directory import is in flight', async () => {
-    let finishRegistration: (() => void) | undefined;
-    const registration = new Promise<void>((resolve) => {
-      finishRegistration = resolve;
+    let finishImport: ((sessionId: SessionId) => void) | undefined;
+    const pendingImport = new Promise<SessionId>((resolve) => {
+      finishImport = resolve;
     });
-    const register = vi.fn(() => registration);
-    const importEntry = vi.fn(() => Promise.resolve('session-one' as SessionId));
+    const importEntry = vi.fn(() => pendingImport);
     const inFlight = new Set<string>();
     const options = {
       cwd: '/work/linkcode',
       entries: [entry('one')],
       inFlight,
-      register,
       importEntry,
     };
 
     const first = importHistoryGroup(options);
     await expect(importHistoryGroup(options)).resolves.toBeNull();
-    expect(register).toHaveBeenCalledOnce();
-    expect(importEntry).not.toHaveBeenCalled();
+    expect(importEntry).toHaveBeenCalledOnce();
 
-    finishRegistration?.();
+    finishImport?.('session-one' as SessionId);
     await expect(first).resolves.toEqual({ imported: ['one'], failures: [] });
     expect(inFlight).toEqual(new Set());
   });

--- a/packages/client/workbench/src/history/use-history-import-surface.ts
+++ b/packages/client/workbench/src/history/use-history-import-surface.ts
@@ -1,7 +1,6 @@
 import type { AgentHistoryId, AgentKind } from '@linkcode/schema';
 import type { HistoryBrowserEntry, HistorySortOrder } from '@linkcode/ui';
 import { AGENT_LABELS, sortHistoryBrowserEntries } from '@linkcode/ui';
-import { noop } from 'foxact/noop';
 import { extractErrorMessage } from 'foxts/extract-error-message';
 import { useState } from 'react';
 import { useWorkbenchSessions } from '../surface/use-workbench-sessions';
@@ -17,12 +16,17 @@ export interface HistoryImportSurface {
   truncated: boolean;
   isLoading: boolean;
   loadError: string | null;
-  importingId: AgentHistoryId | null;
-  /** The most recent import/open failure, cleared on the next attempt or provider switch. */
-  importError: string | null;
+  importingIds: ReadonlySet<AgentHistoryId>;
+  importingCwds: ReadonlySet<string>;
+  /** Per-entry failures stay attached to the rows that did not import. */
+  importErrors: ReadonlyMap<AgentHistoryId, string>;
+  groupImportFailures: ReadonlyMap<string, { imported: number; total: number }>;
+  actionError: string | null;
   refresh: () => void;
   /** Imports the entry as a cold session; the dedup badge flips on list revalidation. */
   importEntry: (historyId: AgentHistoryId) => void;
+  /** Imports every not-yet-imported entry in a directory after registering it as a project. */
+  importGroup: (cwd: string, historyIds: readonly AgentHistoryId[]) => void;
   /** Selects an already-imported entry's session (resuming it cold); the list only offers Open
    * once imported, so there is no import-on-open path. */
   openEntry: (historyId: AgentHistoryId) => void;
@@ -38,18 +42,26 @@ export function useHistoryImportSurface(
   sort: HistorySortOrder,
 ): HistoryImportSurface {
   const history = useProviderHistory(kind);
-  const [openError, setOpenError] = useState<unknown>(null);
-  const sessions = useWorkbenchSessions(setOpenError);
-
-  // Switching provider must not carry the previous pane's failure over — reset during render
-  // (the sanctioned adjust-state-on-prop-change pattern; an effect would flash the stale error).
-  const [errorKind, setErrorKind] = useState(kind);
-  if (errorKind !== kind) {
-    setErrorKind(kind);
-    setOpenError(null);
-  }
+  const [openError, setOpenError] = useState<{ kind: AgentKind; error: unknown } | null>(null);
+  const [importErrorsByKey, setImportErrorsByKey] = useState<ReadonlyMap<string, string>>(
+    () => new Map(),
+  );
+  const [groupImportFailuresByKey, setGroupImportFailuresByKey] = useState<
+    ReadonlyMap<string, { imported: number; total: number }>
+  >(() => new Map());
+  const sessions = useWorkbenchSessions((error) => setOpenError({ kind, error }));
 
   const imported = importedSessionByHistoryId(sessions.sessions);
+  const importErrors = new Map<AgentHistoryId, string>();
+  const groupImportFailures = new Map<string, { imported: number; total: number }>();
+  for (const entry of history.entries) {
+    const entryError = importErrorsByKey.get(historyStateKey(entry.kind, entry.historyId));
+    if (entryError !== undefined) importErrors.set(entry.historyId, entryError);
+    if (!entry.cwd) continue;
+    const groupKey = historyStateKey(kind, entry.cwd);
+    const groupFailure = groupImportFailuresByKey.get(groupKey);
+    if (groupFailure !== undefined) groupImportFailures.set(entry.cwd, groupFailure);
+  }
   const entries = sortHistoryBrowserEntries(
     history.entries.map((entry) => ({
       historyId: entry.historyId,
@@ -71,11 +83,48 @@ export function useHistoryImportSurface(
   function importEntry(historyId: AgentHistoryId): void {
     const entry = entryById(historyId);
     if (!entry) return;
+    const key = historyStateKey(entry.kind, historyId);
+    setImportErrorsByKey((current) => withoutMapKey(current, key));
     // The dedup badge flips once the revalidated session list carries the imported origin.
     void history
       .importEntry(entry)
       .then(() => sessions.refresh())
-      .catch(noop);
+      .catch((error: unknown) => {
+        setImportErrorsByKey((current) => new Map(current).set(key, errorMessage(error)));
+      });
+  }
+
+  function importGroup(cwd: string, historyIds: readonly AgentHistoryId[]): void {
+    const requested = new Set(historyIds);
+    const entriesToImport = history.entries.filter(
+      (entry) =>
+        requested.has(entry.historyId) &&
+        !imported.has(importedSessionKey(entry.kind, entry.historyId)),
+    );
+    if (entriesToImport.length === 0) return;
+
+    const groupKey = historyStateKey(kind, cwd);
+    const entryKeys = entriesToImport.map((entry) => historyStateKey(entry.kind, entry.historyId));
+    setGroupImportFailuresByKey((current) => withoutMapKey(current, groupKey));
+    setImportErrorsByKey((current) => withoutMapKeys(current, entryKeys));
+    void history.importGroup(cwd, entriesToImport).then((result) => {
+      if (!result) return;
+      sessions.refresh();
+      if (result.failures.length === 0) return;
+      setImportErrorsByKey((current) => {
+        const next = new Map(current);
+        for (const failure of result.failures) {
+          next.set(historyStateKey(kind, failure.historyId), errorMessage(failure.error));
+        }
+        return next;
+      });
+      setGroupImportFailuresByKey((current) =>
+        new Map(current).set(groupKey, {
+          imported: result.imported.length,
+          total: entriesToImport.length,
+        }),
+      );
+    });
   }
 
   function openEntry(historyId: AgentHistoryId): void {
@@ -84,10 +133,12 @@ export function useHistoryImportSurface(
     const existing = imported.get(importedSessionKey(entry.kind, entry.historyId));
     // The dedup map is built from the same session list select() resumes against, so the id is
     // always in-list here; select() wakes it if cold and lowers the overlay.
-    if (existing !== undefined) sessions.select(existing);
+    if (existing !== undefined) {
+      setOpenError(null);
+      sessions.select(existing);
+    }
   }
 
-  const inlineError = history.importError ?? openError;
   return {
     entries,
     count: entries.length,
@@ -95,8 +146,11 @@ export function useHistoryImportSurface(
     isLoading: history.isLoading,
     loadError:
       history.loadError == null ? null : (extractErrorMessage(history.loadError, false) ?? ''),
-    importingId: history.importingId,
-    importError: inlineError == null ? null : (extractErrorMessage(inlineError, false) ?? ''),
+    importingIds: history.importingIds,
+    importingCwds: history.importingCwds,
+    importErrors,
+    groupImportFailures,
+    actionError: openError?.kind === kind ? errorMessage(openError.error) : null,
     refresh() {
       // Both keys: the imported badges derive from the session list, so refreshing only the
       // provider history would leave the dedup map stale (and re-offer Import on imported rows).
@@ -104,6 +158,29 @@ export function useHistoryImportSurface(
       sessions.refresh();
     },
     importEntry,
+    importGroup,
     openEntry,
   };
+}
+
+function errorMessage(error: unknown): string {
+  return extractErrorMessage(error, false) ?? '';
+}
+
+function historyStateKey(kind: AgentKind, value: string): string {
+  return `${kind}\0${value}`;
+}
+
+function withoutMapKey<K, V>(map: ReadonlyMap<K, V>, key: K): ReadonlyMap<K, V> {
+  if (!map.has(key)) return map;
+  const next = new Map(map);
+  next.delete(key);
+  return next;
+}
+
+function withoutMapKeys<K, V>(map: ReadonlyMap<K, V>, keys: readonly K[]): ReadonlyMap<K, V> {
+  if (!keys.some((key) => map.has(key))) return map;
+  const next = new Map(map);
+  for (const key of keys) next.delete(key);
+  return next;
 }

--- a/packages/client/workbench/src/history/use-history-import-surface.ts
+++ b/packages/client/workbench/src/history/use-history-import-surface.ts
@@ -7,6 +7,11 @@ import { useWorkbenchSessions } from '../surface/use-workbench-sessions';
 import { importedSessionByHistoryId, importedSessionKey } from './imported';
 import { useProviderHistory } from './use-provider-history';
 
+interface GroupImportFailureState {
+  total: number;
+  failedIds: ReadonlySet<AgentHistoryId>;
+}
+
 export interface HistoryImportSurface {
   /** Dedup-annotated view models in the requested order — feeds the list. */
   entries: HistoryBrowserEntry[];
@@ -47,7 +52,7 @@ export function useHistoryImportSurface(
     () => new Map(),
   );
   const [groupImportFailuresByKey, setGroupImportFailuresByKey] = useState<
-    ReadonlyMap<string, { imported: number; total: number }>
+    ReadonlyMap<string, GroupImportFailureState>
   >(() => new Map());
   const sessions = useWorkbenchSessions((error) => setOpenError({ kind, error }));
 
@@ -60,7 +65,12 @@ export function useHistoryImportSurface(
     if (!entry.cwd) continue;
     const groupKey = historyStateKey(kind, entry.cwd);
     const groupFailure = groupImportFailuresByKey.get(groupKey);
-    if (groupFailure !== undefined) groupImportFailures.set(entry.cwd, groupFailure);
+    if (groupFailure !== undefined) {
+      groupImportFailures.set(entry.cwd, {
+        imported: groupFailure.total - groupFailure.failedIds.size,
+        total: groupFailure.total,
+      });
+    }
   }
   const entries = sortHistoryBrowserEntries(
     history.entries.map((entry) => ({
@@ -88,7 +98,14 @@ export function useHistoryImportSurface(
     // The dedup badge flips once the revalidated session list carries the imported origin.
     void history
       .importEntry(entry)
-      .then(() => sessions.refresh())
+      .then(() => {
+        sessions.refresh();
+        if (!entry.cwd) return;
+        const groupKey = historyStateKey(kind, entry.cwd);
+        setGroupImportFailuresByKey((current) =>
+          groupFailureAfterRetry(current, groupKey, entry.historyId),
+        );
+      })
       .catch((error: unknown) => {
         setImportErrorsByKey((current) => new Map(current).set(key, errorMessage(error)));
       });
@@ -120,8 +137,8 @@ export function useHistoryImportSurface(
       });
       setGroupImportFailuresByKey((current) =>
         new Map(current).set(groupKey, {
-          imported: result.imported.length,
           total: entriesToImport.length,
+          failedIds: new Set(result.failures.map((failure) => failure.historyId)),
         }),
       );
     });
@@ -182,5 +199,20 @@ function withoutMapKeys<K, V>(map: ReadonlyMap<K, V>, keys: readonly K[]): Reado
   if (!keys.some((key) => map.has(key))) return map;
   const next = new Map(map);
   for (const key of keys) next.delete(key);
+  return next;
+}
+
+export function groupFailureAfterRetry(
+  failures: ReadonlyMap<string, GroupImportFailureState>,
+  groupKey: string,
+  historyId: AgentHistoryId,
+): ReadonlyMap<string, GroupImportFailureState> {
+  const failure = failures.get(groupKey);
+  if (!failure?.failedIds.has(historyId)) return failures;
+  const next = new Map(failures);
+  const failedIds = new Set(failure.failedIds);
+  failedIds.delete(historyId);
+  if (failedIds.size === 0) next.delete(groupKey);
+  else next.set(groupKey, { ...failure, failedIds });
   return next;
 }

--- a/packages/client/workbench/src/history/use-provider-history.ts
+++ b/packages/client/workbench/src/history/use-provider-history.ts
@@ -1,10 +1,12 @@
 import type { AgentHistoryId, AgentHistorySession, AgentKind, SessionId } from '@linkcode/schema';
 import { importSession, listHistory } from '@linkcode/sdk';
+import { appendArrayInPlace } from 'foxts/append-array-in-place';
 import { useMemo, useRef, useState } from 'react';
 import { useData, useMutation } from '../runtime/tayori';
 
 /** Single page, newest first; add cursor pagination when a provider actually overflows this. */
 const HISTORY_PAGE_LIMIT = 200;
+const GROUP_IMPORT_CONCURRENCY = 4;
 
 export interface ProviderHistory {
   /** Provider-local sessions across every project, most recent first. */
@@ -57,7 +59,14 @@ export async function importHistoryGroup({
   inFlight.add(inFlightKey);
   try {
     // session.import registers each successful entry's cwd as a project in the engine (CODE-345).
-    const settled = await Promise.allSettled(entries.map((entry) => importEntry(entry)));
+    const settled: Array<PromiseSettledResult<SessionId>> = [];
+    for (let start = 0; start < entries.length; start += GROUP_IMPORT_CONCURRENCY) {
+      const batch = entries.slice(start, start + GROUP_IMPORT_CONCURRENCY);
+      appendArrayInPlace(
+        settled,
+        await Promise.allSettled(batch.map((entry) => importEntry(entry))),
+      );
+    }
     const result: HistoryGroupImportResult = { imported: [], failures: [] };
     for (const [index, outcome] of settled.entries()) {
       const entry = entries[index];

--- a/packages/client/workbench/src/history/use-provider-history.ts
+++ b/packages/client/workbench/src/history/use-provider-history.ts
@@ -1,6 +1,6 @@
 import type { AgentHistoryId, AgentHistorySession, AgentKind, SessionId } from '@linkcode/schema';
-import { importSession, listHistory } from '@linkcode/sdk';
-import { useMemo, useState } from 'react';
+import { importSession, listHistory, listWorkspaces, registerWorkspace } from '@linkcode/sdk';
+import { useMemo, useRef, useState } from 'react';
 import { useData, useMutation } from '../runtime/tayori';
 
 /** Single page, newest first; add cursor pagination when a provider actually overflows this. */
@@ -15,12 +15,66 @@ export interface ProviderHistory {
   /** The list fetch failure (e.g. "history list is not supported" for agents without it). */
   loadError: unknown;
   refresh: () => void;
-  /** The entry currently importing, if any. */
+  /** Every entry currently importing; batch imports may contain several. */
+  importingIds: ReadonlySet<AgentHistoryId>;
+  /** Legacy single-entry state retained while consumers migrate to importingIds. */
   importingId: AgentHistoryId | null;
-  /** The most recent import failure; cleared when the next import starts. */
   importError: unknown;
+  /** Directory groups currently importing. */
+  importingCwds: ReadonlySet<string>;
   /** Imports the entry as a cold session and resolves with its Link Code session id. */
   importEntry: (entry: AgentHistorySession) => Promise<SessionId>;
+  /** Registers the directory as a project and imports all entries; dedupes in-flight requests. */
+  importGroup: (
+    cwd: string,
+    entries: readonly AgentHistorySession[],
+  ) => Promise<HistoryGroupImportResult | null>;
+}
+
+export interface HistoryGroupImportFailure {
+  historyId: AgentHistoryId;
+  error: unknown;
+}
+
+export interface HistoryGroupImportResult {
+  imported: AgentHistoryId[];
+  failures: HistoryGroupImportFailure[];
+}
+
+interface ImportHistoryGroupOptions {
+  cwd: string;
+  inFlightKey?: string;
+  entries: readonly AgentHistorySession[];
+  inFlight: Set<string>;
+  register: (cwd: string) => Promise<unknown>;
+  importEntry: (entry: AgentHistorySession) => Promise<SessionId>;
+}
+
+export async function importHistoryGroup({
+  cwd,
+  inFlightKey = cwd,
+  entries,
+  inFlight,
+  register,
+  importEntry,
+}: ImportHistoryGroupOptions): Promise<HistoryGroupImportResult | null> {
+  if (inFlight.has(inFlightKey)) return null;
+  inFlight.add(inFlightKey);
+  try {
+    // A directory-level action promises a project, so do not create orphaned imported sessions if
+    // the directory cannot be registered. Registration is idempotent for an existing project.
+    await register(cwd);
+    const settled = await Promise.allSettled(entries.map((entry) => importEntry(entry)));
+    const result: HistoryGroupImportResult = { imported: [], failures: [] };
+    for (const [index, outcome] of settled.entries()) {
+      const entry = entries[index];
+      if (outcome.status === 'fulfilled') result.imported.push(entry.historyId);
+      else result.failures.push({ historyId: entry.historyId, error: outcome.reason });
+    }
+    return result;
+  } finally {
+    inFlight.delete(inFlightKey);
+  }
 }
 
 /** Global (cwd-less) provider history for one agent kind, plus the import mutation. */
@@ -35,18 +89,16 @@ export function useProviderHistory(kind: AgentKind): ProviderHistory {
     // agent's sessions as another agent's while the next scan is pending or unavailable.
     { keepPreviousData: false },
   );
+  const { mutate: mutateWorkspaces } = useData(listWorkspaces, {});
   const importMutation = useMutation(importSession);
-  const [importingId, setImportingId] = useState<AgentHistoryId | null>(null);
+  const registerMutation = useMutation(registerWorkspace);
+  const pendingImportsRef = useRef(new Map<string, Promise<SessionId>>());
+  const pendingGroupsRef = useRef(new Set<string>());
+  const [importingKeys, setImportingKeys] = useState<ReadonlySet<string>>(() => new Set());
+  const [importingGroupKeys, setImportingGroupKeys] = useState<ReadonlySet<string>>(
+    () => new Set(),
+  );
   const [importError, setImportError] = useState<unknown>(null);
-
-  // Switching provider must not carry the previous provider's import state over — reset during
-  // render (the sanctioned adjust-state-on-prop-change pattern; an effect would flash it stale).
-  const [stateKind, setStateKind] = useState(kind);
-  if (stateKind !== kind) {
-    setStateKind(kind);
-    setImportingId(null);
-    setImportError(null);
-  }
 
   const entries = useMemo(
     () =>
@@ -57,16 +109,56 @@ export function useProviderHistory(kind: AgentKind): ProviderHistory {
   );
 
   function importEntry(entry: AgentHistorySession): Promise<SessionId> {
-    setImportingId(entry.historyId);
+    const key = importKey(entry.kind, entry.historyId);
+    const existing = pendingImportsRef.current.get(key);
+    if (existing) return existing;
+
     setImportError(null);
-    return importMutation
+    setImportingKeys((current) => new Set(current).add(key));
+    const pending = importMutation
       .trigger({ agentKind: entry.kind, historyId: entry.historyId })
       .then((record) => record.sessionId)
-      .catch((err: unknown) => {
-        setImportError(err);
-        throw err;
+      .catch((error: unknown) => {
+        setImportError(error);
+        throw error;
       })
-      .finally(() => setImportingId(null));
+      .finally(() => {
+        pendingImportsRef.current.delete(key);
+        setImportingKeys((current) => {
+          const next = new Set(current);
+          next.delete(key);
+          return next;
+        });
+      });
+    pendingImportsRef.current.set(key, pending);
+    return pending;
+  }
+
+  function importGroup(
+    cwd: string,
+    groupEntries: readonly AgentHistorySession[],
+  ): Promise<HistoryGroupImportResult | null> {
+    const key = importKey(kind, cwd);
+    if (pendingGroupsRef.current.has(key)) return Promise.resolve(null);
+    setImportingGroupKeys((current) => new Set(current).add(key));
+    return importHistoryGroup({
+      cwd,
+      inFlightKey: key,
+      entries: groupEntries,
+      inFlight: pendingGroupsRef.current,
+      register: (directory) =>
+        registerMutation.trigger({ cwd: directory }).then((record) => {
+          void mutateWorkspaces();
+          return record;
+        }),
+      importEntry,
+    }).finally(() => {
+      setImportingGroupKeys((current) => {
+        const next = new Set(current);
+        next.delete(key);
+        return next;
+      });
+    });
   }
 
   return {
@@ -77,8 +169,38 @@ export function useProviderHistory(kind: AgentKind): ProviderHistory {
     refresh() {
       void mutate();
     },
-    importingId,
+    importingIds: currentImportingIds(entries, importingKeys),
+    importingId: currentImportingIds(entries, importingKeys).values().next().value ?? null,
     importError,
+    importingCwds: currentImportingCwds(kind, entries, importingGroupKeys),
     importEntry,
+    importGroup,
   };
+}
+
+function importKey(kind: AgentKind, value: string): string {
+  return `${kind}\0${value}`;
+}
+
+function currentImportingIds(
+  entries: readonly AgentHistorySession[],
+  importingKeys: ReadonlySet<string>,
+): ReadonlySet<AgentHistoryId> {
+  const ids = new Set<AgentHistoryId>();
+  for (const entry of entries) {
+    if (importingKeys.has(importKey(entry.kind, entry.historyId))) ids.add(entry.historyId);
+  }
+  return ids;
+}
+
+function currentImportingCwds(
+  kind: AgentKind,
+  entries: readonly AgentHistorySession[],
+  importingGroupKeys: ReadonlySet<string>,
+): ReadonlySet<string> {
+  const cwds = new Set<string>();
+  for (const entry of entries) {
+    if (entry.cwd && importingGroupKeys.has(importKey(kind, entry.cwd))) cwds.add(entry.cwd);
+  }
+  return cwds;
 }

--- a/packages/client/workbench/src/history/use-provider-history.ts
+++ b/packages/client/workbench/src/history/use-provider-history.ts
@@ -1,5 +1,5 @@
 import type { AgentHistoryId, AgentHistorySession, AgentKind, SessionId } from '@linkcode/schema';
-import { importSession, listHistory, listWorkspaces, registerWorkspace } from '@linkcode/sdk';
+import { importSession, listHistory } from '@linkcode/sdk';
 import { useMemo, useRef, useState } from 'react';
 import { useData, useMutation } from '../runtime/tayori';
 
@@ -17,14 +17,11 @@ export interface ProviderHistory {
   refresh: () => void;
   /** Every entry currently importing; batch imports may contain several. */
   importingIds: ReadonlySet<AgentHistoryId>;
-  /** Legacy single-entry state retained while consumers migrate to importingIds. */
-  importingId: AgentHistoryId | null;
-  importError: unknown;
   /** Directory groups currently importing. */
   importingCwds: ReadonlySet<string>;
   /** Imports the entry as a cold session and resolves with its Link Code session id. */
   importEntry: (entry: AgentHistorySession) => Promise<SessionId>;
-  /** Registers the directory as a project and imports all entries; dedupes in-flight requests. */
+  /** Imports all entries from one directory; dedupes in-flight requests. */
   importGroup: (
     cwd: string,
     entries: readonly AgentHistorySession[],
@@ -46,7 +43,6 @@ interface ImportHistoryGroupOptions {
   inFlightKey?: string;
   entries: readonly AgentHistorySession[];
   inFlight: Set<string>;
-  register: (cwd: string) => Promise<unknown>;
   importEntry: (entry: AgentHistorySession) => Promise<SessionId>;
 }
 
@@ -55,15 +51,12 @@ export async function importHistoryGroup({
   inFlightKey = cwd,
   entries,
   inFlight,
-  register,
   importEntry,
 }: ImportHistoryGroupOptions): Promise<HistoryGroupImportResult | null> {
   if (inFlight.has(inFlightKey)) return null;
   inFlight.add(inFlightKey);
   try {
-    // A directory-level action promises a project, so do not create orphaned imported sessions if
-    // the directory cannot be registered. Registration is idempotent for an existing project.
-    await register(cwd);
+    // session.import registers each successful entry's cwd as a project in the engine (CODE-345).
     const settled = await Promise.allSettled(entries.map((entry) => importEntry(entry)));
     const result: HistoryGroupImportResult = { imported: [], failures: [] };
     for (const [index, outcome] of settled.entries()) {
@@ -89,16 +82,13 @@ export function useProviderHistory(kind: AgentKind): ProviderHistory {
     // agent's sessions as another agent's while the next scan is pending or unavailable.
     { keepPreviousData: false },
   );
-  const { mutate: mutateWorkspaces } = useData(listWorkspaces, {});
   const importMutation = useMutation(importSession);
-  const registerMutation = useMutation(registerWorkspace);
   const pendingImportsRef = useRef(new Map<string, Promise<SessionId>>());
   const pendingGroupsRef = useRef(new Set<string>());
   const [importingKeys, setImportingKeys] = useState<ReadonlySet<string>>(() => new Set());
   const [importingGroupKeys, setImportingGroupKeys] = useState<ReadonlySet<string>>(
     () => new Set(),
   );
-  const [importError, setImportError] = useState<unknown>(null);
 
   const entries = useMemo(
     () =>
@@ -113,15 +103,10 @@ export function useProviderHistory(kind: AgentKind): ProviderHistory {
     const existing = pendingImportsRef.current.get(key);
     if (existing) return existing;
 
-    setImportError(null);
     setImportingKeys((current) => new Set(current).add(key));
     const pending = importMutation
       .trigger({ agentKind: entry.kind, historyId: entry.historyId })
       .then((record) => record.sessionId)
-      .catch((error: unknown) => {
-        setImportError(error);
-        throw error;
-      })
       .finally(() => {
         pendingImportsRef.current.delete(key);
         setImportingKeys((current) => {
@@ -146,11 +131,6 @@ export function useProviderHistory(kind: AgentKind): ProviderHistory {
       inFlightKey: key,
       entries: groupEntries,
       inFlight: pendingGroupsRef.current,
-      register: (directory) =>
-        registerMutation.trigger({ cwd: directory }).then((record) => {
-          void mutateWorkspaces();
-          return record;
-        }),
       importEntry,
     }).finally(() => {
       setImportingGroupKeys((current) => {
@@ -170,8 +150,6 @@ export function useProviderHistory(kind: AgentKind): ProviderHistory {
       void mutate();
     },
     importingIds: currentImportingIds(entries, importingKeys),
-    importingId: currentImportingIds(entries, importingKeys).values().next().value ?? null,
-    importError,
     importingCwds: currentImportingCwds(kind, entries, importingGroupKeys),
     importEntry,
     importGroup,

--- a/packages/host/engine/src/__tests__/engine-session-records.test.ts
+++ b/packages/host/engine/src/__tests__/engine-session-records.test.ts
@@ -239,7 +239,7 @@ describe('engine session records', () => {
     let shouldFail = true;
     const store: SessionStore = {
       load: () => inner.load(),
-      save: (record) => {
+      save(record) {
         if (shouldFail) {
           shouldFail = false;
           return Promise.reject(new Error('private database detail'));

--- a/packages/host/engine/src/__tests__/engine-session-records.test.ts
+++ b/packages/host/engine/src/__tests__/engine-session-records.test.ts
@@ -137,6 +137,27 @@ describe('engine session records', () => {
     ]);
   });
 
+  it('serializes concurrent imports of the same provider history', async () => {
+    const store = new InMemorySessionStore();
+    const { engine, sent, inject } = harness(store);
+    await engine.start();
+    const request = {
+      kind: 'session.import' as const,
+      agentKind: 'claude-code' as const,
+      historyId: asHistoryId('native-9'),
+    };
+
+    await Promise.all([
+      inject({ ...request, clientReqId: 'r1' }),
+      inject({ ...request, clientReqId: 'r2' }),
+    ]);
+
+    const imported = sent.filter((payload) => payload.kind === 'session.imported');
+    expect(imported).toHaveLength(2);
+    expect(new Set(imported.map((payload) => payload.record.sessionId)).size).toBe(1);
+    expect(await store.load()).toHaveLength(1);
+  });
+
   it('does not register a workspace when imported history has no cwd', async () => {
     const h = harness(new InMemorySessionStore(), () => new CwdlessHistoryAdapter());
     await h.engine.start();
@@ -213,11 +234,19 @@ describe('engine session records', () => {
     ]);
   });
 
-  it('does not retain an imported session when its durable save fails', async () => {
+  it('retries an imported session after its first durable save fails', async () => {
+    const inner = new InMemorySessionStore();
+    let shouldFail = true;
     const store: SessionStore = {
-      load: () => Promise.resolve([]),
-      save: () => Promise.reject(new Error('private database detail')),
-      delete: () => Promise.resolve(),
+      load: () => inner.load(),
+      save: (record) => {
+        if (shouldFail) {
+          shouldFail = false;
+          return Promise.reject(new Error('private database detail'));
+        }
+        return inner.save(record);
+      },
+      delete: (sessionId) => inner.delete(sessionId),
     };
     const { engine, sent, inject } = harness(store);
     await engine.start();
@@ -239,5 +268,15 @@ describe('engine session records', () => {
     ).toBe(false);
     await inject({ kind: 'session.list', clientReqId: 'r2' });
     expect(listedSessions(sent, 'r2')).toEqual([]);
+
+    await inject({
+      kind: 'session.import',
+      clientReqId: 'r3',
+      agentKind: 'claude-code',
+      historyId: asHistoryId('native-9'),
+    });
+    await inject({ kind: 'session.list', clientReqId: 'r4' });
+    expect(listedSessions(sent, 'r4')).toHaveLength(1);
+    expect(await inner.load()).toHaveLength(1);
   });
 });

--- a/packages/host/engine/src/session/lifecycle-service.ts
+++ b/packages/host/engine/src/session/lifecycle-service.ts
@@ -21,7 +21,7 @@ type RunEffect = <A, E>(effect: Effect.Effect<A, E>, options?: Effect.RunOptions
 
 export class SessionLifecycleService {
   readonly driver: SessionDriver;
-  private readonly importSemaphore = Semaphore.makeUnsafe(1);
+  private readonly importSemaphores = new Map<string, Semaphore.Semaphore>();
   private seq = 0;
   private runEffect: RunEffect | undefined;
 
@@ -81,10 +81,14 @@ export class SessionLifecycleService {
     historyId: AgentHistoryId,
   ): Effect.Effect<SessionRecord, EngineFailure> {
     const { history, records, workspaces } = this;
-    return this.importSemaphore.withPermit(
+    return this.importSemaphore(kind, historyId).withPermit(
       Effect.suspend(() => {
         const existing = records.findImported(kind, historyId);
-        if (existing) return Effect.succeed(existing);
+        if (existing) {
+          return existing.cwd
+            ? workspaceTouch(workspaces, existing.cwd).pipe(Effect.as(existing))
+            : Effect.succeed(existing);
+        }
 
         const sessionId = this.nextSessionId();
         return Effect.gen(function* () {
@@ -213,6 +217,15 @@ export class SessionLifecycleService {
   private nextSessionId(): SessionId {
     this.seq += 1;
     return `sess-${Date.now().toString(36)}-${this.seq.toString(36)}` as SessionId;
+  }
+
+  private importSemaphore(kind: AgentKind, historyId: AgentHistoryId): Semaphore.Semaphore {
+    const key = `${kind}\0${historyId}`;
+    const existing = this.importSemaphores.get(key);
+    if (existing) return existing;
+    const semaphore = Semaphore.makeUnsafe(1);
+    this.importSemaphores.set(key, semaphore);
+    return semaphore;
   }
 
   private run<A, E>(effect: Effect.Effect<A, E>, options?: Effect.RunOptions): Promise<A> {

--- a/packages/host/engine/src/session/lifecycle-service.ts
+++ b/packages/host/engine/src/session/lifecycle-service.ts
@@ -6,7 +6,7 @@ import type {
   SessionRecord,
   StartOptions,
 } from '@linkcode/schema';
-import { Effect } from 'effect';
+import { Effect, Semaphore } from 'effect';
 import { nullthrow } from 'foxts/guard';
 import type { SessionDriver } from '../automation';
 import type { EngineFailure } from '../failure';
@@ -21,6 +21,7 @@ type RunEffect = <A, E>(effect: Effect.Effect<A, E>, options?: Effect.RunOptions
 
 export class SessionLifecycleService {
   readonly driver: SessionDriver;
+  private readonly importSemaphore = Semaphore.makeUnsafe(1);
   private seq = 0;
   private runEffect: RunEffect | undefined;
 
@@ -80,25 +81,32 @@ export class SessionLifecycleService {
     historyId: AgentHistoryId,
   ): Effect.Effect<SessionRecord, EngineFailure> {
     const { history, records, workspaces } = this;
-    const sessionId = this.nextSessionId();
-    return Effect.gen(function* () {
-      // Read one event only: the summary (title/cwd/createdAt) is what the record needs.
-      const { session } = yield* history.read(kind, { historyId, limit: 1 });
-      const now = Date.now();
-      const record: SessionRecord = {
-        sessionId,
-        kind,
-        cwd: session.cwd ?? '',
-        title: session.title,
-        origin: { type: 'imported', historyId, importedAt: now },
-        createdAt: session.createdAt ?? now,
-        updatedAt: now,
-        runs: [],
-      };
-      yield* records.importRecord(record);
-      if (record.cwd) yield* workspaceTouch(workspaces, record.cwd);
-      return record;
-    });
+    return this.importSemaphore.withPermit(
+      Effect.suspend(() => {
+        const existing = records.findImported(kind, historyId);
+        if (existing) return Effect.succeed(existing);
+
+        const sessionId = this.nextSessionId();
+        return Effect.gen(function* () {
+          // Read one event only: the summary (title/cwd/createdAt) is what the record needs.
+          const { session } = yield* history.read(kind, { historyId, limit: 1 });
+          const now = Date.now();
+          const record: SessionRecord = {
+            sessionId,
+            kind,
+            cwd: session.cwd ?? '',
+            title: session.title,
+            origin: { type: 'imported', historyId, importedAt: now },
+            createdAt: session.createdAt ?? now,
+            updatedAt: now,
+            runs: [],
+          };
+          yield* records.importRecord(record);
+          if (record.cwd) yield* workspaceTouch(workspaces, record.cwd);
+          return record;
+        });
+      }),
+    );
   }
 
   resumeHistory(

--- a/packages/host/engine/src/session/session-record-registry.ts
+++ b/packages/host/engine/src/session/session-record-registry.ts
@@ -1,5 +1,6 @@
 import type {
   AgentHistoryId,
+  AgentKind,
   ContentBlock,
   SessionId,
   SessionInfo,
@@ -47,6 +48,19 @@ export class SessionRecordRegistry {
 
   values(): IterableIterator<SessionRecord> {
     return this.records.values();
+  }
+
+  findImported(kind: AgentKind, historyId: AgentHistoryId): SessionRecord | undefined {
+    for (const record of this.records.values()) {
+      if (
+        record.kind === kind &&
+        record.origin.type === 'imported' &&
+        record.origin.historyId === historyId
+      ) {
+        return record;
+      }
+    }
+    return undefined;
   }
 
   list(statusOf: (sessionId: SessionId) => SessionInfo['status'] | undefined): SessionInfo[] {

--- a/packages/presentation/i18n/src/locales/en.ts
+++ b/packages/presentation/i18n/src/locales/en.ts
@@ -579,6 +579,7 @@ export const en = {
       sortByProject: 'By project',
       noProject: 'No project',
       importAction: 'Import',
+      importFolder: 'Import all ({count})',
       importedBadge: 'Imported',
       open: 'Open',
       emptyTitle: 'No history yet',
@@ -588,6 +589,10 @@ export const en = {
       showingLatest:
         'Showing the latest {count, plural, one {# conversation} other {# conversations}}',
       importError: 'Failed to import: {message}',
+      groupImportError: 'Failed to import directory as a project: {message}',
+      groupPartialFailure:
+        'Imported {imported} of {total} conversations; failed conversations can be retried.',
+      actionError: 'Action failed: {message}',
       messageCount: '{count, plural, one {# message} other {# messages}}',
     },
     general: {

--- a/packages/presentation/i18n/src/locales/en.ts
+++ b/packages/presentation/i18n/src/locales/en.ts
@@ -589,7 +589,6 @@ export const en = {
       showingLatest:
         'Showing the latest {count, plural, one {# conversation} other {# conversations}}',
       importError: 'Failed to import: {message}',
-      groupImportError: 'Failed to import directory as a project: {message}',
       groupPartialFailure:
         'Imported {imported} of {total} conversations; failed conversations can be retried.',
       actionError: 'Action failed: {message}',

--- a/packages/presentation/i18n/src/locales/zh-cn.ts
+++ b/packages/presentation/i18n/src/locales/zh-cn.ts
@@ -568,6 +568,7 @@ export const zhCN = {
       sortByProject: '按项目',
       noProject: '无项目',
       importAction: '导入',
+      importFolder: '全部导入（{count}）',
       importedBadge: '已导入',
       open: '打开',
       emptyTitle: '暂无历史对话',
@@ -576,6 +577,9 @@ export const zhCN = {
       retry: '重试',
       showingLatest: '仅显示最近 {count} 条对话',
       importError: '导入失败：{message}',
+      groupImportError: '无法将目录导入为项目：{message}',
+      groupPartialFailure: '已导入 {imported}/{total} 条对话；失败项仍可重试。',
+      actionError: '操作失败：{message}',
       messageCount: '{count} 条消息',
     },
     general: {

--- a/packages/presentation/i18n/src/locales/zh-cn.ts
+++ b/packages/presentation/i18n/src/locales/zh-cn.ts
@@ -577,7 +577,6 @@ export const zhCN = {
       retry: '重试',
       showingLatest: '仅显示最近 {count} 条对话',
       importError: '导入失败：{message}',
-      groupImportError: '无法将目录导入为项目：{message}',
       groupPartialFailure: '已导入 {imported}/{total} 条对话；失败项仍可重试。',
       actionError: '操作失败：{message}',
       messageCount: '{count} 条消息',

--- a/packages/presentation/ui/src/shell/history/__tests__/sort.test.ts
+++ b/packages/presentation/ui/src/shell/history/__tests__/sort.test.ts
@@ -104,4 +104,28 @@ describe('groupHistoryBrowserEntries', () => {
       '/b/work',
     ]);
   });
+
+  it('forms stable groups even when the selected time sort interleaves directories', () => {
+    const latest = sortHistoryBrowserEntries(
+      [
+        entry('a-new', { cwd: '/a/work', timestamp: 40 }),
+        entry('b', { cwd: '/b/work', timestamp: 30 }),
+        entry('a-old', { cwd: '/a/work', timestamp: 20 }),
+        entry('no-cwd-new', { timestamp: 35 }),
+        entry('no-cwd-old', { timestamp: 10 }),
+      ],
+      'latest',
+    );
+
+    expect(
+      groupHistoryBrowserEntries(latest).map((group) => ({
+        cwd: group.cwd,
+        entries: ids(group.entries),
+      })),
+    ).toEqual([
+      { cwd: '/a/work', entries: ['a-new', 'a-old'] },
+      { cwd: undefined, entries: ['no-cwd-new', 'no-cwd-old'] },
+      { cwd: '/b/work', entries: ['b'] },
+    ]);
+  });
 });

--- a/packages/presentation/ui/src/shell/history/history-browser.tsx
+++ b/packages/presentation/ui/src/shell/history/history-browser.tsx
@@ -36,10 +36,16 @@ export interface HistoryBrowserListProps {
   isLoading: boolean;
   /** The list fetch failure message, when there is nothing to show. */
   loadError?: string | null;
-  importingId?: AgentHistoryId | null;
-  /** The most recent import failure message; rendered inline, never swallowed. */
-  importError?: string | null;
+  importingIds: ReadonlySet<AgentHistoryId>;
+  importingCwds: ReadonlySet<string>;
+  /** Import failures stay next to the exact rows that remain importable. */
+  importErrors: ReadonlyMap<AgentHistoryId, string>;
+  /** Partial batch outcomes, keyed by full cwd. */
+  groupImportFailures: ReadonlyMap<string, { imported: number; total: number }>;
+  /** Failure from a non-import list action, such as opening an imported conversation. */
+  actionError?: string | null;
   onImport: (historyId: AgentHistoryId) => void;
+  onImportGroup: (cwd: string, historyIds: readonly AgentHistoryId[]) => void;
   onOpen: (historyId: AgentHistoryId) => void;
   /** Backs the error state's Retry; the primary refresh control lives in the host's chrome. */
   onRefresh: () => void;
@@ -52,9 +58,13 @@ export function HistoryBrowserList({
   truncated,
   isLoading,
   loadError,
-  importingId,
-  importError,
+  importingIds,
+  importingCwds,
+  importErrors,
+  groupImportFailures,
+  actionError,
   onImport,
+  onImportGroup,
   onOpen,
   onRefresh,
 }: HistoryBrowserListProps): React.ReactNode {
@@ -107,7 +117,11 @@ export function HistoryBrowserList({
           entry={entry}
           // The section header already names the project; keep grouped row meta to time · count.
           showProject={!groupByProject}
-          importing={importingId === entry.historyId}
+          importing={
+            importingIds.has(entry.historyId) ||
+            (entry.cwd !== undefined && importingCwds.has(entry.cwd))
+          }
+          importError={importErrors.get(entry.historyId)}
           onImport={onImport}
           onOpen={onOpen}
         />
@@ -117,26 +131,49 @@ export function HistoryBrowserList({
 
   return (
     <div className="flex flex-col">
-      {importError != null && (
+      {actionError != null && (
         <p className="pb-2 text-destructive text-xs">
-          {t('importError', { message: importError })}
+          {t('actionError', { message: actionError })}
         </p>
       )}
       {groupByProject ? (
         <div className="flex flex-col gap-5">
-          {groupHistoryBrowserEntries(entries).map((group) => (
-            <section key={group.cwd ?? 'no-project'}>
-              <div
-                className="flex items-center gap-1.5 pb-1 font-medium text-muted-foreground text-xs"
-                title={group.cwd}
-              >
-                <FolderIcon className="size-3.5 shrink-0" />
-                <span className="min-w-0 truncate">{group.label ?? t('noProject')}</span>
-                <span className="ml-auto shrink-0">{group.entries.length}</span>
-              </div>
-              {rows(group.entries)}
-            </section>
-          ))}
+          {groupHistoryBrowserEntries(entries).map((group) => {
+            const importableIds = group.entries.reduce<AgentHistoryId[]>((ids, entry) => {
+              if (!entry.imported) ids.push(entry.historyId);
+              return ids;
+            }, []);
+            const partial = group.cwd ? groupImportFailures.get(group.cwd) : undefined;
+            return (
+              <section key={group.cwd ?? 'no-project'}>
+                <div
+                  className="flex min-h-7 items-center gap-1.5 pb-1 font-medium text-muted-foreground text-xs"
+                  title={group.cwd}
+                >
+                  <FolderIcon className="size-3.5 shrink-0" />
+                  <span className="min-w-0 truncate">{group.label ?? t('noProject')}</span>
+                  <span className="shrink-0">{group.entries.length}</span>
+                  {group.cwd && importableIds.length > 0 && (
+                    <Button
+                      className="ml-auto"
+                      size="xs"
+                      variant="outline"
+                      loading={importingCwds.has(group.cwd)}
+                      onClick={() => onImportGroup(group.cwd!, importableIds)}
+                    >
+                      {t('importFolder', { count: importableIds.length })}
+                    </Button>
+                  )}
+                </div>
+                {partial !== undefined && (
+                  <p className="pb-1 text-destructive text-xs">
+                    {t('groupPartialFailure', partial)}
+                  </p>
+                )}
+                {rows(group.entries)}
+              </section>
+            );
+          })}
         </div>
       ) : (
         rows(entries)
@@ -154,12 +191,14 @@ function HistoryBrowserRow({
   entry,
   showProject,
   importing,
+  importError,
   onImport,
   onOpen,
 }: {
   entry: HistoryBrowserEntry;
   showProject: boolean;
   importing: boolean;
+  importError?: string;
   onImport: (historyId: AgentHistoryId) => void;
   onOpen: (historyId: AgentHistoryId) => void;
 }): React.ReactNode {
@@ -178,6 +217,11 @@ function HistoryBrowserRow({
         <div className="truncate text-sm">{entry.title}</div>
         {meta.length > 0 && (
           <div className="truncate text-muted-foreground text-xs">{meta.join(' · ')}</div>
+        )}
+        {importError !== undefined && (
+          <div className="truncate text-destructive text-xs" title={importError}>
+            {t('importError', { message: importError })}
+          </div>
         )}
       </div>
       <div className="flex shrink-0 items-center gap-1.5">

--- a/packages/presentation/ui/src/shell/history/sort.ts
+++ b/packages/presentation/ui/src/shell/history/sort.ts
@@ -36,22 +36,25 @@ export interface HistoryBrowserGroup {
   entries: HistoryBrowserEntry[];
 }
 
-/** Partitions project-sorted entries into consecutive per-directory groups. */
+/** Groups by full directory while preserving the first occurrence order from the selected sort. */
 export function groupHistoryBrowserEntries(
   sorted: readonly HistoryBrowserEntry[],
 ): HistoryBrowserGroup[] {
   const groups: HistoryBrowserGroup[] = [];
+  const byCwd = new Map<string | undefined, HistoryBrowserGroup>();
   for (const entry of sorted) {
-    const last = groups.at(-1);
-    if (last && last.cwd === entry.cwd) {
-      last.entries.push(entry);
+    const existing = byCwd.get(entry.cwd);
+    if (existing) {
+      existing.entries.push(entry);
       continue;
     }
-    groups.push({
+    const group = {
       cwd: entry.cwd,
       label: entry.cwd === undefined ? null : repositoryLabel(entry.cwd),
       entries: [entry],
-    });
+    };
+    byCwd.set(entry.cwd, group);
+    groups.push(group);
   }
   return groups;
 }


### PR DESCRIPTION
## Summary

- group importable chat history by stable working-directory sections, including a clear no-directory group
- import all available conversations in a directory with bounded concurrency, partial-failure visibility, and duplicate-click protection
- make provider-history imports durable and idempotent under concurrent requests while preserving workspace registration behavior
- keep group failure summaries accurate when failed rows are retried individually

## Review fixes

- serialize duplicate imports per agent/history ID and return one durable session record to every caller
- keep failed saves out of the in-memory dedup index so retries persist normally
- cap each directory batch at four concurrent imports
- track exact failed history IDs so row retries update group summaries idempotently

Linear: CODE-347

## Verification

- `pnpm check:ci`
- `pnpm test` (207 files, 1604 tests passed)
- focused history/UI/engine tests (29 tests passed)
- observed the desktop history-import UI with grouped directories, import-all, single import, and imported/open states
