### PR TITLE
feat(pty): close terminal tabs on process exit

### DIFF
--- a/apps/desktop/src/renderer/src/shell/desktop-shell.tsx
+++ b/apps/desktop/src/renderer/src/shell/desktop-shell.tsx
@@ -460,6 +460,7 @@ export function DesktopShell({
       node: tab.id.startsWith('attach:') ? (
         <AttachedTerminalPanel
           terminalId={tab.id.slice('attach:'.length)}
+          onCloseTab={closeTab}
           interactive={rightOwnsTerminal}
           primary={rightOwnsTerminal}
           suspended={rightTransition.phase !== 'open' || shellAnimating}
@@ -468,6 +469,7 @@ export function DesktopShell({
         <TerminalPanel
           sessionKey={tab.id}
           cwd={active?.cwd}
+          onCloseTab={closeTab}
           interactive={rightOwnsTerminal}
           suspended={rightTransition.phase !== 'open' || shellAnimating}
         />
@@ -493,6 +495,7 @@ export function DesktopShell({
           tab.id.startsWith('attach:') ? (
             <AttachedTerminalPanel
               terminalId={tab.id.slice('attach:'.length)}
+              onCloseTab={closeTab}
               interactive={bottomOwnsTerminal}
               primary={bottomOwnsTerminal}
               suspended={bottomTransition.phase !== 'open' || shellAnimating}
@@ -501,6 +504,7 @@ export function DesktopShell({
             <TerminalPanel
               sessionKey={tab.id}
               cwd={active?.cwd}
+              onCloseTab={closeTab}
               interactive={bottomOwnsTerminal}
               suspended={bottomTransition.phase !== 'open' || shellAnimating}
             />

--- a/packages/client-core/src/__tests__/terminal-client.test.ts
+++ b/packages/client-core/src/__tests__/terminal-client.test.ts
@@ -348,6 +348,50 @@ describe('LinkCodeClient terminal attachments', () => {
     serverTransport.close();
   });
 
+  it('releases an attachment whose final viewer detaches while attach is pending', async () => {
+    const { client, serverTransport } = await createConnectedLocalClient();
+    const received: WirePayload[] = [];
+    let replyAttached = noop;
+    serverTransport.onMessage((message) => {
+      const p = message.payload;
+      received.push(p);
+      if (p.kind !== 'terminal.attach') return;
+      replyAttached = () => {
+        serverTransport.send(
+          createWireMessage({
+            kind: 'terminal.attached',
+            replyTo: p.clientReqId,
+            terminal: metadata(p.terminalId, null),
+            replay: [],
+            cutoffSeq: 0,
+            truncated: false,
+          }),
+        );
+      };
+    });
+
+    const attached = client.attachTerminal('term-pending');
+    await flushMicrotasks();
+    const attachFrame = received.find((payload) => payload.kind === 'terminal.attach');
+    if (attachFrame?.kind !== 'terminal.attach') throw new Error('no terminal.attach frame');
+
+    client.detachTerminal('term-pending');
+    replyAttached();
+    await attached;
+    await flushMicrotasks();
+
+    expect(received.filter((payload) => payload.kind === 'terminal.detach')).toEqual([
+      {
+        kind: 'terminal.detach',
+        terminalId: 'term-pending',
+        attachmentId: attachFrame.attachmentId,
+        attachmentSecret: attachFrame.attachmentSecret,
+      },
+    ]);
+    client.dispose();
+    serverTransport.close();
+  });
+
   it('replays an exit that arrives immediately after a tombstone attachment', async () => {
     const { client, serverTransport } = await createConnectedLocalClient();
     serverTransport.onMessage((message) => {

--- a/packages/workbench/src/terminal/__tests__/attached-panel.test.tsx
+++ b/packages/workbench/src/terminal/__tests__/attached-panel.test.tsx
@@ -25,10 +25,6 @@ vi.mock('@linkcode/ui/shell/terminal', () => ({
   LiveTerminal: () => null,
 }));
 
-vi.mock('../tabs-store', () => ({
-  useTerminalTabsStore: { getState: () => ({ closeTab }) },
-}));
-
 vi.mock('../../settings/terminal-prefs-store', () => ({
   useTerminalPrefsStore: selectTerminalPrefs,
 }));
@@ -66,7 +62,7 @@ describe('AttachedTerminalPanel', () => {
       resizeTerminal: noop,
       takeTerminalControl: () => Promise.resolve(),
     };
-    const view = render(<AttachedTerminalPanel terminalId="term-1" />);
+    const view = render(<AttachedTerminalPanel terminalId="term-1" onCloseTab={closeTab} />);
 
     expect(closeTab).toHaveBeenCalledOnce();
     expect(closeTab).toHaveBeenCalledWith('attach:term-1');
@@ -96,7 +92,9 @@ describe('AttachedTerminalPanel', () => {
       resizeTerminal: noop,
     };
 
-    const view = render(<AttachedTerminalPanel terminalId="term-1" primary={false} />);
+    const view = render(
+      <AttachedTerminalPanel terminalId="term-1" onCloseTab={closeTab} primary={false} />,
+    );
 
     expect(subscribeTerminalExit).not.toHaveBeenCalled();
     expect(closeTab).not.toHaveBeenCalled();

--- a/packages/workbench/src/terminal/__tests__/attached-panel.test.tsx
+++ b/packages/workbench/src/terminal/__tests__/attached-panel.test.tsx
@@ -1,0 +1,105 @@
+/** @vitest-environment jsdom */
+
+import type { TerminalAttachResult } from '@linkcode/client-core';
+import { act, render } from '@testing-library/react';
+import { noop } from 'foxts/noop';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { AttachedTerminalPanel } from '../attached-panel';
+
+const mocks = vi.hoisted<{ client: Record<string, unknown> }>(() => ({ client: {} }));
+const closeTab = vi.hoisted(() => vi.fn());
+
+function selectTerminalPrefs(select: (state: Record<string, unknown>) => unknown): unknown {
+  return select({ fontFamily: 'monospace', fontSize: 13, colorScheme: 'dark' });
+}
+
+function translate(key: string): string {
+  return key;
+}
+
+vi.mock('@linkcode/client-core', () => ({
+  useLinkCodeClient: () => mocks.client,
+}));
+
+vi.mock('@linkcode/ui/shell/terminal', () => ({
+  LiveTerminal: () => null,
+}));
+
+vi.mock('../tabs-store', () => ({
+  useTerminalTabsStore: { getState: () => ({ closeTab }) },
+}));
+
+vi.mock('../../settings/terminal-prefs-store', () => ({
+  useTerminalPrefsStore: selectTerminalPrefs,
+}));
+
+vi.mock('use-intl', () => ({
+  useTranslations: () => translate,
+}));
+
+describe('AttachedTerminalPanel', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    closeTab.mockReset();
+  });
+
+  it('closes once for a replayed exit and detaches once when the pending attach resolves', async () => {
+    let resolveAttach: (result: TerminalAttachResult) => void = noop;
+    const detachTerminal = vi.fn();
+    const unsubscribeExit = vi.fn();
+    mocks.client = {
+      attachTerminal: () =>
+        new Promise<TerminalAttachResult>((resolve) => {
+          resolveAttach = resolve;
+        }),
+      detachTerminal,
+      subscribeTerminalController: () => noop,
+      terminalCanControl: () => false,
+      subscribeTerminalExit(_terminalId: string, onExit: (code: number | null) => void) {
+        onExit(0);
+        return unsubscribeExit;
+      },
+      subscribeTerminalEvents: () => noop,
+      subscribeTerminalReplayTruncated: () => noop,
+      terminalReplayWasTruncated: () => false,
+      terminalInput: noop,
+      resizeTerminal: noop,
+      takeTerminalControl: () => Promise.resolve(),
+    };
+    const view = render(<AttachedTerminalPanel terminalId="term-1" />);
+
+    expect(closeTab).toHaveBeenCalledOnce();
+    expect(closeTab).toHaveBeenCalledWith('attach:term-1');
+
+    view.unmount();
+    expect(detachTerminal).toHaveBeenCalledOnce();
+    expect(detachTerminal).toHaveBeenCalledWith('term-1');
+    await act(async () => {
+      resolveAttach({} as TerminalAttachResult);
+      await Promise.resolve();
+    });
+
+    expect(detachTerminal).toHaveBeenCalledOnce();
+    expect(unsubscribeExit).toHaveBeenCalledOnce();
+  });
+
+  it('leaves exit ownership to the primary duplicate surface', () => {
+    const subscribeTerminalExit = vi.fn(() => noop);
+    mocks.client = {
+      subscribeTerminalController: () => noop,
+      terminalCanControl: () => false,
+      subscribeTerminalExit,
+      subscribeTerminalEvents: () => noop,
+      subscribeTerminalReplayTruncated: () => noop,
+      terminalReplayWasTruncated: () => false,
+      terminalInput: noop,
+      resizeTerminal: noop,
+    };
+
+    const view = render(<AttachedTerminalPanel terminalId="term-1" primary={false} />);
+
+    expect(subscribeTerminalExit).not.toHaveBeenCalled();
+    expect(closeTab).not.toHaveBeenCalled();
+    view.unmount();
+  });
+});

--- a/packages/workbench/src/terminal/__tests__/session-registry.test.ts
+++ b/packages/workbench/src/terminal/__tests__/session-registry.test.ts
@@ -7,6 +7,7 @@ interface FakeClient extends TerminalSessionClient {
   opened: string[];
   closed: string[];
   detached: string[];
+  detachAttempts: string[];
   attachments: Set<string>;
   controlled: Set<string>;
   exitCbs: Map<string, (code: number | null) => void>;
@@ -18,6 +19,7 @@ function createFakeClient(): FakeClient {
   const opened: string[] = [];
   const closed: string[] = [];
   const detached: string[] = [];
+  const detachAttempts: string[] = [];
   const exitCbs = new Map<string, (code: number | null) => void>();
   const controllerCbs = new Map<string, (canControl: boolean) => void>();
   const attached = new Set<string>();
@@ -27,6 +29,7 @@ function createFakeClient(): FakeClient {
     opened,
     closed,
     detached,
+    detachAttempts,
     attachments: attached,
     controlled,
     exitCbs,
@@ -40,6 +43,7 @@ function createFakeClient(): FakeClient {
       return Promise.resolve(id);
     },
     detachTerminal(terminalId) {
+      detachAttempts.push(terminalId);
       if (!attached.delete(terminalId)) return;
       detached.push(terminalId);
       controlled.delete(terminalId);
@@ -202,6 +206,119 @@ describe('terminal session registry', () => {
     await vi.advanceTimersByTimeAsync(1000);
   });
 
+  it('notifies the tab owner once when the terminal exits normally', async () => {
+    const client = createFakeClient();
+    const onExit = vi.fn();
+    const lease = acquireTerminalSession(client, 'tab-1', dims, onExit);
+    await vi.advanceTimersByTimeAsync(0);
+
+    client.exitCbs.get('term-1')?.(0);
+    client.exitCbs.get('term-1')?.(0);
+
+    expect(onExit).toHaveBeenCalledOnce();
+    expect(onExit).toHaveBeenCalledWith(0);
+    lease.release();
+    await vi.advanceTimersByTimeAsync(1000);
+  });
+
+  it('notifies the tab owner when the terminal is killed by a signal', async () => {
+    const client = createFakeClient();
+    const onExit = vi.fn();
+    const lease = acquireTerminalSession(client, 'tab-1', dims, onExit);
+    await vi.advanceTimersByTimeAsync(0);
+
+    client.exitCbs.get('term-1')?.(null);
+
+    expect(onExit).toHaveBeenCalledOnce();
+    expect(onExit).toHaveBeenCalledWith(null);
+    lease.release();
+    await vi.advanceTimersByTimeAsync(1000);
+  });
+
+  it('does not notify after the user releases the tab before a late exit', async () => {
+    const client = createFakeClient();
+    const onExit = vi.fn();
+    const lease = acquireTerminalSession(client, 'tab-1', dims, onExit);
+    await vi.advanceTimersByTimeAsync(0);
+    const lateExit = client.exitCbs.get('term-1');
+
+    lease.release();
+    lateExit?.(0);
+    await vi.advanceTimersByTimeAsync(1000);
+
+    expect(onExit).not.toHaveBeenCalled();
+    expect(client.closed).toEqual([]);
+    expect(client.detached).toEqual([]);
+    expect(client.detachAttempts).toEqual(['term-1']);
+  });
+
+  it('closes only the tab whose terminal exits', async () => {
+    const client = createFakeClient();
+    const onFirstExit = vi.fn();
+    const onSecondExit = vi.fn();
+    const first = acquireTerminalSession(client, 'tab-1', dims, onFirstExit);
+    const second = acquireTerminalSession(client, 'tab-2', dims, onSecondExit);
+    await vi.advanceTimersByTimeAsync(0);
+
+    client.exitCbs.get('term-1')?.(0);
+
+    expect(onFirstExit).toHaveBeenCalledOnce();
+    expect(onSecondExit).not.toHaveBeenCalled();
+    expect(second.getSnapshot().exit).toBeNull();
+    first.release();
+    second.release();
+    await vi.advanceTimersByTimeAsync(1000);
+  });
+
+  it('notifies only once while a tab lease is handed between panel mounts', async () => {
+    const client = createFakeClient();
+    const firstOwner = vi.fn();
+    const secondOwner = vi.fn();
+    const first = acquireTerminalSession(client, 'tab-1', dims, firstOwner);
+    await vi.advanceTimersByTimeAsync(0);
+    const second = acquireTerminalSession(client, 'tab-1', dims, secondOwner);
+
+    client.exitCbs.get('term-1')?.(0);
+
+    expect(firstOwner.mock.calls.length + secondOwner.mock.calls.length).toBe(1);
+    first.release();
+    second.release();
+    await vi.advanceTimersByTimeAsync(1000);
+  });
+
+  it('delivers an exit that arrives between releasing and reacquiring a handed-off tab', async () => {
+    const client = createFakeClient();
+    const staleOwner = vi.fn();
+    const nextOwner = vi.fn();
+    const first = acquireTerminalSession(client, 'tab-1', dims, staleOwner);
+    await vi.advanceTimersByTimeAsync(0);
+
+    first.release();
+    client.exitCbs.get('term-1')?.(0);
+    const second = acquireTerminalSession(client, 'tab-1', dims, nextOwner);
+
+    expect(staleOwner).not.toHaveBeenCalled();
+    expect(nextOwner).toHaveBeenCalledOnce();
+    expect(nextOwner).toHaveBeenCalledWith(0);
+    second.release();
+    await vi.advanceTimersByTimeAsync(1000);
+  });
+
+  it('keeps equal callbacks registered independently for concurrent leases', async () => {
+    const client = createFakeClient();
+    const onExit = vi.fn();
+    const first = acquireTerminalSession(client, 'tab-1', dims, onExit);
+    await vi.advanceTimersByTimeAsync(0);
+    const second = acquireTerminalSession(client, 'tab-1', dims, onExit);
+
+    first.release();
+    client.exitCbs.get('term-1')?.(0);
+
+    expect(onExit).toHaveBeenCalledOnce();
+    second.release();
+    await vi.advanceTimersByTimeAsync(1000);
+  });
+
   it('preserves a signal exit as distinct from a running terminal', async () => {
     const client = createFakeClient();
     const lease = acquireTerminalSession(client, 'tab-1', dims);
@@ -217,12 +334,13 @@ describe('terminal session registry', () => {
 
   it('preserves an exit delivered synchronously while the terminal opens', async () => {
     const client = createFakeClient();
+    const onExit = vi.fn();
     client.subscribeTerminalExit = (_terminalId, cb) => {
       cb(7);
       return noop;
     };
 
-    const lease = acquireTerminalSession(client, 'tab-1', dims);
+    const lease = acquireTerminalSession(client, 'tab-1', dims, onExit);
     await vi.advanceTimersByTimeAsync(0);
 
     expect(lease.getSnapshot()).toMatchObject({
@@ -231,6 +349,8 @@ describe('terminal session registry', () => {
       exit: { code: 7 },
       canControl: false,
     });
+    expect(onExit).toHaveBeenCalledOnce();
+    expect(onExit).toHaveBeenCalledWith(7);
     lease.release();
     await vi.advanceTimersByTimeAsync(1000);
   });

--- a/packages/workbench/src/terminal/attached-panel.tsx
+++ b/packages/workbench/src/terminal/attached-panel.tsx
@@ -6,7 +6,6 @@ import { useEffect as useAbortableEffect } from 'foxact/use-abortable-effect';
 import { useCallback, useMemo, useState, useSyncExternalStore } from 'react';
 import { useTranslations } from 'use-intl';
 import { useTerminalPrefsStore } from '../settings/terminal-prefs-store';
-import { useTerminalTabsStore } from './tabs-store';
 import { createTransportTerminalSession } from './transport-session';
 
 /**
@@ -16,11 +15,14 @@ import { createTransportTerminalSession } from './transport-session';
  */
 export function AttachedTerminalPanel({
   terminalId,
+  onCloseTab,
   interactive,
   primary = true,
   suspended,
 }: {
   terminalId: string;
+  /** Close through the host action so panel selection/open state follows the shared tab store. */
+  onCloseTab: (id: string) => void;
   interactive?: boolean;
   /** Exactly one duplicate surface attaches/detaches the daemon capability. */
   primary?: boolean;
@@ -84,10 +86,10 @@ export function AttachedTerminalPanel({
     (signal) => {
       if (!primary) return;
       return client.subscribeTerminalExit(terminalId, () => {
-        if (!signal.aborted) useTerminalTabsStore.getState().closeTab(`attach:${terminalId}`);
+        if (!signal.aborted) onCloseTab(`attach:${terminalId}`);
       });
     },
-    [client, terminalId, primary],
+    [client, terminalId, onCloseTab, primary],
   );
 
   if (!primary) {

--- a/packages/workbench/src/terminal/attached-panel.tsx
+++ b/packages/workbench/src/terminal/attached-panel.tsx
@@ -6,6 +6,7 @@ import { useEffect as useAbortableEffect } from 'foxact/use-abortable-effect';
 import { useCallback, useMemo, useState, useSyncExternalStore } from 'react';
 import { useTranslations } from 'use-intl';
 import { useTerminalPrefsStore } from '../settings/terminal-prefs-store';
+import { useTerminalTabsStore } from './tabs-store';
 import { createTransportTerminalSession } from './transport-session';
 
 /**
@@ -64,20 +65,27 @@ export function AttachedTerminalPanel({
   useAbortableEffect(
     (signal) => {
       if (!primary) return;
-      let attached = false;
       void client
         .attachTerminal(terminalId)
         .then((result) => {
-          attached = true;
-          if (signal.aborted) client.detachTerminal(terminalId);
-          else setAttachment({ terminalId, result });
+          if (!signal.aborted) setAttachment({ terminalId, result });
         })
         .catch(() => {
           if (!signal.aborted) setAttachment({ terminalId, failed: true });
         });
-      return () => {
-        if (attached) client.detachTerminal(terminalId);
-      };
+      // Balance the retain immediately. If attach is still pending, client-core observes the
+      // zero retain count when the reply arrives and sends the terminal.detach frame then.
+      return () => client.detachTerminal(terminalId);
+    },
+    [client, terminalId, primary],
+  );
+
+  useAbortableEffect(
+    (signal) => {
+      if (!primary) return;
+      return client.subscribeTerminalExit(terminalId, () => {
+        if (!signal.aborted) useTerminalTabsStore.getState().closeTab(`attach:${terminalId}`);
+      });
     },
     [client, terminalId, primary],
   );

--- a/packages/workbench/src/terminal/panel.tsx
+++ b/packages/workbench/src/terminal/panel.tsx
@@ -7,6 +7,7 @@ import { useTranslations } from 'use-intl';
 import { useTerminalPrefsStore } from '../settings/terminal-prefs-store';
 import type { TerminalSessionLease } from './session-registry';
 import { acquireTerminalSession, peekTerminalSnapshot } from './session-registry';
+import { useTerminalTabsStore } from './tabs-store';
 
 const TERMINAL_INITIAL_SIZE = { cols: 80, rows: 24 };
 const INPUT_LOST_BANNER_MS = 4000;
@@ -39,7 +40,12 @@ export function TerminalPanel({
 
   const subscribe = useCallback(
     (onStoreChange: () => void) => {
-      const lease = acquireTerminalSession(client, sessionKey, { ...TERMINAL_INITIAL_SIZE, cwd });
+      const lease = acquireTerminalSession(
+        client,
+        sessionKey,
+        { ...TERMINAL_INITIAL_SIZE, cwd },
+        () => useTerminalTabsStore.getState().closeTab(sessionKey),
+      );
       leaseRef.current = lease;
       const unsubscribe = lease.subscribe(onStoreChange);
       return () => {

--- a/packages/workbench/src/terminal/panel.tsx
+++ b/packages/workbench/src/terminal/panel.tsx
@@ -7,7 +7,6 @@ import { useTranslations } from 'use-intl';
 import { useTerminalPrefsStore } from '../settings/terminal-prefs-store';
 import type { TerminalSessionLease } from './session-registry';
 import { acquireTerminalSession, peekTerminalSnapshot } from './session-registry';
-import { useTerminalTabsStore } from './tabs-store';
 
 const TERMINAL_INITIAL_SIZE = { cols: 80, rows: 24 };
 const INPUT_LOST_BANNER_MS = 4000;
@@ -20,12 +19,15 @@ const INPUT_LOST_BANNER_MS = 4000;
 export function TerminalPanel({
   sessionKey,
   cwd,
+  onCloseTab,
   interactive,
   suspended,
 }: {
   sessionKey: string;
   /** Working directory for the shell, captured when the terminal first opens (host home if omitted). */
   cwd?: string;
+  /** Close through the host action so panel selection/open state follows the shared tab store. */
+  onCloseTab: (id: string) => void;
   interactive?: boolean;
   /** Freeze the terminal's box while the host panel animates shut/open — see {@link LiveTerminal}. */
   suspended?: boolean;
@@ -44,7 +46,7 @@ export function TerminalPanel({
         client,
         sessionKey,
         { ...TERMINAL_INITIAL_SIZE, cwd },
-        () => useTerminalTabsStore.getState().closeTab(sessionKey),
+        () => onCloseTab(sessionKey),
       );
       leaseRef.current = lease;
       const unsubscribe = lease.subscribe(onStoreChange);
@@ -54,7 +56,7 @@ export function TerminalPanel({
         if (leaseRef.current === lease) leaseRef.current = null;
       };
     },
-    [client, sessionKey, cwd],
+    [client, sessionKey, cwd, onCloseTab],
   );
   const snapshot = useSyncExternalStore(subscribe, () => peekTerminalSnapshot(client, sessionKey));
 

--- a/packages/workbench/src/terminal/session-registry.ts
+++ b/packages/workbench/src/terminal/session-registry.ts
@@ -43,6 +43,8 @@ interface RegistryEntry {
   unsubController: (() => void) | null;
   snapshot: TerminalSnapshot;
   listeners: Set<() => void>;
+  exitListeners: Map<symbol, (exitCode: number | null) => void>;
+  exitDelivered: boolean;
 }
 
 /**
@@ -79,6 +81,15 @@ function notify(entry: RegistryEntry): void {
   for (const listener of entry.listeners) listener();
 }
 
+function deliverExit(entry: RegistryEntry): void {
+  if (entry.exitDelivered || entry.snapshot.exit === null) return;
+  let onExit: ((exitCode: number | null) => void) | undefined;
+  for (const listener of entry.exitListeners.values()) onExit = listener;
+  if (!onExit) return;
+  entry.exitDelivered = true;
+  onExit(entry.snapshot.exit.code);
+}
+
 function startOpen(
   client: TerminalSessionClient,
   registry: Map<string, RegistryEntry>,
@@ -87,6 +98,7 @@ function startOpen(
   opts: TerminalOpenOptions,
 ): void {
   entry.attempt += 1;
+  entry.exitDelivered = false;
   const attempt = entry.attempt;
   const isCurrent = (): boolean => registry.get(key) === entry && entry.attempt === attempt;
 
@@ -136,6 +148,7 @@ function startOpen(
           exit: { code: exitCode },
           canControl: false,
         };
+        deliverExit(entry);
         notify(entry);
       });
       notify(entry);
@@ -177,6 +190,7 @@ export function acquireTerminalSession(
   client: TerminalSessionClient,
   key: string,
   opts: TerminalOpenOptions,
+  onExit?: (exitCode: number | null) => void,
 ): TerminalSessionLease {
   const registry = getRegistry(client);
   let entry = registry.get(key);
@@ -197,6 +211,8 @@ export function acquireTerminalSession(
       unsubController: null,
       snapshot: OPENING_SNAPSHOT,
       listeners: new Set(),
+      exitListeners: new Map(),
+      exitDelivered: false,
     };
     registry.set(key, created);
     entry = created;
@@ -205,6 +221,11 @@ export function acquireTerminalSession(
 
   const leased = entry;
   let released = false;
+  const exitListenerId = Symbol('terminal-exit-listener');
+  if (onExit) {
+    leased.exitListeners.set(exitListenerId, onExit);
+    deliverExit(leased);
+  }
 
   return {
     getSnapshot: () => leased.snapshot,
@@ -222,6 +243,7 @@ export function acquireTerminalSession(
     release() {
       if (released) return;
       released = true;
+      leased.exitListeners.delete(exitListenerId);
       leased.refCount -= 1;
       if (leased.refCount > 0) return;
       leased.closeTimer = setTimeout(() => {


### PR DESCRIPTION
## Summary

- close the unique shared terminal tab when its ordinary PTY exits normally or by signal
- route exit closure through CODE-351's shared `closeTab` source of truth for both right and bottom surfaces
- preserve exactly-once teardown across user-close, late exit, owner handoff, attached terminals, and unrelated tabs
- detach attached terminals immediately during a pending attach so the final daemon detach is not lost

## Stack dependency

Depends on #207 (CODE-351). This PR intentionally targets `xuan/code-351`; merge #207 first.

Linear: [CODE-349](https://linear.app/arcbox/issue/CODE-349/featuipty-%E7%BB%88%E7%AB%AF%E8%BF%9B%E7%A8%8B%E8%A2%AB%E6%9D%80%E5%90%8E%E8%87%AA%E5%8A%A8%E5%85%B3%E9%97%AD%E5%AF%B9%E5%BA%94-tab)

## Protocol

Reuses the existing `terminal.exit` event. No wire variant or protocol-version change.

## Verification

- `pnpm check:ci`
- 68 focused tests across daemon sidecar integration, engine terminal service, client terminal channel, workbench terminal lifecycle, shared UI tabs, and desktop shell state
- focused TypeScript, Biome, and ESLint checks for the affected packages/files
- built the release PTY sidecar, daemon, and desktop
- real isolated daemon + Electron flow: normal `exit` removed the shared tab from right and bottom
- real isolated daemon + Electron flow: `kill -KILL $$` removed the shared tab from right and bottom
