### PR TITLE
fix(ui): restore Tailwind sources after package restructure

### DIFF
--- a/packages/presentation/ui/src/styles.css
+++ b/packages/presentation/ui/src/styles.css
@@ -7,11 +7,11 @@
 @import "@fontsource/ibm-plex-mono/700.css";
 
 @source "./";
-@source "../../coss-ui/src";
-@source "../../workbench/src";
+@source "../../../vendor/coss-ui/src";
+@source "../../../client/workbench/src";
 /* streamdown ships precompiled JSX with Tailwind class strings; scan its dist
    so those utilities compile against our theme (hoisted root node_modules). */
-@source "../../../node_modules/streamdown/dist/**/*.js";
+@source "../../../../node_modules/streamdown/dist/**/*.js";
 
 /*
  * coss-ui ships --font-mono as an inlined literal in its @theme, so the


### PR DESCRIPTION
## Summary

Fixes CODE-352 by updating the Tailwind `@source` paths after packages were moved into their architectural scopes.

## Root cause

The package restructure moved the shared UI stylesheet without updating its relative source paths. Tailwind silently ignored the nonexistent paths, so required Coss UI, workbench, and Streamdown utilities were not generated.

## Verification

- Confirmed every `@source` target resolves
- Verified the missing Tailwind selectors are generated again
- Visually verified the Electron and webview interfaces
- `pnpm check:ci`
- `pnpm test` — 1,559 tests passed

Fixes CODE-352