### PR TITLE
fix(ui): support scoped Markdown heading anchors

### DIFF
--- a/packages/presentation/ui/package.json
+++ b/packages/presentation/ui/package.json
@@ -53,6 +53,7 @@
     "motion": "^12.42.2",
     "pretty-bytes": "^7.1.1",
     "pretty-ms": "^9.3.0",
+    "rehype-slug": "^6.0.0",
     "remark-gfm": "^4.0.1",
     "remark-parse": "^11.0.0",
     "remend": "^1.3.0",

--- a/packages/presentation/ui/package.json
+++ b/packages/presentation/ui/package.json
@@ -61,6 +61,7 @@
     "streamdown": "^2.5.0",
     "tailwind-merge": "^3.6.0",
     "unified": "^11.0.5",
+    "unist-util-visit": "^5.1.0",
     "use-intl": "catalog:",
     "use-stick-to-bottom": "^1.1.6",
     "virtua": "^0.49.3",
@@ -68,6 +69,7 @@
   },
   "devDependencies": {
     "@lexical/headless": "^0.47.0",
+    "@types/hast": "^3.0.5",
     "@types/mdast": "^4.0.4",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",

--- a/packages/presentation/ui/src/chat/__tests__/markdown.test.tsx
+++ b/packages/presentation/ui/src/chat/__tests__/markdown.test.tsx
@@ -61,6 +61,20 @@ it('generates scoped anchors for raw HTML headings after parsing them', () => {
   expect(getByRole('link', { name: 'Jump' }).getAttribute('href')).toBe(`#${heading.id}`);
 });
 
+it('scopes explicit heading ids from raw HTML to their Markdown document', () => {
+  const { getAllByRole, getByRole } = render(
+    <>
+      <Markdown headingAnchors>{'<h2 id="custom">Title</h2>\n\n[First](#custom)'}</Markdown>
+      <Markdown headingAnchors>{'<h2 id="custom">Title</h2>\n\n[Second](#custom)'}</Markdown>
+    </>,
+  );
+
+  const headings = getAllByRole('heading', { name: 'Title' });
+  expect(headings[0]?.id).not.toBe(headings[1]?.id);
+  expect(getByRole('link', { name: 'First' }).getAttribute('href')).toBe(`#${headings[0]?.id}`);
+  expect(getByRole('link', { name: 'Second' }).getAttribute('href')).toBe(`#${headings[1]?.id}`);
+});
+
 it('deduplicates repeated headings across one anchored document', () => {
   const { getAllByRole, getByRole } = render(
     <Markdown headingAnchors>{'## Repeat\n\n## Repeat\n\n[Jump](#repeat-1)'}</Markdown>,

--- a/packages/presentation/ui/src/chat/__tests__/markdown.test.tsx
+++ b/packages/presentation/ui/src/chat/__tests__/markdown.test.tsx
@@ -1,12 +1,36 @@
 // @vitest-environment jsdom
 
-import { cleanup, render, waitFor } from '@testing-library/react';
-import { afterEach, expect, it } from 'vitest';
+import { cleanup, fireEvent, render, waitFor } from '@testing-library/react';
+import { afterEach, expect, it, vi } from 'vitest';
 import { Markdown } from '../markdown';
 
 afterEach(cleanup);
 
 const FENCE = '```ts\nconst greeting: string = "hello";\n```';
+
+it('keeps fragment links in the document and opens external links in a new tab', () => {
+  const { getByRole } = render(
+    <Markdown>
+      {'## Target\n\n[Jump to target](#target)\n\n[External](https://example.com)'}
+    </Markdown>,
+  );
+
+  const heading = getByRole('heading', { name: 'Target' });
+  const fragmentLink = getByRole('link', { name: 'Jump to target' });
+  const externalLink = getByRole('link', { name: 'External' });
+
+  expect(heading.getAttribute('id')).toBe('user-content-target');
+  expect(fragmentLink.getAttribute('href')).toBe('#user-content-target');
+  expect(fragmentLink.getAttribute('target')).toBeNull();
+  expect(fragmentLink.getAttribute('rel')).toBeNull();
+  expect(externalLink.getAttribute('target')).toBe('_blank');
+  expect(externalLink.getAttribute('rel')).toBe('noreferrer');
+
+  const scrollIntoView = vi.fn();
+  heading.scrollIntoView = scrollIntoView;
+  fireEvent.click(fragmentLink);
+  expect(scrollIntoView).toHaveBeenCalledOnce();
+});
 
 // Pins the @streamdown/code ↔ shiki contract: the workspace override forces shiki 4 under the
 // plugin (which pins ^3) to keep a single copy in the renderer bundle (CODE-215). If the plugin's

--- a/packages/presentation/ui/src/chat/__tests__/markdown.test.tsx
+++ b/packages/presentation/ui/src/chat/__tests__/markdown.test.tsx
@@ -12,9 +12,11 @@ it('scopes heading anchors to their Markdown document and keeps external links s
   const { getAllByRole, getByRole } = render(
     <>
       <Markdown headingAnchors>{'## Target\n\n[First jump](#target)'}</Markdown>
-      <Markdown headingAnchors>
-        {'## Target\n\n[Second jump](#target)\n\n[External](https://example.com)'}
-      </Markdown>
+      <div data-markdown-scroll-container>
+        <Markdown headingAnchors>
+          {'## Target\n\n[Second jump](#target)\n\n[External](https://example.com)'}
+        </Markdown>
+      </div>
     </>,
   );
 
@@ -31,10 +33,22 @@ it('scopes heading anchors to their Markdown document and keeps external links s
   expect(externalLink.getAttribute('target')).toBe('_blank');
   expect(externalLink.getAttribute('rel')).toBe('noreferrer');
 
+  const scrollContainer = secondFragmentLink.closest<HTMLElement>(
+    '[data-markdown-scroll-container]',
+  );
+  expect(scrollContainer).not.toBeNull();
+  if (!scrollContainer || !headings[1]) return;
+
+  Object.defineProperty(scrollContainer, 'scrollTop', { value: 120, writable: true });
+  const scrollTo = vi.fn();
+  scrollContainer.scrollTo = scrollTo;
+  vi.spyOn(scrollContainer, 'getBoundingClientRect').mockReturnValue(DOMRect.fromRect({ y: 100 }));
+  vi.spyOn(headings[1], 'getBoundingClientRect').mockReturnValue(DOMRect.fromRect({ y: 400 }));
   const scrollIntoView = vi.fn();
-  if (headings[1]) headings[1].scrollIntoView = scrollIntoView;
+  headings[1].scrollIntoView = scrollIntoView;
   fireEvent.click(secondFragmentLink);
-  expect(scrollIntoView).toHaveBeenCalledOnce();
+  expect(scrollTo).toHaveBeenCalledWith({ top: 420 });
+  expect(scrollIntoView).not.toHaveBeenCalled();
 });
 
 it('generates scoped anchors for raw HTML headings after parsing them', () => {

--- a/packages/presentation/ui/src/chat/__tests__/markdown.test.tsx
+++ b/packages/presentation/ui/src/chat/__tests__/markdown.test.tsx
@@ -8,28 +8,53 @@ afterEach(cleanup);
 
 const FENCE = '```ts\nconst greeting: string = "hello";\n```';
 
-it('keeps fragment links in the document and opens external links in a new tab', () => {
-  const { getByRole } = render(
-    <Markdown>
-      {'## Target\n\n[Jump to target](#target)\n\n[External](https://example.com)'}
-    </Markdown>,
+it('scopes heading anchors to their Markdown document and keeps external links separate', () => {
+  const { getAllByRole, getByRole } = render(
+    <>
+      <Markdown headingAnchors>{'## Target\n\n[First jump](#target)'}</Markdown>
+      <Markdown headingAnchors>
+        {'## Target\n\n[Second jump](#target)\n\n[External](https://example.com)'}
+      </Markdown>
+    </>,
   );
 
-  const heading = getByRole('heading', { name: 'Target' });
-  const fragmentLink = getByRole('link', { name: 'Jump to target' });
+  const headings = getAllByRole('heading', { name: 'Target' });
+  const firstFragmentLink = getByRole('link', { name: 'First jump' });
+  const secondFragmentLink = getByRole('link', { name: 'Second jump' });
   const externalLink = getByRole('link', { name: 'External' });
 
-  expect(heading.getAttribute('id')).toBe('user-content-target');
-  expect(fragmentLink.getAttribute('href')).toBe('#user-content-target');
-  expect(fragmentLink.getAttribute('target')).toBeNull();
-  expect(fragmentLink.getAttribute('rel')).toBeNull();
+  expect(headings[0]?.id).not.toBe(headings[1]?.id);
+  expect(firstFragmentLink.getAttribute('href')).toBe(`#${headings[0]?.id}`);
+  expect(secondFragmentLink.getAttribute('href')).toBe(`#${headings[1]?.id}`);
+  expect(secondFragmentLink.getAttribute('target')).toBeNull();
+  expect(secondFragmentLink.getAttribute('rel')).toBeNull();
   expect(externalLink.getAttribute('target')).toBe('_blank');
   expect(externalLink.getAttribute('rel')).toBe('noreferrer');
 
   const scrollIntoView = vi.fn();
-  heading.scrollIntoView = scrollIntoView;
-  fireEvent.click(fragmentLink);
+  if (headings[1]) headings[1].scrollIntoView = scrollIntoView;
+  fireEvent.click(secondFragmentLink);
   expect(scrollIntoView).toHaveBeenCalledOnce();
+});
+
+it('generates scoped anchors for raw HTML headings after parsing them', () => {
+  const { getByRole } = render(
+    <Markdown headingAnchors>{'<h2>HTML Target</h2>\n\n[Jump](#html-target)'}</Markdown>,
+  );
+
+  const heading = getByRole('heading', { name: 'HTML Target' });
+  expect(heading.id).not.toBe('');
+  expect(getByRole('link', { name: 'Jump' }).getAttribute('href')).toBe(`#${heading.id}`);
+});
+
+it('deduplicates repeated headings across one anchored document', () => {
+  const { getAllByRole, getByRole } = render(
+    <Markdown headingAnchors>{'## Repeat\n\n## Repeat\n\n[Jump](#repeat-1)'}</Markdown>,
+  );
+
+  const headings = getAllByRole('heading', { name: 'Repeat' });
+  expect(headings[0]?.id).not.toBe(headings[1]?.id);
+  expect(getByRole('link', { name: 'Jump' }).getAttribute('href')).toBe(`#${headings[1]?.id}`);
 });
 
 // Pins the @streamdown/code ↔ shiki contract: the workspace override forces shiki 4 under the

--- a/packages/presentation/ui/src/chat/markdown.tsx
+++ b/packages/presentation/ui/src/chat/markdown.tsx
@@ -1,7 +1,8 @@
 import { cjk } from '@streamdown/cjk';
 import { createCodePlugin } from '@streamdown/code';
+import rehypeSlug from 'rehype-slug';
 import type { Components, PluginConfig, StreamdownProps } from 'streamdown';
-import { Streamdown } from 'streamdown';
+import { defaultRehypePlugins, Streamdown } from 'streamdown';
 import { cn } from '../lib/cn';
 import { useRenderPrefs } from '../render-prefs';
 import { ArtifactFenceRenderer } from './artifacts/fence-renderer';
@@ -11,6 +12,7 @@ import { artifactFenceLanguages } from './artifacts/registry';
 import { useSmoothText } from './smooth-text-controller';
 
 const INLINE_CODE_CLASS = 'rounded bg-muted px-1 py-0.5 font-mono text-[0.85em]';
+const SANITIZED_HEADING_PREFIX = 'user-content-';
 
 /** Inline code, upgraded to a file link when the span is a viewer-openable path and
  * the host wires `openFile` (degrades to plain code everywhere else). */
@@ -46,19 +48,45 @@ function InlineCode({
   );
 }
 
-// Typography overrides keep the chat-tuned look; fenced code blocks stay on
-// Streamdown's defaults for shiki highlighting and copy controls.
-const components: Components = {
-  a: ({ className, children, node: _node, ...rest }) => (
+function MarkdownLink({
+  className,
+  children,
+  node: _node,
+  href,
+  ...rest
+}: React.ComponentProps<'a'> & { node?: unknown }): React.ReactNode {
+  const isFragment = href?.[0] === '#';
+  const fragmentHref = isFragment ? `#${SANITIZED_HEADING_PREFIX}${href.slice(1)}` : undefined;
+  return (
     <a
       {...rest}
       className={cn('text-primary underline underline-offset-2 hover:opacity-80', className)}
-      target="_blank"
-      rel="noreferrer"
+      href={fragmentHref ?? href}
+      target={isFragment ? undefined : '_blank'}
+      rel={isFragment ? undefined : 'noreferrer'}
+      onClick={
+        fragmentHref
+          ? (event) => {
+              const target = event.currentTarget.ownerDocument.getElementById(
+                fragmentHref.slice(1),
+              );
+              if (target) {
+                event.preventDefault();
+                target.scrollIntoView({ block: 'start' });
+              }
+            }
+          : undefined
+      }
     >
       {children}
     </a>
-  ),
+  );
+}
+
+// Typography overrides keep the chat-tuned look; fenced code blocks stay on
+// Streamdown's defaults for shiki highlighting and copy controls.
+const components: Components = {
+  a: MarkdownLink,
   p: ({ className, children, node: _node, ...rest }) => (
     <p className={cn('my-2 first:mt-0 last:mb-0', className)} {...rest}>
       {children}
@@ -142,6 +170,12 @@ const artifactRenderers = [
   { language: artifactFenceLanguages(), component: ArtifactFenceRenderer },
 ];
 
+// Generate heading IDs before Streamdown's sanitizer so its DOM-clobbering prefix remains intact.
+const markdownRehypePlugins = [
+  rehypeSlug,
+  ...Object.values(defaultRehypePlugins),
+] satisfies NonNullable<StreamdownProps['rehypePlugins']>;
+
 const INSTANT_STREAM_ANIMATION = {
   duration: 0,
   stagger: 0,
@@ -174,6 +208,7 @@ export function Markdown({ children, className, animated }: MarkdownProps): Reac
       components={components}
       animated={animated}
       plugins={plugins}
+      rehypePlugins={markdownRehypePlugins}
     >
       {children}
     </Streamdown>

--- a/packages/presentation/ui/src/chat/markdown.tsx
+++ b/packages/presentation/ui/src/chat/markdown.tsx
@@ -1,5 +1,6 @@
 import { cjk } from '@streamdown/cjk';
 import { createCodePlugin } from '@streamdown/code';
+import { createContext, useContext, useId } from 'react';
 import rehypeSlug from 'rehype-slug';
 import type { Components, PluginConfig, StreamdownProps } from 'streamdown';
 import { defaultRehypePlugins, Streamdown } from 'streamdown';
@@ -12,7 +13,9 @@ import { artifactFenceLanguages } from './artifacts/registry';
 import { useSmoothText } from './smooth-text-controller';
 
 const INLINE_CODE_CLASS = 'rounded bg-muted px-1 py-0.5 font-mono text-[0.85em]';
+const NON_WORD_RE = /\W/g;
 const SANITIZED_HEADING_PREFIX = 'user-content-';
+const MarkdownHeadingPrefixContext = createContext<string | null>(null);
 
 /** Inline code, upgraded to a file link when the span is a viewer-openable path and
  * the host wires `openFile` (degrades to plain code everywhere else). */
@@ -55,8 +58,12 @@ function MarkdownLink({
   href,
   ...rest
 }: React.ComponentProps<'a'> & { node?: unknown }): React.ReactNode {
+  const headingPrefix = useContext(MarkdownHeadingPrefixContext);
   const isFragment = href?.[0] === '#';
-  const fragmentHref = isFragment ? `#${SANITIZED_HEADING_PREFIX}${href.slice(1)}` : undefined;
+  const fragmentHref =
+    isFragment && headingPrefix
+      ? `#${SANITIZED_HEADING_PREFIX}${headingPrefix}${href.slice(1)}`
+      : undefined;
   return (
     <a
       {...rest}
@@ -170,11 +177,23 @@ const artifactRenderers = [
   { language: artifactFenceLanguages(), component: ArtifactFenceRenderer },
 ];
 
-// Generate heading IDs before Streamdown's sanitizer so its DOM-clobbering prefix remains intact.
-const markdownRehypePlugins = [
-  rehypeSlug,
-  ...Object.values(defaultRehypePlugins),
-] satisfies NonNullable<StreamdownProps['rehypePlugins']>;
+type RehypePlugins = NonNullable<StreamdownProps['rehypePlugins']>;
+
+const defaultRehypePluginNames = Object.keys(defaultRehypePlugins);
+const rawRehypePluginIndex = defaultRehypePluginNames.indexOf('raw');
+
+function createMarkdownRehypePlugins(headingPrefix: string): RehypePlugins {
+  if (rawRehypePluginIndex < 0) {
+    throw new Error('Streamdown raw HTML parsing is required for Markdown heading anchors');
+  }
+  const defaults = Object.values(defaultRehypePlugins);
+  const headingSlugPlugin: RehypePlugins[number] = [rehypeSlug, { prefix: headingPrefix }];
+  return [
+    ...defaults.slice(0, rawRehypePluginIndex + 1),
+    headingSlugPlugin,
+    ...defaults.slice(rawRehypePluginIndex + 1),
+  ];
+}
 
 const INSTANT_STREAM_ANIMATION = {
   duration: 0,
@@ -185,14 +204,22 @@ interface MarkdownProps {
   children: string;
   className?: string;
   animated?: StreamdownProps['animated'];
+  headingAnchors?: boolean;
 }
 
 interface SmoothMarkdownProps extends MarkdownProps {
   isStreaming: boolean;
 }
 
-export function Markdown({ children, className, animated }: MarkdownProps): React.ReactNode {
+export function Markdown({
+  children,
+  className,
+  animated,
+  headingAnchors = false,
+}: MarkdownProps): React.ReactNode {
   const { codeTheme } = useRenderPrefs();
+  const markdownId = useId();
+  const headingPrefix = `markdown-${markdownId.replaceAll(NON_WORD_RE, '')}-`;
   // The @streamdown/code plugin's getThemes() wins over the shikiTheme prop, so the selected theme
   // must be baked into the plugin. createCodePlugin is cheap — its highlighter is created lazily.
   const plugins: PluginConfig = {
@@ -200,7 +227,7 @@ export function Markdown({ children, className, animated }: MarkdownProps): Reac
     code: createCodePlugin({ themes: codeTheme }),
     renderers: artifactRenderers,
   };
-  return (
+  const content = (
     <Streamdown
       // space-y-0: block rhythm comes from the per-element my-* overrides above,
       // matching the previous react-markdown renderer.
@@ -208,10 +235,18 @@ export function Markdown({ children, className, animated }: MarkdownProps): Reac
       components={components}
       animated={animated}
       plugins={plugins}
-      rehypePlugins={markdownRehypePlugins}
+      mode={headingAnchors ? 'static' : undefined}
+      rehypePlugins={headingAnchors ? createMarkdownRehypePlugins(headingPrefix) : undefined}
     >
       {children}
     </Streamdown>
+  );
+  return headingAnchors ? (
+    <MarkdownHeadingPrefixContext.Provider value={headingPrefix}>
+      {content}
+    </MarkdownHeadingPrefixContext.Provider>
+  ) : (
+    content
   );
 }
 

--- a/packages/presentation/ui/src/chat/markdown.tsx
+++ b/packages/presentation/ui/src/chat/markdown.tsx
@@ -1,9 +1,12 @@
 import { cjk } from '@streamdown/cjk';
 import { createCodePlugin } from '@streamdown/code';
+import type { Root } from 'hast';
 import { createContext, useContext, useId } from 'react';
 import rehypeSlug from 'rehype-slug';
 import type { Components, PluginConfig, StreamdownProps } from 'streamdown';
 import { defaultRehypePlugins, Streamdown } from 'streamdown';
+import type { Plugin } from 'unified';
+import { visit } from 'unist-util-visit';
 import { cn } from '../lib/cn';
 import { useRenderPrefs } from '../render-prefs';
 import { ArtifactFenceRenderer } from './artifacts/fence-renderer';
@@ -15,7 +18,23 @@ import { useSmoothText } from './smooth-text-controller';
 const INLINE_CODE_CLASS = 'rounded bg-muted px-1 py-0.5 font-mono text-[0.85em]';
 const NON_WORD_RE = /\W/g;
 const SANITIZED_HEADING_PREFIX = 'user-content-';
+const HEADING_TAG_NAMES = new Set(['h1', 'h2', 'h3', 'h4', 'h5', 'h6']);
 const MarkdownHeadingPrefixContext = createContext<string | null>(null);
+
+interface HeadingIdPrefixOptions {
+  prefix: string;
+}
+
+const prefixExplicitHeadingIds: Plugin<[HeadingIdPrefixOptions], Root> =
+  ({ prefix }) =>
+  (tree) => {
+    visit(tree, 'element', (node) => {
+      const id = node.properties.id;
+      if (HEADING_TAG_NAMES.has(node.tagName) && typeof id === 'string' && id.length > 0) {
+        node.properties.id = `${prefix}${id}`;
+      }
+    });
+  };
 
 /** Inline code, upgraded to a file link when the span is a viewer-openable path and
  * the host wires `openFile` (degrades to plain code everywhere else). */
@@ -199,9 +218,14 @@ function createMarkdownRehypePlugins(headingPrefix: string): RehypePlugins {
     throw new Error('Streamdown raw HTML parsing is required for Markdown heading anchors');
   }
   const defaults = Object.values(defaultRehypePlugins);
+  const explicitHeadingIdPlugin: RehypePlugins[number] = [
+    prefixExplicitHeadingIds,
+    { prefix: headingPrefix },
+  ];
   const headingSlugPlugin: RehypePlugins[number] = [rehypeSlug, { prefix: headingPrefix }];
   return [
     ...defaults.slice(0, rawRehypePluginIndex + 1),
+    explicitHeadingIdPlugin,
     headingSlugPlugin,
     ...defaults.slice(rawRehypePluginIndex + 1),
   ];

--- a/packages/presentation/ui/src/chat/markdown.tsx
+++ b/packages/presentation/ui/src/chat/markdown.tsx
@@ -79,7 +79,19 @@ function MarkdownLink({
               );
               if (target) {
                 event.preventDefault();
-                target.scrollIntoView({ block: 'start' });
+                const scrollContainer = event.currentTarget.closest<HTMLElement>(
+                  '[data-markdown-scroll-container]',
+                );
+                if (!scrollContainer) {
+                  target.scrollIntoView({ block: 'start' });
+                  return;
+                }
+                scrollContainer.scrollTo({
+                  top:
+                    scrollContainer.scrollTop +
+                    target.getBoundingClientRect().top -
+                    scrollContainer.getBoundingClientRect().top,
+                });
               }
             }
           : undefined

--- a/packages/presentation/ui/src/shell/files/file-viewer.tsx
+++ b/packages/presentation/ui/src/shell/files/file-viewer.tsx
@@ -62,7 +62,10 @@ export function FileViewer({
   switch (kind) {
     case 'markdown':
       return (
-        <div className={cn('h-full overflow-y-auto px-6 py-5', className)}>
+        <div
+          data-markdown-scroll-container
+          className={cn('h-full overflow-y-auto px-6 py-5', className)}
+        >
           <Markdown headingAnchors className="mx-auto max-w-3xl">
             {file.content}
           </Markdown>

--- a/packages/presentation/ui/src/shell/files/file-viewer.tsx
+++ b/packages/presentation/ui/src/shell/files/file-viewer.tsx
@@ -63,7 +63,9 @@ export function FileViewer({
     case 'markdown':
       return (
         <div className={cn('h-full overflow-y-auto px-6 py-5', className)}>
-          <Markdown className="mx-auto max-w-3xl">{file.content}</Markdown>
+          <Markdown headingAnchors className="mx-auto max-w-3xl">
+            {file.content}
+          </Markdown>
         </div>
       );
     case 'image':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1154,6 +1154,9 @@ importers:
       react-native-safe-area-context:
         specifier: '>=5.0.0'
         version: 5.7.0(react-native@0.86.0(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.7))(react@19.2.7)
+      rehype-slug:
+        specifier: ^6.0.0
+        version: 6.0.0
       remark-gfm:
         specifier: ^4.0.1
         version: 4.0.1
@@ -7773,6 +7776,9 @@ packages:
   github-from-package@0.0.0:
     resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
 
+  github-slugger@2.0.0:
+    resolution: {integrity: sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==}
+
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
@@ -7858,6 +7864,9 @@ packages:
   hast-util-from-parse5@8.0.3:
     resolution: {integrity: sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==}
 
+  hast-util-heading-rank@3.0.0:
+    resolution: {integrity: sha512-EJKb8oMUXVHcWZTDepnr+WNbfnXKFNf9duMesmr4S8SXTJBJ9M4Yok08pu9vxdJwdlGRhVumk9mEhkEvKGifwA==}
+
   hast-util-parse-selector@4.0.0:
     resolution: {integrity: sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==}
 
@@ -7875,6 +7884,9 @@ packages:
 
   hast-util-to-parse5@8.0.1:
     resolution: {integrity: sha512-MlWT6Pjt4CG9lFCjiz4BH7l9wmrMkfkJYCxFwKQic8+RTZgWPuWxwAfjJElsXkex7DJjfSJsQIt931ilUgmwdA==}
+
+  hast-util-to-string@3.0.1:
+    resolution: {integrity: sha512-XelQVTDWvqcl3axRfI0xSeoVKzyIFPwsAGSLIsKdJKQMXDYJS4WYrBNF/8J7RdhIcFI2BOHgAifggsvsxp/3+A==}
 
   hast-util-whitespace@3.0.0:
     resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
@@ -9850,6 +9862,9 @@ packages:
 
   rehype-sanitize@6.0.0:
     resolution: {integrity: sha512-CsnhKNsyI8Tub6L4sm5ZFsme4puGfc6pYylvXo1AeqaGbjOYyzNv3qZPwvs0oMJ39eryyeOdmxwUIo94IpEhqg==}
+
+  rehype-slug@6.0.0:
+    resolution: {integrity: sha512-lWyvf/jwu+oS5+hL5eClVd3hNdmwM1kAC0BUvEGD19pajQMIzcNUd/k9GsfQ+FfECvX+JE+e9/btsKH0EjJT6A==}
 
   remark-cjk-friendly-gfm-strikethrough@2.3.1:
     resolution: {integrity: sha512-JE3TGgouk/sy92SemNMEUhO5mNP4on04cmzOV3s3R5Dbk160ewmpM4tgPiinKKvoJ5UW2fTu7FOYsjVbusSA9w==}
@@ -18206,6 +18221,8 @@ snapshots:
 
   github-from-package@0.0.0: {}
 
+  github-slugger@2.0.0: {}
+
   glob-parent@5.1.2:
     dependencies:
       is-glob: 4.0.3
@@ -18334,6 +18351,10 @@ snapshots:
       vfile-location: 5.0.3
       web-namespaces: 2.0.1
 
+  hast-util-heading-rank@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+
   hast-util-parse-selector@4.0.0:
     dependencies:
       '@types/hast': 3.0.4
@@ -18403,6 +18424,10 @@ snapshots:
       space-separated-tokens: 2.0.2
       web-namespaces: 2.0.1
       zwitch: 2.0.4
+
+  hast-util-to-string@3.0.1:
+    dependencies:
+      '@types/hast': 3.0.4
 
   hast-util-whitespace@3.0.0:
     dependencies:
@@ -20811,6 +20836,14 @@ snapshots:
     dependencies:
       '@types/hast': 3.0.4
       hast-util-sanitize: 5.0.2
+
+  rehype-slug@6.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      github-slugger: 2.0.0
+      hast-util-heading-rank: 3.0.0
+      hast-util-to-string: 3.0.1
+      unist-util-visit: 5.1.0
 
   remark-cjk-friendly-gfm-strikethrough@2.3.1(@types/mdast@4.0.4)(micromark-util-types@2.0.2)(micromark@4.0.2)(unified@11.0.5):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1178,6 +1178,9 @@ importers:
       unified:
         specifier: ^11.0.5
         version: 11.0.5
+      unist-util-visit:
+        specifier: ^5.1.0
+        version: 5.1.0
       use-intl:
         specifier: 'catalog:'
         version: 4.13.2(react@19.2.7)
@@ -1194,6 +1197,9 @@ importers:
       '@lexical/headless':
         specifier: ^0.47.0
         version: 0.47.0(@typescript/typescript6@6.0.2)
+      '@types/hast':
+        specifier: ^3.0.5
+        version: 3.0.5
       '@types/mdast':
         specifier: ^4.0.4
         version: 4.0.4
@@ -5205,6 +5211,9 @@ packages:
 
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
+
+  '@types/hast@3.0.5':
+    resolution: {integrity: sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==}
 
   '@types/http-cache-semantics@4.2.0':
     resolution: {integrity: sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==}
@@ -14802,7 +14811,7 @@ snapshots:
       '@shikijs/primitive': 4.3.0
       '@shikijs/types': 4.3.0
       '@shikijs/vscode-textmate': 10.0.2
-      '@types/hast': 3.0.4
+      '@types/hast': 3.0.5
       hast-util-to-html: 9.0.5
 
   '@shikijs/engine-javascript@4.3.0':
@@ -14824,7 +14833,7 @@ snapshots:
     dependencies:
       '@shikijs/types': 4.3.0
       '@shikijs/vscode-textmate': 10.0.2
-      '@types/hast': 3.0.4
+      '@types/hast': 3.0.5
 
   '@shikijs/themes@4.3.0':
     dependencies:
@@ -14838,7 +14847,7 @@ snapshots:
   '@shikijs/types@4.3.0':
     dependencies:
       '@shikijs/vscode-textmate': 10.0.2
-      '@types/hast': 3.0.4
+      '@types/hast': 3.0.5
 
   '@shikijs/vscode-textmate@10.0.2': {}
 
@@ -15374,6 +15383,10 @@ snapshots:
   '@types/hammerjs@2.0.46': {}
 
   '@types/hast@3.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
+
+  '@types/hast@3.0.5':
     dependencies:
       '@types/unist': 3.0.3
 
@@ -18342,7 +18355,7 @@ snapshots:
 
   hast-util-from-parse5@8.0.3:
     dependencies:
-      '@types/hast': 3.0.4
+      '@types/hast': 3.0.5
       '@types/unist': 3.0.3
       devlop: 1.1.0
       hastscript: 9.0.1
@@ -18353,15 +18366,15 @@ snapshots:
 
   hast-util-heading-rank@3.0.0:
     dependencies:
-      '@types/hast': 3.0.4
+      '@types/hast': 3.0.5
 
   hast-util-parse-selector@4.0.0:
     dependencies:
-      '@types/hast': 3.0.4
+      '@types/hast': 3.0.5
 
   hast-util-raw@9.1.0:
     dependencies:
-      '@types/hast': 3.0.4
+      '@types/hast': 3.0.5
       '@types/unist': 3.0.3
       '@ungap/structured-clone': 1.3.1
       hast-util-from-parse5: 8.0.3
@@ -18377,13 +18390,13 @@ snapshots:
 
   hast-util-sanitize@5.0.2:
     dependencies:
-      '@types/hast': 3.0.4
+      '@types/hast': 3.0.5
       '@ungap/structured-clone': 1.3.1
       unist-util-position: 5.0.0
 
   hast-util-to-html@9.0.5:
     dependencies:
-      '@types/hast': 3.0.4
+      '@types/hast': 3.0.5
       '@types/unist': 3.0.3
       ccount: 2.0.1
       comma-separated-tokens: 2.0.3
@@ -18398,7 +18411,7 @@ snapshots:
   hast-util-to-jsx-runtime@2.3.6:
     dependencies:
       '@types/estree': 1.0.9
-      '@types/hast': 3.0.4
+      '@types/hast': 3.0.5
       '@types/unist': 3.0.3
       comma-separated-tokens: 2.0.3
       devlop: 1.1.0
@@ -18417,7 +18430,7 @@ snapshots:
 
   hast-util-to-parse5@8.0.1:
     dependencies:
-      '@types/hast': 3.0.4
+      '@types/hast': 3.0.5
       comma-separated-tokens: 2.0.3
       devlop: 1.1.0
       property-information: 7.2.0
@@ -18427,15 +18440,15 @@ snapshots:
 
   hast-util-to-string@3.0.1:
     dependencies:
-      '@types/hast': 3.0.4
+      '@types/hast': 3.0.5
 
   hast-util-whitespace@3.0.0:
     dependencies:
-      '@types/hast': 3.0.4
+      '@types/hast': 3.0.5
 
   hastscript@9.0.1:
     dependencies:
-      '@types/hast': 3.0.4
+      '@types/hast': 3.0.5
       comma-separated-tokens: 2.0.3
       hast-util-parse-selector: 4.0.0
       property-information: 7.2.0
@@ -19218,7 +19231,7 @@ snapshots:
   mdast-util-mdx-expression@2.0.1:
     dependencies:
       '@types/estree-jsx': 1.0.5
-      '@types/hast': 3.0.4
+      '@types/hast': 3.0.5
       '@types/mdast': 4.0.4
       devlop: 1.1.0
       mdast-util-from-markdown: 2.0.3
@@ -19229,7 +19242,7 @@ snapshots:
   mdast-util-mdx-jsx@3.2.0:
     dependencies:
       '@types/estree-jsx': 1.0.5
-      '@types/hast': 3.0.4
+      '@types/hast': 3.0.5
       '@types/mdast': 4.0.4
       '@types/unist': 3.0.3
       ccount: 2.0.1
@@ -19246,7 +19259,7 @@ snapshots:
   mdast-util-mdxjs-esm@2.0.1:
     dependencies:
       '@types/estree-jsx': 1.0.5
-      '@types/hast': 3.0.4
+      '@types/hast': 3.0.5
       '@types/mdast': 4.0.4
       devlop: 1.1.0
       mdast-util-from-markdown: 2.0.3
@@ -19261,7 +19274,7 @@ snapshots:
 
   mdast-util-to-hast@13.2.1:
     dependencies:
-      '@types/hast': 3.0.4
+      '@types/hast': 3.0.5
       '@types/mdast': 4.0.4
       '@ungap/structured-clone': 1.3.1
       devlop: 1.1.0
@@ -20828,18 +20841,18 @@ snapshots:
 
   rehype-raw@7.0.0:
     dependencies:
-      '@types/hast': 3.0.4
+      '@types/hast': 3.0.5
       hast-util-raw: 9.1.0
       vfile: 6.0.3
 
   rehype-sanitize@6.0.0:
     dependencies:
-      '@types/hast': 3.0.4
+      '@types/hast': 3.0.5
       hast-util-sanitize: 5.0.2
 
   rehype-slug@6.0.0:
     dependencies:
-      '@types/hast': 3.0.4
+      '@types/hast': 3.0.5
       github-slugger: 2.0.0
       hast-util-heading-rank: 3.0.0
       hast-util-to-string: 3.0.1
@@ -20890,7 +20903,7 @@ snapshots:
 
   remark-rehype@11.1.2:
     dependencies:
-      '@types/hast': 3.0.4
+      '@types/hast': 3.0.5
       '@types/mdast': 4.0.4
       mdast-util-to-hast: 13.2.1
       unified: 11.0.5


### PR DESCRIPTION
## Summary

- generate stable, document-scoped heading anchors in Markdown file previews
- handle internal fragment links inside LinkCode instead of opening the external browser
- scroll only the file preview when jumping to a heading
- prevent anchor navigation from shifting the Electron shell and window chrome
- support raw HTML headings and duplicate heading names

## Verification

- `pnpm check:ci`
- `pnpm test` — 194 files, 1,562 tests
- manually verified anchor navigation in the Electron side-panel file preview
- confirmed the preview scrolls while the surrounding shell remains fixed

Closes CODE-255