### PR TITLE
fix(engine): preserve invalid UTF-8 file bytes

### DIFF
--- a/packages/host/engine/src/__tests__/file-service.test.ts
+++ b/packages/host/engine/src/__tests__/file-service.test.ts
@@ -58,6 +58,16 @@ describe('readWorkspaceFile', () => {
     expect(Buffer.from(file.content, 'base64')).toEqual(pdf);
   });
 
+  it('returns invalid UTF-8 as base64 when the invalid byte is after the sniff window', async () => {
+    const root = makeTempDir();
+    const bytes = Buffer.concat([Buffer.alloc(8192, 0x61), Buffer.from([0xff])]);
+    writeFileSync(join(root, 'invalid.txt'), bytes);
+
+    const file = await runReadWorkspaceFile(root, 'invalid.txt');
+    expect(file.encoding).toBe('base64');
+    expect(Buffer.from(file.content, 'base64')).toEqual(bytes);
+  });
+
   it('keeps svg as utf8 text (it is XML, not binary)', async () => {
     const root = makeTempDir();
     const svg = '<svg xmlns="http://www.w3.org/2000/svg"></svg>';

--- a/packages/host/engine/src/workspace/file-service.ts
+++ b/packages/host/engine/src/workspace/file-service.ts
@@ -1,3 +1,4 @@
+import { isUtf8 } from 'node:buffer';
 import { open } from 'node:fs/promises';
 import path from 'node:path';
 import { toHostPath } from '@linkcode/common/node';
@@ -84,8 +85,8 @@ export const readWorkspaceFile: (
 
         const mimeType = MIME_BY_EXTENSION[path.extname(resolved).toLowerCase()];
         // Known-binary types (PDF, raster images) must round-trip as base64 even when no NUL lands
-        // in the sniff window — a utf8 decode would corrupt the bytes. SVG stays text (it's XML).
-        const binary = isBinary(buffer) || isBinaryMime(mimeType);
+        // in the sniff window. Invalid UTF-8 must also stay byte-exact. SVG stays text (it's XML).
+        const binary = isBinary(buffer) || !isUtf8(buffer) || isBinaryMime(mimeType);
         return {
           path: resolved,
           size: stat.size,

--- a/packages/presentation/ui/src/shell/files/__tests__/file-viewer.test.tsx
+++ b/packages/presentation/ui/src/shell/files/__tests__/file-viewer.test.tsx
@@ -1,0 +1,50 @@
+// @vitest-environment jsdom
+
+import type { WorkspaceFile } from '@linkcode/schema';
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { FileViewer } from '../file-viewer';
+
+function translateKey(key: string): string {
+  return key;
+}
+
+vi.mock('use-intl', () => ({
+  useTranslations: () => translateKey,
+}));
+
+afterEach(cleanup);
+
+function fileFixture(path: string, mimeType: string): WorkspaceFile {
+  return {
+    path,
+    size: 4,
+    mtimeMs: 1,
+    encoding: 'base64',
+    content: 'YWJj/w==',
+    mimeType,
+  };
+}
+
+describe('FileViewer', () => {
+  it.each([
+    'invalid.txt',
+    'invalid.md',
+    'invalid.json',
+  ])('does not render a base64 payload through the %s text viewer', (path) => {
+    const file = fileFixture(path, 'text/plain');
+    render(<FileViewer path={path} file={file} isLoading={false} />);
+
+    expect(screen.getByText('unsupported')).toBeTruthy();
+    expect(screen.queryByText(file.content)).toBeNull();
+  });
+
+  it('continues to render base64 images', () => {
+    const file = fileFixture('image.png', 'image/png');
+    render(<FileViewer path={file.path} file={file} isLoading={false} />);
+
+    expect(screen.getByRole('img', { name: file.path }).getAttribute('src')).toBe(
+      `data:image/png;base64,${file.content}`,
+    );
+  });
+});

--- a/packages/presentation/ui/src/shell/files/file-viewer.tsx
+++ b/packages/presentation/ui/src/shell/files/file-viewer.tsx
@@ -57,7 +57,11 @@ export function FileViewer({
     );
   }
 
-  const kind = artifactKindForPath(file.path) ?? (file.encoding === 'utf8' ? 'text' : null);
+  const pathKind = artifactKindForPath(file.path);
+  const kind =
+    file.encoding !== 'utf8' && (pathKind === 'markdown' || pathKind === 'text')
+      ? null
+      : (pathKind ?? (file.encoding === 'utf8' ? 'text' : null));
 
   switch (kind) {
     case 'markdown':


### PR DESCRIPTION
## Summary

- validate the complete workspace file buffer with Node's built-in `isUtf8`
- return invalid UTF-8 as base64 while preserving the existing NUL sniff and known-binary MIME behavior
- add a regression test for an invalid byte beyond the binary sniff window

No third-party dependency or wire schema change is required.

## Testing

- `pnpm check:ci`
- `pnpm test packages/host/engine/src/__tests__/file-service.test.ts`
- `GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null pnpm test` (194 files, 1560 tests)
