### PR TITLE
feat(ui): close file tabs with middle click

### DIFF
--- a/packages/presentation/ui/src/shell/files/__tests__/file-tabs.test.tsx
+++ b/packages/presentation/ui/src/shell/files/__tests__/file-tabs.test.tsx
@@ -31,7 +31,23 @@ describe('FileTabStrip', () => {
     );
 
     const sourceTab = screen.getByRole('button', { name: 'index.ts' });
+    const rightMouseDown = new MouseEvent('mousedown', {
+      bubbles: true,
+      button: 2,
+      cancelable: true,
+    });
+    fireEvent(sourceTab, rightMouseDown);
+    expect(rightMouseDown.defaultPrevented).toBe(false);
     fireEvent(sourceTab, new MouseEvent('auxclick', { bubbles: true, button: 2 }));
+    expect(onCloseTab).not.toHaveBeenCalled();
+
+    const middleMouseDown = new MouseEvent('mousedown', {
+      bubbles: true,
+      button: 1,
+      cancelable: true,
+    });
+    fireEvent(sourceTab, middleMouseDown);
+    expect(middleMouseDown.defaultPrevented).toBe(true);
     expect(onCloseTab).not.toHaveBeenCalled();
 
     fireEvent(sourceTab, new MouseEvent('auxclick', { bubbles: true, button: 1 }));

--- a/packages/presentation/ui/src/shell/files/__tests__/file-tabs.test.tsx
+++ b/packages/presentation/ui/src/shell/files/__tests__/file-tabs.test.tsx
@@ -1,0 +1,42 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { FileTabStrip } from '../file-tabs';
+
+function translateKey(key: string): string {
+  return key;
+}
+
+vi.mock('use-intl', () => ({
+  useTranslations: () => translateKey,
+}));
+
+afterEach(cleanup);
+
+describe('FileTabStrip', () => {
+  it('closes the targeted tab only for a middle click', () => {
+    const onSelectTab = vi.fn();
+    const onCloseTab = vi.fn();
+    render(
+      <FileTabStrip
+        tabs={[
+          { id: 'readme', path: '/repo/README.md' },
+          { id: 'source', path: '/repo/src/index.ts' },
+        ]}
+        activeTabId="readme"
+        onSelectTab={onSelectTab}
+        onCloseTab={onCloseTab}
+      />,
+    );
+
+    const sourceTab = screen.getByRole('button', { name: 'index.ts' });
+    fireEvent(sourceTab, new MouseEvent('auxclick', { bubbles: true, button: 2 }));
+    expect(onCloseTab).not.toHaveBeenCalled();
+
+    fireEvent(sourceTab, new MouseEvent('auxclick', { bubbles: true, button: 1 }));
+    expect(onCloseTab).toHaveBeenCalledOnce();
+    expect(onCloseTab).toHaveBeenCalledWith('source');
+    expect(onSelectTab).not.toHaveBeenCalled();
+  });
+});

--- a/packages/presentation/ui/src/shell/files/file-tabs.tsx
+++ b/packages/presentation/ui/src/shell/files/file-tabs.tsx
@@ -43,6 +43,7 @@ export function FileTabStrip({
             closeLabel={t('closeTab', { label })}
             onSelect={() => onSelectTab(tab.id)}
             onClose={() => onCloseTab(tab.id)}
+            onMiddleClick={() => onCloseTab(tab.id)}
           />
         );
       })}

--- a/packages/presentation/ui/src/shell/panels/section-tab-button.tsx
+++ b/packages/presentation/ui/src/shell/panels/section-tab-button.tsx
@@ -14,6 +14,7 @@ export function SectionTabButton({
   title,
   onSelect,
   onClose,
+  onMiddleClick,
 }: {
   label: string;
   icon: React.ReactNode;
@@ -23,6 +24,7 @@ export function SectionTabButton({
   title?: string;
   onSelect: () => void;
   onClose: () => void;
+  onMiddleClick?: () => void;
 }): React.ReactNode {
   return (
     <div
@@ -32,6 +34,11 @@ export function SectionTabButton({
           ? 'bg-background font-semibold text-foreground after:absolute after:inset-x-0 after:-bottom-px after:h-px after:bg-background'
           : 'text-muted-foreground hover:bg-accent hover:text-foreground',
       )}
+      onAuxClick={(event) => {
+        if (event.button !== 1 || !onMiddleClick) return;
+        event.preventDefault();
+        onMiddleClick();
+      }}
     >
       <button
         type="button"

--- a/packages/presentation/ui/src/shell/panels/section-tab-button.tsx
+++ b/packages/presentation/ui/src/shell/panels/section-tab-button.tsx
@@ -39,6 +39,9 @@ export function SectionTabButton({
         event.preventDefault();
         onMiddleClick();
       }}
+      onMouseDown={(event) => {
+        if (event.button === 1 && onMiddleClick) event.preventDefault();
+      }}
     >
       <button
         type="button"


### PR DESCRIPTION
## Summary

- close file viewer tabs on middle click without selecting them first
- keep middle-click behavior opt-in so shared terminal tabs remain unchanged
- cover middle-click close and right-click no-op with a jsdom interaction test

## Testing

- `pnpm check:ci`
- `GIT_CONFIG_GLOBAL=/dev/null pnpm test` (195 files, 1560 tests)

Closes #202