### PR TITLE
ci(desktop): move macOS build to arcbox self-hosted fleet

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -65,7 +65,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: blacksmith-6vcpu-macos-26 # arm64 (M4); Xcode 26 (actool >= 26) compiles mac.icon into Assets.car
+          - os: arcbox-macos-arm64 # arm64 macOS; host must have Xcode 26 (actool >= 26) to compile mac.icon into Assets.car
             platform: mac
           - os: blacksmith-4vcpu-windows-2025 # public beta; VS Build Tools only — enough for NSIS
             platform: win


### PR DESCRIPTION
## Summary

- Switch the desktop macOS build matrix entry from `blacksmith-6vcpu-macos-26` to `arcbox-macos-arm64`, routing the job to our self-hosted arm64 macOS runner.
- Linux and Windows matrix entries are unchanged.

## Requirements on the host

`mac.icon` → `Assets.car` still needs `actool >= 26`, so the arcbox macOS host must have Xcode 26 installed and selected (`sudo xcode-select -s /Applications/Xcode.app` or `DEVELOPER_DIR` set). The prior comment on the line has been updated to make this explicit.

Signing/notarization is unaffected — `MACOS_CSC_*`, `APPLE_API_KEY*`, and `APPLE_TEAM_ID` still come from the `release` environment.

## Test plan

- [x] Verify the arcbox macOS host has `xcodebuild -version` reporting 26.x.
- [x] Trigger `Build Desktop` via `workflow_dispatch` with `sign=false` and confirm the `Build (mac)` job runs on the arcbox runner and packages successfully.
- [ ] Cut a signed pre-release / dry run through `release-desktop.yml` with `sign=true` and confirm codesign + notarization still pass.