### PR TITLE
fix(sidebar): use disclosure chevrons

### DIFF
--- a/packages/presentation/ui/src/shell/sidebar/section-header.tsx
+++ b/packages/presentation/ui/src/shell/sidebar/section-header.tsx
@@ -4,7 +4,7 @@ import { AccordionTrigger } from 'coss-ui/components/accordion';
  * geometry to the sidebar's h-8 row, chevron pulled next to the label and centered. */
 export function SectionAccordionTrigger({ children }: React.PropsWithChildren): React.ReactNode {
   return (
-    <AccordionTrigger className="*:data-[slot=accordion-indicator]:size-3.5 *:data-[slot=accordion-indicator]:translate-y-0 h-8 items-center justify-start gap-2 rounded-lg px-2 py-0 text-xs focus-visible:ring-1 focus-visible:ring-inset">
+    <AccordionTrigger className="*:data-[slot=accordion-indicator]:-rotate-90 *:data-[slot=accordion-indicator]:size-3.5 *:data-[slot=accordion-indicator]:translate-y-0 data-panel-open:*:data-[slot=accordion-indicator]:rotate-0 h-8 items-center justify-start gap-2 rounded-lg px-2 py-0 text-xs focus-visible:ring-1 focus-visible:ring-inset">
       {children}
     </AccordionTrigger>
   );


### PR DESCRIPTION
## Summary

- point Sidebar section chevrons right when collapsed and down when expanded
- scope the override to `SectionAccordionTrigger` so the shared coss-ui accordion keeps its default up/down behavior

## Testing

- `pnpm check:ci`
- `GIT_CONFIG_GLOBAL=/dev/null pnpm test` (196 test files, 1565 tests)
- manually verified Projects and Chats in the Electron desktop renderer in expanded, collapsed, and mixed states