### PR TITLE
chore(orb): manage toolchain with devenv

### DIFF
--- a/.agents/orb/desktop-vnc
+++ b/.agents/orb/desktop-vnc
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-export PATH="$HOME/.local/bin:$HOME/.cargo/bin:$PATH"
 export LINKCODE_PROFILE=orb
 
 display=:99

--- a/.agents/resume
+++ b/.agents/resume
@@ -1,47 +1,32 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-export PATH="$HOME/.local/bin:$HOME/.cargo/bin:$PATH"
-
-node_major="$(tr -d '[:space:]' < .nvmrc)"
-
-if ! command -v node >/dev/null 2>&1 || [ "$(node -p 'process.versions.node.split(`.`)[0]' 2>/dev/null)" != "$node_major" ]; then
-  echo "Expected Node.js ${node_major}; rerun .agents/setup" >&2
+if [ ! -r /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh ]; then
+  echo "Expected Nix; rerun .agents/setup" >&2
   exit 1
 fi
 
-pnpm_version="$(node -p 'require(`./package.json`).packageManager.split(`@`)[1]')"
-if ! command -v pnpm >/dev/null 2>&1 || [ "$(pnpm --version 2>/dev/null)" != "$pnpm_version" ]; then
-  echo "Expected pnpm ${pnpm_version}; rerun .agents/setup" >&2
+. /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
+export PATH="$HOME/.nix-profile/bin:$PATH"
+
+if ! nix --extra-experimental-features nix-command store info >/dev/null 2>&1; then
+  echo "Nix is present but unusable; rerun .agents/setup" >&2
   exit 1
 fi
 
-mkdir -p "$HOME/.local/bin"
-for executable in cargo cargo-clippy cargo-fmt clippy-driver rustc rustdoc rustfmt rustup; do
-  if [ -x "$HOME/.cargo/bin/$executable" ]; then
-    ln -sfn "$HOME/.cargo/bin/$executable" "$HOME/.local/bin/$executable"
-  fi
-done
-
-for executable in rustup cargo rustc rustfmt; do
-  if ! command -v "$executable" >/dev/null 2>&1 || ! "$executable" --version >/dev/null 2>&1; then
-    echo "Expected stable Rust with rustfmt and Clippy; rerun .agents/setup" >&2
-    exit 1
-  fi
-done
-if ! cargo clippy --version >/dev/null 2>&1 || [[ "$(rustup show active-toolchain 2>/dev/null)" != stable-* ]]; then
-  echo "Expected stable Rust with rustfmt and Clippy; rerun .agents/setup" >&2
+if ! command -v devenv >/dev/null 2>&1 || ! devenv version >/dev/null 2>&1; then
+  echo "Expected devenv; rerun .agents/setup" >&2
   exit 1
 fi
 
 if [ ! -x target/release/linkcode-pty ]; then
   echo "Rebuilding the missing terminal PTY sidecar"
-  pnpm -F @linkcode/daemon run build:rust
+  devenv shell -- pnpm -F @linkcode/daemon run build:rust
 fi
 
 if [ ! -f apps/daemon/dist/index.js ]; then
   echo "Rebuilding the missing daemon bundle"
-  pnpm -F @linkcode/daemon run build
+  devenv shell -- pnpm -F @linkcode/daemon run build
 fi
 
 echo "Ensuring supervised Orb development services are running"

--- a/.agents/setup
+++ b/.agents/setup
@@ -44,8 +44,9 @@ fi
 
 if ! command -v devenv >/dev/null 2>&1; then
   echo "==> Installing devenv"
+  nixpkgs_revision="$(python3 -c 'import json; print(json.load(open("devenv.lock"))["nodes"]["nixpkgs-src"]["locked"]["rev"])')"
   nix-env --install --attr devenv \
-    -f https://github.com/NixOS/nixpkgs/tarball/nixpkgs-unstable
+    -f "https://github.com/NixOS/nixpkgs/archive/${nixpkgs_revision}.tar.gz"
 fi
 
 echo "==> Installing JavaScript dependencies"

--- a/.agents/setup
+++ b/.agents/setup
@@ -2,7 +2,6 @@
 set -euo pipefail
 
 export DEBIAN_FRONTEND=noninteractive
-export PATH="$HOME/.local/bin:$HOME/.cargo/bin:$PATH"
 
 echo "==> Installing native build prerequisites"
 sudo apt-get update -qq
@@ -28,79 +27,41 @@ sudo env DEBIAN_FRONTEND=noninteractive apt-get install -y -qq \
   xz-utils \
   xvfb
 
-node_major="$(tr -d '[:space:]' < .nvmrc)"
-case "$(uname -m)" in
-  x86_64) node_arch="x64" ;;
-  aarch64 | arm64) node_arch="arm64" ;;
-  *) echo "Unsupported CPU architecture: $(uname -m)" >&2; exit 1 ;;
-esac
-
-if ! command -v node >/dev/null 2>&1 || [ "$(node -p 'process.versions.node.split(`.`)[0]')" != "$node_major" ]; then
-  echo "==> Installing Node.js ${node_major}"
-  node_version="$(curl -fsSL "https://nodejs.org/dist/latest-v${node_major}.x/SHASUMS256.txt" | sed -nE '1{s/.*node-(v[^-]+)-.*/\1/;p;}')"
-  node_archive="node-${node_version}-linux-${node_arch}.tar.xz"
-  node_root="$HOME/.local/share/node-${node_version}-linux-${node_arch}"
-
-  if [ ! -x "$node_root/bin/node" ] || [ ! -x "$node_root/bin/npm" ]; then
-    tmp_dir="$(mktemp -d)"
-    mkdir -p "$(dirname "$node_root")"
-    node_stage="$(mktemp -d "$(dirname "$node_root")/.node-${node_version}.XXXXXX")"
-    trap 'rm -rf "$tmp_dir" "${node_stage:-}"' EXIT
-    curl -fsSL "https://nodejs.org/dist/${node_version}/${node_archive}" -o "$tmp_dir/$node_archive"
-    curl -fsSL "https://nodejs.org/dist/${node_version}/SHASUMS256.txt" -o "$tmp_dir/SHASUMS256.txt"
-    (
-      cd "$tmp_dir"
-      grep "  ${node_archive}$" SHASUMS256.txt | sha256sum --check --status
-    )
-    tar -xJf "$tmp_dir/$node_archive" --strip-components=1 -C "$node_stage"
-    [ -x "$node_stage/bin/node" ] && [ -x "$node_stage/bin/npm" ]
-    rm -rf "$node_root"
-    mv "$node_stage" "$node_root"
-    node_stage=""
-  fi
-
-  mkdir -p "$HOME/.local/bin"
-  ln -sfn "$node_root/bin/node" "$HOME/.local/bin/node"
-  hash -r
+if [ ! -r /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh ]; then
+  echo "==> Installing Nix"
+  curl --proto '=https' --tlsv1.2 -fsSL https://artifacts.nixos.org/nix-installer \
+    | sh -s -- install --no-confirm
 fi
 
-pnpm_version="$(node -p 'require(`./package.json`).packageManager.split(`@`)[1]')"
-if ! command -v pnpm >/dev/null 2>&1 || [ "$(pnpm --version 2>/dev/null || true)" != "$pnpm_version" ]; then
-  echo "==> Installing pnpm ${pnpm_version}"
-  node_bin_dir="$(dirname "$(readlink -f "$(command -v node)")")"
-  "$node_bin_dir/npm" install --global --prefix "$HOME/.local" "pnpm@${pnpm_version}"
-  hash -r
+. /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
+export PATH="$HOME/.nix-profile/bin:$PATH"
+
+if ! nix --extra-experimental-features nix-command store info >/dev/null 2>&1; then
+  echo "Nix is present but unusable; the installation may be incomplete." >&2
+  echo "Run /nix/nix-installer uninstall --no-confirm, then rerun .agents/setup." >&2
+  exit 1
 fi
 
-if [ ! -x "$HOME/.cargo/bin/rustup" ]; then
-  echo "==> Installing stable Rust"
-  curl --proto '=https' --tlsv1.2 -fsSL https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain none
+if ! command -v devenv >/dev/null 2>&1; then
+  echo "==> Installing devenv"
+  nix-env --install --attr devenv \
+    -f https://github.com/NixOS/nixpkgs/tarball/nixpkgs-unstable
 fi
-
-echo "==> Installing the stable Rust toolchain"
-"$HOME/.cargo/bin/rustup" toolchain install stable --profile minimal --component clippy,rustfmt
-"$HOME/.cargo/bin/rustup" default stable
-
-mkdir -p "$HOME/.local/bin"
-for executable in cargo cargo-clippy cargo-fmt clippy-driver rustc rustdoc rustfmt rustup; do
-  [ -x "$HOME/.cargo/bin/$executable" ] || continue
-  ln -sfn "$HOME/.cargo/bin/$executable" "$HOME/.local/bin/$executable"
-done
 
 echo "==> Installing JavaScript dependencies"
-pnpm install --frozen-lockfile
+devenv shell -- pnpm install --frozen-lockfile
 
 echo "==> Ensuring the Electron runtime is downloaded"
-pnpm exec electron --version >/dev/null
+devenv shell -- pnpm exec electron --version >/dev/null
 
 echo "==> Fetching Rust dependencies"
-cargo fetch --locked
+devenv shell -- cargo fetch --locked
 
 echo "==> Building the terminal PTY sidecar"
-pnpm -F @linkcode/daemon run build:rust
+devenv shell -- pnpm -F @linkcode/daemon run build:rust
 
 echo "==> Building the daemon bundle required by Electron development"
-pnpm -F @linkcode/daemon run build
+devenv shell -- pnpm -F @linkcode/daemon run build
 
 echo "==> Starting supervised Orb development services"
 amp orb services ensure

--- a/.amp/services.yaml
+++ b/.amp/services.yaml
@@ -1,13 +1,17 @@
 services:
   linkcode-daemon:
     command: >-
-      export PATH="$HOME/.local/bin:$HOME/.cargo/bin:$PATH";
+      . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh;
+      export PATH="$HOME/.nix-profile/bin:$PATH";
       export LINKCODE_PROFILE=orb;
       export LINKCODE_PTY_SIDECAR_PATH="$PWD/target/release/linkcode-pty";
-      exec pnpm -F @linkcode/daemon run dev
+      exec devenv shell -- pnpm -F @linkcode/daemon run dev
 
   linkcode-desktop-vnc:
-    command: exec .agents/orb/desktop-vnc
+    command: >-
+      . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh;
+      export PATH="$HOME/.nix-profile/bin:$PATH";
+      exec devenv shell -- .agents/orb/desktop-vnc
     access: same-as-thread
     portal:
       title: LinkCode Electron Desktop
@@ -15,8 +19,9 @@ services:
 
   linkcode-devtools:
     command: >-
-      export PATH="$HOME/.local/bin:$PATH";
-      exec node .agents/orb/cdp-proxy.cjs
+      . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh;
+      export PATH="$HOME/.nix-profile/bin:$PATH";
+      exec devenv shell -- node .agents/orb/cdp-proxy.cjs
     access: same-as-thread
     portal:
       title: LinkCode DevTools

--- a/devenv.nix
+++ b/devenv.nix
@@ -4,6 +4,8 @@
 }:
 
 {
+  dotenv.disableHint = true;
+
   packages = [
     pkgs.git
     pkgs.prek
@@ -20,7 +22,8 @@
     corepack.enable = false;
     pnpm = {
       enable = true;
-      install.enable = true;
+      # Orb setup owns the frozen install; shell activation must stay side-effect free.
+      install.enable = false;
     };
   };
   languages.typescript.enable = true;

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -30,7 +30,7 @@ pnpm install
 ### Daemon + desktop together
 
 ```bash
-devenv run app
+devenv shell -- app
 ```
 
 `app` first builds the Rust PTY sidecar, then starts the daemon and desktop dev processes in parallel. Without `devenv`, run the same sequence:
@@ -45,7 +45,7 @@ Root `pnpm dev` (= `turbo run dev`) is different: it starts the three persistent
 ### Daemon only
 
 ```bash
-devenv run daemon
+devenv shell -- daemon
 # without devenv:
 pnpm -F @linkcode/daemon run build:rust
 pnpm -F @linkcode/daemon run dev
@@ -54,7 +54,7 @@ pnpm -F @linkcode/daemon run dev
 ### Desktop only
 
 ```bash
-devenv run desktop
+devenv shell -- desktop
 # without devenv:
 pnpm -F @linkcode/desktop run dev   # scripts/dev.mts: vite builds + dev server + electron
 ```


### PR DESCRIPTION
## Summary

- install Nix and devenv during Orb setup, then run pnpm and Rust setup/build commands inside the project-locked environment
- launch daemon, desktop VNC, and DevTools services through devenv while retaining Amp service supervision
- keep resume lightweight, disable automatic pnpm installation during shell activation, and correct devenv commands in the development runbook

## Validation

- `.agents/setup` warm path: 9.84s
- `.agents/resume`: 0.90s
- daemon `GET /linkcode` returned the `orb` profile after a supervised restart
- VNC portal returned HTTP 200; DevTools portal returned HTTP 302
- `pnpm check:ci`
- `GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_NOSYSTEM=1 pnpm test` — 196 files, 1565 tests

The Git config isolation is needed in this Orb because its global `insteadOf` rule rewrites the SSH remote used by one git fixture to HTTPS. A second fresh Orb has not yet been created to measure the full cold setup path; the Nix/devenv cold path was exercised independently before this integration.