### PR TITLE
fix(ui): replace hand-rolled components with shared coss-ui primitives

### DIFF
--- a/packages/presentation/ui/src/chat/web-preview.tsx
+++ b/packages/presentation/ui/src/chat/web-preview.tsx
@@ -3,6 +3,7 @@ import {
   CollapsibleContent,
   CollapsibleTrigger,
 } from 'coss-ui/components/collapsible';
+import { InputGroup, InputGroupAddon, InputGroupInput } from 'coss-ui/components/input-group';
 import { ChevronRightIcon, ExternalLinkIcon, GlobeIcon, RotateCwIcon } from 'lucide-react';
 import { useState } from 'react';
 import { cn } from '../lib/cn';
@@ -129,20 +130,19 @@ export function WebPreviewUrl({
   ...props
 }: WebPreviewUrlProps): React.ReactNode {
   return (
-    <span className="flex h-7 min-w-0 flex-1 items-center gap-1.5 rounded-full border border-input bg-background px-3 shadow-xs/5 transition-shadow focus-within:border-ring focus-within:ring-[3px] focus-within:ring-ring/24 dark:bg-input/32">
-      <GlobeIcon className="size-3.5 shrink-0 text-muted-foreground" />
-      <input
-        className={cn(
-          'min-w-0 flex-1 bg-transparent font-mono text-[12px] text-foreground outline-none placeholder:text-muted-foreground/72',
-          className,
-        )}
+    <InputGroup className="h-7 flex-1 rounded-full before:rounded-full">
+      <InputGroupAddon>
+        <GlobeIcon className="size-3.5 text-muted-foreground" />
+      </InputGroupAddon>
+      <InputGroupInput
+        className={cn('font-mono text-[12px] placeholder:text-muted-foreground/72', className)}
         onKeyDown={(event) => {
           if (event.key === 'Enter') onCommit?.(event.currentTarget.value);
         }}
         spellCheck={false}
         {...props}
       />
-    </span>
+    </InputGroup>
   );
 }
 

--- a/packages/presentation/ui/src/shell/composer-editor/__tests__/composer-editor-dom.test.ts
+++ b/packages/presentation/ui/src/shell/composer-editor/__tests__/composer-editor-dom.test.ts
@@ -14,7 +14,7 @@ describe('composer chip DOM export', () => {
     const editor = createHeadlessEditor({
       namespace: 'composer-editor-dom-test',
       nodes: COMPOSER_EDITOR_NODES,
-      onError(error) {
+      onError(error: Error) {
         throw error;
       },
     });

--- a/packages/presentation/ui/src/shell/notifications-settings-panel.tsx
+++ b/packages/presentation/ui/src/shell/notifications-settings-panel.tsx
@@ -1,6 +1,6 @@
-import { Field, FieldDescription, FieldLabel } from 'coss-ui/components/field';
 import { Switch } from 'coss-ui/components/switch';
 import { useTranslations } from 'use-intl';
+import { SettingsCard, SettingsRow } from './settings-page';
 
 export type NotificationToggleKey = 'enabled' | 'turnCompleted' | 'awaitingApproval' | 'error';
 
@@ -25,70 +25,42 @@ export function NotificationsSettingsPanel({
   const t = useTranslations('settings.notifications');
 
   return (
-    <div className="flex flex-col gap-6">
-      <Field>
-        <div className="flex items-center justify-between gap-4">
-          <div className="flex flex-col gap-1">
-            <FieldLabel>{t('enable')}</FieldLabel>
-            <FieldDescription>{t('enableHint')}</FieldDescription>
-          </div>
+    <div className="flex flex-col gap-8">
+      <SettingsCard>
+        <SettingsRow title={t('enable')} description={t('enableHint')}>
           <Switch checked={enabled} onCheckedChange={(value) => onChange('enabled', value)} />
-        </div>
+        </SettingsRow>
         {permission === 'denied' ? (
-          <p className="mt-1 text-destructive text-sm">{t('permissionDenied')}</p>
+          <p className="px-4 py-3 text-destructive text-xs">{t('permissionDenied')}</p>
         ) : null}
         {enabled && permission === 'default' ? (
-          <p className="mt-1 text-muted-foreground text-sm">{t('permissionRequest')}</p>
+          <p className="px-4 py-3 text-muted-foreground text-xs">{t('permissionRequest')}</p>
         ) : null}
-      </Field>
+      </SettingsCard>
 
-      <div className="flex flex-col gap-4 rounded-lg border border-border p-4">
-        <ReasonToggle
-          label={t('turnCompleted')}
-          hint={t('turnCompletedHint')}
-          checked={turnCompleted}
-          disabled={!enabled}
-          onChange={(value) => onChange('turnCompleted', value)}
-        />
-        <ReasonToggle
-          label={t('awaitingApproval')}
-          hint={t('awaitingApprovalHint')}
-          checked={awaitingApproval}
-          disabled={!enabled}
-          onChange={(value) => onChange('awaitingApproval', value)}
-        />
-        <ReasonToggle
-          label={t('error')}
-          hint={t('errorHint')}
-          checked={error}
-          disabled={!enabled}
-          onChange={(value) => onChange('error', value)}
-        />
-      </div>
-    </div>
-  );
-}
-
-function ReasonToggle({
-  label,
-  hint,
-  checked,
-  disabled,
-  onChange,
-}: {
-  label: string;
-  hint: string;
-  checked: boolean;
-  disabled: boolean;
-  onChange: (value: boolean) => void;
-}): React.ReactNode {
-  return (
-    <div className="flex items-center justify-between gap-4">
-      <div className="flex flex-col gap-0.5">
-        <span className="font-medium text-sm">{label}</span>
-        <span className="text-muted-foreground text-xs">{hint}</span>
-      </div>
-      <Switch checked={checked} disabled={disabled} onCheckedChange={onChange} />
+      <SettingsCard>
+        <SettingsRow title={t('turnCompleted')} description={t('turnCompletedHint')}>
+          <Switch
+            checked={turnCompleted}
+            disabled={!enabled}
+            onCheckedChange={(value) => onChange('turnCompleted', value)}
+          />
+        </SettingsRow>
+        <SettingsRow title={t('awaitingApproval')} description={t('awaitingApprovalHint')}>
+          <Switch
+            checked={awaitingApproval}
+            disabled={!enabled}
+            onCheckedChange={(value) => onChange('awaitingApproval', value)}
+          />
+        </SettingsRow>
+        <SettingsRow title={t('error')} description={t('errorHint')}>
+          <Switch
+            checked={error}
+            disabled={!enabled}
+            onCheckedChange={(value) => onChange('error', value)}
+          />
+        </SettingsRow>
+      </SettingsCard>
     </div>
   );
 }

--- a/packages/presentation/ui/src/shell/providers/account-master-list.tsx
+++ b/packages/presentation/ui/src/shell/providers/account-master-list.tsx
@@ -1,4 +1,5 @@
 import type { AgentKind } from '@linkcode/schema';
+import { Badge } from 'coss-ui/components/badge';
 import { Button } from 'coss-ui/components/button';
 import { Input } from 'coss-ui/components/input';
 import { Skeleton } from 'coss-ui/components/skeleton';
@@ -114,17 +115,18 @@ export function AccountMasterList({
                   </span>
                   <span className="mt-1 flex flex-wrap gap-1">
                     {account.boundAgents.length === 0 ? (
-                      <span className="rounded-full border border-border border-dashed px-1.5 text-[10px] text-muted-foreground leading-4">
+                      <Badge
+                        variant="outline"
+                        size="sm"
+                        className="rounded-full border-dashed text-muted-foreground"
+                      >
                         {t('unbound')}
-                      </span>
+                      </Badge>
                     ) : (
                       account.boundAgents.map((kind) => (
-                        <span
-                          key={kind}
-                          className="rounded-full border border-border bg-background px-1.5 text-[10px] leading-4"
-                        >
+                        <Badge key={kind} variant="outline" size="sm" className="rounded-full">
                           {tAgent(kind)}
-                        </span>
+                        </Badge>
                       ))
                     )}
                   </span>
@@ -150,9 +152,13 @@ export function AccountMasterList({
                       <span className="truncate font-medium text-sm">
                         {t(`serviceName.${login.service}`)}
                       </span>
-                      <span className="rounded-full border border-border px-1.5 text-[10px] text-muted-foreground leading-4">
+                      <Badge
+                        variant="outline"
+                        size="sm"
+                        className="rounded-full text-muted-foreground"
+                      >
                         {t('detected')}
-                      </span>
+                      </Badge>
                     </span>
                     <span className="block truncate text-muted-foreground text-xs">
                       {login.email ?? t('loggedIn')}


### PR DESCRIPTION
Closes CODE-357.

Several settings/provider surfaces hand-rolled UI that the shared primitives already cover, so they looked inconsistent with the rest of Settings (user-reported: the Notifications tab).

## Changes (`dbf962d2`)
- **notifications-settings-panel** → shared `SettingsCard`/`SettingsRow`, matching the other Settings tabs (was a custom `Field` + bordered box + private toggle helper). Browser-permission note kept as a full-width row inside the first card.
- **providers/account-master-list** → bound / unbound / detected chips now use `Badge variant="outline"` (its sibling `account-detail` already renders the same chip concept with `Badge`).
- **chat/web-preview** → the address bar now composes `InputGroup` + `InputGroupAddon` + `InputGroupInput` instead of re-implementing the input tokens by hand.

## Drive-by unblock (`e9974d59`)
`composer-editor/__tests__/composer-editor-dom.test.ts` — `onError(error)` had an implicit `any` (surfaced by the #214 @types/node 24→26 / lexical bumps), which failed the whole-repo prek typecheck hook and blocked every commit. Annotated `error: Error` to match the library's `onError(error: Error, editor)` signature.

## Notes
- `agents-settings.tsx → SettingsCard` was intentionally left out — a concurrent Settings-shell refactor also edits that file; the swap rides with that work.
- Static gates green (typecheck / lint / format). The 3 presentation files are pure view swaps with no unit tests importing them.