### PR TITLE
ci(workflows): select runners via repo vars with hosted fallbacks

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -63,13 +63,18 @@ jobs:
     environment: ${{ inputs.sign && 'release' || '' }}
     strategy:
       fail-fast: false
+      # Runners resolve through repo/org `vars` (ArcBox pins Blacksmith labels there); forks
+      # fall back to GitHub-hosted images. Whatever the source, each platform keeps its floor:
+      # mac needs arm64 + Xcode 26 (actool >= 26 compiles mac.icon into Assets.car), windows
+      # needs VS Build Tools (enough for NSIS), linux stays on 22.04-era glibc so AppImages
+      # stay broadly compatible.
       matrix:
         include:
-          - os: blacksmith-6vcpu-macos-26 # arm64 (M4); Xcode 26 (actool >= 26) compiles mac.icon into Assets.car
+          - os: ${{ vars.CI_RUNNER_MACOS || 'macos-26' }}
             platform: mac
-          - os: blacksmith-4vcpu-windows-2025 # public beta; VS Build Tools only — enough for NSIS
+          - os: ${{ vars.CI_RUNNER_WINDOWS || 'windows-2025' }}
             platform: win
-          - os: blacksmith-4vcpu-ubuntu-2204 # older glibc => broader AppImage compatibility
+          - os: ${{ vars.CI_RUNNER_LINUX_PACKAGING || 'ubuntu-22.04' }}
             platform: linux
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,8 @@ on:
           - Dry Run
           - Release
 
+# Runners resolve through repo/org `vars` (ArcBox pins paid Blacksmith labels there);
+# forks without the vars fall back to GitHub-hosted labels with zero setup.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -29,7 +31,7 @@ env:
 jobs:
   typescript:
     name: TypeScript
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_LINUX || 'ubuntu-latest' }}
     timeout-minutes: 30
 
     steps:
@@ -83,7 +85,7 @@ jobs:
 
   desktop:
     name: Desktop App Entry
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_LINUX || 'ubuntu-latest' }}
     timeout-minutes: 30
 
     steps:
@@ -130,7 +132,7 @@ jobs:
 
   webview:
     name: Webview Browser Entry
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_LINUX || 'ubuntu-latest' }}
     timeout-minutes: 20
 
     steps:
@@ -157,7 +159,7 @@ jobs:
 
   mobile:
     name: Mobile Native Bundles
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_LINUX || 'ubuntu-latest' }}
     timeout-minutes: 20
 
     steps:
@@ -181,7 +183,7 @@ jobs:
 
   rust:
     name: Rust
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_LINUX || 'ubuntu-latest' }}
     timeout-minutes: 20
 
     steps:
@@ -207,7 +209,7 @@ jobs:
 
   all-green:
     name: All Green
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_LINUX || 'ubuntu-latest' }}
     timeout-minutes: 5
     needs:
       - typescript


### PR DESCRIPTION
## Summary

First slice of CODE-367 (portable public CI): all `runs-on` labels now resolve through repo/org variables, with GitHub-hosted images as fallbacks.

- `ci.yml` — all six jobs use `vars.CI_RUNNER_LINUX` → `ubuntu-latest`.
- `build-desktop.yml` — the platform matrix uses `vars.CI_RUNNER_MACOS` → `macos-26` (arm64, Xcode 26), `vars.CI_RUNNER_WINDOWS` → `windows-2025`, `vars.CI_RUNNER_LINUX_PACKAGING` → `ubuntu-22.04` (older glibc for AppImage compatibility).

The four variables are already set on this repository to the previous Blacksmith labels, so CI behavior here is unchanged; a fork without the vars falls back to hosted runners with zero setup.

## Verification

- `yq` parses both workflows; hosted fallback labels verified against the current runner-images catalog (`macos-26` GA, `windows-2025`, `ubuntu-22.04`).
- This PR's own checks must come up green on the Blacksmith labels (proves the `vars` path resolves).