### PR TITLE
feat(ui): polish agent selector

### DIFF
--- a/packages/presentation/i18n/src/locales/en.ts
+++ b/packages/presentation/i18n/src/locales/en.ts
@@ -260,7 +260,7 @@ export const en = {
       badgeDownloading: 'Downloading',
       badgeFailed: 'Download failed',
       badgeUnverified: 'Unverified',
-      badgeNeedsLogin: 'Sign in',
+      badgeNeedsLogin: 'Signed out',
       needsLoginTitle: '{agent} needs you to sign in',
       needsLoginBody: 'Sign in to your {agent} account to get started.',
       login: 'Sign in to {agent}',

--- a/packages/presentation/i18n/src/locales/zh-cn.ts
+++ b/packages/presentation/i18n/src/locales/zh-cn.ts
@@ -252,7 +252,7 @@ export const zhCN = {
       badgeDownloading: '下载中',
       badgeFailed: '下载失败',
       badgeUnverified: '未验证',
-      badgeNeedsLogin: '需登录',
+      badgeNeedsLogin: '未登录',
       needsLoginTitle: '{agent} 需要登录',
       needsLoginBody: '登录你的 {agent} 账号后即可开始使用。',
       login: '登录 {agent}',

--- a/packages/presentation/ui/src/chat/agent-icon.tsx
+++ b/packages/presentation/ui/src/chat/agent-icon.tsx
@@ -1,7 +1,9 @@
 /// <reference types="unplugin-icons/types/react" />
 import type { AgentKind } from '@linkcode/schema';
 import ClaudeCodeGlyph from '~icons/lobe-icons/claudecode';
+import ClaudeCodeColorGlyph from '~icons/lobe-icons/claudecode-color';
 import CodexGlyph from '~icons/lobe-icons/codex';
+import CodexColorGlyph from '~icons/lobe-icons/codex-color';
 import OpenCodeGlyph from '~icons/lobe-icons/opencode';
 import { AGENT_INITIALS } from '../agent-meta';
 import { cn } from '../lib/cn';
@@ -14,17 +16,42 @@ const AGENT_GLYPHS: Partial<Record<AgentKind, typeof ClaudeCodeGlyph>> = {
   opencode: OpenCodeGlyph,
 };
 
+const AGENT_COLOR_GLYPHS: Partial<Record<AgentKind, typeof ClaudeCodeColorGlyph>> = {
+  'claude-code': ClaudeCodeColorGlyph,
+  codex: CodexColorGlyph,
+};
+
 export function AgentIcon({
   kind,
   variant = 'solid',
   className,
 }: {
   kind: AgentKind;
-  /** `ghost` drops the brand-chip box: bare glyph, color inherited from the surrounding text. */
-  variant?: 'solid' | 'ghost';
+  /** `ghost` inherits text color; `brand` uses an official color glyph when one exists. */
+  variant?: 'solid' | 'ghost' | 'brand';
   className?: string;
 }): React.ReactNode {
   const Glyph = AGENT_GLYPHS[kind];
+
+  if (variant === 'brand') {
+    const ColorGlyph = AGENT_COLOR_GLYPHS[kind];
+    return (
+      <span
+        className={cn(
+          'flex size-4 shrink-0 items-center justify-center font-semibold text-foreground text-xs',
+          className,
+        )}
+      >
+        {ColorGlyph ? (
+          <ColorGlyph aria-hidden className="size-4" />
+        ) : Glyph ? (
+          <Glyph aria-hidden className="size-4" />
+        ) : (
+          AGENT_INITIALS[kind]
+        )}
+      </span>
+    );
+  }
 
   if (variant === 'ghost') {
     return (

--- a/packages/presentation/ui/src/shell/__tests__/new-session-surface.test.tsx
+++ b/packages/presentation/ui/src/shell/__tests__/new-session-surface.test.tsx
@@ -91,6 +91,26 @@ describe('NewSessionSurface', () => {
     expect(screen.getByRole('button', { name: RE_MODEL_DEFAULT })).toBeTruthy();
   });
 
+  it('names the model selector with its agent, model, and reasoning effort', () => {
+    render(
+      <NewSessionSurface
+        chatWorkspace={CHAT_WORKSPACE}
+        draft={{ initialProvider: 'claude-code', initialWorkspaceId: CHAT_WORKSPACE.workspaceId }}
+        mentionItems={[]}
+        onMentionQueryChange={vi.fn()}
+        onRegisterWorkspace={vi.fn().mockResolvedValue(CHAT_WORKSPACE)}
+        onSubmit={vi.fn().mockResolvedValue(undefined)}
+        workspaces={[]}
+      />,
+    );
+
+    expect(
+      screen.getByRole('button', {
+        name: 'Claude Code, Sonnet 5, reasoning: effortDefault',
+      }),
+    ).toBeTruthy();
+  });
+
   it.each([
     'codex',
     'opencode',

--- a/packages/presentation/ui/src/shell/composer-controls.tsx
+++ b/packages/presentation/ui/src/shell/composer-controls.tsx
@@ -1,4 +1,5 @@
 import type { AgentKind, ApprovalPolicy, EffortLevel, SessionMode } from '@linkcode/schema';
+import { Badge } from 'coss-ui/components/badge';
 import { Button } from 'coss-ui/components/button';
 import {
   Menu,
@@ -16,6 +17,7 @@ import {
 } from 'coss-ui/components/menu';
 import { Separator } from 'coss-ui/components/separator';
 import {
+  BrainCircuitIcon,
   ChevronDownIcon,
   ListTodoIcon,
   PlusIcon,
@@ -170,10 +172,18 @@ export function SessionModeChip({
   );
 }
 
-/** Muted availability badge on a provider submenu item; nothing renders for a ready runtime. */
+/** Availability badge on a provider submenu item; nothing renders for a ready runtime. */
 function RuntimeCueBadge({ cue }: { cue?: AgentRuntimeCue }): React.ReactNode {
   const t = useTranslations('workbench.agentRuntime');
   if (!cue) return null;
+  const variant =
+    cue.state === 'missing' || cue.state === 'needs-login'
+      ? 'outline'
+      : cue.state === 'downloading'
+        ? 'info'
+        : cue.state === 'failed'
+          ? 'error'
+          : 'warning';
   const label =
     cue.state === 'missing'
       ? t('badgeMissing')
@@ -184,7 +194,11 @@ function RuntimeCueBadge({ cue }: { cue?: AgentRuntimeCue }): React.ReactNode {
           : cue.state === 'needs-login'
             ? t('badgeNeedsLogin')
             : t('badgeUnverified');
-  return <span className="ml-auto shrink-0 text-muted-foreground text-xs">{label}</span>;
+  return (
+    <Badge className="font-normal" variant={variant}>
+      {label}
+    </Badge>
+  );
 }
 
 /** Codex-style model trigger: [provider glyph] model + effort, opening reasoning/model/provider menus. */
@@ -231,27 +245,30 @@ export function ModelSelectorMenu({
   const hasEfforts = Boolean(effortOptions?.length);
   const hasModels = Boolean(modelOptions?.length);
   const modelLabel = selectedModel?.label ?? selectedModelId ?? t('modelDefault');
+  const effortLabel = selectedEffort?.label ?? t('effortDefault');
   // A draft provider picker must keep the model axis visible even when that provider discovers
   // its concrete model only after session start (OpenCode/Pi). The live update replaces Default.
   const showsModel = providers.length > 0 || hasModels || selectedModelId !== null;
 
   if (!hasEfforts && !showsModel && providers.length === 0) return null;
+  const selectorLabels: string[] = [];
+  if (provider) selectorLabels.push(AGENT_LABELS[provider]);
+  if (showsModel) selectorLabels.push(modelLabel);
+  if (hasEfforts) selectorLabels.push(`${t('reasoning')}: ${effortLabel}`);
 
   return (
     <Menu>
       <MenuTrigger
+        aria-label={selectorLabels.join(', ')}
         disabled={disabled}
         render={<Button className="shrink-0" size="sm" type="button" variant="ghost" />}
       >
-        {providers.length > 0 && provider ? (
-          <AgentIcon className="text-muted-foreground" kind={provider} variant="ghost" />
-        ) : null}
+        {providers.length > 0 && provider ? <AgentIcon kind={provider} variant="brand" /> : null}
         {showsModel ? modelLabel : null}
         {hasEfforts ? (
-          <span className="font-normal text-muted-foreground">
-            <span className="@max-[480px]/composer:sr-only">
-              {selectedEffort?.label ?? t('effortDefault')}
-            </span>
+          <span className="flex items-center gap-2 font-normal text-muted-foreground">
+            <span aria-hidden>·</span>
+            <span className="@max-[480px]/composer:sr-only">{effortLabel}</span>
             <span aria-hidden className="hidden @max-[480px]/composer:inline">
               {selectedEffort?.shortLabel ?? t('effortShort')}
             </span>
@@ -284,7 +301,12 @@ export function ModelSelectorMenu({
           <>
             {hasEfforts ? <MenuSeparator /> : null}
             <MenuSub>
-              <MenuSubTrigger>{modelLabel}</MenuSubTrigger>
+              <MenuSubTrigger>
+                <span className="flex size-4 shrink-0 items-center justify-center">
+                  <BrainCircuitIcon className="size-4" />
+                </span>
+                {modelLabel}
+              </MenuSubTrigger>
               <MenuSubPopup className="w-56">
                 <MenuRadioGroup
                   value={selectedModel?.id ?? selectedModelId ?? ''}
@@ -336,25 +358,27 @@ export function ModelSelectorMenu({
             <MenuSubTrigger>
               {provider ? (
                 <>
-                  <AgentIcon kind={provider} variant="ghost" />
+                  <AgentIcon kind={provider} variant="brand" />
                   {AGENT_LABELS[provider]}
                 </>
               ) : (
                 t('provider')
               )}
             </MenuSubTrigger>
-            <MenuSubPopup className="w-48">
+            <MenuSubPopup className="w-60">
               <MenuRadioGroup
                 value={provider ?? ''}
                 onValueChange={(value) => onSelectProvider(value as AgentKind)}
               >
                 {providers.map((kind) => (
-                  <MenuRadioItem key={kind} closeOnClick value={kind}>
-                    <span className="flex min-w-0 flex-1 items-center gap-2">
-                      <AgentIcon kind={kind} variant="ghost" />
-                      {AGENT_LABELS[kind]}
+                  <MenuRadioItem key={kind} className="pe-2" closeOnClick value={kind}>
+                    <span className="flex min-w-0 items-center justify-between gap-2">
+                      <span className="flex min-w-0 items-center gap-2">
+                        <AgentIcon kind={kind} variant="brand" />
+                        <span className="truncate">{AGENT_LABELS[kind]}</span>
+                      </span>
+                      <RuntimeCueBadge cue={runtimeCues?.[kind]} />
                     </span>
-                    <RuntimeCueBadge cue={runtimeCues?.[kind]} />
                   </MenuRadioItem>
                 ))}
               </MenuRadioGroup>


### PR DESCRIPTION
## Summary

- use official color glyphs for supported agents in the selector
- present signed-out, missing, downloading, failed, and unverified states as compact right-aligned badges
- add a model icon, align menu icons, and make the trigger announce agent/model/reasoning context
- widen and rebalance the provider menu with explicit left/right groups

## Verification

- `pnpm exec tsc --build --noEmit packages/presentation/i18n packages/presentation/ui`
- `pnpm exec biome check` on the five changed files
- `pnpm exec eslint --format=sukka` on the five changed files (existing warnings only)
- `pnpm test packages/presentation/ui/src/shell/__tests__/new-session-surface.test.tsx` (29/29)