### PR TITLE
fix(desktop): gate the Browser pane's media pause on dom-ready

### DIFF
--- a/apps/desktop/src/renderer/src/shell/browser/browser-webview-pane.tsx
+++ b/apps/desktop/src/renderer/src/shell/browser/browser-webview-pane.tsx
@@ -37,6 +37,10 @@ export function BrowserWebviewPane(): React.ReactNode {
     (state) => state.rightPanel.open && state.rightPanel.activeSection === 'browser',
   );
   const [webview, setWebview] = useState<WebviewTag | null>(null);
+  // The guest that reached `dom-ready`, held by identity rather than as a boolean: a replacement
+  // element is then simply not the ready one, with no reset to keep in sync.
+  const [readyGuest, setReadyGuest] = useState<WebviewTag | null>(null);
+  const guestReady = webview !== null && readyGuest === webview;
   const [nav, setNav] = useState<WebviewNavState>(IDLE_NAV);
   // React's built-in `webview` intrinsic types the element as a bare HTMLWebViewElement;
   // in Electron (webviewTag enabled) the live element is always the full WebviewTag.
@@ -72,12 +76,17 @@ export function BrowserWebviewPane(): React.ReactNode {
           failure: t('loadFailed', { error: event.errorDescription }),
         }));
       };
+      const onReady = (): void => {
+        if (!signal.aborted) setReadyGuest(webview);
+      };
+      webview.addEventListener('dom-ready', onReady);
       webview.addEventListener('did-start-loading', sync);
       webview.addEventListener('did-stop-loading', sync);
       webview.addEventListener('did-navigate', onNavigate);
       webview.addEventListener('did-navigate-in-page', onNavigate);
       webview.addEventListener('did-fail-load', onFail);
       return () => {
+        webview.removeEventListener('dom-ready', onReady);
         webview.removeEventListener('did-start-loading', sync);
         webview.removeEventListener('did-stop-loading', sync);
         webview.removeEventListener('did-navigate', onNavigate);
@@ -91,13 +100,18 @@ export function BrowserWebviewPane(): React.ReactNode {
   // Pause any playing media when the pane is hidden (panel collapsed or another section shown),
   // so a preview stops instead of playing audio out of sight. Paused, not resumed — the user
   // restarts it on their next visit.
+  //
+  // Gated on `dom-ready`: the resident webview normally mounts hidden, and `executeJavaScript`
+  // THROWS SYNCHRONOUSLY on a guest that isn't attached yet (no rejected promise, so `.catch`
+  // can't see it) — the escaping error used to unmount the whole renderer (CODE-380). A guest
+  // that never became ready has nothing playing anyway.
   useEffect(() => {
-    if (webview === null || visible) return;
-    // Guest may be mid-navigation or detached, in which case there is nothing to pause.
+    if (webview === null || visible || !guestReady) return;
+    // Still fallible once ready: the guest may be mid-navigation or already gone.
     webview
       .executeJavaScript('document.querySelectorAll("video,audio").forEach((m) => m.pause())')
       .catch(noop);
-  }, [webview, visible]);
+  }, [webview, visible, guestReady]);
 
   return (
     <BrowserPane


### PR DESCRIPTION
Fixes CODE-380. Shipped in v0.6.0 and v0.6.1 — the desktop renderer boots to a **blank window** with no error surface for anyone who has opened a page in the Browser pane.

## Root cause

`BrowserWebviewPane`'s hidden-media pause calls `WebviewTag.executeJavaScript` on a guest that is not attached yet. That method **throws synchronously** — it does not return a rejected promise — so the `.catch(noop)` never sees it, the error escapes the effect, and React tears down the entire tree.

Introduced by #224 (`d078fd49`, sub-commit *fix(desktop): pause Browser pane media when the panel is hidden*), not by the resident-webview work that preceded it.

## Why it hits real users

The crash needs `webview !== null && !visible`, and both hold on an ordinary launch:

1. `<webview>` mounts whenever `rightPanel.browser.url !== null`, and that URL is persisted — `durableBrowserUrl` (`store/model.ts:317`) drops only `blob:` URLs.
2. `visible = rightPanel.open && activeSection === 'browser'` is false whenever Browser is not the active section at boot.

The ref callback sets the element long before `dom-ready`, so the effect fires at mount. Mount-while-hidden is the resident webview's normal path, not an edge case.

## Fix

Track a `guestReady` flag from a `dom-ready` listener registered alongside the existing nav listeners, and gate the pause effect on it. The flag resets in the ref callback so a replacement element starts not-ready instead of inheriting the previous guest's state. Nothing is swallowed: the `.catch(noop)` remains only for the genuine post-ready async failure.

## Verification

A probe forcing the exact production trigger (persisted Browser URL, Browser section not active), same build steps on each side:

| | `#root` children | `<webview>` | pageerror |
| --- | --- | --- | --- |
| `master` | 0 | 0 | `The WebView must be attached to the DOM…` |
| this branch | 1 | 1 | none |

`pnpm check:ci` and `pnpm test` (222 files / 1732 tests) pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved browser pane reliability while pages are loading.
  * Prevented media pause actions from running before the page is ready, avoiding related errors.
  * Ensured browser actions target the currently loaded page instance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->