### PR TITLE
fix(agent-adapter): reconcile Claude messages on reseed

### DIFF
--- a/packages/client/core/tests/integration/conversation-store.test.ts
+++ b/packages/client/core/tests/integration/conversation-store.test.ts
@@ -139,6 +139,32 @@ describe('createConversationStore', () => {
     close();
   });
 
+  // CODE-328: once history flushes a completed block under the same provider id, a reseed must
+  // replace its buffered live chunks rather than render the transcript row beside a second copy.
+  it('deduplicates live chunks that the snapshot covers by message id', async () => {
+    const { client, send, close } = await harness();
+    const chunk = (text: string): AgentEvent => ({
+      type: 'agent-message-chunk',
+      messageId: 'history-row' as MessageId,
+      content: { type: 'text', text },
+    });
+    send(userText('tell a story'));
+    send({ type: 'status', status: 'running' });
+    send(chunk('Once upon '));
+    send(chunk('a time'));
+    await tick();
+
+    const store = createConversationStore(client, sessionId, {
+      events: [{ event: userText('tell a story') }, { event: chunk('Once upon a time') }],
+      uptoSeq: 4,
+    });
+
+    const messages = store.getSnapshot().items.filter((item) => item.kind === 'message');
+    expect(messages).toHaveLength(2);
+    expect(messages[1].blocks).toEqual([{ type: 'text', text: 'Once upon a time' }]);
+    close();
+  });
+
   it('keeps an in-flight tool call the snapshot has not flushed yet', async () => {
     const { client, send, close } = await harness();
     const announce: AgentEvent = {

--- a/packages/host/agent-adapter/src/__tests__/claude-code-commands.test.ts
+++ b/packages/host/agent-adapter/src/__tests__/claude-code-commands.test.ts
@@ -185,6 +185,10 @@ class FakeQuery {
   }
 }
 
+function pushMessages(query: FakeQuery, ...messages: WireMessage[]): void {
+  for (const message of messages) query.push(message);
+}
+
 const queries: FakeQuery[] = [];
 let nextQuerySetup: ((q: FakeQuery) => void) | null = null;
 
@@ -343,10 +347,23 @@ describe('ClaudeCodeAdapter slash commands', () => {
     await prompt(adapter);
     const q0 = queries[0];
 
-    q0.push({
-      type: 'stream_event',
-      event: { type: 'content_block_delta', delta: { type: 'text_delta', text: 'before' } },
-    });
+    pushMessages(
+      q0,
+      {
+        type: 'stream_event',
+        uuid: 'before-start-frame',
+        parent_tool_use_id: null,
+        session_id: 's1',
+        event: { type: 'message_start', message: { id: 'before-message' } },
+      },
+      {
+        type: 'stream_event',
+        uuid: 'before-row',
+        parent_tool_use_id: null,
+        session_id: 's1',
+        event: { type: 'content_block_delta', delta: { type: 'text_delta', text: 'before' } },
+      },
+    );
     await vi.waitFor(() => {
       expect(agentChunks(events)).toHaveLength(1);
     });
@@ -366,10 +383,23 @@ describe('ClaudeCodeAdapter slash commands', () => {
     expect(output.content).toEqual(textBlock('Usage: 42% used'));
     expect(output.messageId).not.toBe(before.messageId);
 
-    q0.push({
-      type: 'stream_event',
-      event: { type: 'content_block_delta', delta: { type: 'text_delta', text: 'after' } },
-    });
+    pushMessages(
+      q0,
+      {
+        type: 'stream_event',
+        uuid: 'after-start-frame',
+        parent_tool_use_id: null,
+        session_id: 's1',
+        event: { type: 'message_start', message: { id: 'after-message' } },
+      },
+      {
+        type: 'stream_event',
+        uuid: 'after-row',
+        parent_tool_use_id: null,
+        session_id: 's1',
+        event: { type: 'content_block_delta', delta: { type: 'text_delta', text: 'after' } },
+      },
+    );
     await vi.waitFor(() => {
       expect(agentChunks(events)).toHaveLength(3);
     });

--- a/packages/host/agent-adapter/src/__tests__/claude-code-subagent.test.ts
+++ b/packages/host/agent-adapter/src/__tests__/claude-code-subagent.test.ts
@@ -102,13 +102,14 @@ describe('ClaudeCodeAdapter subagent routing', () => {
     expect(sub[0].kind).toBe('read');
   });
 
-  it('renders subagent text message-level under the frame uuid, thinking under a distinct id', () => {
+  it('renders subagent text under the provider message id, thinking under a distinct id', () => {
     const h = harness();
     h.feed({
       type: 'assistant',
       parent_tool_use_id: TASK_ID,
       uuid: 'uuid-sub-2',
       message: {
+        id: 'provider-sub-2',
         content: [
           { type: 'thinking', thinking: 'hmm' },
           { type: 'text', text: 'found it' },
@@ -117,10 +118,10 @@ describe('ClaudeCodeAdapter subagent routing', () => {
     });
     const [chunk] = h.chunks();
     expect(chunk.content).toEqual({ type: 'text', text: 'found it' });
-    expect(chunk.messageId).toBe('uuid-sub-2');
+    expect(chunk.messageId).toBe('provider-sub-2');
     expect(chunk.parentToolCallId).toBe(TASK_ID);
     const [thought] = h.thoughts();
-    expect(thought.messageId).toBe('uuid-sub-2:think');
+    expect(thought.messageId).toBe('provider-sub-2:think');
     expect(thought.parentToolCallId).toBe(TASK_ID);
   });
 
@@ -128,12 +129,23 @@ describe('ClaudeCodeAdapter subagent routing', () => {
     const h = harness();
     h.feed({
       type: 'stream_event',
+      uuid: 'uuid-sub-delta',
+      session_id: 's1',
       parent_tool_use_id: TASK_ID,
       event: { type: 'content_block_delta', delta: { type: 'text_delta', text: 'sub' } },
     });
     expect(h.chunks()).toHaveLength(0);
     h.feed({
       type: 'stream_event',
+      uuid: 'uuid-main-start',
+      session_id: 's1',
+      parent_tool_use_id: null,
+      event: { type: 'message_start', message: { id: 'provider-main' } },
+    });
+    h.feed({
+      type: 'stream_event',
+      uuid: 'uuid-main-delta',
+      session_id: 's1',
       parent_tool_use_id: null,
       event: { type: 'content_block_delta', delta: { type: 'text_delta', text: 'main' } },
     });
@@ -142,8 +154,17 @@ describe('ClaudeCodeAdapter subagent routing', () => {
 
   it('keeps the main messageId cursor across an interleaved subagent frame', () => {
     const h = harness();
+    h.feed({
+      type: 'stream_event',
+      uuid: 'uuid-main-start',
+      session_id: 's1',
+      parent_tool_use_id: null,
+      event: { type: 'message_start', message: { id: 'provider-main' } },
+    });
     const mainDelta = (text: string) => ({
       type: 'stream_event',
+      uuid: 'uuid-main-segment',
+      session_id: 's1',
       parent_tool_use_id: null,
       event: { type: 'content_block_delta', delta: { type: 'text_delta', text } },
     });
@@ -152,7 +173,7 @@ describe('ClaudeCodeAdapter subagent routing', () => {
       type: 'assistant',
       parent_tool_use_id: TASK_ID,
       uuid: 'uuid-sub-3',
-      message: { content: [{ type: 'text', text: 'subagent says' }] },
+      message: { id: 'provider-sub-3', content: [{ type: 'text', text: 'subagent says' }] },
     });
     h.feed(mainDelta('after'));
     const main = h.chunks().filter((c) => c.parentToolCallId === undefined);

--- a/packages/host/agent-adapter/src/__tests__/message-grouping.test.ts
+++ b/packages/host/agent-adapter/src/__tests__/message-grouping.test.ts
@@ -14,9 +14,14 @@ import { PiAdapter } from '../native/pi';
  */
 
 type AgentMessageChunk = Extract<AgentEvent, { type: 'agent-message-chunk' }>;
+type AgentThoughtChunk = Extract<AgentEvent, { type: 'agent-thought-chunk' }>;
 
 function agentChunks(events: AgentEvent[]): AgentMessageChunk[] {
   return events.filter((e): e is AgentMessageChunk => e.type === 'agent-message-chunk');
+}
+
+function agentThoughts(events: AgentEvent[]): AgentThoughtChunk[] {
+  return events.filter((e): e is AgentThoughtChunk => e.type === 'agent-thought-chunk');
 }
 
 /** Capture every emitted event from an adapter into a flat list. */
@@ -38,9 +43,22 @@ class TestClaude extends ClaudeCodeAdapter {
   }
 }
 
+function claudeMessageStart(messageId: string): object {
+  return {
+    type: 'stream_event',
+    uuid: 'start-frame',
+    session_id: 's1',
+    parent_tool_use_id: null,
+    event: { type: 'message_start', message: { id: messageId } },
+  };
+}
+
 function claudeTextDelta(text: string): object {
   return {
     type: 'stream_event',
+    uuid: `delta-frame-${text}`,
+    session_id: 's1',
+    parent_tool_use_id: null,
     event: { type: 'content_block_delta', delta: { type: 'text_delta', text } },
   };
 }
@@ -75,6 +93,7 @@ function piDriver(): AdapterDriver {
 function claudeDriver(): AdapterDriver {
   const adapter = new TestClaude();
   const seen = record(adapter);
+  adapter.feed(claudeMessageStart('claude-before-tool'));
   return {
     seen,
     text: (delta) => adapter.feed(claudeTextDelta(delta)),
@@ -87,6 +106,7 @@ function claudeDriver(): AdapterDriver {
         type: 'user',
         message: { content: [{ type: 'tool_result', tool_use_id: 't1', content: 'ok' }] },
       });
+      adapter.feed(claudeMessageStart('claude-after-tool'));
     },
   };
 }
@@ -128,5 +148,32 @@ describe('PiAdapter message grouping', () => {
     const chunks = agentChunks(seen);
     expect(chunks).toHaveLength(2);
     expect(chunks[0].messageId).toBe(chunks[1].messageId);
+  });
+});
+
+describe('ClaudeCodeAdapter message identity', () => {
+  it('uses the provider message id across SDK frames and history', () => {
+    const adapter = new TestClaude();
+    const seen = record(adapter);
+
+    adapter.feed(claudeMessageStart('provider-message'));
+    adapter.feed(claudeTextDelta('a'));
+    adapter.feed(claudeTextDelta('b'));
+    adapter.feed({
+      type: 'stream_event',
+      uuid: 'thought-delta-frame',
+      session_id: 's1',
+      parent_tool_use_id: null,
+      event: {
+        type: 'content_block_delta',
+        delta: { type: 'thinking_delta', thinking: 'hmm' },
+      },
+    });
+
+    expect(agentChunks(seen).map((chunk) => chunk.messageId)).toEqual([
+      'provider-message',
+      'provider-message',
+    ]);
+    expect(agentThoughts(seen).map((event) => event.messageId)).toEqual(['provider-message:think']);
   });
 });

--- a/packages/host/agent-adapter/src/__tests__/normalize.test.ts
+++ b/packages/host/agent-adapter/src/__tests__/normalize.test.ts
@@ -47,7 +47,7 @@ function row(
   uuid: string,
   content: string | unknown[],
   parentToolUseId: string | null = null,
-  extra?: { timestamp?: string; model?: string },
+  extra?: { timestamp?: string; model?: string; messageId?: string },
 ): SessionMessage {
   return {
     type,
@@ -55,7 +55,11 @@ function row(
     session_id: 'h1',
     parent_tool_use_id: parentToolUseId,
     parent_agent_id: null,
-    message: { content, ...(extra?.model && { model: extra.model }) },
+    message: {
+      content,
+      ...(extra?.model && { model: extra.model }),
+      ...(extra?.messageId && { id: extra.messageId }),
+    },
     ...(extra?.timestamp && { timestamp: extra.timestamp }),
   };
 }
@@ -241,21 +245,27 @@ describe('createClaudeHistoryEventMapper', () => {
     expect(reply.map((e) => e.event.type)).toEqual(['agent-message-chunk']);
   });
 
-  it('replays thinking as a thought chunk under the uuid:think id, never inside the message text', () => {
+  it('replays thinking and text under the provider message id used by the live stream', () => {
     const map = createClaudeHistoryEventMapper(historyId);
     const events = map(
-      row('assistant', 'u1', [
-        { type: 'thinking', thinking: 'let me reason', signature: 'sig' },
-        { type: 'text', text: 'the answer' },
-      ]),
+      row(
+        'assistant',
+        'u1',
+        [
+          { type: 'thinking', thinking: 'let me reason', signature: 'sig' },
+          { type: 'text', text: 'the answer' },
+        ],
+        null,
+        { messageId: 'provider-message' },
+      ),
     );
     expect(events.map((e) => e.event.type)).toEqual(['agent-thought-chunk', 'agent-message-chunk']);
     expect(events[0].event).toMatchObject({
-      messageId: 'u1:think',
+      messageId: 'provider-message:think',
       content: { type: 'text', text: 'let me reason' },
     });
     expect(events[1].event).toMatchObject({
-      messageId: 'u1',
+      messageId: 'provider-message',
       content: { type: 'text', text: 'the answer' },
     });
   });

--- a/packages/host/agent-adapter/src/native/claude-code.ts
+++ b/packages/host/agent-adapter/src/native/claude-code.ts
@@ -76,7 +76,6 @@ import {
 import { agentRuntimeProber } from '../probe';
 import { contentToText, imageBlocksFrom, locationsFromToolInput, toolKindFromName } from '../util';
 
-type StreamEvent = Extract<SDKMessage, { type: 'stream_event' }>['event'];
 type AssistantSDKMessage = Extract<SDKMessage, { type: 'assistant' }>;
 type AssistantMessage = AssistantSDKMessage['message'];
 type UserSDKMessage = Extract<SDKMessage, { type: 'user' }>;
@@ -1039,7 +1038,7 @@ export class ClaudeCodeAdapter extends BaseAgentAdapter {
     if ('isReplay' in msg) return;
     switch (msg.type) {
       case 'stream_event':
-        this.handleStreamEvent(msg.event, msg.parent_tool_use_id);
+        this.handleStreamEvent(msg);
         break;
       case 'assistant':
         this.handleAssistant(msg);
@@ -1133,19 +1132,27 @@ export class ClaudeCodeAdapter extends BaseAgentAdapter {
     });
   }
 
-  private handleStreamEvent(event: StreamEvent, parentToolUseId: string | null): void {
+  private handleStreamEvent(msg: Extract<SDKMessage, { type: 'stream_event' }>): void {
     // Subagent narration renders message-level from the forwarded assistant frames
     // (handleSubagentAssistant); consuming its deltas here would render the same text twice.
-    if (parentToolUseId) return;
+    if (msg.parent_tool_use_id) return;
+    const event = msg.event;
+    if (event.type === 'message_start') {
+      this.messageId = asMessageId(event.message.id);
+      this.thoughtId = asMessageId(`${event.message.id}:think`);
+      return;
+    }
     if (event.type !== 'content_block_delta') return;
     const delta = event.delta;
+    // message_start's API id is stable across every delta and is persisted inside each transcript
+    // row; the SDK envelope uuid is per-frame and cannot group or reconcile streamed chunks.
     if (delta.type === 'text_delta') this.emitAssistantText(delta.text, this.messageId);
     else if (delta.type === 'thinking_delta') this.emitThought(delta.thinking, this.thoughtId);
   }
 
   private handleAssistant(msg: AssistantSDKMessage): void {
     if (msg.parent_tool_use_id) {
-      this.handleSubagentAssistant(msg.message, msg.parent_tool_use_id, msg.uuid);
+      this.handleSubagentAssistant(msg.message, msg.parent_tool_use_id);
       return;
     }
     const message = msg.message;
@@ -1177,11 +1184,11 @@ export class ClaudeCodeAdapter extends BaseAgentAdapter {
 
   /**
    * A subagent's assistant frame (`parent_tool_use_id` set): tool calls carry the spawning Task's
-   * id; text/thinking render message-level under the frame's own uuid (which doubles as the history
-   * mapper's id, so live and cold-resume converge). It never touches the main message/thought
+   * id; text/thinking render message-level under the provider message id (which the history mapper
+   * also reads from the transcript row). It never touches the main message/thought
    * cursors or calls `freshSegment()`, so a mid-turn subagent can't break the main streaming bubble.
    */
-  private handleSubagentAssistant(message: AssistantMessage, parent: string, uuid: string): void {
+  private handleSubagentAssistant(message: AssistantMessage, parent: string): void {
     for (const block of message.content) {
       // eslint-disable-next-line sukka/unicorn/prefer-switch -- deliberately non-exhaustive (other block variants are ignored); the switch autofix then trips the error-level default-case rule
       if (block.type === 'tool_use') {
@@ -1198,9 +1205,9 @@ export class ClaudeCodeAdapter extends BaseAgentAdapter {
           locations: hostLocationsFromToolInput(block.input),
         });
       } else if (block.type === 'text') {
-        this.emitAssistantText(block.text, asMessageId(uuid), parent);
+        this.emitAssistantText(block.text, asMessageId(message.id), parent);
       } else if (block.type === 'thinking') {
-        this.emitThought(block.thinking, asMessageId(`${uuid}:think`), parent);
+        this.emitThought(block.thinking, asMessageId(`${message.id}:think`), parent);
       }
     }
   }
@@ -1610,6 +1617,10 @@ export function createClaudeHistoryEventMapper(
     const parent = message.parent_tool_use_id ?? undefined;
 
     if (message.type === 'assistant') {
+      const providerMessageId = isRecord(message.message)
+        ? stringField(message.message, 'id')
+        : undefined;
+      const messageId = providerMessageId ?? message.uuid;
       // Every assistant row records the model that served it; replay it as the same model-update
       // the live stream emits so seeded messages get their per-turn model stamp. Subagent rows
       // are skipped — their model must not masquerade as the session's.
@@ -1619,28 +1630,20 @@ export function createClaudeHistoryEventMapper(
         lastModel = model;
         events.push({ historyId, ts, event: { type: 'model-update', model } });
       }
-      // Thinking replays as thought chunks under `${uuid}:think` — the id the live subagent path
-      // already emits, so live-forwarded and cold-replayed thinking converge. Pre-CODE-273
+      // Thinking replays under the provider message id used by the live stream. Pre-CODE-273
       // transcripts store empty thinking text; the helper's empty-drop rule skips those.
       for (const block of blocks) {
         if (!isThinkingBlock(block)) continue;
         const thought = thoughtHistoryEvent(
           historyId,
-          `${message.uuid}:think`,
+          `${messageId}:think`,
           block.thinking,
           ts,
           parent,
         );
         if (thought) events.push(thought);
       }
-      const text = textHistoryEvent(
-        historyId,
-        'assistant',
-        message.uuid,
-        message.message,
-        ts,
-        parent,
-      );
+      const text = textHistoryEvent(historyId, 'assistant', messageId, message.message, ts, parent);
       if (text) events.push(text);
       for (const block of blocks) {
         if (!isToolUseBlock(block)) continue;


### PR DESCRIPTION
## Summary

- Fixes CODE-328 by reconciling Claude live-stream and history messages with the stable provider message ID.
- Prevents SWR focus/reconnect revalidation from duplicating completed responses.
- Preserves the CODE-272 behavior that keeps unmatched in-flight content during reseeding.
- Applies the runtime change only to the Claude adapter; other adapters and the wire protocol are unchanged.
- Adds regression coverage for main-agent, subagent, history, and conversation-store reconciliation.

## Verification

- `devenv shell -- pnpm check:ci`
- `devenv shell -- pnpm test` — 222 files and 1,734 tests passed.
- Ran the desktop app with the debug protocol enabled.
- Verified an 80-line completed response remained single after focus and online revalidation.
- Verified a 60-line streaming response while repeatedly scrolling and triggering focus revalidation:
  - No rendered content disappeared.
  - All lines appeared exactly once.
  - No console errors were observed.

## Checklist

- [x] `pnpm check:ci` and `pnpm test` both pass (no Rust changes)
- [x] I ran the affected surface and observed the change working
- [x] No wire message changed; `WIRE_PROTOCOL_VERSION` does not require a bump
- [x] New code and assets are my own work
- [x] Relevant comments were updated; no documentation changes were required