### PR TITLE
ci: adopt org-level fast-forward merge

### DIFF
--- a/.github/workflows/fast-forward.yml
+++ b/.github/workflows/fast-forward.yml
@@ -1,0 +1,30 @@
+name: Fast Forward Merge
+
+# 薄壳:全部逻辑在 arcboxlabs/actions 的 reusable workflow 里。
+# 在 PR 评论 `/fast-forward` 即可把 head 分支原样推进到 base 分支(签名保留、历史线性)。
+# 文档:https://github.com/arcboxlabs/actions/blob/master/docs/fast-forward.md
+
+on:
+  issue_comment:
+    types: [created]
+
+# 这是 GITHUB_TOKEN 的权限上限;被调用的 workflow 只会申请其中的子集。
+# 推送由 GitHub App token 完成,所以这里的 contents 只需要 read。
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+  checks: read
+  statuses: read
+
+jobs:
+  fast-forward:
+    # 粗筛:PR 上的评论、且提到了触发命令。精确判定在 reusable workflow 里。
+    if: >-
+      github.event.issue.pull_request != null &&
+      contains(github.event.comment.body, '/fast-forward')
+    # 必须 pin 到 40 位 commit SHA:能改动该仓库的人等于能向本仓库默认分支直推。
+    uses: arcboxlabs/actions/.github/workflows/fast-forward.yml@a940102d549190d703ae06a2c6ab97721ae7d32a # ff-v1
+    secrets:
+      app_id: ${{ secrets.BOT_APP_ID }}
+      app_private_key: ${{ secrets.BOT_APP_PRIVATE_KEY }}

--- a/.github/workflows/fast-forward.yml
+++ b/.github/workflows/fast-forward.yml
@@ -1,15 +1,18 @@
 name: Fast Forward Merge
 
-# 薄壳:全部逻辑在 arcboxlabs/actions 的 reusable workflow 里。
-# 在 PR 评论 `/fast-forward` 即可把 head 分支原样推进到 base 分支(签名保留、历史线性)。
-# 文档:https://github.com/arcboxlabs/actions/blob/master/docs/fast-forward.md
+# Thin caller. All logic lives in the reusable workflow in arcboxlabs/actions.
+# Comment `/fast-forward` on a PR to advance base to the PR head as-is, so commit
+# SHAs and their signatures survive and history stays linear.
+# Docs: https://github.com/arcboxlabs/actions/blob/master/docs/fast-forward.md
 
 on:
   issue_comment:
     types: [created]
 
-# 这是 GITHUB_TOKEN 的权限上限;被调用的 workflow 只会申请其中的子集。
-# 推送由 GitHub App token 完成,所以这里的 contents 只需要 read。
+# This is the ceiling for GITHUB_TOKEN; the called workflow only requests a
+# subset of it. Pushing is done with a GitHub App token, so contents needs read
+# only. Do not trim this block: a called workflow may lower these permissions
+# but never raise them, and one missing entry fails the whole run.
 permissions:
   contents: read
   issues: write
@@ -19,12 +22,14 @@ permissions:
 
 jobs:
   fast-forward:
-    # 粗筛:PR 上的评论、且提到了触发命令。精确判定在 reusable workflow 里。
+    # Coarse filter: a comment on a PR that mentions the command. The reusable
+    # workflow makes the authoritative decision.
     if: >-
       github.event.issue.pull_request != null &&
       contains(github.event.comment.body, '/fast-forward')
-    # 必须 pin 到 40 位 commit SHA:能改动该仓库的人等于能向本仓库默认分支直推。
-    uses: arcboxlabs/actions/.github/workflows/fast-forward.yml@a940102d549190d703ae06a2c6ab97721ae7d32a # ff-v1
+    # Pin to a 40-char commit SHA: whoever can change that repo can effectively
+    # push straight to this repository's default branch.
+    uses: arcboxlabs/actions/.github/workflows/fast-forward.yml@086869fedf5c303a86521ac17d5fa34ec8e5d408 # ff-v1
     secrets:
       app_id: ${{ secrets.BOT_APP_ID }}
       app_private_key: ${{ secrets.BOT_APP_PRIVATE_KEY }}


### PR DESCRIPTION
Comment `/fast-forward` on a PR and this repo's `master` is advanced to the PR
head **as-is** — commit SHAs unchanged, so GPG/SSH signatures survive and the
history stays linear. GitHub's "Rebase and merge" rewrites every commit
(new committer, new SHA) and voids all signatures; the web UI offers no
fast-forward option.

All logic lives in the shared reusable workflow at
[`arcboxlabs/actions`](https://github.com/arcboxlabs/actions/blob/master/docs/fast-forward.md);
this is a ~20-line shell pinned to `arcboxlabs/actions@a940102`.

### What it does not change

Nothing about this repo's merge policy. The gate is GitHub's own
`mergeable_state` — i.e. exactly what the native merge button requires right
now under our rulesets (1 approval, Copilot review, resolved threads). Change a
ruleset and the gate follows automatically; the workflow defines no policy of
its own. Repo `write` is required to trigger; admins can explicitly bypass with
`/fast-forward bypass`, which leaves an audit trail in the PR and the run log.

### Prerequisites (already done)

- `arcbox-labs` App is in the bypass list of both `Protect default branch` (org)
  and `Require Reviewer` (repo), mode `always`.
- Org secrets `BOT_APP_ID` / `BOT_APP_PRIVATE_KEY` are reachable from this repo.

### One caveat

The App has no `Workflows` permission, so PRs that touch `.github/workflows/`
cannot be fast-forwarded — **including this one**. Merge this with the native
button; subsequent regular PRs get signature-preserving merges.