### PR TITLE
ci: repin fast-forward so the bot replies in English

### DIFF
--- a/.github/workflows/fast-forward.yml
+++ b/.github/workflows/fast-forward.yml
@@ -29,7 +29,7 @@ jobs:
       contains(github.event.comment.body, '/fast-forward')
     # Pin to a 40-char commit SHA: whoever can change that repo can effectively
     # push straight to this repository's default branch.
-    uses: arcboxlabs/actions/.github/workflows/fast-forward.yml@086869fedf5c303a86521ac17d5fa34ec8e5d408 # ff-v1
+    uses: arcboxlabs/actions/.github/workflows/fast-forward.yml@d4cfe773a715f7d9c6b383269332bf90952f6971 # ff-v1
     secrets:
       app_id: ${{ secrets.BOT_APP_ID }}
       app_private_key: ${{ secrets.BOT_APP_PRIVATE_KEY }}


### PR DESCRIPTION
The fast-forward bot replied in Chinese on #243. Upstream `arcboxlabs/actions`
now emits English for everything a human sees — PR replies, step summaries, log
lines, job and step names — so this just moves the pin.

`arcboxlabs/actions@086869f` → `@d4cfe77`. One line changed; no behaviour change.