### PR TITLE
refactor(ui): frame chat flow cards with coss-ui Frame headers (CODE-381)

### DIFF
--- a/packages/client/workbench/src/terminal/block.tsx
+++ b/packages/client/workbench/src/terminal/block.tsx
@@ -5,7 +5,13 @@ import { useState } from 'react';
 import { useTranslations } from 'use-intl';
 
 /** Adapter subscribing a rendered `TerminalBlock` to the daemon-backed terminal output stream. */
-export function RuntimeTerminalBlock({ terminalId }: { terminalId: string }): React.ReactNode {
+export function RuntimeTerminalBlock({
+  terminalId,
+  command,
+}: {
+  terminalId: string;
+  command?: string;
+}): React.ReactNode {
   const t = useTranslations('workbench.panel');
   const client = useLinkCodeClient();
   const output = useTerminalOutput(terminalId);
@@ -44,5 +50,5 @@ export function RuntimeTerminalBlock({ terminalId }: { terminalId: string }): Re
       </div>
     );
   }
-  return <TerminalBlock terminalId={terminalId} output={output} />;
+  return <TerminalBlock command={command} terminalId={terminalId} output={output} />;
 }

--- a/packages/host/agent-adapter/src/__tests__/opencode.test.ts
+++ b/packages/host/agent-adapter/src/__tests__/opencode.test.ts
@@ -707,30 +707,30 @@ describe('OpenCodeAdapter permission round-trip', () => {
   });
 });
 
-describe('OpenCodeAdapter question round-trip', () => {
-  function pushQuestionAsked(): void {
-    client.stream.push({
-      id: 'e-question',
-      type: 'question.asked',
-      properties: {
-        id: 'que-1',
-        sessionID: 'sess-1',
-        questions: [
-          {
-            question: 'Proceed?',
-            header: 'Proceed',
-            options: [
-              { label: 'Yes', description: 'Go ahead.' },
-              { label: 'No', description: 'Stop here.' },
-            ],
-            multiple: false,
-          },
-        ],
-        tool: { messageID: 'msg-1', callID: 'call-1' },
-      },
-    });
-  }
+function pushQuestionAsked(): void {
+  client.stream.push({
+    id: 'e-question',
+    type: 'question.asked',
+    properties: {
+      id: 'que-1',
+      sessionID: 'sess-1',
+      questions: [
+        {
+          question: 'Proceed?',
+          header: 'Proceed',
+          options: [
+            { label: 'Yes', description: 'Go ahead.' },
+            { label: 'No', description: 'Stop here.' },
+          ],
+          multiple: false,
+        },
+      ],
+      tool: { messageID: 'msg-1', callID: 'call-1' },
+    },
+  });
+}
 
+describe('OpenCodeAdapter question round-trip', () => {
   it('surfaces question.asked as a question-request and replies with the selected labels', async () => {
     const { adapter, events } = await makeAdapter();
     pushQuestionAsked();
@@ -777,6 +777,18 @@ describe('OpenCodeAdapter question round-trip', () => {
   });
 });
 
+/** A non-abort `session.error` as the server emits it mid-turn AND re-fires post-settle. */
+function pushUnknownSessionError(): void {
+  client.stream.push({
+    id: 'e-err',
+    type: 'session.error',
+    properties: {
+      sessionID: 'sess-1',
+      error: { name: 'UnknownError', data: { message: 'model not found' } },
+    },
+  });
+}
+
 describe('OpenCodeAdapter session.error and turn settle', () => {
   it('maps ProviderAuthError to a non-recoverable authentication_failed error, and the idle settle skips end_turn', async () => {
     const { adapter, events } = await makeAdapter();
@@ -813,24 +825,14 @@ describe('OpenCodeAdapter session.error and turn settle', () => {
     events.length = 0;
     pushBusy();
 
-    const push = () => {
-      client.stream.push({
-        id: 'e-err',
-        type: 'session.error',
-        properties: {
-          sessionID: 'sess-1',
-          error: { name: 'UnknownError', data: { message: 'model not found' } },
-        },
-      });
-    };
-    push();
+    pushUnknownSessionError();
     pushIdle();
     await vi.waitFor(() => {
       expect(events.some((e) => e.type === 'status' && e.status === 'idle')).toBe(true);
     });
     events.length = 0;
 
-    push();
+    pushUnknownSessionError();
     await drained();
     expect(events).toHaveLength(0);
   });
@@ -933,21 +935,10 @@ describe('OpenCodeAdapter session.error and turn settle', () => {
   it("drops the previous turn's re-fired session.error instead of failing the next un-started turn", async () => {
     const { adapter, events } = await makeAdapter();
 
-    const pushError = () => {
-      client.stream.push({
-        id: 'e-err',
-        type: 'session.error',
-        properties: {
-          sessionID: 'sess-1',
-          error: { name: 'UnknownError', data: { message: 'model not found' } },
-        },
-      });
-    };
-
     // Turn 1 fails and settles.
     await adapter.send({ type: 'prompt', content: [] });
     pushBusy();
-    pushError();
+    pushUnknownSessionError();
     pushIdle();
     await vi.waitFor(() => {
       expect(errors(events)).toHaveLength(1);
@@ -956,7 +947,7 @@ describe('OpenCodeAdapter session.error and turn settle', () => {
     // Turn 2 dispatched; turn 1's stale re-fire lands before turn 2's busy acknowledgement.
     await adapter.send({ type: 'prompt', content: [] });
     events.length = 0;
-    pushError();
+    pushUnknownSessionError();
     pushBusy();
     pushIdle();
     await vi.waitFor(() => {
@@ -1372,6 +1363,33 @@ describe('OpenCodeAdapter server spawn retry', () => {
   });
 });
 
+/** Seed the agent catalog the way a real `app.agents` responds: primaries, an `all`-mode
+ * agent, plus the two kinds that must be filtered out (hidden, subagent). */
+function seedAgents(): void {
+  sdkMock.createOpencode = () => {
+    client = new FakeClient();
+    client.app.agents.mockReturnValue({
+      data: [
+        { name: 'build', mode: 'primary', description: 'Default implementation agent' },
+        { name: 'plan', mode: 'primary' },
+        { name: 'helper', mode: 'all' },
+        { name: 'stealth', mode: 'primary', hidden: true },
+        { name: 'reviewer', mode: 'subagent' },
+      ],
+    });
+    return Promise.resolve({ client, server: { url: 'http://fake', close: closeServer } });
+  };
+}
+
+function policyUpdates(
+  events: AgentEvent[],
+): Array<Extract<AgentEvent, { type: 'approval-policy-update' }>> {
+  return events.filter(
+    (e): e is Extract<AgentEvent, { type: 'approval-policy-update' }> =>
+      e.type === 'approval-policy-update',
+  );
+}
+
 describe('OpenCodeAdapter control plane (CODE-224)', () => {
   afterEach(() => {
     // Restore the default fresh-client factory (same discipline as the command-catalog block).
@@ -1380,33 +1398,6 @@ describe('OpenCodeAdapter control plane (CODE-224)', () => {
       return Promise.resolve({ client, server: { url: 'http://fake', close: closeServer } });
     };
   });
-
-  /** Seed the agent catalog the way a real `app.agents` responds: primaries, an `all`-mode
-   * agent, plus the two kinds that must be filtered out (hidden, subagent). */
-  function seedAgents(): void {
-    sdkMock.createOpencode = () => {
-      client = new FakeClient();
-      client.app.agents.mockReturnValue({
-        data: [
-          { name: 'build', mode: 'primary', description: 'Default implementation agent' },
-          { name: 'plan', mode: 'primary' },
-          { name: 'helper', mode: 'all' },
-          { name: 'stealth', mode: 'primary', hidden: true },
-          { name: 'reviewer', mode: 'subagent' },
-        ],
-      });
-      return Promise.resolve({ client, server: { url: 'http://fake', close: closeServer } });
-    };
-  }
-
-  function policyUpdates(
-    events: AgentEvent[],
-  ): Array<Extract<AgentEvent, { type: 'approval-policy-update' }>> {
-    return events.filter(
-      (e): e is Extract<AgentEvent, { type: 'approval-policy-update' }> =>
-        e.type === 'approval-policy-update',
-    );
-  }
 
   it('advertises selectable agents as the approval-policy axis at start', async () => {
     seedAgents();

--- a/packages/host/agent-adapter/src/native/opencode/adapter.ts
+++ b/packages/host/agent-adapter/src/native/opencode/adapter.ts
@@ -90,7 +90,7 @@ function okOrThrow<T extends { error?: unknown }>(result: T, context: string): T
     detail = result.error;
   } else {
     try {
-      detail = JSON.stringify(result.error) ?? 'unknown error';
+      detail = JSON.stringify(result.error);
     } catch {
       detail = extractErrorMessage(result.error) ?? 'unknown error';
     }
@@ -188,7 +188,7 @@ export class OpenCodeAdapter extends BaseAgentAdapter {
       const sessionID = this.resumeFrom;
       try {
         const got = await this.withHistoryClient((client) => client.session.get({ sessionID }));
-        if (got.error === undefined && got.data?.model) {
+        if (got.error === undefined && got.data.model) {
           opts.model = `${got.data.model.providerID}/${got.data.model.id}`;
         }
       } catch {
@@ -233,7 +233,7 @@ export class OpenCodeAdapter extends BaseAgentAdapter {
       // Adopt the existing provider session and announce its id right away — a resumed session's
       // transcript is real, so the seed read is safe immediately (unlike the fresh path below).
       const got = await this.client.session.get({ sessionID: this.resumeFrom });
-      if (got.error !== undefined || !got.data) {
+      if (got.error !== undefined) {
         throw new Error(`opencode: history '${this.resumeFrom}' was not found`);
       }
       this.sessionId = got.data.id;
@@ -564,7 +564,7 @@ export class OpenCodeAdapter extends BaseAgentAdapter {
         client.session.get({ sessionID: opts.historyId }),
         client.session.messages({ sessionID: opts.historyId }),
       ]);
-      if (got.error !== undefined || !got.data) {
+      if (got.error !== undefined) {
         throw new Error(`opencode: history '${opts.historyId}' was not found`);
       }
       okOrThrow(messages, 'opencode: session.messages');
@@ -686,8 +686,11 @@ export class OpenCodeAdapter extends BaseAgentAdapter {
       try {
         // The directory scope is load-bearing: a bare subscribe() carries only the server-cwd
         // instance's bus and silently misses every session event (verified live on 1.17.11).
+        // eslint-disable-next-line no-await-in-loop -- each pass replaces the one live subscription; sequential by design
         const sub = await this.client.event.subscribe({ directory: this.directory });
+        // eslint-disable-next-line no-await-in-loop -- the await IS the next-event signal
         for await (const ev of sub.stream) {
+          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- onStop flips `stopped` across the awaits
           if (this.stopped) break;
           // Every successful subscription starts with this synthetic greeting, including a broken
           // stream that immediately closes. Only a real bus event proves the replacement is healthy.
@@ -697,6 +700,7 @@ export class OpenCodeAdapter extends BaseAgentAdapter {
       } catch (err) {
         caught = err;
       }
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- onStop flips `stopped` across the awaits
       if (this.stopped) return;
       const fatal = !this.cancelling && (caught !== undefined || this.turnActive);
       if (fatal) {
@@ -716,6 +720,7 @@ export class OpenCodeAdapter extends BaseAgentAdapter {
       // receiving lifecycle events immediately. Back off only after an empty replacement also
       // closes, preventing a hot loop without adding a gap after a healthy turn's stream.
       emptyCloses = sawProgress ? 0 : emptyCloses + 1;
+      // eslint-disable-next-line no-await-in-loop -- backoff before the replacement subscribe
       if (emptyCloses > 0) await wait(EVENT_RESUBSCRIBE_DELAY_MS);
     }
   }
@@ -813,6 +818,7 @@ export class OpenCodeAdapter extends BaseAgentAdapter {
         // Normally the previous turn's straggler; but if the server never emits `session.status`
         // (busy-precedes-idle is only live-verified on 1.17.11), this WAS the real settle and the
         // turn will hang at `running` — leave a trace so a stuck turn is attributable.
+        // eslint-disable-next-line no-console -- deliberate daemon-log trace, not a session event
         console.warn(
           'opencode: absorbed a session.idle that preceded the busy acknowledgement (straggler, or a server that never emits session.status)',
         );

--- a/packages/host/agent-adapter/src/native/pi/adapter.ts
+++ b/packages/host/agent-adapter/src/native/pi/adapter.ts
@@ -89,7 +89,7 @@ function effortLevels(model: PiModel): PiEffort[] {
 function modelOptions(models: PiModel[]) {
   return models.map((model) => ({
     id: `${model.provider}/${model.id}`,
-    label: model.name ?? model.id,
+    label: model.name,
     description: `${model.provider}/${model.id}`,
     effortLevels: effortLevels(model),
   }));
@@ -124,7 +124,7 @@ function createConfiguredRegistry(
     authStorage,
     modelRegistry,
     ref,
-    credentialProviderId: key || cred.baseUrl ? (provider ?? null) : null,
+    credentialProviderId: key || cred.baseUrl ? provider : null,
   };
 }
 
@@ -307,6 +307,7 @@ export class PiAdapter extends BaseAgentAdapter {
         await this.session.prompt(text, { ...imageOptions, streamingBehavior: 'followUp' });
       } else await this.session.prompt(text, imageOptions);
       this.promptInFlight = false;
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- the subscribe handler flips `settlementPending` while prompt() is awaited
       if (this.settlementPending) this.settleTurn();
     } catch (error) {
       this.promptInFlight = false;
@@ -476,12 +477,21 @@ export class PiAdapter extends BaseAgentAdapter {
             kind,
           );
         };
-        if (a.type === 'text_delta') this.emitAssistantText(a.delta, id('message'));
-        else if (a.type === 'thinking_delta') this.emitThought(a.delta, id('thought'));
-        else if (a.type === 'text_end') {
-          this.emitAgentMessage(id('message'), [textBlock(a.content)]);
-        } else if (a.type === 'thinking_end') {
-          this.emitAgentThought(id('thought'), [textBlock(a.content)]);
+        switch (a.type) {
+          case 'text_delta':
+            this.emitAssistantText(a.delta, id('message'));
+            break;
+          case 'thinking_delta':
+            this.emitThought(a.delta, id('thought'));
+            break;
+          case 'text_end':
+            this.emitAgentMessage(id('message'), [textBlock(a.content)]);
+            break;
+          case 'thinking_end':
+            this.emitAgentThought(id('thought'), [textBlock(a.content)]);
+            break;
+          default:
+            break;
         }
         break;
       }

--- a/packages/host/assets/src/system-proxy/win32.ts
+++ b/packages/host/assets/src/system-proxy/win32.ts
@@ -18,6 +18,8 @@ const INTERNET_SETTINGS = String.raw`HKEY_CURRENT_USER\Software\Microsoft\Window
 /** A `reg.exe query` value row: 4-space indent, then name / REG_* type / data, 4-space separated. */
 const VALUE_ROW = /^ {4}(.+?) {4}(REG_[A-Z_]+) {4}(.*)$/;
 
+const NEWLINE = /\r?\n/;
+
 export function getWin32SystemProxy(): SystemProxyDetection | undefined {
   const regExe = join(process.env.SystemRoot ?? String.raw`C:\Windows`, 'System32', 'reg.exe');
   const output = execFileSync(regExe, ['query', INTERNET_SETTINGS], {
@@ -33,7 +35,7 @@ export function getWin32SystemProxy(): SystemProxyDetection | undefined {
  */
 export function parseRegQueryOutput(output: string): Map<string, string | number> {
   const values = new Map<string, string | number>();
-  for (const line of output.split(/\r?\n/)) {
+  for (const line of output.split(NEWLINE)) {
     const row = VALUE_ROW.exec(line);
     if (!row) continue;
     const [, name, type, data] = row;

--- a/packages/presentation/ui/src/chat/__tests__/card-radius.test.tsx
+++ b/packages/presentation/ui/src/chat/__tests__/card-radius.test.tsx
@@ -25,39 +25,59 @@ vi.mock('use-intl', () => ({ useTranslations: () => (key: string) => key }));
 
 afterEach(cleanup);
 
-describe('Chat card radius contract', () => {
-  it('uses coss Card chrome for every top-level card surface', () => {
+describe('Chat card chrome contract', () => {
+  it('uses coss Frame chrome with a frame header for every core card surface', () => {
     const { container } = render(
       <>
-        <Artifact>Artifact</Artifact>
         <ArtifactFrame code="" isIncomplete={false} kindLabel="artifact-frame">
           Frame
         </ArtifactFrame>
         <CodeBlock code="source" title="code-block" />
         <FilePreviewCard path="file.txt" />
+        <Terminal title="terminal" />
+        <ToolPreviewCard icon={FileIcon} title="tool-preview">
+          Tool
+        </ToolPreviewCard>
+        <TurnDiffSummary edits={{ additions: 1, deletions: 0, files: [] }} />
+      </>,
+    );
+
+    const frames = container.querySelectorAll(':scope > [data-slot="frame"]');
+    expect(frames).toHaveLength(6);
+    for (const frame of frames) {
+      expect(frame.classList.contains('rounded-2xl')).toBe(true);
+      // FrameHeader renders a literal <header>; render compositions may override its data-slot.
+      expect(frame.querySelector('header')).not.toBeNull();
+    }
+  });
+
+  it('renders a headerless code block as a bare frame panel', () => {
+    const { container } = render(<CodeBlock code="source" />);
+
+    expect(container.querySelector('[data-slot="frame"]')).toBeNull();
+    const panel = container.querySelector(':scope > [data-slot="frame-panel"]');
+    expect(panel?.classList.contains('rounded-xl')).toBe(true);
+  });
+
+  it('uses coss Card chrome for the remaining card surfaces', () => {
+    const { container } = render(
+      <>
+        <Artifact>Artifact</Artifact>
         <PackageInfo packageInfo={{ id: 'package', name: 'package' }}>Package</PackageInfo>
         <Queue>Queue</Queue>
         <SchemaDisplay endpoint={{ id: 'endpoint', method: 'GET', path: '/status' }}>
           Schema
         </SchemaDisplay>
-        <Terminal title="terminal" />
         <TestResults>Tests</TestResults>
-        <ToolPreviewCard icon={FileIcon} title="tool-preview">
-          Tool
-        </ToolPreviewCard>
         <WebPreview preview={{ id: 'preview', url: 'https://example.test' }}>Preview</WebPreview>
-        <TurnDiffSummary edits={{ additions: 1, deletions: 0, files: [] }} />
       </>,
     );
 
     const cards = container.querySelectorAll(':scope > [data-slot="card"]');
-    expect(cards).toHaveLength(12);
+    expect(cards).toHaveLength(6);
     for (const card of cards) {
       expect(card.classList.contains('rounded-2xl')).toBe(true);
     }
-
-    const turnDiff = screen.getByRole('button', { name: 'undo' }).closest('[data-slot="card"]');
-    expect(turnDiff?.classList.contains('bg-card')).toBe(true);
   });
 
   it('keeps collapsible cards at 2xl without changing nested row and control radii', () => {

--- a/packages/presentation/ui/src/chat/__tests__/markdown.test.tsx
+++ b/packages/presentation/ui/src/chat/__tests__/markdown.test.tsx
@@ -5,7 +5,11 @@ import { afterEach, expect, it, vi } from 'vitest';
 import { Markdown } from '../markdown';
 
 // Fences render through ArtifactFenceRenderer, which resolves failure notes via use-intl.
-vi.mock('use-intl', () => ({ useTranslations: () => (key: string) => key }));
+// A function declaration: its hoisting is what lets the hoisted vi.mock factory reference it.
+function identityTranslator(key: string): string {
+  return key;
+}
+vi.mock('use-intl', () => ({ useTranslations: () => identityTranslator }));
 
 afterEach(cleanup);
 
@@ -137,11 +141,11 @@ it('scopes footnote targets to their own Markdown instance', () => {
 
   const definitions = container.querySelectorAll<HTMLElement>('li[id$="user-content-fn-1"]');
   expect(definitions).toHaveLength(2);
-  expect(definitions[0]?.id).not.toBe(definitions[1]?.id);
-  if (!definitions[0] || !definitions[1]) return;
+  const [firstDefinition, secondDefinition] = definitions;
+  expect(firstDefinition.id).not.toBe(secondDefinition.id);
 
-  vi.spyOn(definitions[0], 'getBoundingClientRect').mockReturnValue(DOMRect.fromRect({ y: 111 }));
-  vi.spyOn(definitions[1], 'getBoundingClientRect').mockReturnValue(DOMRect.fromRect({ y: 333 }));
+  vi.spyOn(firstDefinition, 'getBoundingClientRect').mockReturnValue(DOMRect.fromRect({ y: 111 }));
+  vi.spyOn(secondDefinition, 'getBoundingClientRect').mockReturnValue(DOMRect.fromRect({ y: 333 }));
   const references = getAllByRole('link', { name: '1' });
   expect(references).toHaveLength(2);
   if (!references[1]) return;

--- a/packages/presentation/ui/src/chat/__tests__/terminal.test.tsx
+++ b/packages/presentation/ui/src/chat/__tests__/terminal.test.tsx
@@ -17,3 +17,9 @@ it('renders output when the ANSI component is wrapped by its CommonJS default ex
 
   expect(screen.getByText('command output')).toBeDefined();
 });
+
+it('drops trailing newlines so PTY tails do not render as blank panel space', () => {
+  const { container } = render(<TerminalContent>{'line one\nline two\n\n\n'}</TerminalContent>);
+
+  expect(container.querySelector('pre')?.textContent).toBe('line one\nline two');
+});

--- a/packages/presentation/ui/src/chat/__tests__/terminal.test.tsx
+++ b/packages/presentation/ui/src/chat/__tests__/terminal.test.tsx
@@ -19,7 +19,13 @@ it('renders output when the ANSI component is wrapped by its CommonJS default ex
 });
 
 it('drops trailing newlines so PTY tails do not render as blank panel space', () => {
-  const { container } = render(<TerminalContent>{'line one\nline two\n\n\n'}</TerminalContent>);
+  const { container } = render(<TerminalContent>{'line one\nline two\n\r\n\n'}</TerminalContent>);
 
   expect(container.querySelector('pre')?.textContent).toBe('line one\nline two');
+});
+
+it('keeps meaningful trailing spaces on the last content line', () => {
+  const { container } = render(<TerminalContent>{'Password: \n'}</TerminalContent>);
+
+  expect(container.querySelector('pre')?.textContent).toBe('Password: ');
 });

--- a/packages/presentation/ui/src/chat/__tests__/tool-call-item.test.tsx
+++ b/packages/presentation/ui/src/chat/__tests__/tool-call-item.test.tsx
@@ -334,7 +334,8 @@ describe('ToolCallBody', () => {
     const receiptNode = screen.getByText(receipt);
     expect(screen.getAllByText('hello.py')).toHaveLength(1);
     expect(fileCard?.contains(receiptNode)).toBe(false);
-    expect(receiptNode.closest('[data-slot="frame"]')?.textContent).toContain('Edit');
+    // Receipts are auxiliary prose, not artifacts — they render outside any card.
+    expect(receiptNode.closest('[data-slot="frame"]')).toBeNull();
   });
 
   it('renders patch-only moves and textless binary deletes', () => {

--- a/packages/presentation/ui/src/chat/__tests__/tool-call-item.test.tsx
+++ b/packages/presentation/ui/src/chat/__tests__/tool-call-item.test.tsx
@@ -217,9 +217,9 @@ describe('ToolCallBody', () => {
     );
 
     const resourceLabel = screen.getByText('manifest.json');
-    const resourceCard = resourceLabel.closest('[data-slot="card"]');
+    const resourceCard = resourceLabel.closest('[data-slot="frame"]');
     const resourceHeader = resourceLabel.closest<HTMLElement>('[data-slot="tooltip-trigger"]');
-    expect(resourceCard?.querySelector('[data-slot="card-panel"]')).not.toBeNull();
+    expect(resourceCard?.querySelector('[data-slot="frame-panel"]')).not.toBeNull();
     expect(resourceHeader?.tabIndex).toBe(0);
     expect(screen.queryByText('https://example.test/manifest.json?token=secret')).toBeNull();
     await user.hover(resourceHeader!);
@@ -267,9 +267,9 @@ describe('ToolCallBody', () => {
     );
 
     const resourceLabel = screen.getByText('resource');
-    const resourceCard = resourceLabel.closest('[data-slot="card"]');
+    const resourceCard = resourceLabel.closest('[data-slot="frame"]');
     const resourceHeader = resourceLabel.closest<HTMLElement>('[data-slot="tooltip-trigger"]');
-    expect(resourceCard?.querySelector('[data-slot="card-panel"]')).toBeNull();
+    expect(resourceCard?.querySelector('[data-slot="frame-panel"]')).toBeNull();
     expect(resourceHeader?.tabIndex).toBe(0);
     expect(screen.queryByRole('button', { name: 'resource' })).toBeNull();
     await user.hover(resourceHeader!);
@@ -330,11 +330,11 @@ describe('ToolCallBody', () => {
 
     render(<ToolCallBody toolCall={toolCall} />);
 
-    const fileCard = screen.getByText('hello.py').closest('[data-slot="card"]');
+    const fileCard = screen.getByText('hello.py').closest('[data-slot="frame"]');
     const receiptNode = screen.getByText(receipt);
     expect(screen.getAllByText('hello.py')).toHaveLength(1);
     expect(fileCard?.contains(receiptNode)).toBe(false);
-    expect(receiptNode.closest('[data-slot="card"]')?.textContent).toContain('Edit');
+    expect(receiptNode.closest('[data-slot="frame"]')?.textContent).toContain('Edit');
   });
 
   it('renders patch-only moves and textless binary deletes', () => {
@@ -388,7 +388,7 @@ describe('ToolCallBody', () => {
 
     render(<ToolCallBody toolCall={toolCall} />);
 
-    const fileCard = screen.getByText('hello.py').closest('[data-slot="card"]');
+    const fileCard = screen.getByText('hello.py').closest('[data-slot="frame"]');
     const explanationNode = screen.getByText(explanation);
     expect(explanationNode).toBeDefined();
     expect(fileCard?.contains(explanationNode)).toBe(false);
@@ -414,9 +414,9 @@ describe('ToolCallBody', () => {
 
     render(<ToolCallBody toolCall={toolCall} />);
 
-    const fileCard = screen.getByText('hello.py').closest('[data-slot="card"]');
+    const fileCard = screen.getByText('hello.py').closest('[data-slot="frame"]');
     const receiptNode = screen.getByText('Updated hello.py');
-    expect(fileCard?.querySelector('[data-slot="card-panel"]')).toBeNull();
+    expect(fileCard?.querySelector('[data-slot="frame-panel"]')).toBeNull();
     expect(fileCard?.contains(receiptNode)).toBe(false);
   });
 
@@ -489,9 +489,9 @@ describe('FileArtifactCard', () => {
     );
 
     const header = screen.getByRole('button', { name: 'report.pdf' });
-    const card = header.closest('[data-slot="card"]');
+    const card = header.closest('[data-slot="frame"]');
     expect(card?.className).toContain('max-w-md');
-    expect(card?.querySelector('[data-slot="card-panel"]')).toBeNull();
+    expect(card?.querySelector('[data-slot="frame-panel"]')).toBeNull();
     await user.hover(header);
     expect(await screen.findByText(path)).toBeDefined();
     await user.click(header);

--- a/packages/presentation/ui/src/chat/__tests__/tool-call-metadata.test.tsx
+++ b/packages/presentation/ui/src/chat/__tests__/tool-call-metadata.test.tsx
@@ -201,7 +201,10 @@ describe('tool metadata policy', () => {
       <ToolCallBody TerminalBlockComponent={LiveTerminal} toolCall={toolCall} />,
     );
 
-    expect(LiveTerminal).toHaveBeenCalledWith({ terminalId: 'terminal-live' }, undefined);
+    expect(LiveTerminal).toHaveBeenCalledWith(
+      { terminalId: 'terminal-live', command: 'pnpm test' },
+      undefined,
+    );
     expect(container.textContent).toBe('terminal-live');
     expect(container.textContent).not.toContain('description');
   });

--- a/packages/presentation/ui/src/chat/__tests__/turn-diff-summary.test.tsx
+++ b/packages/presentation/ui/src/chat/__tests__/turn-diff-summary.test.tsx
@@ -42,7 +42,7 @@ describe('TurnDiffSummary', () => {
     await user.click(screen.getByRole('button', { name: RE_SHOW_MORE }));
     const fileButtons = FILES.map((file) =>
       screen.getByRole('button', {
-        name: `${file.path} +${file.additions}-${file.deletions}`,
+        name: `${file.path.split('/').at(-1)} +${file.additions}-${file.deletions}`,
       }),
     );
     expect(fileButtons).toHaveLength(FILES.length);

--- a/packages/presentation/ui/src/chat/artifacts/__tests__/html-inline.test.tsx
+++ b/packages/presentation/ui/src/chat/artifacts/__tests__/html-inline.test.tsx
@@ -39,12 +39,12 @@ it('places the ghost Preview action in the source header before Copy', async () 
   );
 
   const preview = screen.getByRole('button', { name: 'Preview' });
-  const header = preview.closest('[data-slot="card-header"]');
+  const header = preview.closest('header');
   const actions = preview.parentElement;
   expect(header).not.toBeNull();
   expect(preview.className).toContain('border-transparent');
   expect(actions?.lastElementChild?.getAttribute('aria-label')).toBe('Copy');
-  expect(container.querySelector('[data-slot="card"] + div')).toBeNull();
+  expect(container.querySelector('[data-slot="frame-panel"] + div')).toBeNull();
   await waitFor(
     () => {
       expect(container.querySelectorAll('code span[style*="--sdm-c"]').length).toBeGreaterThan(2);
@@ -69,5 +69,5 @@ it('keeps a hosting failure visible in the source header', async () => {
 
   await user.click(screen.getByRole('button', { name: 'Preview' }));
   const failure = await screen.findByText('Failed to host the preview');
-  expect(failure.closest('[data-slot="card-header"]')).not.toBeNull();
+  expect(failure.closest('header')).not.toBeNull();
 });

--- a/packages/presentation/ui/src/chat/artifacts/artifact-frame.tsx
+++ b/packages/presentation/ui/src/chat/artifacts/artifact-frame.tsx
@@ -1,12 +1,8 @@
-import { Card } from 'coss-ui/components/card';
+import { Frame } from 'coss-ui/components/frame';
 import { useTranslations } from 'use-intl';
 import { cn } from '../../lib/cn';
-import {
-  CodeBlockActions,
-  CodeBlockCopyButton,
-  CodeBlockHeader,
-  CodeBlockTitle,
-} from '../code-block';
+import { ChatCardActions, ChatCardHeader, ChatCardPanel, ChatCardTitle } from '../chat-card';
+import { CodeBlockCopyButton } from '../code-block';
 
 export interface ArtifactFrameProps {
   /** Shown in the header (the fence language / kind id — technical, not translated). */
@@ -18,8 +14,8 @@ export interface ArtifactFrameProps {
   children: React.ReactNode;
 }
 
-/** Chrome shared by inline artifact renderers: bordered card with a code-block-style
- * header (kind label, streaming indicator, copy-source button). */
+/** Chrome shared by inline artifact renderers: coss-ui frame with the kind label,
+ * streaming indicator, and copy-source button in the frame header. */
 export function ArtifactFrame({
   kindLabel,
   code,
@@ -30,17 +26,15 @@ export function ArtifactFrame({
   const t = useTranslations('workbench.artifact');
 
   return (
-    <Card className={cn('my-2 overflow-hidden', className)} data-artifact-kind={kindLabel}>
-      <CodeBlockHeader>
-        <CodeBlockTitle>{kindLabel}</CodeBlockTitle>
-        <CodeBlockActions>
-          {isIncomplete ? (
-            <span className="animate-pulse text-muted-foreground">{t('streaming')}</span>
-          ) : null}
+    <Frame className={cn('my-2', className)} data-artifact-kind={kindLabel}>
+      <ChatCardHeader>
+        <ChatCardTitle>{kindLabel}</ChatCardTitle>
+        <ChatCardActions>
+          {isIncomplete ? <span className="animate-pulse">{t('streaming')}</span> : null}
           <CodeBlockCopyButton code={code} />
-        </CodeBlockActions>
-      </CodeBlockHeader>
-      {children}
-    </Card>
+        </ChatCardActions>
+      </ChatCardHeader>
+      <ChatCardPanel className="overflow-hidden p-0">{children}</ChatCardPanel>
+    </Frame>
   );
 }

--- a/packages/presentation/ui/src/chat/artifacts/fence-fallback.tsx
+++ b/packages/presentation/ui/src/chat/artifacts/fence-fallback.tsx
@@ -1,4 +1,5 @@
-import { CodeBlock, CodeBlockActions, CodeBlockCopyButton } from '../code-block';
+import { ChatCardActions } from '../chat-card';
+import { CodeBlock, CodeBlockCopyButton } from '../code-block';
 
 /** The degradation target for every artifact path (unknown kind, render failure):
  * the fence shows as a plain code block, exactly what a non-artifact fence would be. */
@@ -17,11 +18,11 @@ export function FenceFallback({
 }): React.ReactNode {
   return (
     <CodeBlock code={code} language={language} title={language}>
-      <CodeBlockActions>
+      <ChatCardActions>
         {note ? <span className="min-w-0 truncate text-muted-foreground">{note}</span> : null}
         {action}
         <CodeBlockCopyButton code={code} />
-      </CodeBlockActions>
+      </ChatCardActions>
     </CodeBlock>
   );
 }

--- a/packages/presentation/ui/src/chat/chat-card.tsx
+++ b/packages/presentation/ui/src/chat/chat-card.tsx
@@ -1,0 +1,43 @@
+import { FrameHeader, FramePanel } from 'coss-ui/components/frame';
+import { cn } from '../lib/cn';
+
+export type ChatCardHeaderProps = React.ComponentProps<typeof FrameHeader>;
+
+/** coss-ui `FrameHeader` as a single compact row, at chat-flow density. */
+export function ChatCardHeader({ className, ...props }: ChatCardHeaderProps): React.ReactNode {
+  return (
+    <FrameHeader
+      className={cn(
+        'flex-row items-center gap-2 px-3 py-1.5 text-muted-foreground text-xs',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export type ChatCardTitleProps = React.ComponentProps<'span'>;
+
+/** Header title with the chat cards' mono label look; a span so headers can render as buttons. */
+export function ChatCardTitle({ className, ...props }: ChatCardTitleProps): React.ReactNode {
+  return (
+    <span
+      className={cn('min-w-0 truncate font-mono text-xs leading-normal', className)}
+      {...props}
+    />
+  );
+}
+
+export type ChatCardActionsProps = React.ComponentProps<'span'>;
+
+/** Trailing header slot; a span so it stays valid inside header buttons. */
+export function ChatCardActions({ className, ...props }: ChatCardActionsProps): React.ReactNode {
+  return <span className={cn('ml-auto flex shrink-0 items-center gap-1', className)} {...props} />;
+}
+
+export type ChatCardPanelProps = React.ComponentProps<typeof FramePanel>;
+
+/** coss-ui `FramePanel` body at chat-flow density. */
+export function ChatCardPanel({ className, ...props }: ChatCardPanelProps): React.ReactNode {
+  return <FramePanel className={cn('px-3 py-2', className)} {...props} />;
+}

--- a/packages/presentation/ui/src/chat/chat-card.tsx
+++ b/packages/presentation/ui/src/chat/chat-card.tsx
@@ -18,14 +18,10 @@ export function ChatCardHeader({ className, ...props }: ChatCardHeaderProps): Re
 
 export type ChatCardTitleProps = React.ComponentProps<'span'>;
 
-/** Header title with the chat cards' mono label look; a span so headers can render as buttons. */
+/** Header title label; a span so headers can render as buttons. Sans by design — only
+ * terminal/execute headers opt into mono for the command they display. */
 export function ChatCardTitle({ className, ...props }: ChatCardTitleProps): React.ReactNode {
-  return (
-    <span
-      className={cn('min-w-0 truncate font-mono text-xs leading-normal', className)}
-      {...props}
-    />
-  );
+  return <span className={cn('min-w-0 truncate text-xs leading-normal', className)} {...props} />;
 }
 
 export type ChatCardActionsProps = React.ComponentProps<'span'>;

--- a/packages/presentation/ui/src/chat/code-block.tsx
+++ b/packages/presentation/ui/src/chat/code-block.tsx
@@ -1,10 +1,11 @@
-import { Card, CardHeader, CardPanel, CardTitle } from 'coss-ui/components/card';
+import { Frame } from 'coss-ui/components/frame';
 import { cn } from '../lib/cn';
+import { ChatCardHeader, ChatCardPanel, ChatCardTitle } from './chat-card';
 import type { CopyIconButtonProps } from './copy-icon-button';
 import { CopyIconButton } from './copy-icon-button';
 import { HighlightedCode } from './highlighted-code';
 
-export interface CodeBlockProps extends React.ComponentProps<typeof Card> {
+export interface CodeBlockProps extends React.ComponentProps<typeof Frame> {
   code: string;
   language?: string;
   title?: string;
@@ -18,55 +19,29 @@ export function CodeBlock({
   children,
   ...props
 }: CodeBlockProps): React.ReactNode {
-  const hasHeader = Boolean(title || language || children);
-
-  return (
-    <Card className={cn('my-2 overflow-hidden', className)} data-language={language} {...props}>
-      {hasHeader ? (
-        <CodeBlockHeader>
-          <CodeBlockTitle>{title ?? language}</CodeBlockTitle>
-          {children}
-        </CodeBlockHeader>
-      ) : null}
-      <CardPanel className="p-0">
+  if (!title && !language && !children) {
+    return (
+      <ChatCardPanel
+        className={cn('my-2 overflow-hidden p-0', className)}
+        data-language={language}
+        {...props}
+      >
         <HighlightedCode className="p-3" code={code} language={language} />
-      </CardPanel>
-    </Card>
-  );
-}
+      </ChatCardPanel>
+    );
+  }
 
-export type CodeBlockHeaderProps = React.ComponentProps<typeof CardHeader>;
-
-export function CodeBlockHeader({ className, ...props }: CodeBlockHeaderProps): React.ReactNode {
   return (
-    <CardHeader
-      className={cn(
-        'grid-cols-[minmax(0,1fr)_auto] grid-rows-[auto] items-center gap-2 border-b bg-muted px-3 py-1.5 text-xs in-[[data-slot=card]:has(>[data-slot=card-panel])]:pb-1.5',
-        className,
-      )}
-      {...props}
-    />
+    <Frame className={cn('my-2', className)} data-language={language} {...props}>
+      <ChatCardHeader>
+        <ChatCardTitle>{title ?? language}</ChatCardTitle>
+        {children}
+      </ChatCardHeader>
+      <ChatCardPanel className="overflow-hidden p-0">
+        <HighlightedCode className="p-3" code={code} language={language} />
+      </ChatCardPanel>
+    </Frame>
   );
-}
-
-export type CodeBlockTitleProps = React.ComponentProps<typeof CardTitle>;
-
-export function CodeBlockTitle({ className, ...props }: CodeBlockTitleProps): React.ReactNode {
-  return (
-    <CardTitle
-      className={cn(
-        'truncate font-mono font-normal text-muted-foreground text-xs leading-normal',
-        className,
-      )}
-      {...props}
-    />
-  );
-}
-
-export type CodeBlockActionsProps = React.ComponentProps<'div'>;
-
-export function CodeBlockActions({ className, ...props }: CodeBlockActionsProps): React.ReactNode {
-  return <div className={cn('-my-1 flex items-center gap-1', className)} {...props} />;
 }
 
 export type CodeBlockCopyButtonProps = Omit<CopyIconButtonProps, 'value'> & {

--- a/packages/presentation/ui/src/chat/code-block.tsx
+++ b/packages/presentation/ui/src/chat/code-block.tsx
@@ -1,6 +1,6 @@
 import { Frame } from 'coss-ui/components/frame';
 import { cn } from '../lib/cn';
-import { ChatCardHeader, ChatCardPanel, ChatCardTitle } from './chat-card';
+import { ChatCardActions, ChatCardHeader, ChatCardPanel, ChatCardTitle } from './chat-card';
 import type { CopyIconButtonProps } from './copy-icon-button';
 import { CopyIconButton } from './copy-icon-button';
 import { HighlightedCode } from './highlighted-code';
@@ -35,7 +35,11 @@ export function CodeBlock({
     <Frame className={cn('my-2', className)} data-language={language} {...props}>
       <ChatCardHeader>
         <ChatCardTitle>{title ?? language}</ChatCardTitle>
-        {children}
+        {children ?? (
+          <ChatCardActions>
+            <CodeBlockCopyButton code={code} />
+          </ChatCardActions>
+        )}
       </ChatCardHeader>
       <ChatCardPanel className="overflow-hidden p-0">
         <HighlightedCode className="p-3" code={code} language={language} />

--- a/packages/presentation/ui/src/chat/file-preview-card.tsx
+++ b/packages/presentation/ui/src/chat/file-preview-card.tsx
@@ -1,15 +1,16 @@
 import { Badge } from 'coss-ui/components/badge';
-import { Button } from 'coss-ui/components/button';
-import { Card, CardHeader, CardPanel, CardTitle } from 'coss-ui/components/card';
+import { Frame } from 'coss-ui/components/frame';
 import { useRef } from 'react';
 import { cn } from '../lib/cn';
 import { fileBasename } from './artifacts/file-kind';
 import type { ArtifactNavigation } from './artifacts/host-actions';
 import { artifactNavigationAction, useArtifactHostActions } from './artifacts/host-actions';
+import { ChatCardActions, ChatCardHeader, ChatCardPanel, ChatCardTitle } from './chat-card';
 import { FileIdentityIcon } from './file-identity-icon';
 import { FilePathTooltip } from './with-tooltip';
 
-/** Shared file-result surface: basename in chrome, full path in a coss tooltip, and host navigation. */
+/** Shared file-result surface: basename in the frame header, full path in a coss tooltip,
+ * and host navigation on the header row. */
 export function FilePreviewCard({
   badge,
   children,
@@ -39,53 +40,46 @@ export function FilePreviewCard({
   const content = (
     <>
       <FileIdentityIcon className="shrink-0" path={path} ref={tooltipAnchorRef} />
-      <CardTitle
-        className="min-w-0 flex-1 truncate text-left font-mono font-normal text-xs leading-normal"
-        render={<span />}
-      >
-        {label ?? fileBasename(path)}
-      </CardTitle>
-      {badge ? (
-        <Badge size="sm" variant="secondary">
-          {badge}
-        </Badge>
+      <ChatCardTitle className="text-left">{label ?? fileBasename(path)}</ChatCardTitle>
+      {badge || headerEnd ? (
+        <ChatCardActions>
+          {badge ? (
+            <Badge size="sm" variant="secondary">
+              {badge}
+            </Badge>
+          ) : null}
+          {headerEnd}
+        </ChatCardActions>
       ) : null}
-      {headerEnd}
     </>
   );
   const header = onOpen ? (
-    <Button
-      className="w-full justify-start rounded-none border-0 px-3 py-1.5 font-normal text-muted-foreground text-xs focus-visible:ring-inset sm:text-xs"
-      size="sm"
-      variant="ghost"
-      onClick={onOpen}
-    >
-      {content}
-    </Button>
+    <ChatCardHeader className="p-0">
+      <button
+        className="flex min-w-0 flex-1 cursor-pointer items-center gap-2 px-3 py-1.5 text-left outline-none transition-colors hover:text-foreground focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
+        type="button"
+        onClick={onOpen}
+      >
+        {content}
+      </button>
+    </ChatCardHeader>
   ) : (
-    <div
-      className="flex items-center gap-2 px-3 py-1.5 text-muted-foreground text-xs outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
+    <ChatCardHeader
+      className="outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
       tabIndex={0}
     >
       {content}
-    </div>
+    </ChatCardHeader>
   );
 
   return (
-    <Card className={cn('my-1 overflow-hidden', className)}>
-      <CardHeader
-        className={cn(
-          'grid-cols-1 grid-rows-[auto] bg-muted p-0 in-[[data-slot=card]:has(>[data-slot=card-panel])]:pb-0',
-          children !== undefined && 'border-b',
-        )}
-      >
-        <FilePathTooltip anchor={tooltipAnchorRef} tooltip={fullPath}>
-          {header}
-        </FilePathTooltip>
-      </CardHeader>
+    <Frame className={cn('my-1', className)}>
+      <FilePathTooltip anchor={tooltipAnchorRef} tooltip={fullPath}>
+        {header}
+      </FilePathTooltip>
       {children === undefined ? null : (
-        <CardPanel className={cn('px-3 py-2', panelClassName)}>{children}</CardPanel>
+        <ChatCardPanel className={panelClassName}>{children}</ChatCardPanel>
       )}
-    </Card>
+    </Frame>
   );
 }

--- a/packages/presentation/ui/src/chat/index.ts
+++ b/packages/presentation/ui/src/chat/index.ts
@@ -4,6 +4,7 @@ export * from './agent-icon';
 export * from './artifact';
 export * from './artifacts';
 export * from './attachments';
+export * from './chat-card';
 export * from './checkpoint';
 export * from './circular-progress';
 export * from './code-block';

--- a/packages/presentation/ui/src/chat/markdown.tsx
+++ b/packages/presentation/ui/src/chat/markdown.tsx
@@ -89,6 +89,7 @@ function InlineCode({
 }
 
 const FENCE_LANGUAGE_RE = /language-(\S+)/;
+const TRAILING_NEWLINES_RE = /\n+$/;
 
 /** The fence text child is a plain string, except while the animate plugin wraps it. */
 function fenceText(children: React.ReactNode): string {
@@ -112,7 +113,7 @@ function FencedCode({
   const metastring = node?.properties.metastring;
   return (
     <ArtifactFenceRenderer
-      code={fenceText(children).replace(/\n+$/, '')}
+      code={fenceText(children).replace(TRAILING_NEWLINES_RE, '')}
       language={language}
       meta={typeof metastring === 'string' ? metastring : undefined}
       isIncomplete={isIncomplete}

--- a/packages/presentation/ui/src/chat/terminal-block.tsx
+++ b/packages/presentation/ui/src/chat/terminal-block.tsx
@@ -1,14 +1,18 @@
 import { useTranslations } from 'use-intl';
-import { ChatCardHeader } from './chat-card';
+import { ChatCardActions, ChatCardHeader } from './chat-card';
+import { CopyIconButton } from './copy-icon-button';
 import { Terminal, TerminalContent, TerminalTitle } from './terminal';
 
 /** Read-only view of an agent-spawned terminal referenced from tool-call content, streamed live. */
 export function TerminalBlock({
   terminalId,
   output,
+  command,
 }: {
   terminalId: string;
   output?: string;
+  /** The command the tool ran in this terminal; shown nowhere, but offered for copying. */
+  command?: string;
 }): React.ReactNode {
   const t = useTranslations('workbench.tool');
 
@@ -18,6 +22,11 @@ export function TerminalBlock({
         <TerminalTitle>
           {t('terminal')} <span className="opacity-70">{terminalId}</span>
         </TerminalTitle>
+        {command ? (
+          <ChatCardActions>
+            <CopyIconButton label="command" value={command} />
+          </ChatCardActions>
+        ) : null}
       </ChatCardHeader>
       {output?.trim() ? <TerminalContent>{output}</TerminalContent> : null}
     </Terminal>

--- a/packages/presentation/ui/src/chat/terminal-block.tsx
+++ b/packages/presentation/ui/src/chat/terminal-block.tsx
@@ -1,5 +1,6 @@
 import { useTranslations } from 'use-intl';
-import { Terminal, TerminalContent, TerminalHeader, TerminalTitle } from './terminal';
+import { ChatCardHeader } from './chat-card';
+import { Terminal, TerminalContent, TerminalTitle } from './terminal';
 
 /** Read-only view of an agent-spawned terminal referenced from tool-call content, streamed live. */
 export function TerminalBlock({
@@ -13,12 +14,12 @@ export function TerminalBlock({
 
   return (
     <Terminal>
-      <TerminalHeader>
+      <ChatCardHeader>
         <TerminalTitle>
           {t('terminal')} <span className="opacity-70">{terminalId}</span>
         </TerminalTitle>
-      </TerminalHeader>
-      {output ? <TerminalContent>{output}</TerminalContent> : null}
+      </ChatCardHeader>
+      {output?.trim() ? <TerminalContent>{output}</TerminalContent> : null}
     </Terminal>
   );
 }

--- a/packages/presentation/ui/src/chat/terminal.tsx
+++ b/packages/presentation/ui/src/chat/terminal.tsx
@@ -3,6 +3,7 @@ import { Frame } from 'coss-ui/components/frame';
 import { TerminalIcon } from 'lucide-react';
 import { cn } from '../lib/cn';
 import { ChatCardActions, ChatCardHeader, ChatCardPanel, ChatCardTitle } from './chat-card';
+import { CopyIconButton } from './copy-icon-button';
 import { Shimmer } from './shimmer';
 
 type AnsiComponent = typeof AnsiImport;
@@ -34,11 +35,10 @@ export function Terminal({
         <>
           <ChatCardHeader>
             <TerminalTitle>{title}</TerminalTitle>
-            {isStreaming ? (
-              <ChatCardActions>
-                <Shimmer className="text-xs">running</Shimmer>
-              </ChatCardActions>
-            ) : null}
+            <ChatCardActions>
+              {isStreaming ? <Shimmer className="text-xs">running</Shimmer> : null}
+              {title ? <CopyIconButton label="command" value={title} /> : null}
+            </ChatCardActions>
           </ChatCardHeader>
           {output?.trim() ? <TerminalContent>{output}</TerminalContent> : null}
         </>
@@ -55,7 +55,7 @@ export function TerminalTitle({
   ...props
 }: TerminalTitleProps): React.ReactNode {
   return (
-    <ChatCardTitle className={cn('flex items-center gap-2', className)} {...props}>
+    <ChatCardTitle className={cn('flex items-center gap-2 font-mono', className)} {...props}>
       <TerminalIcon className="size-3.5 shrink-0" />
       <span className="truncate">{children ?? 'Terminal'}</span>
     </ChatCardTitle>

--- a/packages/presentation/ui/src/chat/terminal.tsx
+++ b/packages/presentation/ui/src/chat/terminal.tsx
@@ -13,8 +13,6 @@ type AnsiComponent = typeof AnsiImport;
 const ansiModule = AnsiImport as AnsiComponent | { default: AnsiComponent };
 const Ansi = typeof ansiModule === 'function' ? ansiModule : ansiModule.default;
 
-const RE_TRAILING_WHITESPACE = /\s+$/;
-
 export interface TerminalProps extends React.ComponentProps<typeof Frame> {
   title?: string;
   output?: string;
@@ -82,7 +80,7 @@ export function TerminalContent({
         {typeof children === 'string' ? (
           <Ansi useClasses linkify={false}>
             {/* PTY buffers and stdout end in newlines; blank tail lines read as dead space. */}
-            {children.replace(RE_TRAILING_WHITESPACE, '')}
+            {children.trimEnd()}
           </Ansi>
         ) : (
           children

--- a/packages/presentation/ui/src/chat/terminal.tsx
+++ b/packages/presentation/ui/src/chat/terminal.tsx
@@ -1,7 +1,8 @@
 import AnsiImport from 'ansi-to-react';
-import { Card, CardHeader, CardTitle } from 'coss-ui/components/card';
+import { Frame } from 'coss-ui/components/frame';
 import { TerminalIcon } from 'lucide-react';
 import { cn } from '../lib/cn';
+import { ChatCardActions, ChatCardHeader, ChatCardPanel, ChatCardTitle } from './chat-card';
 import { Shimmer } from './shimmer';
 
 type AnsiComponent = typeof AnsiImport;
@@ -11,7 +12,9 @@ type AnsiComponent = typeof AnsiImport;
 const ansiModule = AnsiImport as AnsiComponent | { default: AnsiComponent };
 const Ansi = typeof ansiModule === 'function' ? ansiModule : ansiModule.default;
 
-export interface TerminalProps extends React.ComponentProps<typeof Card> {
+const RE_TRAILING_WHITESPACE = /\s+$/;
+
+export interface TerminalProps extends React.ComponentProps<typeof Frame> {
   title?: string;
   output?: string;
   isStreaming?: boolean;
@@ -26,34 +29,25 @@ export function Terminal({
   ...props
 }: TerminalProps): React.ReactNode {
   return (
-    <Card
-      className={cn('my-1 overflow-hidden bg-muted text-muted-foreground', className)}
-      {...props}
-    >
-      <TerminalHeader>
-        <TerminalTitle>{title}</TerminalTitle>
-        {isStreaming ? <Shimmer className="text-xs">running</Shimmer> : null}
-      </TerminalHeader>
-      {children ?? (output ? <TerminalContent>{output}</TerminalContent> : null)}
-    </Card>
-  );
-}
-
-export type TerminalHeaderProps = React.ComponentProps<typeof CardHeader>;
-
-export function TerminalHeader({ className, ...props }: TerminalHeaderProps): React.ReactNode {
-  return (
-    <CardHeader
-      className={cn(
-        'grid-cols-[minmax(0,1fr)_auto] grid-rows-[auto] items-center gap-2 px-3 py-1.5 text-xs',
-        className,
+    <Frame className={cn('my-1', className)} {...props}>
+      {children ?? (
+        <>
+          <ChatCardHeader>
+            <TerminalTitle>{title}</TerminalTitle>
+            {isStreaming ? (
+              <ChatCardActions>
+                <Shimmer className="text-xs">running</Shimmer>
+              </ChatCardActions>
+            ) : null}
+          </ChatCardHeader>
+          {output?.trim() ? <TerminalContent>{output}</TerminalContent> : null}
+        </>
       )}
-      {...props}
-    />
+    </Frame>
   );
 }
 
-export type TerminalTitleProps = React.ComponentProps<typeof CardTitle>;
+export type TerminalTitleProps = React.ComponentProps<typeof ChatCardTitle>;
 
 export function TerminalTitle({
   className,
@@ -61,16 +55,10 @@ export function TerminalTitle({
   ...props
 }: TerminalTitleProps): React.ReactNode {
   return (
-    <CardTitle
-      className={cn(
-        'flex min-w-0 items-center gap-2 font-mono font-normal text-xs leading-normal',
-        className,
-      )}
-      {...props}
-    >
+    <ChatCardTitle className={cn('flex items-center gap-2', className)} {...props}>
       <TerminalIcon className="size-3.5 shrink-0" />
       <span className="truncate">{children ?? 'Terminal'}</span>
-    </CardTitle>
+    </ChatCardTitle>
   );
 }
 
@@ -82,20 +70,24 @@ export function TerminalContent({
   ...props
 }: TerminalContentProps): React.ReactNode {
   return (
-    <pre
-      className={cn(
-        'chat-terminal-output max-h-80 overflow-auto border-t border-border px-3 py-2 font-mono text-xs leading-relaxed',
-        className,
-      )}
-      {...props}
-    >
-      {typeof children === 'string' ? (
-        <Ansi useClasses linkify={false}>
-          {children}
-        </Ansi>
-      ) : (
-        children
-      )}
-    </pre>
+    // overflow-hidden clips the pre's own terminal surface to the panel radius.
+    <ChatCardPanel className="overflow-hidden p-0">
+      <pre
+        className={cn(
+          'chat-terminal-output max-h-80 overflow-auto px-3 py-2 font-mono text-xs leading-relaxed',
+          className,
+        )}
+        {...props}
+      >
+        {typeof children === 'string' ? (
+          <Ansi useClasses linkify={false}>
+            {/* PTY buffers and stdout end in newlines; blank tail lines read as dead space. */}
+            {children.replace(RE_TRAILING_WHITESPACE, '')}
+          </Ansi>
+        ) : (
+          children
+        )}
+      </pre>
+    </ChatCardPanel>
   );
 }

--- a/packages/presentation/ui/src/chat/terminal.tsx
+++ b/packages/presentation/ui/src/chat/terminal.tsx
@@ -13,6 +13,15 @@ type AnsiComponent = typeof AnsiImport;
 const ansiModule = AnsiImport as AnsiComponent | { default: AnsiComponent };
 const Ansi = typeof ansiModule === 'function' ? ansiModule : ansiModule.default;
 
+/** Drops blank tail lines only — trailing spaces on the last content line stay (prompt
+ * padding, ANSI-colored blocks). A scan, not a regex: output is unbounded input and
+ * `q+$`-style patterns backtrack polynomially on it. */
+function trimTrailingNewlines(text: string): string {
+  let end = text.length;
+  while (end > 0 && (text[end - 1] === '\n' || text[end - 1] === '\r')) end -= 1;
+  return text.slice(0, end);
+}
+
 export interface TerminalProps extends React.ComponentProps<typeof Frame> {
   title?: string;
   output?: string;
@@ -80,7 +89,7 @@ export function TerminalContent({
         {typeof children === 'string' ? (
           <Ansi useClasses linkify={false}>
             {/* PTY buffers and stdout end in newlines; blank tail lines read as dead space. */}
-            {children.trimEnd()}
+            {trimTrailingNewlines(children)}
           </Ansi>
         ) : (
           children

--- a/packages/presentation/ui/src/chat/tool-preview-card.tsx
+++ b/packages/presentation/ui/src/chat/tool-preview-card.tsx
@@ -1,5 +1,6 @@
 import { Badge } from 'coss-ui/components/badge';
-import { Card, CardHeader, CardPanel, CardTitle } from 'coss-ui/components/card';
+import { Frame } from 'coss-ui/components/frame';
+import { ChatCardActions, ChatCardHeader, ChatCardPanel, ChatCardTitle } from './chat-card';
 
 export function ToolPreviewCard({
   badge,
@@ -13,19 +14,19 @@ export function ToolPreviewCard({
   title: string;
 }): React.ReactNode {
   return (
-    <Card className="my-1 overflow-hidden">
-      <CardHeader className="grid-cols-[auto_minmax(0,1fr)_auto] grid-rows-[auto] items-center gap-2 border-b bg-muted px-3 py-1.5 in-[[data-slot=card]:has(>[data-slot=card-panel])]:pb-1.5">
-        <Icon className="size-3.5 text-muted-foreground" />
-        <CardTitle className="truncate font-mono font-normal text-muted-foreground text-xs leading-normal">
-          {title}
-        </CardTitle>
+    <Frame className="my-1">
+      <ChatCardHeader>
+        <Icon className="size-3.5 shrink-0" />
+        <ChatCardTitle>{title}</ChatCardTitle>
         {badge ? (
-          <Badge size="sm" variant="secondary">
-            {badge}
-          </Badge>
+          <ChatCardActions>
+            <Badge size="sm" variant="secondary">
+              {badge}
+            </Badge>
+          </ChatCardActions>
         ) : null}
-      </CardHeader>
-      <CardPanel className="px-3 py-2">{children}</CardPanel>
-    </Card>
+      </ChatCardHeader>
+      <ChatCardPanel>{children}</ChatCardPanel>
+    </Frame>
   );
 }

--- a/packages/presentation/ui/src/chat/tool-result-preview.tsx
+++ b/packages/presentation/ui/src/chat/tool-result-preview.tsx
@@ -22,7 +22,7 @@ import {
   toolCallReadPreviewText,
   toolCallSearchQuery,
 } from './tool-result-content';
-import { TOOL_KIND_ICONS, toolCallCommand, toolCallDisplayTitle } from './tool-utils';
+import { toolCallCommand, toolCallDisplayTitle } from './tool-utils';
 
 /** Host-provided replacement for the static `TerminalBlock` (e.g. the live daemon-backed one). */
 export type TerminalBlockComponent = React.ComponentType<{
@@ -235,16 +235,6 @@ function renderTextPreview(toolCall: ToolCall, text: string): React.ReactNode {
         </ToolPreviewCard>
       );
     }
-    case 'edit':
-    case 'delete':
-    case 'move': {
-      const Icon = TOOL_KIND_ICONS[toolCall.kind];
-      return (
-        <ToolPreviewCard icon={Icon} title={displayTitle}>
-          <Markdown>{text}</Markdown>
-        </ToolPreviewCard>
-      );
-    }
     case 'search':
       return <SearchRows text={text} toolCall={toolCall} />;
     case 'fetch': {
@@ -269,6 +259,10 @@ function renderTextPreview(toolCall: ToolCall, text: string): React.ReactNode {
         </ToolPreviewCard>
       );
     }
+    // Mutation receipts and reasoning summaries are auxiliary prose, not artifacts — no card.
+    case 'edit':
+    case 'delete':
+    case 'move':
     case 'think':
     case 'task':
       return <Markdown>{text}</Markdown>;

--- a/packages/presentation/ui/src/chat/tool-result-preview.tsx
+++ b/packages/presentation/ui/src/chat/tool-result-preview.tsx
@@ -24,9 +24,15 @@ import {
 } from './tool-result-content';
 import { TOOL_KIND_ICONS, toolCallCommand, toolCallDisplayTitle } from './tool-utils';
 
+/** Host-provided replacement for the static `TerminalBlock` (e.g. the live daemon-backed one). */
+export type TerminalBlockComponent = React.ComponentType<{
+  terminalId: string;
+  command?: string;
+}>;
+
 interface ToolResultPreviewProps {
   toolCall: ToolCall;
-  TerminalBlockComponent?: React.ComponentType<{ terminalId: string }>;
+  TerminalBlockComponent?: TerminalBlockComponent;
 }
 
 function RenderedContent({
@@ -35,7 +41,7 @@ function RenderedContent({
   toolCall,
 }: {
   content: ToolCallContent;
-  TerminalBlockComponent?: React.ComponentType<{ terminalId: string }>;
+  TerminalBlockComponent?: TerminalBlockComponent;
   toolCall: ToolCall;
 }): React.ReactNode {
   if (content.type === 'content') return <ContentBlockView block={content.content} />;
@@ -51,10 +57,11 @@ function RenderedContent({
       />
     );
   }
+  const command = toolCallCommand(toolCall);
   if (TerminalBlockComponent) {
-    return <TerminalBlockComponent terminalId={content.terminalId} />;
+    return <TerminalBlockComponent command={command} terminalId={content.terminalId} />;
   }
-  return <TerminalBlock terminalId={content.terminalId} />;
+  return <TerminalBlock command={command} terminalId={content.terminalId} />;
 }
 
 function SearchRows({ toolCall, text }: { toolCall: ToolCall; text: string }): React.ReactNode {

--- a/packages/presentation/ui/src/chat/turn-diff-summary.tsx
+++ b/packages/presentation/ui/src/chat/turn-diff-summary.tsx
@@ -2,8 +2,10 @@ import { Button } from 'coss-ui/components/button';
 import { Collapsible, CollapsibleTrigger } from 'coss-ui/components/collapsible';
 import { Frame } from 'coss-ui/components/frame';
 import { FileDiffIcon, Undo2Icon } from 'lucide-react';
+import { useRef } from 'react';
 import { useTranslations } from 'use-intl';
 import { cn } from '../lib/cn';
+import { fileBasename } from './artifacts/file-kind';
 import { useArtifactHostActions } from './artifacts/host-actions';
 import { ChatCardActions, ChatCardHeader, ChatCardPanel } from './chat-card';
 import { ChatDisclosureContent } from './disclosure-content';
@@ -14,7 +16,9 @@ import {
   ChatDisclosureChevron,
   ChatDisclosureIconSlot,
 } from './disclosure-header';
+import { FileIdentityIcon } from './file-identity-icon';
 import type { TurnEdits, TurnFileEdit } from './turn-edits';
+import { FilePathTooltip } from './with-tooltip';
 
 const COLLAPSED_FILE_COUNT = 3;
 
@@ -56,7 +60,7 @@ export function TurnDiffSummary({
         </ChatCardActions>
       </ChatCardHeader>
       {edits.files.length > 0 ? (
-        <ChatCardPanel className="px-3 py-1">
+        <ChatCardPanel className="overflow-hidden px-0 py-1">
           <Collapsible>
             {visibleFiles.map((file) => (
               <FileRow key={file.path} file={file} onOpenFile={openFile} />
@@ -69,7 +73,7 @@ export function TurnDiffSummary({
                   ))}
                 </ChatDisclosureContent>
                 <CollapsibleTrigger
-                  className={cn(CHAT_DISCLOSURE_TRIGGER_CLASS_NAME, 'w-fit max-w-full')}
+                  className={cn(CHAT_DISCLOSURE_TRIGGER_CLASS_NAME, 'w-fit max-w-full px-3')}
                 >
                   <span className={CHAT_DISCLOSURE_TEXT_CLASS_NAME}>
                     <span
@@ -89,7 +93,8 @@ export function TurnDiffSummary({
                       {t('showLess')}
                     </span>
                   </span>
-                  <ChatDisclosureChevron />
+                  {/* Expands downward, collapses upward — not the tree-node right→down chevron. */}
+                  <ChatDisclosureChevron className="rotate-90 group-data-[panel-open]:-rotate-90" />
                 </CollapsibleTrigger>
               </>
             )}
@@ -100,6 +105,7 @@ export function TurnDiffSummary({
   );
 }
 
+/** Basename row with the file-identity icon; the full path lives in the hover tooltip. */
 function FileRow({
   file,
   onOpenFile,
@@ -107,29 +113,33 @@ function FileRow({
   file: TurnFileEdit;
   onOpenFile?: (path: string) => void;
 }): React.ReactNode {
-  const basenameStart = file.path.lastIndexOf('/') + 1;
+  const tooltipAnchorRef = useRef<HTMLSpanElement>(null);
+  const rowClassName =
+    'flex w-full items-center gap-2 px-3 py-1 text-left text-sm outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring';
   const body = (
     <>
-      <span className="min-w-0 flex-1 truncate text-ellipsis text-sm">
-        <span className="text-muted-foreground transition-colors group-hover/file:text-foreground">
-          {file.path.slice(0, basenameStart)}
-        </span>
-        <span className="text-foreground">{file.path.slice(basenameStart)}</span>
-      </span>
+      <FileIdentityIcon className="shrink-0" path={file.path} ref={tooltipAnchorRef} />
+      <span className="min-w-0 flex-1 truncate">{fileBasename(file.path)}</span>
       <DiffStat additions={file.additions} deletions={file.deletions} />
     </>
   );
 
-  if (!onOpenFile) return <div className="flex items-center gap-2 py-1">{body}</div>;
-
   return (
-    <Button
-      className="group/file h-auto w-full justify-start rounded-none border-0 px-0 py-1 text-left font-normal text-sm hover:bg-transparent sm:text-sm"
-      variant="ghost"
-      onClick={() => onOpenFile(file.path)}
-    >
-      {body}
-    </Button>
+    <FilePathTooltip anchor={tooltipAnchorRef} tooltip={file.path}>
+      {onOpenFile ? (
+        <button
+          className={cn(rowClassName, 'cursor-pointer transition-colors hover:bg-muted')}
+          type="button"
+          onClick={() => onOpenFile(file.path)}
+        >
+          {body}
+        </button>
+      ) : (
+        <div className={rowClassName} tabIndex={0}>
+          {body}
+        </div>
+      )}
+    </FilePathTooltip>
   );
 }
 

--- a/packages/presentation/ui/src/chat/turn-diff-summary.tsx
+++ b/packages/presentation/ui/src/chat/turn-diff-summary.tsx
@@ -1,10 +1,11 @@
 import { Button } from 'coss-ui/components/button';
-import { Card } from 'coss-ui/components/card';
 import { Collapsible, CollapsibleTrigger } from 'coss-ui/components/collapsible';
+import { Frame } from 'coss-ui/components/frame';
 import { FileDiffIcon, Undo2Icon } from 'lucide-react';
 import { useTranslations } from 'use-intl';
 import { cn } from '../lib/cn';
 import { useArtifactHostActions } from './artifacts/host-actions';
+import { ChatCardActions, ChatCardHeader, ChatCardPanel } from './chat-card';
 import { ChatDisclosureContent } from './disclosure-content';
 import {
   CHAT_DISCLOSURE_TEXT_CLASS_NAME,
@@ -35,60 +36,67 @@ export function TurnDiffSummary({
   const overflowFiles = edits.files.slice(COLLAPSED_FILE_COUNT);
 
   return (
-    <Card className="my-1 bg-card text-sm">
-      <div className="flex items-center pl-4 pr-2 py-2 gap-1">
-        <div className="min-w-0 flex flex-1 gap-2 items-center">
-          <ChatDisclosureIconSlot className="text-muted-foreground">
-            <FileDiffIcon />
-          </ChatDisclosureIconSlot>
-          <div className="min-w-0 shrink truncate font-medium">
-            {t('title', { count: edits.files.length })}
-          </div>
-          <DiffStat additions={edits.additions} deletions={edits.deletions} />
-        </div>
-        <Button disabled={!onUndo} size="sm" type="button" variant="ghost" onClick={onUndo}>
-          <Undo2Icon />
-          {t('undo')}
-        </Button>
-        <Button disabled={!onReview} size="sm" type="button" variant="outline" onClick={onReview}>
-          {t('review')}
-        </Button>
-      </div>
-      <Collapsible className="border-border border-t px-3 py-1">
-        {visibleFiles.map((file) => (
-          <FileRow key={file.path} file={file} onOpenFile={openFile} />
-        ))}
-        {overflowFiles.length > 0 && (
-          <>
-            <ChatDisclosureContent>
-              {overflowFiles.map((file) => (
-                <FileRow key={file.path} file={file} onOpenFile={openFile} />
-              ))}
-            </ChatDisclosureContent>
-            <CollapsibleTrigger
-              className={cn(CHAT_DISCLOSURE_TRIGGER_CLASS_NAME, 'w-fit max-w-full')}
-            >
-              <span className={CHAT_DISCLOSURE_TEXT_CLASS_NAME}>
-                <span
-                  className={cn(CHAT_DISCLOSURE_TITLE_CLASS_NAME, 'group-data-[panel-open]:hidden')}
+    <Frame className="my-1 text-sm">
+      <ChatCardHeader className="text-sm">
+        <ChatDisclosureIconSlot>
+          <FileDiffIcon />
+        </ChatDisclosureIconSlot>
+        <span className="min-w-0 truncate font-medium text-foreground">
+          {t('title', { count: edits.files.length })}
+        </span>
+        <DiffStat additions={edits.additions} deletions={edits.deletions} />
+        <ChatCardActions>
+          <Button disabled={!onUndo} size="sm" type="button" variant="ghost" onClick={onUndo}>
+            <Undo2Icon />
+            {t('undo')}
+          </Button>
+          <Button disabled={!onReview} size="sm" type="button" variant="outline" onClick={onReview}>
+            {t('review')}
+          </Button>
+        </ChatCardActions>
+      </ChatCardHeader>
+      {edits.files.length > 0 ? (
+        <ChatCardPanel className="px-3 py-1">
+          <Collapsible>
+            {visibleFiles.map((file) => (
+              <FileRow key={file.path} file={file} onOpenFile={openFile} />
+            ))}
+            {overflowFiles.length > 0 && (
+              <>
+                <ChatDisclosureContent>
+                  {overflowFiles.map((file) => (
+                    <FileRow key={file.path} file={file} onOpenFile={openFile} />
+                  ))}
+                </ChatDisclosureContent>
+                <CollapsibleTrigger
+                  className={cn(CHAT_DISCLOSURE_TRIGGER_CLASS_NAME, 'w-fit max-w-full')}
                 >
-                  {t('showMore', { count: overflowFiles.length })}
-                </span>
-                <span
-                  className={cn(
-                    CHAT_DISCLOSURE_TITLE_CLASS_NAME,
-                    'hidden group-data-[panel-open]:inline',
-                  )}
-                >
-                  {t('showLess')}
-                </span>
-              </span>
-              <ChatDisclosureChevron />
-            </CollapsibleTrigger>
-          </>
-        )}
-      </Collapsible>
-    </Card>
+                  <span className={CHAT_DISCLOSURE_TEXT_CLASS_NAME}>
+                    <span
+                      className={cn(
+                        CHAT_DISCLOSURE_TITLE_CLASS_NAME,
+                        'group-data-[panel-open]:hidden',
+                      )}
+                    >
+                      {t('showMore', { count: overflowFiles.length })}
+                    </span>
+                    <span
+                      className={cn(
+                        CHAT_DISCLOSURE_TITLE_CLASS_NAME,
+                        'hidden group-data-[panel-open]:inline',
+                      )}
+                    >
+                      {t('showLess')}
+                    </span>
+                  </span>
+                  <ChatDisclosureChevron />
+                </CollapsibleTrigger>
+              </>
+            )}
+          </Collapsible>
+        </ChatCardPanel>
+      ) : null}
+    </Frame>
   );
 }
 

--- a/packages/presentation/ui/src/shell/new-session-surface.tsx
+++ b/packages/presentation/ui/src/shell/new-session-surface.tsx
@@ -178,7 +178,8 @@ export function NewSessionSurface({
   const effort = localEffort === undefined ? (preferredEfforts?.[provider] ?? null) : localEffort;
   const catalog = agentCatalogs?.[provider];
   const dynamicModels = catalog && catalog.models.length > 0 ? catalog.models : null;
-  const modelOption = dynamicModels?.find((option) => option.id === displayedModel);
+  const modelOptionById = new Map(dynamicModels?.map((option) => [option.id, option] as const));
+  const modelOption = displayedModel === null ? undefined : modelOptionById.get(displayedModel);
   const effortLevels = modelOption?.effortLevels;
   const constrainedEffort =
     effortLevels === undefined || effortLevels.includes(effort ?? 'low') ? effort : null;

--- a/packages/presentation/ui/src/shell/terminal/live-terminal.tsx
+++ b/packages/presentation/ui/src/shell/terminal/live-terminal.tsx
@@ -247,7 +247,7 @@ export function LiveTerminal({
     },
     // fontFamily/fontSize/colorScheme only seed the initial config (live-synced by the effects
     // below); as deps they would tear the terminal down and rebuild it on every change.
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- intentional: initial seed only
+    // eslint-disable-next-line react-hooks/exhaustive-deps, @eslint-react/exhaustive-deps -- intentional: initial seed only
     [session],
   );
 


### PR DESCRIPTION
## Summary

Closes CODE-381.

Chat-flow cards (code block, terminal, file/tool previews, edited-files rollup) hand-rolled their header chrome as `Card` + `CardHeader` with `bg-muted`/`border-b` overrides. This converts them to the coss-ui **Frame** pattern — a borderless muted tray (`Frame`) with the card's upper part in the tray header (`FrameHeader`) and content in the inset panel (`FramePanel`) — via new shared chat-density slots in `chat/chat-card.tsx` (`ChatCardHeader`/`ChatCardTitle`/`ChatCardActions`/`ChatCardPanel`, density overrides only).

Converted surfaces: `CodeBlock`, `ArtifactFrame` (+ `FenceFallback`), `Terminal` + `TerminalBlock`, `FilePreviewCard` (`DiffBlock` follows), `ToolPreviewCard`, `TurnDiffSummary`. Showcase-only cards (test-results, schema-display, artifact, web-preview, package-info, queue, step, commit, stack-trace) are deliberately left on `Card` chrome until they're wired.

Design refinements from review:

- Frame-header labels are sans; only terminal/execute headers keep mono for the command they display.
- Copy buttons: code blocks copy their source (now built-in, so tool-result JSON/HTML blocks get one too); terminal headers copy the executed command only — threaded to the live adapter as a new optional `command` prop on `TerminalBlock`/`RuntimeTerminalBlock`.
- Mutation receipts ("The file … has been updated successfully") render as plain prose under the diff instead of a second preview card.
- Turn-diff rows show the file-identity icon + basename with the full path in a hover tooltip; no divider lines; the show-more chevron points down/up (expand/collapse) instead of the tree-node right→down.
- Terminal fixes along the way: `TerminalBlock` no longer double-renders a header, the ANSI surface is clipped to the panel radius (was square-cornered and theme-mismatched in dark mode), and trailing PTY/stdout newlines no longer render as blank panel space (regression test added).

The chrome contract test (`card-radius.test.tsx`) now asserts the `frame` slot with a `<header>` row per card.

## Verification

- `pnpm check:ci` and `pnpm test` (1772) pass on the rebased branch.
- Drove the webview `dev:mock` conversation showcase headless (playwright-core + Chrome): code fence, file read/write cards, diff card, search card, artifact frames (mermaid/svg/html), execute terminals, and the PTY terminal block all render the borderless tray + inset panel, with the expected header fonts and copy buttons; mutation receipt renders as prose under the diff.
- `TurnDiffSummary` doesn't render in the mock (its stream never completes a turn with edits), so its rows are covered by unit tests plus live review over HMR against a real session.

## Checklist

- [x] `pnpm check:ci` and `pnpm test` both pass (plus `cargo fmt` / `clippy` / `test` for Rust changes)
- [x] I ran the affected surface and observed the change working
- [x] If a wire message changed: `WIRE_PROTOCOL_VERSION` is bumped — no wire changes
- [x] New code and assets are my own work, or their origin and license compatibility are noted above
- [x] Docs and comments are updated where behavior changed