### PR TITLE
feat(sim): device rotation via GraphicsServices GSEvent (CODE-408)

### DIFF
--- a/apps/daemon/src/__tests__/sim-mcp-endpoint.test.ts
+++ b/apps/daemon/src/__tests__/sim-mcp-endpoint.test.ts
@@ -43,6 +43,7 @@ function fakeBackend(): SimulatorBackend {
     key: vi.fn(asyncNoop),
     swipe: vi.fn(asyncNoop),
     button: vi.fn(asyncNoop),
+    rotate: vi.fn(asyncNoop),
     streamStart: vi.fn(() =>
       Promise.resolve({ streaming: true as const, fps: 60, scale: 1, codec: 'jpeg' as const }),
     ),
@@ -89,6 +90,7 @@ describe('SimulatorMcpEndpoint', () => {
       'sim_launch',
       'sim_list_devices',
       'sim_open_url',
+      'sim_rotate',
       'sim_screenshot',
       'sim_shutdown',
       'sim_terminate',

--- a/apps/daemon/src/sim/mcp-endpoint.ts
+++ b/apps/daemon/src/sim/mcp-endpoint.ts
@@ -258,6 +258,27 @@ export class SimulatorMcpEndpoint implements SimulatorMcpProvider {
         }),
     );
     server.registerTool(
+      'sim_rotate',
+      {
+        description:
+          'Rotate a booted iOS Simulator device to an interface orientation (portrait, portraitUpsideDown, landscapeLeft, landscapeRight), then re-screenshot to check the landscape/portrait layout. A foreground app that does not support the orientation keeps its current frame.',
+        inputSchema: {
+          udid: z.string().min(1),
+          orientation: z.enum([
+            'portrait',
+            'portraitUpsideDown',
+            'landscapeLeft',
+            'landscapeRight',
+          ]),
+        },
+      },
+      ({ udid, orientation }) =>
+        run('sim_rotate', udid, async () => {
+          await simulators.rotate(sessionId, udid, orientation);
+          return `rotated ${udid} to ${orientation}`;
+        }),
+    );
+    server.registerTool(
       'sim_screenshot',
       {
         description:

--- a/apps/desktop/e2e/simulator-live.mts
+++ b/apps/desktop/e2e/simulator-live.mts
@@ -25,7 +25,7 @@ const simSidecar = join(repoRoot, 'target', 'release', 'linkcode-sim');
 const electronBinary = require('electron') as unknown as string;
 
 const PORT = 43000 + (process.pid % 1000);
-const WIRE_VERSION = 51;
+const WIRE_VERSION = 52;
 
 async function waitForDaemon(): Promise<void> {
   const deadline = Date.now() + 30000;

--- a/apps/desktop/e2e/simulator-panel.e2e.mts
+++ b/apps/desktop/e2e/simulator-panel.e2e.mts
@@ -29,7 +29,7 @@ const PORT = 43000 + (process.pid % 1000);
 
 /** Must match `WIRE_PROTOCOL_VERSION` (node can't load the raw-TS schema barrel); a mismatch is
  * silently discarded by the daemon, surfacing here as the session.start timeout. */
-const WIRE_VERSION = 51;
+const WIRE_VERSION = 52;
 
 function fail(message: string): never {
   console.error(`FAIL: ${message}`);
@@ -334,6 +334,14 @@ async function run(win: Page, chatRoot: string, deepPass: boolean): Promise<void
       await win.keyboard.up('Alt');
       if ((await sectionTab.count()) === 0) fail('the panel died during the pinch gesture');
       console.log('option-drag pinch drove a two-finger gesture');
+
+      // Rotate: the panel's rotate button injects an orientation GSEvent; Safari re-lays-out to
+      // landscape, so the streamed framebuffer must change.
+      const beforeRotate = await canvasHash();
+      await win.getByRole('button', { name: 'Rotate', exact: true }).click();
+      await waitForHashChange(beforeRotate, 'rotating the device');
+      console.log('rotate button rotated the device');
+
       const tapShot = join(tmpdir(), `linkcode-e2e-simulator-tap-${process.pid}.png`);
       await win.screenshot({ path: tapShot });
       console.log(`screenshot: ${tapShot}`);

--- a/crates/linkcode-sim/src/interactive.rs
+++ b/crates/linkcode-sim/src/interactive.rs
@@ -11,7 +11,7 @@ use std::sync::mpsc::Sender;
 use serde_json::{Value, json};
 
 use crate::OutMsg;
-use crate::rpc::{ButtonKind, ErrorCode, OpError, TouchPhase};
+use crate::rpc::{ButtonKind, ErrorCode, OpError, RotateOrientation, TouchPhase};
 
 fn unsupported() -> OpError {
     OpError::new(
@@ -21,7 +21,9 @@ fn unsupported() -> OpError {
 }
 
 #[cfg(target_os = "macos")]
-pub use imp::{available, button, key, pinch, stream_start, stream_stop, swipe, tap, touch};
+pub use imp::{
+    available, button, key, pinch, rotate, stream_start, stream_stop, swipe, tap, touch,
+};
 
 #[cfg(not(target_os = "macos"))]
 mod stubs {
@@ -57,6 +59,9 @@ mod stubs {
     pub fn button(_udid: &str, _button: ButtonKind) -> Result<Value, OpError> {
         Err(unsupported())
     }
+    pub fn rotate(_udid: &str, _orientation: RotateOrientation) -> Result<Value, OpError> {
+        Err(unsupported())
+    }
     pub fn key(_udid: &str, _usage: u32, _modifiers: &[u32]) -> Result<Value, OpError> {
         Err(unsupported())
     }
@@ -76,7 +81,9 @@ mod stubs {
 }
 
 #[cfg(not(target_os = "macos"))]
-pub use stubs::{available, button, key, pinch, stream_start, stream_stop, swipe, tap, touch};
+pub use stubs::{
+    available, button, key, pinch, rotate, stream_start, stream_stop, swipe, tap, touch,
+};
 
 #[cfg(target_os = "macos")]
 mod imp {
@@ -251,6 +258,28 @@ mod imp {
             Ok(json!({}))
         } else {
             Err(OpError::new(ErrorCode::SimctlFailed, "button press failed"))
+        }
+    }
+
+    /// Rotate the interface orientation. Unlike the HID ops this needs no warmed `Input` — it is a
+    /// mach GSEvent to the guest's `PurpleWorkspacePort` — so it only resolves the `SimDevice`.
+    pub fn rotate(udid: &str, orientation: RotateOrientation) -> Result<Value, OpError> {
+        let device = SimDevice::resolve(udid).ok_or_else(|| {
+            OpError::new(ErrorCode::SimctlFailed, format!("device {udid} not found"))
+        })?;
+        let orientation = match orientation {
+            RotateOrientation::Portrait => private::Orientation::Portrait,
+            RotateOrientation::PortraitUpsideDown => private::Orientation::PortraitUpsideDown,
+            RotateOrientation::LandscapeLeft => private::Orientation::LandscapeLeft,
+            RotateOrientation::LandscapeRight => private::Orientation::LandscapeRight,
+        };
+        if device.set_orientation(orientation) {
+            Ok(json!({}))
+        } else {
+            Err(OpError::new(
+                ErrorCode::SimctlFailed,
+                "orientation change failed (device not booted, or port unvended)",
+            ))
         }
     }
 

--- a/crates/linkcode-sim/src/main.rs
+++ b/crates/linkcode-sim/src/main.rs
@@ -121,6 +121,12 @@ fn main() {
         diag_mask();
         return;
     }
+    // Diagnostic: inject an orientation change: `linkcode-sim diag-rotate <udid> <orientation>`.
+    #[cfg(target_os = "macos")]
+    if subcommand.as_deref() == Some("diag-rotate") {
+        diag_rotate();
+        return;
+    }
 
     let (tx, rx) = channel::<OutMsg>();
 
@@ -277,6 +283,7 @@ fn serve(request: Request, tx: &Sender<OutMsg>) {
             duration_ms,
         } => interactive::swipe(&udid, x0, y0, x1, y1, duration_ms),
         Op::Button { udid, button } => interactive::button(&udid, button),
+        Op::Rotate { udid, orientation } => interactive::rotate(&udid, orientation),
         Op::Key {
             udid,
             usage,
@@ -388,6 +395,30 @@ fn diag_interactive() {
         "stream dead={} frames-seen={frames} last={last_len} bytes; wrote {out}",
         stream.is_dead()
     );
+}
+
+/// Diagnostic (macOS only): inject an interface-orientation change against a booted device — the
+/// spike that decides whether the GraphicsServices `PurpleWorkspacePort` GSEvent path works before
+/// it is threaded through the stack. `linkcode-sim diag-rotate <udid> <portrait|portrait-upside-down|
+/// landscape-left|landscape-right>`.
+#[cfg(target_os = "macos")]
+fn diag_rotate() {
+    let udid = std::env::args()
+        .nth(2)
+        .expect("usage: diag-rotate <udid> <orientation>");
+    let name = std::env::args()
+        .nth(3)
+        .unwrap_or_else(|| "landscape-left".to_owned());
+    let orientation = match name.as_str() {
+        "portrait" => private::Orientation::Portrait,
+        "portrait-upside-down" => private::Orientation::PortraitUpsideDown,
+        "landscape-left" => private::Orientation::LandscapeLeft,
+        "landscape-right" => private::Orientation::LandscapeRight,
+        other => panic!("unknown orientation: {other}"),
+    };
+    let device = private::SimDevice::resolve(&udid).expect("device not found");
+    let ok = device.set_orientation(orientation);
+    eprintln!("set_orientation({name}) -> {ok}");
 }
 
 /// Benchmark entry (macOS only): time the JPEG encode across a resolution/quality sweep and print the

--- a/crates/linkcode-sim/src/private/mod.rs
+++ b/crates/linkcode-sim/src/private/mod.rs
@@ -9,11 +9,13 @@ pub(crate) mod debug;
 mod device;
 mod framework;
 mod input;
+mod orientation;
 mod screen;
 mod vt;
 
 pub use device::SimDevice;
 pub use input::{Button, Input, Phase};
+pub use orientation::Orientation;
 pub use screen::{Screen, bench_encode};
 pub use vt::VtEncoder;
 

--- a/crates/linkcode-sim/src/private/orientation.rs
+++ b/crates/linkcode-sim/src/private/orientation.rs
@@ -18,8 +18,11 @@ use objc2_foundation::NSString;
 
 use super::device::SimDevice;
 
-/// Interface orientation; raw values match `UIDeviceOrientation` — the GSEvent's 4-byte payload at
-/// offset 0x4C is exactly this number.
+/// Interface orientation; raw values match `UIInterfaceOrientation` — landscapeRight = 3 and
+/// landscapeLeft = 4, the inverse of `UIDeviceOrientation`'s landscape pair (device-left is
+/// interface-right). The GSEvent's 4-byte payload at offset 0x4C is exactly this number. Verified on
+/// a booted device: portrait → landscapeRight → portraitUpsideDown → landscapeLeft steps a
+/// consistent 90° clockwise cycle.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Orientation {
     Portrait = 1,

--- a/crates/linkcode-sim/src/private/orientation.rs
+++ b/crates/linkcode-sim/src/private/orientation.rs
@@ -1,0 +1,134 @@
+//! Interface-orientation injection for a booted simulator.
+//!
+//! Recipe ported from baguette's `PurpleEventOrientation.swift` + `OrientationEvent.swift`
+//! (Apache-2.0; see crate NOTICE). Orientation is NOT a SimulatorKit/Indigo HID event — it is a
+//! `GSEventTypeDeviceOrientationChanged` mach message delivered to the guest's `PurpleWorkspacePort`,
+//! the same path `Simulator.app`'s `-[SimDevice(GSEvents) gsEventsSendOrientation:]` takes. We look
+//! the port up by name via `-[SimDevice lookup:error:]`, patch a 112-byte GSEvent buffer, and
+//! `mach_msg_send` it. Write-only: GraphicsServices vends no "current orientation" back to the host,
+//! and a guest app whose `UISupportedInterfaceOrientations` excludes the target silently keeps its
+//! frame — neither is observable here.
+
+use std::ffi::c_void;
+use std::ptr;
+
+use objc2::runtime::AnyObject;
+use objc2::{msg_send, sel};
+use objc2_foundation::NSString;
+
+use super::device::SimDevice;
+
+/// Interface orientation; raw values match `UIDeviceOrientation` — the GSEvent's 4-byte payload at
+/// offset 0x4C is exactly this number.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Orientation {
+    Portrait = 1,
+    PortraitUpsideDown = 2,
+    /// Home indicator on the right (rotated 90° CW).
+    LandscapeRight = 3,
+    /// Home indicator on the left (rotated 90° CCW).
+    LandscapeLeft = 4,
+}
+
+/// `mach_msg` send-only option (== what `mach_msg_send` passes).
+const MACH_SEND_MSG: i32 = 0x0000_0001;
+const KERN_SUCCESS: i32 = 0;
+/// GSEvent mach-message layout constants (baguette `OrientationEvent`).
+const MSGH_BITS_COPY_SEND: u32 = 0x13;
+const MSGH_SIZE: u32 = 108;
+const GS_MESSAGE_ID: u32 = 0x7B;
+/// `GSEventTypeDeviceOrientationChanged (50) | GSEventHostFlag (0x20000)`.
+const GS_ORIENTATION_TYPE: u32 = 50 | 0x0002_0000;
+const BUFFER_LEN: usize = 112;
+
+unsafe extern "C" {
+    /// libSystem `mach_msg(msg, option, send_size, rcv_size, rcv_name, timeout, notify)`.
+    fn mach_msg(
+        msg: *mut c_void,
+        option: i32,
+        send_size: u32,
+        rcv_size: u32,
+        rcv_name: u32,
+        timeout: u32,
+        notify: u32,
+    ) -> i32;
+}
+
+impl SimDevice {
+    /// Rotate the booted guest to `orientation`. Returns `false` when the device hasn't vended a
+    /// `PurpleWorkspacePort` yet (not booted / pre-SpringBoard) or the mach send failed.
+    pub fn set_orientation(&self, orientation: Orientation) -> bool {
+        let Some(port) = self.lookup_port("PurpleWorkspacePort") else {
+            return false;
+        };
+        let mut buffer = orientation_message(orientation, port);
+        // SAFETY: buffer is a live 112-byte GSEvent whose mach header (first 24 bytes) is well-formed
+        // and carries a copy-send right to `port`; mach_msg reads only `send_size` (108) bytes.
+        let kr = unsafe {
+            mach_msg(
+                buffer.as_mut_ptr().cast(),
+                MACH_SEND_MSG,
+                MSGH_SIZE,
+                0,
+                0,
+                0,
+                0,
+            )
+        };
+        kr == KERN_SUCCESS
+    }
+
+    /// Resolve a mach port from the simulator's bootstrap namespace by name
+    /// (`-[SimDevice lookup:error:]`), or `None` when the port is unvended or the selector is absent.
+    fn lookup_port(&self, name: &str) -> Option<u32> {
+        // SAFETY: respondsToSelector: is defined on NSObject.
+        let responds: bool =
+            unsafe { msg_send![&*self.object, respondsToSelector: sel!(lookup:error:)] };
+        if !responds {
+            return None;
+        }
+        let name = NSString::from_str(name);
+        let mut err: *mut AnyObject = ptr::null_mut();
+        // SAFETY: dynamic message to `lookup:error:` (guarded above); NSString arg + (NSError**)
+        // out-param. Returns a mach_port_t (u32); 0 means the port is not currently vended.
+        let port: u32 = unsafe { msg_send![&*self.object, lookup: &*name, error: &mut err] };
+        (port != 0).then_some(port)
+    }
+}
+
+/// Build the 112-byte `PurpleWorkspacePort` GSEvent for `orientation`, with `port` patched into the
+/// mach header's remote-port slot.
+fn orientation_message(orientation: Orientation, port: u32) -> [u8; BUFFER_LEN] {
+    let mut bytes = [0u8; BUFFER_LEN];
+    let mut put = |offset: usize, value: u32| {
+        bytes[offset..offset + 4].copy_from_slice(&value.to_le_bytes());
+    };
+    put(0x00, MSGH_BITS_COPY_SEND); // msgh_bits
+    put(0x04, MSGH_SIZE); // msgh_size
+    put(0x08, port); // msgh_remote_port (PurpleWorkspacePort)
+    put(0x14, GS_MESSAGE_ID); // msgh_id
+    put(0x18, GS_ORIENTATION_TYPE); // GSEvent.type
+    put(0x48, 4); // record_info_size
+    put(0x4C, orientation as u32); // record_info_data
+    bytes
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn message_layout_matches_the_gsevent_wire_format() {
+        let msg = orientation_message(Orientation::LandscapeLeft, 0xDEAD_BEEF);
+        let word = |off: usize| u32::from_le_bytes(msg[off..off + 4].try_into().unwrap());
+        assert_eq!(word(0x00), 0x13);
+        assert_eq!(word(0x04), 108);
+        assert_eq!(word(0x08), 0xDEAD_BEEF);
+        assert_eq!(word(0x14), 0x7B);
+        assert_eq!(word(0x18), 50 | 0x0002_0000);
+        assert_eq!(word(0x48), 4);
+        assert_eq!(word(0x4C), 4); // LandscapeLeft
+        // The unused location/timestamp span stays zeroed.
+        assert!(msg[0x1C..0x48].iter().all(|&b| b == 0));
+    }
+}

--- a/crates/linkcode-sim/src/rpc.rs
+++ b/crates/linkcode-sim/src/rpc.rs
@@ -90,6 +90,12 @@ pub enum Op {
     },
     /// Press a hardware button (private API; P1).
     Button { udid: String, button: ButtonKind },
+    /// Rotate the device's interface orientation (private API; a GraphicsServices
+    /// `PurpleWorkspacePort` GSEvent, not an HID event).
+    Rotate {
+        udid: String,
+        orientation: RotateOrientation,
+    },
     /// Press one keyboard key: an HID usage on page 7 with modifier usages (`0xE0..`) bracketed
     /// around it (private API; P1). Key order is preserved (handled inline like `touch`).
     Key {
@@ -131,6 +137,16 @@ fn default_scale() -> f64 {
 pub enum ButtonKind {
     Home,
     Lock,
+}
+
+/// Interface orientation for `rotate`; maps 1:1 onto the private `Orientation`.
+#[derive(Clone, Copy, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum RotateOrientation {
+    Portrait,
+    PortraitUpsideDown,
+    LandscapeLeft,
+    LandscapeRight,
 }
 
 /// One phase of a streamed touch gesture.

--- a/packages/client/core/src/client.ts
+++ b/packages/client/core/src/client.ts
@@ -40,6 +40,7 @@ import type {
   SessionRecord,
   SimulatorDevice,
   SimulatorImageFormat,
+  SimulatorOrientation,
   SimulatorStatus,
   SimulatorStreamCodec,
   SimulatorTouchPhase,
@@ -763,6 +764,14 @@ export class LinkCodeClient {
     button: 'home' | 'lock',
   ): Promise<RequestAck> {
     return this.control.simulatorButton(sessionId, udid, button);
+  }
+
+  simulatorRotate(
+    sessionId: SessionId,
+    udid: string,
+    orientation: SimulatorOrientation,
+  ): Promise<RequestAck> {
+    return this.control.simulatorRotate(sessionId, udid, orientation);
   }
 
   /** Start streaming a device's framebuffer; frames arrive via {@link subscribeSimulatorFrames}. */

--- a/packages/client/core/src/client/control-channel.ts
+++ b/packages/client/core/src/client/control-channel.ts
@@ -37,6 +37,7 @@ import type {
   SessionRecord,
   SimulatorDevice,
   SimulatorImageFormat,
+  SimulatorOrientation,
   SimulatorStatus,
   SimulatorStreamCodec,
   SimulatorTouchPhase,
@@ -808,6 +809,20 @@ export class ControlChannel {
       sessionId,
       udid,
       button,
+    }));
+  }
+
+  simulatorRotate(
+    sessionId: SessionId,
+    udid: string,
+    orientation: SimulatorOrientation,
+  ): Promise<RequestAck> {
+    return this.sendCorrelated('ack', (clientReqId) => ({
+      kind: 'simulator.rotate',
+      clientReqId,
+      sessionId,
+      udid,
+      orientation,
     }));
   }
 

--- a/packages/client/workbench/package.json
+++ b/packages/client/workbench/package.json
@@ -25,6 +25,7 @@
     "coss-ui": "workspace:*",
     "foxact": "^0.3.8",
     "foxts": "^5.8.0",
+    "lucide-react": "catalog:",
     "motion": "^12.42.2",
     "pathe": "^2.0.3",
     "posthog-js": "^1.405.3",

--- a/packages/client/workbench/src/simulator/panel.tsx
+++ b/packages/client/workbench/src/simulator/panel.tsx
@@ -188,8 +188,14 @@ export function SimulatorPanel({ sessionId }: { sessionId: SessionId | null }): 
     const current =
       rotateStateRef.current.udid === udid ? rotateStateRef.current.orientation : 'portrait';
     const next = ROTATE_CYCLE[(ROTATE_CYCLE.indexOf(current) + 1) % ROTATE_CYCLE.length];
-    rotateStateRef.current = { udid, orientation: next };
-    void client.simulatorRotate(ownerSessionId, udid, next).catch(flagBusy);
+    // Advance the assumed orientation only once the rotation is acknowledged: a failed send (port
+    // unvended, Mach send failed, transport down) must not desync the cycle from the device.
+    void client
+      .simulatorRotate(ownerSessionId, udid, next)
+      .then(() => {
+        rotateStateRef.current = { udid, orientation: next };
+      })
+      .catch(flagBusy);
   };
   const bootDevice = (): void => {
     if (sessionId === null || udid === null) return;

--- a/packages/client/workbench/src/simulator/panel.tsx
+++ b/packages/client/workbench/src/simulator/panel.tsx
@@ -1,5 +1,10 @@
 import { useLinkCodeClient } from '@linkcode/client-core';
-import type { SessionId, SimulatorDevice, SimulatorStatus } from '@linkcode/schema';
+import type {
+  SessionId,
+  SimulatorDevice,
+  SimulatorOrientation,
+  SimulatorStatus,
+} from '@linkcode/schema';
 import type {
   SimulatorKeyPress,
   SimulatorScreenFrame,
@@ -17,12 +22,22 @@ import {
 } from 'coss-ui/components/select';
 import { useEffect } from 'foxact/use-abortable-effect';
 import { noop } from 'foxts/noop';
+import { RotateCwIcon } from 'lucide-react';
 import { useCallback, useRef, useState, useSyncExternalStore } from 'react';
 import { useTranslations } from 'use-intl';
 import type { SimulatorStreamLease } from './stream-registry';
 import { acquireSimulatorStream, peekSimulatorStream } from './stream-registry';
 
 const BUSY_BANNER_MS = 3000;
+
+/** Interface orientations in clockwise order, so the rotate button steps device rotation 90° CW
+ * each press (portrait → home-on-right → upside-down → home-on-left → portrait). */
+const ROTATE_CYCLE = [
+  'portrait',
+  'landscapeRight',
+  'portraitUpsideDown',
+  'landscapeLeft',
+] as const satisfies readonly SimulatorOrientation[];
 
 /**
  * The right panel's Simulator section: device picker plus a live, touchable device screen.
@@ -40,6 +55,10 @@ export function SimulatorPanel({ sessionId }: { sessionId: SessionId | null }): 
   const [busy, setBusy] = useState(false);
   const busyTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
   const leaseRef = useRef<SimulatorStreamLease | null>(null);
+  const rotateStateRef = useRef<{ udid: string | null; orientation: SimulatorOrientation }>({
+    udid: null,
+    orientation: 'portrait',
+  });
 
   useEffect(
     (signal) => {
@@ -162,6 +181,16 @@ export function SimulatorPanel({ sessionId }: { sessionId: SessionId | null }): 
     if (ownerSessionId === null || udid === null) return;
     void client.simulatorButton(ownerSessionId, udid, button).catch(flagBusy);
   };
+  // Orientation is write-only (the guest never reports it back), so the rotate button just steps
+  // clockwise from the last value we sent; a device switch resets the assumption to portrait.
+  const handleRotate = (): void => {
+    if (ownerSessionId === null || udid === null) return;
+    const current =
+      rotateStateRef.current.udid === udid ? rotateStateRef.current.orientation : 'portrait';
+    const next = ROTATE_CYCLE[(ROTATE_CYCLE.indexOf(current) + 1) % ROTATE_CYCLE.length];
+    rotateStateRef.current = { udid, orientation: next };
+    void client.simulatorRotate(ownerSessionId, udid, next).catch(flagBusy);
+  };
   const bootDevice = (): void => {
     if (sessionId === null || udid === null) return;
     void client.simulatorBoot(sessionId, udid).catch(flagBusy);
@@ -190,6 +219,15 @@ export function SimulatorPanel({ sessionId }: { sessionId: SessionId | null }): 
           </Select>
         )}
         <div className="ml-auto flex shrink-0 items-center gap-1">
+          <Button
+            variant="ghost"
+            size="sm"
+            aria-label={t('simulatorRotate')}
+            disabled={ownerSessionId === null}
+            onClick={handleRotate}
+          >
+            <RotateCwIcon className="size-4" />
+          </Button>
           <Button
             variant="ghost"
             size="sm"

--- a/packages/foundation/schema/src/model/simulator.ts
+++ b/packages/foundation/schema/src/model/simulator.ts
@@ -45,8 +45,9 @@ export type SimulatorStreamCodec = z.infer<typeof SimulatorStreamCodecSchema>;
 export const SimulatorTouchPhaseSchema = z.enum(['down', 'move', 'up']);
 export type SimulatorTouchPhase = z.infer<typeof SimulatorTouchPhaseSchema>;
 
-/** Interface orientation for a rotate command; the four `UIDeviceOrientation` cases. `landscapeLeft`
- * puts the home indicator on the left (rotated 90° CCW), `landscapeRight` on the right. */
+/** Interface orientation for a rotate command; the four `UIInterfaceOrientation` cases.
+ * `landscapeLeft` puts the home indicator on the left (rotated 90° CCW), `landscapeRight` on the
+ * right (90° CW). */
 export const SimulatorOrientationSchema = z.enum([
   'portrait',
   'portraitUpsideDown',

--- a/packages/foundation/schema/src/model/simulator.ts
+++ b/packages/foundation/schema/src/model/simulator.ts
@@ -44,3 +44,13 @@ export type SimulatorStreamCodec = z.infer<typeof SimulatorStreamCodecSchema>;
 /** One phase of a streamed touch gesture (one `down`, moves, one `up` per gesture). */
 export const SimulatorTouchPhaseSchema = z.enum(['down', 'move', 'up']);
 export type SimulatorTouchPhase = z.infer<typeof SimulatorTouchPhaseSchema>;
+
+/** Interface orientation for a rotate command; the four `UIDeviceOrientation` cases. `landscapeLeft`
+ * puts the home indicator on the left (rotated 90° CCW), `landscapeRight` on the right. */
+export const SimulatorOrientationSchema = z.enum([
+  'portrait',
+  'portraitUpsideDown',
+  'landscapeLeft',
+  'landscapeRight',
+]);
+export type SimulatorOrientation = z.infer<typeof SimulatorOrientationSchema>;

--- a/packages/foundation/schema/src/wire/message.ts
+++ b/packages/foundation/schema/src/wire/message.ts
@@ -21,7 +21,8 @@ import { WirePayloadSchema } from './payload';
 // 49 adds streamed touch, wheel scroll, and HID keyboard input (CODE-397).
 // 50 adds two-finger pinch and IME pasteboard input (CODE-397).
 // 51 adds the simulator interactive-capability flag to the status wire (CODE-397).
-export const WIRE_PROTOCOL_VERSION = 51 as const;
+// 52 adds the simulator device-rotation wire (CODE-408).
+export const WIRE_PROTOCOL_VERSION = 52 as const;
 
 /** Complete wire message: version + unique id + timestamp + payload. */
 export const WireMessageSchema = z.object({

--- a/packages/foundation/schema/src/wire/simulator.ts
+++ b/packages/foundation/schema/src/wire/simulator.ts
@@ -3,6 +3,7 @@ import { SessionIdSchema } from '../model/primitives';
 import {
   SimulatorDeviceSchema,
   SimulatorImageFormatSchema,
+  SimulatorOrientationSchema,
   SimulatorStatusSchema,
   SimulatorStreamCodecSchema,
   SimulatorTouchPhaseSchema,
@@ -181,6 +182,15 @@ export const simulatorWireVariants = [
     sessionId: SessionIdSchema,
     udid,
     button: SimulatorButtonSchema,
+  }),
+  /** Rotate the device's interface orientation (a GraphicsServices GSEvent, not HID). A guest app
+   * that doesn't support the target orientation silently keeps its frame — not observable here. */
+  z.object({
+    kind: z.literal('simulator.rotate'),
+    clientReqId: WireRequestIdSchema,
+    sessionId: SessionIdSchema,
+    udid,
+    orientation: SimulatorOrientationSchema,
   }),
   /** One keyboard key press: an HID usage on page 7 with modifier usages (`0xE0..`) held
    * around it. Clients decompose typed characters (US layout) before sending. */

--- a/packages/host/engine/src/__tests__/simulator-request-handler.test.ts
+++ b/packages/host/engine/src/__tests__/simulator-request-handler.test.ts
@@ -42,6 +42,7 @@ function fakeBackend() {
     key: vi.fn(asyncNoop),
     swipe: vi.fn(asyncNoop),
     button: vi.fn(asyncNoop),
+    rotate: vi.fn(asyncNoop),
     streamStart: vi.fn(() =>
       Promise.resolve({ streaming: true as const, fps: 60, scale: 1, codec: 'jpeg' as const }),
     ),

--- a/packages/host/engine/src/__tests__/simulator-request-handler.test.ts
+++ b/packages/host/engine/src/__tests__/simulator-request-handler.test.ts
@@ -180,6 +180,26 @@ describe('simulator wire requests', () => {
     await h.engine.stop();
   });
 
+  it('routes a rotate request through the wire router to the backend', async () => {
+    const backend = fakeBackend();
+    const h = harness(backend);
+    await h.engine.start();
+    const s1 = await h.startSession('s1');
+
+    // Guards the router's simulator group: if `simulator.rotate` is not enumerated there, the
+    // request falls through to a no-op and this reply never arrives.
+    await h.inject({
+      kind: 'simulator.rotate',
+      clientReqId: 'rot',
+      sessionId: s1,
+      udid: 'U-1',
+      orientation: 'landscapeRight',
+    });
+    expect(h.reply('rot')).toMatchObject({ kind: 'request.succeeded' });
+    expect(backend.rotate).toHaveBeenCalledWith('U-1', 'landscapeRight');
+    await h.engine.stop();
+  });
+
   it('start subscribes frames and fans them out session-scoped; stop unsubscribes', async () => {
     const backend = fakeBackend();
     const h = harness(backend);

--- a/packages/host/engine/src/__tests__/simulator-service.test.ts
+++ b/packages/host/engine/src/__tests__/simulator-service.test.ts
@@ -39,6 +39,7 @@ function fakeBackend(devices: SimulatorDeviceInfo[]) {
     key: vi.fn(asyncNoop),
     swipe: vi.fn(asyncNoop),
     button: vi.fn(asyncNoop),
+    rotate: vi.fn(asyncNoop),
     streamStart: vi.fn(() =>
       Promise.resolve<Awaited<ReturnType<SimulatorBackend['streamStart']>>>({
         streaming: true,

--- a/packages/host/engine/src/simulator/backend.ts
+++ b/packages/host/engine/src/simulator/backend.ts
@@ -33,7 +33,7 @@ export type SimulatorImageFormat = 'jpeg' | 'png';
 /** A hardware button the private HID layer can press. */
 export type SimulatorButton = 'home' | 'lock';
 
-/** Interface orientation for a rotate command (matches `UIDeviceOrientation`). */
+/** Interface orientation for a rotate command (matches `UIInterfaceOrientation`). */
 export type SimulatorOrientation =
   | 'portrait'
   | 'portraitUpsideDown'

--- a/packages/host/engine/src/simulator/backend.ts
+++ b/packages/host/engine/src/simulator/backend.ts
@@ -33,6 +33,13 @@ export type SimulatorImageFormat = 'jpeg' | 'png';
 /** A hardware button the private HID layer can press. */
 export type SimulatorButton = 'home' | 'lock';
 
+/** Interface orientation for a rotate command (matches `UIDeviceOrientation`). */
+export type SimulatorOrientation =
+  | 'portrait'
+  | 'portraitUpsideDown'
+  | 'landscapeLeft'
+  | 'landscapeRight';
+
 /** One phase of a streamed touch gesture (one `down`, moves, one `up` per gesture). */
 export type SimulatorTouchPhase = 'down' | 'move' | 'up';
 
@@ -100,6 +107,8 @@ export interface SimulatorBackend {
   swipe(udid: string, from: SimulatorPoint, to: SimulatorPoint, durationMs?: number): Promise<void>;
   /** Press a hardware button (private HID; macOS only). */
   button(udid: string, button: SimulatorButton): Promise<void>;
+  /** Rotate the interface orientation (GraphicsServices GSEvent; macOS only). */
+  rotate(udid: string, orientation: SimulatorOrientation): Promise<void>;
   /** Press one keyboard key (HID usage on page 7) with modifier usages held around it. */
   key(udid: string, usage: number, modifiers: number[]): Promise<void>;
   /** Start streaming `udid`'s framebuffer; frames arrive via {@link onFrame} listeners. */

--- a/packages/host/engine/src/simulator/request-handler.ts
+++ b/packages/host/engine/src/simulator/request-handler.ts
@@ -28,6 +28,7 @@ type SimulatorRequest = Extract<
       | 'simulator.paste'
       | 'simulator.swipe'
       | 'simulator.button'
+      | 'simulator.rotate'
       | 'simulator.key'
       | 'simulator.stream.start'
       | 'simulator.stream.stop';
@@ -225,6 +226,13 @@ export class SimulatorRequestHandler {
         return this.withSimulators(payload.clientReqId, (simulators) =>
           simulatorOperation('simulator.button', 'Failed to press button', async () => {
             await simulators.button(payload.sessionId, payload.udid, payload.button);
+            this.responder.sendSuccess(payload.clientReqId);
+          }),
+        );
+      case 'simulator.rotate':
+        return this.withSimulators(payload.clientReqId, (simulators) =>
+          simulatorOperation('simulator.rotate', 'Failed to rotate device', async () => {
+            await simulators.rotate(payload.sessionId, payload.udid, payload.orientation);
             this.responder.sendSuccess(payload.clientReqId);
           }),
         );

--- a/packages/host/engine/src/simulator/service.ts
+++ b/packages/host/engine/src/simulator/service.ts
@@ -9,6 +9,7 @@ import type {
   SimulatorDeviceInfo,
   SimulatorFrameListener,
   SimulatorImageFormat,
+  SimulatorOrientation,
   SimulatorPoint,
   SimulatorStreamOptions,
   SimulatorStreamStartResult,
@@ -218,6 +219,15 @@ export class SimulatorService {
   async button(sessionId: SessionId, udid: string, button: SimulatorButton): Promise<void> {
     this.claim(sessionId, udid);
     return this.backend.button(udid, button);
+  }
+
+  async rotate(
+    sessionId: SessionId,
+    udid: string,
+    orientation: SimulatorOrientation,
+  ): Promise<void> {
+    this.claim(sessionId, udid);
+    return this.backend.rotate(udid, orientation);
   }
 
   async key(sessionId: SessionId, udid: string, usage: number, modifiers: number[]): Promise<void> {

--- a/packages/host/engine/src/wire/request-router.ts
+++ b/packages/host/engine/src/wire/request-router.ts
@@ -146,6 +146,7 @@ export class WireRequestRouter {
       case 'simulator.key':
       case 'simulator.swipe':
       case 'simulator.button':
+      case 'simulator.rotate':
       case 'simulator.stream.start':
       case 'simulator.stream.stop': {
         return this.handlers.simulator.handle(p);

--- a/packages/host/sim/src/client.ts
+++ b/packages/host/sim/src/client.ts
@@ -19,6 +19,7 @@ import type {
   SimButton,
   SimDevice,
   SimImageFormat,
+  SimOrientation,
   SimProbe,
   SimStreamCodec,
   SimStreamStartResult,
@@ -192,6 +193,11 @@ export class SimSidecarClient {
   /** Press a hardware button (private HID; macOS only). */
   async button(udid: string, button: SimButton): Promise<void> {
     await this.call('button', { udid, button });
+  }
+
+  /** Rotate the interface orientation (GraphicsServices GSEvent; macOS only). */
+  async rotate(udid: string, orientation: SimOrientation): Promise<void> {
+    await this.call('rotate', { udid, orientation });
   }
 
   /** Press one keyboard key (HID usage on page 7) with modifier usages held around it. */

--- a/packages/host/sim/src/schema.ts
+++ b/packages/host/sim/src/schema.ts
@@ -65,6 +65,9 @@ export type SimStreamStartResult = z.infer<typeof SimStreamStartResultSchema>;
 /** A hardware button the private HID layer can press. */
 export type SimButton = 'home' | 'lock';
 
+/** Interface orientation for a rotate command (matches `UIDeviceOrientation`). */
+export type SimOrientation = 'portrait' | 'portraitUpsideDown' | 'landscapeLeft' | 'landscapeRight';
+
 /** One phase of a streamed touch gesture (one `down`, moves, one `up` per gesture). */
 export type SimTouchPhase = 'down' | 'move' | 'up';
 

--- a/packages/presentation/i18n/src/locales/en.ts
+++ b/packages/presentation/i18n/src/locales/en.ts
@@ -385,6 +385,7 @@ export const en = {
       simulatorStreamFailed: 'Screen stream failed to start',
       simulatorRetry: 'Retry',
       simulatorBusy: 'Device is in use by another thread',
+      simulatorRotate: 'Rotate',
       simulatorHome: 'Home',
       simulatorLock: 'Lock screen',
     },

--- a/packages/presentation/i18n/src/locales/zh-cn.ts
+++ b/packages/presentation/i18n/src/locales/zh-cn.ts
@@ -374,6 +374,7 @@ export const zhCN = {
       simulatorStreamFailed: '画面流启动失败',
       simulatorRetry: '重试',
       simulatorBusy: '设备正被其他线程使用',
+      simulatorRotate: '旋转',
       simulatorHome: '主屏幕',
       simulatorLock: '锁屏',
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -801,6 +801,9 @@ importers:
       foxts:
         specifier: ^5.8.0
         version: 5.8.0
+      lucide-react:
+        specifier: 'catalog:'
+        version: 1.24.0(react@19.2.7)
       motion:
         specifier: ^12.42.2
         version: 12.42.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)


### PR DESCRIPTION
Adds interface-orientation injection to the iOS Simulator support — the one common input dimension missing after touch/pinch/key. Closes CODE-408.

## What

- **Rust sidecar** (`crates/linkcode-sim`): `SimDevice::set_orientation` sends a `GSEventTypeDeviceOrientationChanged` mach message to the guest's `PurpleWorkspacePort` (looked up via `-[SimDevice lookup:error:]`, 112-byte GSEvent, `mach_msg_send`). This is **not** an Indigo/HID event — it's the same path `Simulator.app` uses. Recipe ported from baguette's `PurpleEventOrientation`/`OrientationEvent` (Apache-2.0). New `rotate` RPC op + `diag-rotate` command.
- **Data plane** (wire 49 → **50**): `simulator.rotate` variant, `@linkcode/sim` client `rotate`, engine `SimulatorBackend`/`SimulatorService` (session-claimed), request-handler dispatch, client-core `simulatorRotate`.
- **Agent surface**: `sim_rotate` MCP tool — rotate → screenshot → verify a landscape layout, which fits the agent loop better than tap does.
- **Panel**: a rotate button that steps the orientation clockwise (write-only property, so the button tracks the last value it sent; resets per device).

## Why GraphicsServices, not SimulatorKit

Orientation is the one capability from the 2026-07 SimulatorKit API scan that isn't in SimulatorKit at all — it lives in GraphicsServices. (That scan also confirmed the interaction paths are already native HID and that scroll/IME are platform-canonical, not workarounds — see `input.rs`.)

## Verified

- `diag-rotate <udid> landscape-left` on a real iPhone 17 Pro: the Safari page + chrome rotate 90° inside the fixed portrait framebuffer; `set_orientation → true`.
- Full E2E (`pnpm -F @linkcode/desktop e2e:simulator`) **PASS**: the panel rotate button changes the streamed framebuffer, alongside Home / dock-tap / drag-scroll / pinch.
- 1807 unit tests pass; `check:ci` clean.

## Notes / follow-ups

- The panel shows rotated content **sideways** in the fixed portrait bezel (an honest reflection of the framebuffer). Rotating the whole rendered device 90° (with the matching touch inverse-transform) is deliberate follow-up polish, not in this PR.
- A guest app whose `UISupportedInterfaceOrientations` excludes the target silently keeps its frame — not observable from the host.

Stacked on #259 (`xuan/code-397`).