### PR TITLE
feat(workbench): simulator stream tuning row — frame rate, resolution, encoding, FPS

### DIFF
--- a/packages/client/workbench/src/simulator/__tests__/stream-registry.test.ts
+++ b/packages/client/workbench/src/simulator/__tests__/stream-registry.test.ts
@@ -1,29 +1,40 @@
 import type { SessionId } from '@linkcode/schema';
 import { noop } from 'foxts/noop';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import type { SimulatorStreamClient } from '../stream-registry';
-import { acquireSimulatorStream, peekSimulatorStream } from '../stream-registry';
+import type { SimulatorStreamClient, SimulatorStreamOptions } from '../stream-registry';
+import {
+  acquireSimulatorStream,
+  peekSimulatorStream,
+  setSimulatorStreamOptions,
+} from '../stream-registry';
 
 interface FakeClient extends SimulatorStreamClient {
-  started: Array<{ sessionId: SessionId; udid: string }>;
+  started: Array<{ sessionId: SessionId; udid: string; options: SimulatorStreamOptions }>;
   stopped: Array<{ sessionId: SessionId; udid: string }>;
   failNextStart: boolean;
 }
 
+const OPTS: SimulatorStreamOptions = { fps: 60, scale: 1, codec: 'h264' };
+
 function createFakeClient(): FakeClient {
-  const started: Array<{ sessionId: SessionId; udid: string }> = [];
+  const started: Array<{ sessionId: SessionId; udid: string; options: SimulatorStreamOptions }> =
+    [];
   const stopped: Array<{ sessionId: SessionId; udid: string }> = [];
   return {
     started,
     stopped,
     failNextStart: false,
-    simulatorStreamStart(this: FakeClient, sessionId, udid) {
+    simulatorStreamStart(this: FakeClient, sessionId, udid, options) {
       if (this.failNextStart) {
         this.failNextStart = false;
         return Promise.reject(new Error('conflict'));
       }
-      started.push({ sessionId, udid });
-      return Promise.resolve({ fps: 30, scale: 0.5, codec: 'h264' as const });
+      started.push({ sessionId, udid, options: options as SimulatorStreamOptions });
+      return Promise.resolve({
+        fps: options?.fps ?? 60,
+        scale: options?.scale ?? 1,
+        codec: options?.codec ?? ('h264' as const),
+      });
     },
     simulatorStreamStop(sessionId, udid) {
       stopped.push({ sessionId, udid });
@@ -45,11 +56,11 @@ describe('simulator stream registry', () => {
 
   it('starts one stream per device and stops it after the last release', async () => {
     const client = createFakeClient();
-    const lease = acquireSimulatorStream(client, 'U-1', S1);
+    const lease = acquireSimulatorStream(client, 'U-1', S1, OPTS);
     expect(lease.getSnapshot().phase).toBe('starting');
     await vi.advanceTimersByTimeAsync(0);
     expect(lease.getSnapshot().phase).toBe('streaming');
-    expect(client.started).toEqual([{ sessionId: S1, udid: 'U-1' }]);
+    expect(client.started).toMatchObject([{ sessionId: S1, udid: 'U-1', options: OPTS }]);
 
     lease.release();
     await vi.advanceTimersByTimeAsync(1000);
@@ -59,12 +70,12 @@ describe('simulator stream registry', () => {
 
   it('shares the entry across a release/acquire handoff and keeps the owner session', async () => {
     const client = createFakeClient();
-    const first = acquireSimulatorStream(client, 'U-1', S1);
+    const first = acquireSimulatorStream(client, 'U-1', S1, OPTS);
     await vi.advanceTimersByTimeAsync(0);
 
     // Docked → maximized remount, meanwhile the active thread switched to another session.
     first.release();
-    const second = acquireSimulatorStream(client, 'U-1', S2);
+    const second = acquireSimulatorStream(client, 'U-1', S2, OPTS);
     await vi.advanceTimersByTimeAsync(1000);
     expect(client.started).toHaveLength(1);
     expect(client.stopped).toEqual([]);
@@ -79,7 +90,7 @@ describe('simulator stream registry', () => {
   it('surfaces a failed start and restarts on demand', async () => {
     const client = createFakeClient();
     client.failNextStart = true;
-    const lease = acquireSimulatorStream(client, 'U-1', S1);
+    const lease = acquireSimulatorStream(client, 'U-1', S1, OPTS);
     const phases: string[] = [];
     lease.subscribe(() => phases.push(lease.getSnapshot().phase));
     await vi.advanceTimersByTimeAsync(0);
@@ -93,6 +104,34 @@ describe('simulator stream registry', () => {
     await vi.advanceTimersByTimeAsync(1000);
   });
 
+  it('restarts a live stream with new options and no-ops on an unchanged retune', async () => {
+    const client = createFakeClient();
+    const lease = acquireSimulatorStream(client, 'U-1', S1, OPTS);
+    const phases: string[] = [];
+    lease.subscribe(() => phases.push(lease.getSnapshot().phase));
+    await vi.advanceTimersByTimeAsync(0);
+    expect(lease.getSnapshot().phase).toBe('streaming');
+
+    // Same options: no stop/start.
+    setSimulatorStreamOptions(client, 'U-1', OPTS);
+    expect(client.stopped).toEqual([]);
+    expect(client.started).toHaveLength(1);
+
+    // Changed options: stop then restart, and the new stream carries them.
+    const next: SimulatorStreamOptions = { fps: 30, scale: 0.5, codec: 'jpeg' };
+    setSimulatorStreamOptions(client, 'U-1', next);
+    expect(lease.getSnapshot().phase).toBe('starting');
+    await vi.advanceTimersByTimeAsync(0);
+    expect(lease.getSnapshot().phase).toBe('streaming');
+    expect(client.stopped).toEqual([{ sessionId: S1, udid: 'U-1' }]);
+    expect(client.started).toHaveLength(2);
+    expect(client.started[1].options).toEqual(next);
+    expect(phases).toEqual(['streaming', 'starting', 'streaming']);
+
+    lease.release();
+    await vi.advanceTimersByTimeAsync(1000);
+  });
+
   it('ignores a stale start resolution after the entry was released', async () => {
     const client = createFakeClient();
     let resolveStart: () => void = noop;
@@ -100,7 +139,7 @@ describe('simulator stream registry', () => {
       new Promise((resolve) => {
         resolveStart = () => resolve({ fps: 30, scale: 0.5, codec: 'h264' });
       });
-    const lease = acquireSimulatorStream(client, 'U-1', S1);
+    const lease = acquireSimulatorStream(client, 'U-1', S1, OPTS);
     lease.release();
     await vi.advanceTimersByTimeAsync(1000);
     resolveStart();

--- a/packages/client/workbench/src/simulator/panel.tsx
+++ b/packages/client/workbench/src/simulator/panel.tsx
@@ -13,6 +13,7 @@ import type {
 } from '@linkcode/ui/shell/simulator';
 import { SimulatorScreen } from '@linkcode/ui/shell/simulator';
 import { Button } from 'coss-ui/components/button';
+import { Checkbox } from 'coss-ui/components/checkbox';
 import { Select, SelectItem, SelectPopup, SelectPrimitive } from 'coss-ui/components/select';
 import { useEffect } from 'foxact/use-abortable-effect';
 import { noop } from 'foxts/noop';
@@ -20,7 +21,17 @@ import { ChevronDownIcon, HouseIcon, LockIcon, RotateCwIcon } from 'lucide-react
 import { useCallback, useRef, useState, useSyncExternalStore } from 'react';
 import { useTranslations } from 'use-intl';
 import type { SimulatorStreamLease } from './stream-registry';
-import { acquireSimulatorStream, peekSimulatorStream } from './stream-registry';
+import {
+  acquireSimulatorStream,
+  peekSimulatorStream,
+  setSimulatorStreamOptions,
+} from './stream-registry';
+import {
+  STREAM_CODEC_OPTIONS,
+  STREAM_FPS_OPTIONS,
+  STREAM_SCALE_OPTIONS,
+  useSimulatorStreamSettings,
+} from './stream-settings-store';
 
 const BUSY_BANNER_MS = 3000;
 
@@ -37,6 +48,88 @@ const ROTATE_CYCLE = [
  * token-based accent hover would flash a light blob there in the light theme. */
 const STAGE_BUTTON_CLASS =
   'text-neutral-300 hover:bg-white/10 hover:text-white data-pressed:bg-white/10 disabled:opacity-40';
+
+const FPS_ITEMS = STREAM_FPS_OPTIONS.map((n) => ({ value: String(n), label: `${n} FPS` }));
+const SCALE_ITEMS = STREAM_SCALE_OPTIONS.map((n) => ({
+  value: String(n),
+  label: `${Math.round(n * 100)}%`,
+}));
+const CODEC_ITEMS = STREAM_CODEC_OPTIONS.map((c) => ({
+  value: c,
+  label: c === 'h264' ? 'H.264' : 'JPEG',
+}));
+
+/** Count frames arriving over `subscribeFrames` in one-second windows; `null` while disabled. State
+ * updates at most once per second (not per frame), so the readout never drives the render loop. */
+function useReceivedFps(
+  subscribeFrames: (onFrame: (frame: SimulatorScreenFrame) => void) => () => void,
+  enabled: boolean,
+): number | null {
+  const [fps, setFps] = useState(0);
+  useEffect(() => {
+    if (!enabled) return;
+    let count = 0;
+    const unsubscribe = subscribeFrames(() => {
+      count += 1;
+    });
+    const interval = setInterval(() => {
+      setFps(count);
+      count = 0;
+    }, 1000);
+    return () => {
+      unsubscribe();
+      clearInterval(interval);
+    };
+  }, [subscribeFrames, enabled]);
+  return enabled ? fps : null;
+}
+
+/** A compact "label value ⌄" dropdown for the stream-tuning row — quiet gray label, bold value.
+ * The caller passes the already-formatted `display` for the current value (avoiding a render-phase
+ * lookup); `items` is only the popup list. */
+function QuietSelect({
+  label,
+  ariaLabel,
+  display,
+  value,
+  items,
+  onValueChange,
+}: {
+  label: string;
+  ariaLabel: string;
+  display: string;
+  value: string;
+  items: ReadonlyArray<{ value: string; label: string }>;
+  onValueChange: (value: string) => void;
+}): React.ReactNode {
+  return (
+    <Select
+      items={items}
+      value={value}
+      onValueChange={(next) => {
+        if (next !== null) onValueChange(next);
+      }}
+    >
+      <SelectPrimitive.Trigger
+        aria-label={ariaLabel}
+        className="flex items-center gap-1 rounded px-1 py-0.5 text-xs outline-none hover:bg-accent focus-visible:ring-2 focus-visible:ring-ring"
+      >
+        <span className="text-muted-foreground">{label}</span>
+        <span className="font-medium">{display}</span>
+        <SelectPrimitive.Icon>
+          <ChevronDownIcon className="size-3 text-muted-foreground" />
+        </SelectPrimitive.Icon>
+      </SelectPrimitive.Trigger>
+      <SelectPopup>
+        {items.map((item) => (
+          <SelectItem key={item.value} value={item.value}>
+            {item.label}
+          </SelectItem>
+        ))}
+      </SelectPopup>
+    </Select>
+  );
+}
 
 /**
  * The right panel's Simulator section: device picker plus a live, touchable device screen.
@@ -58,6 +151,8 @@ export function SimulatorPanel({ sessionId }: { sessionId: SessionId | null }): 
     udid: null,
     orientation: 'portrait',
   });
+  const { fps, scale, codec, showFps, setFps, setScale, setCodec, toggleShowFps } =
+    useSimulatorStreamSettings();
 
   useEffect(
     (signal) => {
@@ -111,7 +206,14 @@ export function SimulatorPanel({ sessionId }: { sessionId: SessionId | null }): 
   const subscribe = useCallback(
     (onStoreChange: () => void) => {
       if (sessionId === null || udid === null || !booted) return noop;
-      const lease = acquireSimulatorStream(client, udid, sessionId);
+      // Options are read from the store here (not a hook dep) so a tuning change retunes the running
+      // stream via the effect below instead of tearing this subscription down and reacquiring.
+      const settings = useSimulatorStreamSettings.getState();
+      const lease = acquireSimulatorStream(client, udid, sessionId, {
+        fps: settings.fps,
+        scale: settings.scale,
+        codec: settings.codec,
+      });
       leaseRef.current = lease;
       const unsubscribe = lease.subscribe(onStoreChange);
       return () => {
@@ -128,6 +230,13 @@ export function SimulatorPanel({ sessionId }: { sessionId: SessionId | null }): 
   /** The claim-holding session every interaction must ride. */
   const ownerSessionId = snapshot?.sessionId ?? null;
 
+  // Push tuning changes onto the running stream (a stop→start restart inside the registry). Fires on
+  // mount with the same options `subscribe` used, which the registry no-ops as unchanged.
+  useEffect(() => {
+    if (udid === null) return;
+    setSimulatorStreamOptions(client, udid, { fps, scale, codec });
+  }, [client, udid, fps, scale, codec]);
+
   const subscribeFrames = useCallback(
     (onFrame: (frame: SimulatorScreenFrame) => void) =>
       udid === null
@@ -137,6 +246,7 @@ export function SimulatorPanel({ sessionId }: { sessionId: SessionId | null }): 
           ),
     [client, udid],
   );
+  const measuredFps = useReceivedFps(subscribeFrames, showFps && canStream);
 
   const flagBusy = useCallback(() => {
     setBusy(true);
@@ -209,28 +319,63 @@ export function SimulatorPanel({ sessionId }: { sessionId: SessionId | null }): 
   return (
     <div className="flex h-full min-h-0 flex-col">
       {deviceItems.length > 0 && device !== null && (
-        <div className="flex shrink-0 items-center border-border border-b px-2 py-1.5">
-          <Select items={deviceItems} value={device.udid} onValueChange={setSelectedUdid}>
-            <SelectPrimitive.Trigger
-              aria-label={t('simulatorSelectDevice')}
-              className="flex min-w-0 items-center gap-1.5 rounded-md px-1.5 py-1 text-sm outline-none hover:bg-accent focus-visible:ring-2 focus-visible:ring-ring"
-            >
-              <span className="truncate font-medium">{device.name}</span>
-              {device.runtimeName !== undefined && (
-                <span className="truncate text-muted-foreground">{device.runtimeName}</span>
-              )}
-              <SelectPrimitive.Icon>
-                <ChevronDownIcon className="size-3.5 shrink-0 text-muted-foreground" />
-              </SelectPrimitive.Icon>
-            </SelectPrimitive.Trigger>
-            <SelectPopup>
-              {deviceItems.map((item) => (
-                <SelectItem key={item.value} value={item.value}>
-                  {item.label}
-                </SelectItem>
-              ))}
-            </SelectPopup>
-          </Select>
+        <div className="flex shrink-0 flex-col gap-1 border-border border-b px-2 py-1.5">
+          <div className="flex items-center">
+            <Select items={deviceItems} value={device.udid} onValueChange={setSelectedUdid}>
+              <SelectPrimitive.Trigger
+                aria-label={t('simulatorSelectDevice')}
+                className="flex min-w-0 items-center gap-1.5 rounded-md px-1.5 py-1 text-sm outline-none hover:bg-accent focus-visible:ring-2 focus-visible:ring-ring"
+              >
+                <span className="truncate font-medium">{device.name}</span>
+                {device.runtimeName !== undefined && (
+                  <span className="truncate text-muted-foreground">{device.runtimeName}</span>
+                )}
+                <SelectPrimitive.Icon>
+                  <ChevronDownIcon className="size-3.5 shrink-0 text-muted-foreground" />
+                </SelectPrimitive.Icon>
+              </SelectPrimitive.Trigger>
+              <SelectPopup>
+                {deviceItems.map((item) => (
+                  <SelectItem key={item.value} value={item.value}>
+                    {item.label}
+                  </SelectItem>
+                ))}
+              </SelectPopup>
+            </Select>
+          </div>
+          {canStream && (
+            <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
+              <QuietSelect
+                label={t('simulatorFrameRate')}
+                ariaLabel={t('simulatorFrameRate')}
+                display={`${fps} FPS`}
+                value={String(fps)}
+                items={FPS_ITEMS}
+                onValueChange={(next) => setFps(Number(next))}
+              />
+              <QuietSelect
+                label={t('simulatorResolution')}
+                ariaLabel={t('simulatorResolution')}
+                display={`${Math.round(scale * 100)}%`}
+                value={String(scale)}
+                items={SCALE_ITEMS}
+                onValueChange={(next) => setScale(Number(next))}
+              />
+              <QuietSelect
+                label={t('simulatorEncoding')}
+                ariaLabel={t('simulatorEncoding')}
+                display={codec === 'h264' ? 'H.264' : 'JPEG'}
+                value={codec}
+                items={CODEC_ITEMS}
+                onValueChange={(next) => setCodec(next === 'jpeg' ? 'jpeg' : 'h264')}
+              />
+              <label className="flex items-center gap-1.5 text-xs">
+                <Checkbox checked={showFps} onCheckedChange={toggleShowFps} />
+                <span className="text-muted-foreground">{t('simulatorFps')}</span>
+                {showFps && <span className="font-medium tabular-nums">{measuredFps ?? '—'}</span>}
+              </label>
+            </div>
+          )}
         </div>
       )}
       <div className="relative min-h-0 flex-1">

--- a/packages/client/workbench/src/simulator/stream-registry.ts
+++ b/packages/client/workbench/src/simulator/stream-registry.ts
@@ -1,5 +1,5 @@
 import type { LinkCodeClient } from '@linkcode/client-core';
-import type { SessionId } from '@linkcode/schema';
+import type { SessionId, SimulatorStreamCodec } from '@linkcode/schema';
 import { noop } from 'foxts/noop';
 
 /** The slice of `LinkCodeClient` the stream registry needs. */
@@ -8,11 +8,19 @@ export type SimulatorStreamClient = Pick<
   'simulatorStreamStart' | 'simulatorStreamStop'
 >;
 
-/** Panel-facing stream parameters: hardware H.264 at native resolution, 60 fps. The client draws
- * the framebuffer on its own layer (one draw + one mask composite per frame, vsync-aligned), so
- * 60 fps no longer saturates a core the way the old whole-device repaint did; hosts without H.264
- * fall back to JPEG frames. */
-const STREAM_OPTIONS = { fps: 60, codec: 'h264' } as const;
+/** Panel-facing stream parameters. The client draws the framebuffer on its own layer (one draw + one
+ * mask composite per frame, vsync-aligned), so even 60 fps no longer saturates a core the way the old
+ * whole-device repaint did; a host without H.264 falls back to JPEG frames regardless of `codec`. */
+export interface SimulatorStreamOptions {
+  fps: number;
+  /** Downscale factor before encode (0..1; 1 = native). */
+  scale: number;
+  codec: SimulatorStreamCodec;
+}
+
+function optionsEqual(a: SimulatorStreamOptions, b: SimulatorStreamOptions): boolean {
+  return a.fps === b.fps && a.scale === b.scale && a.codec === b.codec;
+}
 
 /** Bridges the unmount→mount gap of the docked↔maximized handoff without stopping the stream. */
 const CLOSE_DELAY_MS = 250;
@@ -36,6 +44,8 @@ interface RegistryEntry {
   closeTimer: ReturnType<typeof setTimeout> | null;
   snapshot: SimulatorStreamSnapshot;
   listeners: Set<() => void>;
+  /** Parameters the running (or next) stream uses; changing them restarts the stream in place. */
+  options: SimulatorStreamOptions;
 }
 
 const registries = new WeakMap<SimulatorStreamClient, Map<string, RegistryEntry>>();
@@ -59,17 +69,39 @@ function startStream(
   udid: string,
   entry: RegistryEntry,
 ): void {
+  const started = entry.options;
   client
-    .simulatorStreamStart(entry.snapshot.sessionId, udid, STREAM_OPTIONS)
+    .simulatorStreamStart(entry.snapshot.sessionId, udid, started)
     .then(() => {
       if (registry.get(udid) !== entry) return;
       entry.snapshot = { ...entry.snapshot, phase: 'streaming' };
       notify(entry);
+      // A retune that landed mid-start could not restart yet (no stream to stop); do it now.
+      if (!optionsEqual(started, entry.options)) restartStream(client, registry, udid, entry);
     })
     .catch(() => {
       if (registry.get(udid) !== entry) return;
       entry.snapshot = { ...entry.snapshot, phase: 'failed' };
       notify(entry);
+    });
+}
+
+/** Stop then restart a live stream so the sidecar re-parameterizes it (it no-ops a `streamStart`
+ * while one already runs). The lease, its listeners, and the frame subscription all survive. */
+function restartStream(
+  client: SimulatorStreamClient,
+  registry: Map<string, RegistryEntry>,
+  udid: string,
+  entry: RegistryEntry,
+): void {
+  entry.snapshot = { ...entry.snapshot, phase: 'starting' };
+  notify(entry);
+  void client
+    .simulatorStreamStop(entry.snapshot.sessionId, udid)
+    .catch(noop)
+    .finally(() => {
+      if (registry.get(udid) !== entry) return;
+      startStream(client, registry, udid, entry);
     });
 }
 
@@ -82,6 +114,7 @@ export function acquireSimulatorStream(
   client: SimulatorStreamClient,
   udid: string,
   sessionId: SessionId,
+  options: SimulatorStreamOptions,
 ): SimulatorStreamLease {
   const registry = getRegistry(client);
   let entry = registry.get(udid);
@@ -98,6 +131,7 @@ export function acquireSimulatorStream(
       closeTimer: null,
       snapshot: { phase: 'starting', sessionId },
       listeners: new Set(),
+      options,
     };
     registry.set(udid, created);
     entry = created;
@@ -139,4 +173,24 @@ export function peekSimulatorStream(
   udid: string,
 ): SimulatorStreamSnapshot | null {
   return registries.get(client)?.get(udid)?.snapshot ?? null;
+}
+
+/**
+ * Retune a running device stream. The sidecar cannot re-parameterize a live stream (`streamStart`
+ * no-ops once one exists), so a change stops and restarts it in place — the lease, its listeners,
+ * and the independent frame subscription all survive; only the daemon stream blips. A no-op when the
+ * options are unchanged or no stream exists (the next {@link acquireSimulatorStream} carries them).
+ */
+export function setSimulatorStreamOptions(
+  client: SimulatorStreamClient,
+  udid: string,
+  options: SimulatorStreamOptions,
+): void {
+  const registry = registries.get(client);
+  const entry = registry?.get(udid);
+  if (registry === undefined || entry === undefined || optionsEqual(entry.options, options)) return;
+  entry.options = options;
+  // Only an established stream restarts now; a still-starting one adopts the options when its start
+  // completes (startStream re-checks), and a failed one uses them on the next `restart`.
+  if (entry.snapshot.phase === 'streaming') restartStream(client, registry, udid, entry);
 }

--- a/packages/client/workbench/src/simulator/stream-settings-store.ts
+++ b/packages/client/workbench/src/simulator/stream-settings-store.ts
@@ -1,0 +1,75 @@
+import { zodPersist } from '@linkcode/common/zustand';
+import type { SimulatorStreamCodec } from '@linkcode/schema';
+import { z } from 'zod';
+import { create } from 'zustand';
+
+/** Frame-rate choices offered in the panel; 60 is the stream default. */
+export const STREAM_FPS_OPTIONS = [60, 30, 15] as const;
+/** Downscale-before-encode choices as a fraction of native resolution; 1 = native. */
+export const STREAM_SCALE_OPTIONS = [1, 0.75, 0.5, 0.25] as const;
+/** Stream encodings offered; a host without H.264 falls back to JPEG regardless of the choice. */
+export const STREAM_CODEC_OPTIONS = [
+  'h264',
+  'jpeg',
+] as const satisfies readonly SimulatorStreamCodec[];
+
+const PersistedStreamSettingsSchema = z
+  .object({
+    fps: z.number(),
+    scale: z.number(),
+    codec: z.enum(['h264', 'jpeg']),
+    showFps: z.boolean(),
+  })
+  .partial();
+type PersistedStreamSettings = z.infer<typeof PersistedStreamSettingsSchema>;
+
+export interface SimulatorStreamSettingsState {
+  /** Target capture frame rate (fps). */
+  fps: number;
+  /** Downscale factor before encode (0..1; 1 = native). */
+  scale: number;
+  /** Stream encoding; a host without H.264 falls back to JPEG regardless. */
+  codec: SimulatorStreamCodec;
+  /** Whether the received frame-rate readout is shown. */
+  showFps: boolean;
+  setFps: (fps: number) => void;
+  setScale: (scale: number) => void;
+  setCodec: (codec: SimulatorStreamCodec) => void;
+  toggleShowFps: () => void;
+}
+
+/**
+ * Panel-wide simulator stream tuning, shared across devices and persisted. Defaults mirror the
+ * previously hardcoded stream options (60 fps, native scale, H.264), so a first run streams exactly
+ * as before; changing a value restarts the running stream in place (see `stream-registry`).
+ */
+export const useSimulatorStreamSettings = create<SimulatorStreamSettingsState>()(
+  zodPersist<
+    SimulatorStreamSettingsState,
+    [],
+    [],
+    PersistedStreamSettings,
+    PersistedStreamSettings
+  >(
+    (set) => ({
+      fps: 60,
+      scale: 1,
+      codec: 'h264',
+      showFps: false,
+      setFps: (fps) => set({ fps }),
+      setScale: (scale) => set({ scale }),
+      setCodec: (codec) => set({ codec }),
+      toggleShowFps: () => set((state) => ({ showFps: !state.showFps })),
+    }),
+    {
+      name: 'linkcode.simulator.stream:v1',
+      schema: PersistedStreamSettingsSchema,
+      partialize: (state) => ({
+        fps: state.fps,
+        scale: state.scale,
+        codec: state.codec,
+        showFps: state.showFps,
+      }),
+    },
+  ),
+);

--- a/packages/presentation/i18n/src/locales/en.ts
+++ b/packages/presentation/i18n/src/locales/en.ts
@@ -388,6 +388,10 @@ export const en = {
       simulatorRotate: 'Rotate',
       simulatorHome: 'Home',
       simulatorLock: 'Lock screen',
+      simulatorFrameRate: 'Frame rate',
+      simulatorResolution: 'Resolution',
+      simulatorEncoding: 'Encoding',
+      simulatorFps: 'FPS',
     },
     git: {
       emptyTitle: 'No active thread',

--- a/packages/presentation/i18n/src/locales/zh-cn.ts
+++ b/packages/presentation/i18n/src/locales/zh-cn.ts
@@ -377,6 +377,10 @@ export const zhCN = {
       simulatorRotate: '旋转',
       simulatorHome: '主屏幕',
       simulatorLock: '锁屏',
+      simulatorFrameRate: '帧率',
+      simulatorResolution: '分辨率',
+      simulatorEncoding: '编码',
+      simulatorFps: 'FPS',
     },
     git: {
       emptyTitle: '暂无活跃线程',


### PR DESCRIPTION
CODE-413. Adds the stream-parameter row to the simulator panel header (frame rate / resolution / encoding + a received-FPS readout), matching the reference layout. Pure client work — the wire already carries every parameter. Builds on the CODE-424 layout (#267, merged).

## What

- **Tuning row** under the device picker: `Frame rate` (60/30/15), `Resolution` (100/75/50/25 %), `Encoding` (H.264/JPEG), and an `FPS` checkbox whose readout shows the frame rate the pane is actually receiving. Quiet text-style dropdowns matching the device picker.
- **Persisted** via `zodPersist` (`linkcode.simulator.stream:v1`), shared across devices. Defaults — 60 fps, native scale, H.264, FPS-readout off — mirror the previously hardcoded stream options, so a first run streams exactly as before.
- **Live retune.** The sidecar no-ops a `streamStart` while a stream already runs, so a parameter change stops and restarts the stream *in place* inside `stream-registry` — the lease, its listeners, and the independent frame subscription all survive; only the daemon stream blips. A retune that lands mid-start is applied once the start completes.
- The FPS readout counts frames in one-second windows and updates state at most once per second, never per frame.

## Verification

- New unit test covers the retune path: unchanged options no-op; changed options stop→restart and the new stream carries them. `pnpm test` 1876 green; `pnpm check:ci` green.
- Desktop simulator E2E deep pass green end-to-end on a booted iPhone 17 Pro; the header renders both rows (device + tuning) and the live stream is unaffected at the default parameters (verified `Frame rate 60 FPS · Resolution 100% · Encoding H.264` in the streamed screenshot).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added simulator streaming controls for frame rate, resolution, and encoding.
  - Stream settings now update while streaming without requiring manual restart.
  - Added an optional live FPS readout.
  - Stream preferences are saved for future sessions.
  - Added English and Chinese translations for the new controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->