### PR TITLE
feat(sim,workbench): reconfigure the simulator stream in place — no worker respawn on tuning changes

### DIFF
--- a/apps/desktop/e2e/simulator-panel.e2e.mts
+++ b/apps/desktop/e2e/simulator-panel.e2e.mts
@@ -29,7 +29,7 @@ const PORT = 43000 + (process.pid % 1000);
 
 /** Must match `WIRE_PROTOCOL_VERSION` (node can't load the raw-TS schema barrel); a mismatch is
  * silently discarded by the daemon, surfacing here as the session.start timeout. */
-const WIRE_VERSION = 52;
+const WIRE_VERSION = 53;
 
 function fail(message: string): never {
   console.error(`FAIL: ${message}`);
@@ -341,6 +341,40 @@ async function run(win: Page, chatRoot: string, deepPass: boolean): Promise<void
       await win.getByRole('button', { name: 'Rotate', exact: true }).click();
       await waitForHashChange(beforeRotate, 'rotating the device');
       console.log('rotate button rotated the device');
+
+      // Live reconfigure (CODE-433): a stream start with new options retunes the running stream in
+      // place. Assert the capture-worker process is NOT respawned (same pid) and the picture keeps
+      // painting — the seamless path the panel's tuning row rides. A start on an already-running
+      // stream is the same wire the panel sends when a dropdown changes.
+      const workerPid = (): string | null => {
+        try {
+          return execFileSync('pgrep', ['-f', `capture-worker ${bootedUdid}`], { encoding: 'utf8' })
+            .trim()
+            .split('\n', 1)[0];
+        } catch {
+          return null;
+        }
+      };
+      const pidBefore = workerPid();
+      if (pidBefore === null) fail('no capture-worker process running before reconfigure');
+      const beforeReconfigure = await canvasHash();
+      // A start on an already-running stream (switching codec here) must retune it, not respawn the
+      // worker: the same pid before and after is the proof it happened in place. The wire reply omits
+      // the sidecar's internal `alreadyStreaming` flag, so the pid is the observable signal.
+      await wireRequest({
+        kind: 'simulator.stream.start',
+        clientReqId: 'e2e-reconfigure',
+        sessionId,
+        udid: bootedUdid,
+        codec: 'jpeg',
+        fps: 30,
+      });
+      await waitForHashChange(beforeReconfigure, 'reconfiguring the stream');
+      const pidAfter = workerPid();
+      if (pidAfter !== pidBefore) {
+        fail(`capture-worker respawned on reconfigure (pid ${pidBefore} → ${pidAfter ?? 'gone'})`);
+      }
+      console.log(`live reconfigure retuned in place (capture-worker pid stable ${pidBefore})`);
 
       const tapShot = join(tmpdir(), `linkcode-e2e-simulator-tap-${process.pid}.png`);
       await win.screenshot({ path: tapShot });

--- a/crates/linkcode-sim/src/capture.rs
+++ b/crates/linkcode-sim/src/capture.rs
@@ -14,8 +14,8 @@
 
 use std::collections::VecDeque;
 use std::io::{self, Read, Write};
-use std::process::{Child, Command, Stdio};
-use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+use std::process::{Child, ChildStdin, Command, Stdio};
+use std::sync::atomic::{AtomicBool, AtomicU8, AtomicU32, AtomicU64, Ordering};
 use std::sync::{Arc, Condvar, Mutex};
 use std::thread;
 use std::time::{Duration, Instant};
@@ -112,6 +112,11 @@ mod mach_time {
 
 /// Largest accepted worker frame (a JPEG at simulator resolution is well under this).
 const MAX_WORKER_FRAME: usize = 32 * 1024 * 1024;
+/// Worker-frame flag bits. Bit 0 marks an H.264 keyframe; bit 1 marks the codec (set = H.264, clear
+/// = JPEG) so the parent routes each frame without tracking the live codec. A JPEG frame is always
+/// `KEY` (independently decodable), so its byte stays `0x1` — unchanged from the pre-reconfig format.
+const FRAME_FLAG_KEY: u8 = 0x1;
+const FRAME_FLAG_H264: u8 = 0x2;
 /// Backoff between worker respawns after a crash.
 const RESPAWN_BACKOFF: Duration = Duration::from_millis(500);
 /// A worker that lived at least this long resets the crash-loop counter.
@@ -120,7 +125,8 @@ const HEALTHY_AFTER: Duration = Duration::from_secs(5);
 const MAX_FAST_CRASHES: u32 = 6;
 
 /// Encoder/pacing parameters for a capture stream, threaded from `streamStart` down to the worker
-/// (and across the process boundary as CLI args). Clamping happens at the boundary, not here.
+/// (as initial CLI args, then as live reconfigure records on the worker's stdin). Clamping happens
+/// at the boundary, not here.
 #[derive(Clone, Copy)]
 pub struct StreamParams {
     pub fps: u32,
@@ -129,6 +135,101 @@ pub struct StreamParams {
     /// encodes at native resolution — bitrate, not resolution, carries its bandwidth budget.
     pub scale: f64,
     pub codec: StreamCodec,
+}
+
+/// Fixed reconfigure record written to the worker's stdin: `[u32 fps][f64 quality][f64 scale][u8
+/// codec]`, all little-endian.
+const RECONFIG_RECORD_LEN: usize = 21;
+
+impl StreamParams {
+    fn to_record(self) -> [u8; RECONFIG_RECORD_LEN] {
+        let mut buf = [0u8; RECONFIG_RECORD_LEN];
+        buf[0..4].copy_from_slice(&self.fps.to_le_bytes());
+        buf[4..12].copy_from_slice(&self.quality.to_le_bytes());
+        buf[12..20].copy_from_slice(&self.scale.to_le_bytes());
+        buf[20] = codec_to_u8(self.codec);
+        buf
+    }
+
+    fn from_record(buf: &[u8; RECONFIG_RECORD_LEN]) -> StreamParams {
+        let mut fps = [0u8; 4];
+        fps.copy_from_slice(&buf[0..4]);
+        let mut quality = [0u8; 8];
+        quality.copy_from_slice(&buf[4..12]);
+        let mut scale = [0u8; 8];
+        scale.copy_from_slice(&buf[12..20]);
+        StreamParams {
+            fps: u32::from_le_bytes(fps),
+            quality: f64::from_le_bytes(quality),
+            scale: f64::from_le_bytes(scale),
+            codec: codec_from_u8(buf[20]),
+        }
+    }
+}
+
+fn codec_to_u8(codec: StreamCodec) -> u8 {
+    match codec {
+        StreamCodec::Jpeg => 0,
+        StreamCodec::H264 => 1,
+    }
+}
+
+fn codec_from_u8(byte: u8) -> StreamCodec {
+    if byte == 1 {
+        StreamCodec::H264
+    } else {
+        StreamCodec::Jpeg
+    }
+}
+
+/// Live stream parameters, shared (behind atomics) between the reconfigure path and a running
+/// stream's readers — the worker respawn (which reads them for fresh CLI args) and the pusher (which
+/// reads `codec`/`fps` each frame). Fields are independent atomics: a torn read across them is
+/// harmless, the next frame re-coheres. The worker process keeps its own copy, updated over stdin.
+pub struct StreamConfig {
+    fps: AtomicU32,
+    quality: AtomicU64,
+    scale: AtomicU64,
+    codec: AtomicU8,
+}
+
+impl StreamConfig {
+    fn new(params: StreamParams) -> StreamConfig {
+        let config = StreamConfig {
+            fps: AtomicU32::new(0),
+            quality: AtomicU64::new(0),
+            scale: AtomicU64::new(0),
+            codec: AtomicU8::new(0),
+        };
+        config.set(params);
+        config
+    }
+
+    fn set(&self, params: StreamParams) {
+        self.fps.store(params.fps, Ordering::Relaxed);
+        self.quality
+            .store(params.quality.to_bits(), Ordering::Relaxed);
+        self.scale.store(params.scale.to_bits(), Ordering::Relaxed);
+        self.codec
+            .store(codec_to_u8(params.codec), Ordering::Relaxed);
+    }
+
+    fn params(&self) -> StreamParams {
+        StreamParams {
+            fps: self.fps(),
+            quality: f64::from_bits(self.quality.load(Ordering::Relaxed)),
+            scale: f64::from_bits(self.scale.load(Ordering::Relaxed)),
+            codec: self.codec(),
+        }
+    }
+
+    pub fn fps(&self) -> u32 {
+        self.fps.load(Ordering::Relaxed)
+    }
+
+    pub fn codec(&self) -> StreamCodec {
+        codec_from_u8(self.codec.load(Ordering::Relaxed))
+    }
 }
 
 /// Bounded H.264 delivery queue. On overflow (a stalled consumer) the whole queue is dropped and
@@ -201,6 +302,12 @@ pub struct CaptureStream {
     /// The live worker child's pid (0 = none). Non-zero only while the manager holds the un-reaped
     /// `Child`, so the pid can't be reused — making a kill-on-drop safe to target it.
     worker_pid: Arc<AtomicU32>,
+    /// Live parameters. `reconfigure` writes here; the pusher reads `codec`/`fps` each frame and the
+    /// supervisor reads all of them for the next worker's CLI args.
+    config: Arc<StreamConfig>,
+    /// The current worker's stdin, if one is running. `reconfigure` writes a record here to retune
+    /// the live worker; the supervisor swaps it on each (re)spawn and clears it when the worker dies.
+    stdin: Arc<Mutex<Option<ChildStdin>>>,
     manager: Option<thread::JoinHandle<()>>,
 }
 
@@ -212,21 +319,26 @@ impl CaptureStream {
         let stopped = Arc::new(AtomicBool::new(false));
         let dead = Arc::new(AtomicBool::new(false));
         let worker_pid = Arc::new(AtomicU32::new(0));
+        let config = Arc::new(StreamConfig::new(params));
+        let stdin = Arc::new(Mutex::new(None));
         let manager = thread::spawn({
             let latest = Arc::clone(&latest);
             let encoded = Arc::clone(&encoded);
             let stopped = Arc::clone(&stopped);
             let dead = Arc::clone(&dead);
             let worker_pid = Arc::clone(&worker_pid);
+            let config = Arc::clone(&config);
+            let stdin = Arc::clone(&stdin);
             move || {
                 supervise(
                     &udid,
-                    params,
+                    &config,
                     &latest,
                     &encoded,
                     &stopped,
                     &dead,
                     &worker_pid,
+                    &stdin,
                 )
             }
         });
@@ -236,8 +348,32 @@ impl CaptureStream {
             stopped,
             dead,
             worker_pid,
+            config,
+            stdin,
             manager: Some(manager),
         }
+    }
+
+    /// Retune the running stream in place — no worker respawn, no XPC re-warm. Updates the shared
+    /// config (the pusher and the next respawn read it) and pushes a record to the live worker's
+    /// stdin; a write failure means the worker is mid-respawn, which then adopts the config via CLI
+    /// args, so it self-heals.
+    pub fn reconfigure(&self, params: StreamParams) {
+        self.config.set(params);
+        if let Some(stdin) = self
+            .stdin
+            .lock()
+            .expect("capture stream stdin mutex poisoned")
+            .as_mut()
+        {
+            let _ = stdin.write_all(&params.to_record());
+            let _ = stdin.flush();
+        }
+    }
+
+    /// The live stream parameters (the pusher reads `codec`/`fps` from here each frame).
+    pub fn config(&self) -> &StreamConfig {
+        &self.config
     }
 
     /// The most recently delivered JPEG frame, or `None` before the first frame (or once dead).
@@ -256,6 +392,12 @@ impl CaptureStream {
     /// Whether the worker crash-looped and the stream gave up.
     pub fn is_dead(&self) -> bool {
         self.dead.load(Ordering::Relaxed)
+    }
+
+    /// The live worker's pid (0 = none running). Used by diagnostics to prove a reconfigure retunes
+    /// in place rather than respawning the worker.
+    pub fn worker_pid(&self) -> u32 {
+        self.worker_pid.load(Ordering::Relaxed)
     }
 }
 
@@ -280,23 +422,32 @@ impl Drop for CaptureStream {
 
 /// Manager loop: (re)spawn the worker, pump its frames, back off and retry on crash, give up after
 /// too many fast crashes.
+#[allow(
+    clippy::too_many_arguments,
+    reason = "supervisor threads the stream's shared state by ref"
+)]
 fn supervise(
     udid: &str,
-    params: StreamParams,
+    config: &Arc<StreamConfig>,
     latest: &Arc<Mutex<Option<Frame>>>,
     encoded: &Arc<EncodedQueue>,
     stopped: &Arc<AtomicBool>,
     dead: &Arc<AtomicBool>,
     worker_pid: &Arc<AtomicU32>,
+    stdin: &Arc<Mutex<Option<ChildStdin>>>,
 ) {
     let mut fast_crashes = 0u32;
     while !stopped.load(Ordering::Relaxed) {
         let started = Instant::now();
-        match spawn_worker(udid, params) {
+        // Read the current params for CLI args: a fresh (or respawned) worker starts with the latest
+        // config even if a reconfigure record was missed during the crash gap.
+        match spawn_worker(udid, config.params()) {
             Ok(mut child) => {
                 // Publish the pid before reading so a concurrent drop can kill a stuck worker; clear
                 // it only after `wait()` reaps it, keeping the pid unreusable while it is set.
                 worker_pid.store(child.id(), Ordering::Relaxed);
+                // Hand the worker's stdin to the reconfigure path so it can retune this worker live.
+                *stdin.lock().expect("capture stream stdin mutex poisoned") = child.stdin.take();
                 // A drop that set `stopped` between the spawn and the store above may have read pid 0
                 // and not killed us; kill the child ourselves so the pump/wait below can't block on
                 // a worker that never writes.
@@ -304,7 +455,10 @@ fn supervise(
                     // SAFETY: our own just-spawned, un-reaped child pid.
                     unsafe { libc::kill(child.id() as libc::pid_t, libc::SIGKILL) };
                 }
-                pump_worker(&mut child, params.codec, latest, encoded, stopped);
+                pump_worker(&mut child, latest, encoded, stopped);
+                // Drop this dead worker's stdin before reaping so a concurrent reconfigure can't
+                // write to a stale pipe; the next spawn installs the new one.
+                *stdin.lock().expect("capture stream stdin mutex poisoned") = None;
                 let _ = child.wait();
                 worker_pid.store(0, Ordering::Relaxed);
             }
@@ -339,17 +493,20 @@ fn spawn_worker(udid: &str, params: StreamParams) -> io::Result<Child> {
         .arg(format!("{}", params.fps))
         .arg(format!("{}", params.scale))
         .arg(params.codec.cli_name())
-        .stdin(Stdio::null())
+        // Piped so `reconfigure` can push retune records to this worker; the worker reads them on a
+        // side thread and updates its live params without restarting.
+        .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::inherit())
         .spawn()
 }
 
 /// Read `[u32 LE len][u8 flags][payload]` frames from the worker until EOF (worker exit/crash) or
-/// stop. JPEG payloads replace the latest slot; H.264 payloads append to the ordered queue.
+/// stop. Each frame self-describes its codec (flags bit 1), so a live codec switch routes correctly
+/// without the parent tracking it: JPEG payloads replace the latest slot, H.264 payloads append to
+/// the ordered queue (flags bit 0 = keyframe).
 fn pump_worker(
     child: &mut Child,
-    codec: StreamCodec,
     latest: &Arc<Mutex<Option<Frame>>>,
     encoded: &Arc<EncodedQueue>,
     stopped: &Arc<AtomicBool>,
@@ -373,11 +530,10 @@ fn pump_worker(
         }
         let flags = frame[0];
         frame.drain(..1);
-        match codec {
-            StreamCodec::Jpeg => {
-                *latest.lock().expect("capture stream mutex poisoned") = Some(Arc::new(frame));
-            }
-            StreamCodec::H264 => encoded.push(frame, flags & 1 != 0),
+        if flags & FRAME_FLAG_H264 != 0 {
+            encoded.push(frame, flags & FRAME_FLAG_KEY != 0);
+        } else {
+            *latest.lock().expect("capture stream mutex poisoned") = Some(Arc::new(frame));
         }
     }
 }
@@ -422,28 +578,59 @@ pub fn run_worker() -> ! {
         std::process::exit(3);
     };
 
-    let mut clock = FrameClock::new(fps);
-    let mut stdout = io::stdout().lock();
-    match codec {
-        StreamCodec::Jpeg => loop {
-            if let Some(jpeg) = screen.capture_jpeg(quality, scale)
-                && !write_worker_frame(&mut stdout, 1, &jpeg)
-            {
-                break; // parent closed the pipe
+    // Live params start from the CLI args, then track reconfigure records the parent writes to
+    // stdin. A side thread applies them so the capture loop never blocks on the pipe; on EOF (parent
+    // gone) it just exits and the loop keeps the last params until the process is torn down.
+    let config = Arc::new(StreamConfig::new(StreamParams {
+        fps,
+        quality,
+        scale,
+        codec,
+    }));
+    thread::spawn({
+        let config = Arc::clone(&config);
+        move || {
+            let mut stdin = io::stdin().lock();
+            let mut record = [0u8; RECONFIG_RECORD_LEN];
+            while stdin.read_exact(&mut record).is_ok() {
+                config.set(StreamParams::from_record(&record));
             }
-            clock.tick();
-        },
-        StreamCodec::H264 => {
-            // Lazy per-dimension encoder: a rotation changes the surface size mid-stream.
-            let mut encoder: Option<(VtEncoder, usize, usize)> = None;
-            'stream: loop {
+        }
+    });
+
+    let mut clock = FrameClock::new(config.fps());
+    let mut last_fps = config.fps();
+    let mut stdout = io::stdout().lock();
+    // Lazy per-dimension H.264 encoder: a rotation changes the surface size mid-stream, and a switch
+    // to JPEG drops it (freeing the VideoToolbox session) — switching back rebuilds it, which also
+    // yields a fresh keyframe for the decoder to resync on.
+    let mut encoder: Option<(VtEncoder, usize, usize)> = None;
+    'run: loop {
+        let params = config.params();
+        if params.fps != last_fps {
+            // Re-pace only; the VT session's ExpectedFrameRate is advisory, so leave the encoder be
+            // (rebuilding it would drop a keyframe for a rate change that does not need one).
+            clock = FrameClock::new(params.fps);
+            last_fps = params.fps;
+        }
+        match params.codec {
+            StreamCodec::Jpeg => {
+                encoder = None;
+                if let Some(jpeg) = screen.capture_jpeg(params.quality, params.scale)
+                    && !write_worker_frame(&mut stdout, FRAME_FLAG_KEY, &jpeg)
+                {
+                    break 'run; // parent closed the pipe
+                }
+            }
+            StreamCodec::H264 => {
                 if let Some(surface) = screen.capture_surface() {
                     let (width, height) = (surface.width(), surface.height());
                     if encoder
                         .as_ref()
                         .is_none_or(|(_, w, h)| *w != width || *h != height)
                     {
-                        encoder = VtEncoder::new(width, height, fps).map(|e| (e, width, height));
+                        encoder =
+                            VtEncoder::new(width, height, params.fps).map(|e| (e, width, height));
                         if encoder.is_none() {
                             eprintln!("sim capture-worker: VideoToolbox session failed");
                             std::process::exit(4);
@@ -451,15 +638,16 @@ pub fn run_worker() -> ! {
                     }
                     if let Some((vt, _, _)) = encoder.as_mut() {
                         for unit in vt.encode(&surface) {
-                            if !write_worker_frame(&mut stdout, u8::from(unit.key), &unit.data) {
-                                break 'stream; // parent closed the pipe
+                            let flags = FRAME_FLAG_H264 | if unit.key { FRAME_FLAG_KEY } else { 0 };
+                            if !write_worker_frame(&mut stdout, flags, &unit.data) {
+                                break 'run; // parent closed the pipe
                             }
                         }
                     }
                 }
-                clock.tick();
             }
         }
+        clock.tick();
     }
     std::process::exit(0);
 }
@@ -475,4 +663,48 @@ fn write_worker_frame(stdout: &mut impl Write, flags: u8, payload: &[u8]) -> boo
         && stdout.write_all(&[flags]).is_ok()
         && stdout.write_all(payload).is_ok()
         && stdout.flush().is_ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reconfigure_record_roundtrips() {
+        let params = StreamParams {
+            fps: 30,
+            quality: 0.42,
+            scale: 0.5,
+            codec: StreamCodec::H264,
+        };
+        let decoded = StreamParams::from_record(&params.to_record());
+        assert_eq!(decoded.fps, 30);
+        assert_eq!(decoded.quality, 0.42);
+        assert_eq!(decoded.scale, 0.5);
+        assert_eq!(decoded.codec, StreamCodec::H264);
+    }
+
+    #[test]
+    fn config_applies_reconfigured_params() {
+        let config = StreamConfig::new(StreamParams {
+            fps: 60,
+            quality: 0.6,
+            scale: 1.0,
+            codec: StreamCodec::Jpeg,
+        });
+        assert_eq!(config.fps(), 60);
+        assert_eq!(config.codec(), StreamCodec::Jpeg);
+
+        config.set(StreamParams {
+            fps: 15,
+            quality: 0.3,
+            scale: 0.25,
+            codec: StreamCodec::H264,
+        });
+        assert_eq!(config.fps(), 15);
+        assert_eq!(config.codec(), StreamCodec::H264);
+        let params = config.params();
+        assert_eq!(params.quality, 0.3);
+        assert_eq!(params.scale, 0.25);
+    }
 }

--- a/crates/linkcode-sim/src/interactive.rs
+++ b/crates/linkcode-sim/src/interactive.rs
@@ -306,34 +306,30 @@ mod imp {
         let _ = input_for(udid);
         let fps = fps.clamp(1, 60);
         let scale = scale.clamp(0.1, 1.0);
+        let params = crate::capture::StreamParams {
+            fps,
+            quality: quality.clamp(0.1, 1.0),
+            scale,
+            codec,
+        };
         let mut reg = registry().lock().expect("interactive registry poisoned");
-        if reg.streams.contains_key(udid) {
-            // An idempotent retry keeps the documented success shape (PROTOCOL.md), with
-            // `alreadyStreaming` only as an extra flag, so a caller validating the result still sees
-            // `streaming`/`fps`/`scale`.
+        if let Some(handle) = reg.streams.get(udid) {
+            // A start on a running stream retunes it in place — no worker respawn, no XPC re-warm.
+            // The unified pusher and the worker pick up the new params; `alreadyStreaming` marks that
+            // this was a reconfigure, while the shape still carries `streaming`/`fps`/`scale`/`codec`.
+            handle.stream.reconfigure(params);
             return Ok(
-                json!({ "streaming": true, "fps": fps, "scale": scale, "alreadyStreaming": true }),
+                json!({ "streaming": true, "fps": fps, "scale": scale, "codec": codec, "alreadyStreaming": true }),
             );
         }
-        let stream = Arc::new(CaptureStream::start(
-            udid.to_owned(),
-            crate::capture::StreamParams {
-                fps,
-                quality: quality.clamp(0.1, 1.0),
-                scale,
-                codec,
-            },
-        ));
+        let stream = Arc::new(CaptureStream::start(udid.to_owned(), params));
         let stop = Arc::new(AtomicBool::new(false));
         let pusher = thread::spawn({
             let stream = Arc::clone(&stream);
             let stop = Arc::clone(&stop);
             let tx = tx.clone();
             let udid = udid.to_owned();
-            move || match codec {
-                StreamCodec::Jpeg => push_frames(&udid, fps, &stream, &stop, &tx),
-                StreamCodec::H264 => push_h264(&udid, &stream, &stop, &tx),
-            }
+            move || push_stream(&udid, &stream, &stop, &tx)
         });
         reg.streams.insert(
             udid.to_owned(),
@@ -361,78 +357,25 @@ mod imp {
         Ok(json!({}))
     }
 
-    /// Push framebuffer frames to the daemon at `fps`. Prefers the fast private capture stream; if
-    /// its crash-isolated worker gives up (the private API is unusable on this host/state), it
-    /// degrades to `simctl io screenshot` — slower, but frames never stop and the sidecar never
-    /// crashes. De-duplicates the private frames by identity so a static screen doesn't flood.
-    fn push_frames(
-        udid: &str,
-        fps: u32,
-        stream: &CaptureStream,
-        stop: &AtomicBool,
-        tx: &Sender<OutMsg>,
-    ) {
-        // Poll the private stream on a drift-free clock so a locked worker fps reaches the wire
-        // without the per-frame sleep overshoot that would otherwise sample it below target.
-        let mut clock = FrameClock::new(fps);
-        // simctl screenshots cost ~200-400ms, so poll them well below the private fps.
+    /// Push framebuffer frames to the daemon, adapting to the stream's live codec each frame so a
+    /// reconfigure (JPEG↔H.264, fps) needs no pusher restart. JPEG is latest-wins — deduped by
+    /// identity so a static screen doesn't flood, paced on a drift-free clock at the current fps;
+    /// H.264 drains the ordered queue (deltas must not be dropped). If the crash-isolated worker
+    /// gives up (or stays silent in JPEG mode), it degrades to `simctl io screenshot` — slower, but
+    /// frames never stop; each wire frame carries its codec so a mixed stream stays decodable.
+    fn push_stream(udid: &str, stream: &CaptureStream, stop: &AtomicBool, tx: &Sender<OutMsg>) {
+        // simctl screenshots cost ~200-400ms, so poll the fallback well below the private fps.
         let fallback_interval = Duration::from_millis(500);
-        // Retain the last-sent frame (not a raw pointer): comparing addresses alone risks ABA — a
-        // freed frame's address reused by a new one would read as "already sent".
+        let mut clock = FrameClock::new(stream.config().fps());
+        let mut clock_fps = stream.config().fps();
+        // Retain the last-sent JPEG frame (not a raw pointer): comparing addresses alone risks ABA —
+        // a freed frame's address reused by a new one would read as "already sent".
         let mut last: Option<Frame> = None;
-        // If the worker stays alive but never delivers (framebuffer registration produced no
-        // callbacks), fall back to simctl instead of sending nothing forever.
+        // Last time a real private frame (either codec) reached the wire; a JPEG-mode silence past
+        // the timeout means the framebuffer produced no callbacks, so degrade to simctl.
         let mut last_progress = Instant::now();
         while !stop.load(Ordering::Relaxed) {
-            // Prefer a fresh private frame; sending one marks the worker as producing.
-            if let Some(frame) = stream.latest()
-                && last.as_ref().is_none_or(|prev| !Arc::ptr_eq(prev, &frame))
-            {
-                last = Some(Arc::clone(&frame));
-                last_progress = Instant::now();
-                if let Ok(body) = encode_stream_frame(udid, &frame)
-                    && tx
-                        .send(OutMsg::Frame {
-                            type_byte: STREAM_FRAME,
-                            body,
-                        })
-                        .is_err()
-                {
-                    break; // daemon gone
-                }
-                clock.tick();
-                continue;
-            }
-            // No fresh private frame: if the worker gave up, or has been silent past the timeout,
-            // degrade to a public simctl screenshot so frames never stop.
-            if stream.is_dead() || last_progress.elapsed() >= SILENT_FALLBACK_AFTER {
-                let tick = Instant::now();
-                if let Ok(jpeg) = crate::simctl::screenshot(udid, crate::rpc::ImageFormat::Jpeg)
-                    && let Ok(body) = encode_stream_frame(udid, &jpeg)
-                    && tx
-                        .send(OutMsg::Frame {
-                            type_byte: STREAM_FRAME,
-                            body,
-                        })
-                        .is_err()
-                {
-                    break; // daemon gone
-                }
-                if let Some(rest) = fallback_interval.checked_sub(tick.elapsed()) {
-                    thread::sleep(rest);
-                }
-            } else {
-                clock.tick();
-            }
-        }
-    }
-
-    /// Push H.264 access units in order (deltas must not be dropped). If the private worker gives
-    /// up, degrades to slow simctl JPEG frames — each wire frame carries its codec, so a mixed
-    /// stream stays decodable client-side.
-    fn push_h264(udid: &str, stream: &CaptureStream, stop: &AtomicBool, tx: &Sender<OutMsg>) {
-        let fallback_interval = Duration::from_millis(500);
-        while !stop.load(Ordering::Relaxed) {
+            // The worker gave up entirely: degrade to a public screenshot so frames never stop.
             if stream.is_dead() {
                 let tick = Instant::now();
                 if let Ok(jpeg) = crate::simctl::screenshot(udid, crate::rpc::ImageFormat::Jpeg)
@@ -451,18 +394,67 @@ mod imp {
                 }
                 continue;
             }
-            let Some(unit) = stream.next_encoded(Duration::from_millis(250)) else {
-                continue;
-            };
-            if let Ok(body) = encode_stream_frame_h264(udid, unit.key, &unit.data)
-                && tx
-                    .send(OutMsg::Frame {
-                        type_byte: STREAM_FRAME_H264,
-                        body,
-                    })
-                    .is_err()
-            {
-                break; // daemon gone
+            match stream.config().codec() {
+                StreamCodec::H264 => {
+                    // The queue pop paces this branch (blocks up to 250ms for the next unit).
+                    let Some(unit) = stream.next_encoded(Duration::from_millis(250)) else {
+                        continue;
+                    };
+                    last_progress = Instant::now();
+                    if let Ok(body) = encode_stream_frame_h264(udid, unit.key, &unit.data)
+                        && tx
+                            .send(OutMsg::Frame {
+                                type_byte: STREAM_FRAME_H264,
+                                body,
+                            })
+                            .is_err()
+                    {
+                        break; // daemon gone
+                    }
+                }
+                StreamCodec::Jpeg => {
+                    let fps = stream.config().fps();
+                    if fps != clock_fps {
+                        clock = FrameClock::new(fps);
+                        clock_fps = fps;
+                    }
+                    if let Some(frame) = stream.latest()
+                        && last.as_ref().is_none_or(|prev| !Arc::ptr_eq(prev, &frame))
+                    {
+                        last = Some(Arc::clone(&frame));
+                        last_progress = Instant::now();
+                        if let Ok(body) = encode_stream_frame(udid, &frame)
+                            && tx
+                                .send(OutMsg::Frame {
+                                    type_byte: STREAM_FRAME,
+                                    body,
+                                })
+                                .is_err()
+                        {
+                            break; // daemon gone
+                        }
+                        clock.tick();
+                    } else if last_progress.elapsed() >= SILENT_FALLBACK_AFTER {
+                        let tick = Instant::now();
+                        if let Ok(jpeg) =
+                            crate::simctl::screenshot(udid, crate::rpc::ImageFormat::Jpeg)
+                            && let Ok(body) = encode_stream_frame(udid, &jpeg)
+                            && tx
+                                .send(OutMsg::Frame {
+                                    type_byte: STREAM_FRAME,
+                                    body,
+                                })
+                                .is_err()
+                        {
+                            break; // daemon gone
+                        }
+                        if let Some(rest) = fallback_interval.checked_sub(tick.elapsed()) {
+                            thread::sleep(rest);
+                        }
+                    } else {
+                        clock.tick();
+                    }
+                }
             }
         }
     }

--- a/crates/linkcode-sim/src/main.rs
+++ b/crates/linkcode-sim/src/main.rs
@@ -127,6 +127,13 @@ fn main() {
         diag_rotate();
         return;
     }
+    // Diagnostic: prove a live reconfigure retunes the stream without respawning the worker:
+    // `linkcode-sim diag-reconfigure <udid>`.
+    #[cfg(target_os = "macos")]
+    if subcommand.as_deref() == Some("diag-reconfigure") {
+        diag_reconfigure();
+        return;
+    }
 
     let (tx, rx) = channel::<OutMsg>();
 
@@ -394,6 +401,77 @@ fn diag_interactive() {
     eprintln!(
         "stream dead={} frames-seen={frames} last={last_len} bytes; wrote {out}",
         stream.is_dead()
+    );
+}
+
+/// Diagnostic (macOS only): prove `CaptureStream::reconfigure` retunes a running stream in place —
+/// the worker pid stays the same across a JPEG→H.264 + fps change, and H.264 units start flowing.
+/// `linkcode-sim diag-reconfigure <udid>`. Needs a booted device with an active framebuffer.
+#[cfg(target_os = "macos")]
+fn diag_reconfigure() {
+    let udid = std::env::args()
+        .nth(2)
+        .expect("usage: diag-reconfigure <udid>");
+    eprintln!(
+        "interactive available: {}",
+        private::interactive_available()
+    );
+
+    let stream = capture::CaptureStream::start(
+        udid.clone(),
+        capture::StreamParams {
+            fps: 30,
+            quality: 0.6,
+            scale: 1.0,
+            codec: rpc::StreamCodec::Jpeg,
+        },
+    );
+
+    // JPEG phase: wait for the first frame, then count distinct frames for ~2s.
+    let mut jpeg_frames = 0u32;
+    let mut last: Option<capture::Frame> = None;
+    let phase = Instant::now();
+    while phase.elapsed() < Duration::from_secs(3) && !stream.is_dead() {
+        if let Some(frame) = stream.latest()
+            && last.as_ref().is_none_or(|prev| !Arc::ptr_eq(prev, &frame))
+        {
+            jpeg_frames += 1;
+            last = Some(frame);
+        }
+        thread::sleep(Duration::from_millis(30));
+    }
+    let pid_before = stream.worker_pid();
+    eprintln!("JPEG @30fps: worker pid={pid_before}, distinct frames≈{jpeg_frames}");
+
+    // Reconfigure to H.264 @15fps — expected to retune in place, no respawn.
+    stream.reconfigure(capture::StreamParams {
+        fps: 15,
+        quality: 0.6,
+        scale: 1.0,
+        codec: rpc::StreamCodec::H264,
+    });
+    let mut units = 0u32;
+    let mut keyframes = 0u32;
+    let phase = Instant::now();
+    while phase.elapsed() < Duration::from_secs(3) {
+        if let Some(unit) = stream.next_encoded(Duration::from_millis(250)) {
+            units += 1;
+            if unit.key {
+                keyframes += 1;
+            }
+        }
+    }
+    let pid_after = stream.worker_pid();
+    eprintln!("H.264 @15fps: worker pid={pid_after}, units={units} (keyframes={keyframes})");
+
+    assert_eq!(
+        pid_before, pid_after,
+        "worker pid changed — reconfigure respawned the worker instead of retuning it"
+    );
+    assert!(pid_before != 0, "no worker was running to reconfigure");
+    assert!(units > 0, "no H.264 units after switching codec live");
+    eprintln!(
+        "PASS: reconfigure retuned in place (pid stable {pid_before}); codec switched jpeg→h264"
     );
 }
 

--- a/crates/linkcode-sim/src/rpc.rs
+++ b/crates/linkcode-sim/src/rpc.rs
@@ -160,7 +160,7 @@ pub enum TouchPhase {
 
 /// Framebuffer stream encodings. JPEG frames are independently decodable (latest-wins delivery);
 /// H.264 access units are ordered and delta-dependent (hardware encode/decode, ~10× less bandwidth).
-#[derive(Clone, Copy, Default, PartialEq, Eq, Deserialize, Serialize)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub enum StreamCodec {
     #[default]

--- a/packages/client/workbench/src/simulator/__tests__/stream-registry.test.ts
+++ b/packages/client/workbench/src/simulator/__tests__/stream-registry.test.ts
@@ -104,7 +104,7 @@ describe('simulator stream registry', () => {
     await vi.advanceTimersByTimeAsync(1000);
   });
 
-  it('restarts a live stream with new options and no-ops on an unchanged retune', async () => {
+  it('retunes a live stream in place with new options and no-ops on an unchanged retune', async () => {
     const client = createFakeClient();
     const lease = acquireSimulatorStream(client, 'U-1', S1, OPTS);
     const phases: string[] = [];
@@ -112,21 +112,20 @@ describe('simulator stream registry', () => {
     await vi.advanceTimersByTimeAsync(0);
     expect(lease.getSnapshot().phase).toBe('streaming');
 
-    // Same options: no stop/start.
+    // Same options: no extra start.
     setSimulatorStreamOptions(client, 'U-1', OPTS);
-    expect(client.stopped).toEqual([]);
     expect(client.started).toHaveLength(1);
 
-    // Changed options: stop then restart, and the new stream carries them.
+    // Changed options: a second start with the new options reconfigures the running stream in place
+    // — no stop, and the phase never leaves `streaming` (the picture doesn't blip).
     const next: SimulatorStreamOptions = { fps: 30, scale: 0.5, codec: 'jpeg' };
     setSimulatorStreamOptions(client, 'U-1', next);
-    expect(lease.getSnapshot().phase).toBe('starting');
     await vi.advanceTimersByTimeAsync(0);
-    expect(lease.getSnapshot().phase).toBe('streaming');
-    expect(client.stopped).toEqual([{ sessionId: S1, udid: 'U-1' }]);
+    expect(client.stopped).toEqual([]);
     expect(client.started).toHaveLength(2);
     expect(client.started[1].options).toEqual(next);
-    expect(phases).toEqual(['streaming', 'starting', 'streaming']);
+    expect(lease.getSnapshot().phase).toBe('streaming');
+    expect(phases).toEqual(['streaming']);
 
     lease.release();
     await vi.advanceTimersByTimeAsync(1000);

--- a/packages/client/workbench/src/simulator/stream-registry.ts
+++ b/packages/client/workbench/src/simulator/stream-registry.ts
@@ -44,7 +44,7 @@ interface RegistryEntry {
   closeTimer: ReturnType<typeof setTimeout> | null;
   snapshot: SimulatorStreamSnapshot;
   listeners: Set<() => void>;
-  /** Parameters the running (or next) stream uses; changing them restarts the stream in place. */
+  /** Parameters the running (or next) stream uses; changing them retunes the stream in place. */
   options: SimulatorStreamOptions;
 }
 
@@ -76,8 +76,8 @@ function startStream(
       if (registry.get(udid) !== entry) return;
       entry.snapshot = { ...entry.snapshot, phase: 'streaming' };
       notify(entry);
-      // A retune that landed mid-start could not restart yet (no stream to stop); do it now.
-      if (!optionsEqual(started, entry.options)) restartStream(client, registry, udid, entry);
+      // A retune that landed mid-start applies now that the stream exists to reconfigure.
+      if (!optionsEqual(started, entry.options)) applyStreamOptions(client, registry, udid, entry);
     })
     .catch(() => {
       if (registry.get(udid) !== entry) return;
@@ -86,23 +86,20 @@ function startStream(
     });
 }
 
-/** Stop then restart a live stream so the sidecar re-parameterizes it (it no-ops a `streamStart`
- * while one already runs). The lease, its listeners, and the frame subscription all survive. */
-function restartStream(
+/** Retune an established stream in place: a `streamStart` on a running stream reconfigures the
+ * daemon-side capture in place (no worker respawn, no visible blip), so the phase stays `streaming`
+ * and only a failure surfaces. */
+function applyStreamOptions(
   client: SimulatorStreamClient,
   registry: Map<string, RegistryEntry>,
   udid: string,
   entry: RegistryEntry,
 ): void {
-  entry.snapshot = { ...entry.snapshot, phase: 'starting' };
-  notify(entry);
-  void client
-    .simulatorStreamStop(entry.snapshot.sessionId, udid)
-    .catch(noop)
-    .finally(() => {
-      if (registry.get(udid) !== entry) return;
-      startStream(client, registry, udid, entry);
-    });
+  void client.simulatorStreamStart(entry.snapshot.sessionId, udid, entry.options).catch(() => {
+    if (registry.get(udid) !== entry) return;
+    entry.snapshot = { ...entry.snapshot, phase: 'failed' };
+    notify(entry);
+  });
 }
 
 /**
@@ -176,9 +173,9 @@ export function peekSimulatorStream(
 }
 
 /**
- * Retune a running device stream. The sidecar cannot re-parameterize a live stream (`streamStart`
- * no-ops once one exists), so a change stops and restarts it in place — the lease, its listeners,
- * and the independent frame subscription all survive; only the daemon stream blips. A no-op when the
+ * Retune a running device stream in place. A `streamStart` on a running stream reconfigures the
+ * daemon-side capture without respawning its worker, so the change is seamless — the lease, its
+ * listeners, and the frame subscription all survive and the picture never blips. A no-op when the
  * options are unchanged or no stream exists (the next {@link acquireSimulatorStream} carries them).
  */
 export function setSimulatorStreamOptions(
@@ -190,7 +187,7 @@ export function setSimulatorStreamOptions(
   const entry = registry?.get(udid);
   if (registry === undefined || entry === undefined || optionsEqual(entry.options, options)) return;
   entry.options = options;
-  // Only an established stream restarts now; a still-starting one adopts the options when its start
+  // Only an established stream retunes now; a still-starting one adopts the options when its start
   // completes (startStream re-checks), and a failed one uses them on the next `restart`.
-  if (entry.snapshot.phase === 'streaming') restartStream(client, registry, udid, entry);
+  if (entry.snapshot.phase === 'streaming') applyStreamOptions(client, registry, udid, entry);
 }


### PR DESCRIPTION
CODE-433. Changing a stream parameter (frame rate / resolution / encoding) no longer stops the stream and respawns the capture worker — it retunes the running stream in place. The worker process keeps running, the CoreSimulator XPC connection is never re-warmed, and the picture never blips. Succeeds CODE-413 (#268), whose client-side stop→start was the interim approach; **stacked on it**.

## Zero wire change — `streamStart` becomes idempotent-with-reconfigure

The sidecar's `stream_start` used to no-op (`alreadyStreaming`) when a stream already ran; it now reconfigures that stream. So "change a parameter" reuses the existing `streamStart(fps, quality, scale, codec)` path end to end — the SDK, engine, wire, and client-core already carry every parameter each call. No new wire op, no `WIRE_PROTOCOL_VERSION` bump, no SDK/engine/client-core change. Only two layers move:

- **sidecar** (`crates/linkcode-sim`): `stream_start` on a running stream → `CaptureStream::reconfigure`.
- **client** (`stream-registry`): `setSimulatorStreamOptions` calls `streamStart` again (in-place retune) instead of stop→start; the phase stays `streaming`, so no "reconnecting" fl: the picture is seamless.

## Sidecar design

- **Control channel**: the worker's stdin (was `null`) is now piped; `CaptureStream` holds the current `ChildStdin`, and `reconfigure` updates a shared atomic `StreamConfig` and writes a fixed 21-byte record to the live worker. On a crash respawn the worker reads the latest config as CLI args, so a missed record self-heals.
- **Unified worker loop**: one loop branches on the live codec/fps each frame — fps change re-paces the `FrameClock` (the VT `ExpectedFrameRate` is advisory, so the encoder isn't rebuilt); switching to JPEG drops the VideoToolbox session and switching back rebuilds it (yielding a fresh keyframe for the decoder).
- **Self-describing frames**: each worker frame tags its codec (flags bit 1), so the parent routes a live codec switch without tracking it. A JPEG frame's byte is unchanged (`0x1`).
- **Unified pusher**: the two pusher functions merge into one that reads the codec/fps each frame; the simctl fallback survives for both.

## Verification

- `cargo fmt`/`clippy -D warnings`/`test` green; two new unit tests cover the reconfigure record round-trip and `StreamConfig`.
- New `diag-reconfigure <udid>` proved it on a booted iPhone 17 Pro: JPEG@30 → H.264@15 with the **capture-worker pid stable (54578)** and H.264 units flowing.
- `pnpm check:ci` + `pnpm test` (1918) green.
- Desktop simulator E2E deep pass extended with a live-reconfigure step: a codec switch over the wire retunes the stream with **the capture-worker pid unchanged** and the canvas still painting. Green end to end.

The wire E2E pin was also bumped 52→53 to track master's current `WIRE_PROTOCOL_VERSION` (unrelated managed-asset bump from #263).

## Known limitation (out of scope, tracked separately)

H.264 still ignores `scale` (native resolution by design), so the Resolution control is a no-op in the default codec — pre-existing, to be handled on its own.