### PR TITLE
feat(workbench): agent-driving badge over the simulator stage

### DIFF
--- a/packages/client/workbench/src/simulator/__tests__/agent-activity.test.ts
+++ b/packages/client/workbench/src/simulator/__tests__/agent-activity.test.ts
@@ -1,0 +1,85 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { SimulatorActivityClient } from '../agent-activity';
+import { useSimulatorAgentActivity } from '../agent-activity';
+
+type Activity = Parameters<Parameters<SimulatorActivityClient['subscribeSimulatorActivity']>[0]>[0];
+
+/** A client whose activity feed the test drives by hand. */
+function fakeClient(): SimulatorActivityClient & { emit: (activity: Activity) => void } {
+  const listeners = new Set<(activity: Activity) => void>();
+  return {
+    subscribeSimulatorActivity(cb) {
+      listeners.add(cb);
+      return () => listeners.delete(cb);
+    },
+    emit(activity) {
+      act(() => {
+        for (const listener of listeners) listener(activity);
+      });
+    },
+  };
+}
+
+const started = (udid: string | undefined, tool = 'sim_tap'): Activity =>
+  ({ sessionId: 's1', udid, tool, phase: 'started' }) as Activity;
+const settled = (udid: string | undefined, tool = 'sim_tap'): Activity =>
+  ({ sessionId: 's1', udid, tool, phase: 'settled' }) as Activity;
+
+describe('useSimulatorAgentActivity', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+  });
+
+  it('lights while a tool runs and clears after the linger', () => {
+    const client = fakeClient();
+    const { result } = renderHook(() => useSimulatorAgentActivity(client, 'U-1'));
+    expect(result.current).toBe(false);
+
+    client.emit(started('U-1'));
+    expect(result.current).toBe(true);
+
+    client.emit(settled('U-1'));
+    // Still lit: the linger is what keeps a burst of taps from strobing the badge.
+    expect(result.current).toBe(true);
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+    expect(result.current).toBe(false);
+  });
+
+  it('stays lit until the last overlapping tool settles', () => {
+    const client = fakeClient();
+    const { result } = renderHook(() => useSimulatorAgentActivity(client, 'U-1'));
+
+    client.emit(started('U-1', 'sim_tap'));
+    client.emit(started('U-1', 'sim_screenshot'));
+    client.emit(settled('U-1', 'sim_tap'));
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+    // One tool is still running, so the first settle must not clear the badge.
+    expect(result.current).toBe(true);
+
+    client.emit(settled('U-1', 'sim_screenshot'));
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+    expect(result.current).toBe(false);
+  });
+
+  it('ignores activity for other devices and device-less tools', () => {
+    const client = fakeClient();
+    const { result } = renderHook(() => useSimulatorAgentActivity(client, 'U-1'));
+
+    client.emit(started('U-2'));
+    client.emit(started(undefined, 'sim_list_devices'));
+    expect(result.current).toBe(false);
+  });
+});

--- a/packages/client/workbench/src/simulator/agent-activity.ts
+++ b/packages/client/workbench/src/simulator/agent-activity.ts
@@ -1,0 +1,53 @@
+import type { LinkCodeClient } from '@linkcode/client-core';
+import { useEffect } from 'foxact/use-abortable-effect';
+import { useState } from 'react';
+
+/** The slice of `LinkCodeClient` the activity hook needs. */
+export type SimulatorActivityClient = Pick<LinkCodeClient, 'subscribeSimulatorActivity'>;
+
+/** How long the indicator lingers after the last tool settles. Agents drive a device as a burst of
+ * short calls, so clearing instantly would strobe the badge between consecutive taps. */
+const LINGER_MS = 1200;
+
+/**
+ * Whether an agent is currently driving `udid`, from the daemon's `simulator.activity` broadcast.
+ * That feed originates only in the built-in simulator MCP server, so it is agent activity by
+ * construction — the user's own taps in this panel never raise it.
+ */
+export function useSimulatorAgentActivity(
+  client: SimulatorActivityClient,
+  udid: string | null,
+): boolean {
+  const [active, setActive] = useState(false);
+
+  useEffect(() => {
+    if (udid === null) return;
+    // Tools can overlap, so track depth rather than a boolean: the badge clears on the *last*
+    // settle, not the first. Every started is paired with a settled in a `finally`, so this
+    // cannot leak a permanently-lit badge.
+    let inflight = 0;
+    let clearTimer: ReturnType<typeof setTimeout> | undefined;
+    const unsubscribe = client.subscribeSimulatorActivity((activity) => {
+      // Device-less tools (listing devices, probing) are not "driving this device".
+      if (activity.udid !== udid) return;
+      if (activity.phase === 'started') {
+        inflight += 1;
+        clearTimeout(clearTimer);
+        setActive(true);
+        return;
+      }
+      inflight = Math.max(0, inflight - 1);
+      if (inflight === 0) {
+        clearTimeout(clearTimer);
+        clearTimer = setTimeout(() => setActive(false), LINGER_MS);
+      }
+    });
+    return () => {
+      unsubscribe();
+      clearTimeout(clearTimer);
+      setActive(false);
+    };
+  }, [client, udid]);
+
+  return active;
+}

--- a/packages/client/workbench/src/simulator/panel.tsx
+++ b/packages/client/workbench/src/simulator/panel.tsx
@@ -30,6 +30,7 @@ import {
 } from 'lucide-react';
 import { useCallback, useRef, useState, useSyncExternalStore } from 'react';
 import { useTranslations } from 'use-intl';
+import { useSimulatorAgentActivity } from './agent-activity';
 import { base64Blob, captureFileStem, downloadBlob, useSimulatorRecorder } from './capture';
 import type { SimulatorStreamLease } from './stream-registry';
 import {
@@ -265,6 +266,7 @@ export function SimulatorPanel({ sessionId }: { sessionId: SessionId | null }): 
     [client, udid],
   );
   const measuredFps = useReceivedFps(subscribeFrames, showFps && canStream);
+  const agentDriving = useSimulatorAgentActivity(client, udid);
 
   const flagBusy = useCallback(() => {
     setBusy(true);
@@ -485,6 +487,14 @@ export function SimulatorPanel({ sessionId }: { sessionId: SessionId | null }): 
           // The stage stays near-black in both themes (video-player convention) so the streamed
           // frame carries the contrast; everything on it uses fixed neutrals, not theme tokens.
           <div className="absolute inset-2 overflow-hidden rounded-lg bg-neutral-950">
+            {agentDriving && (
+              // Floats over the stage rather than displacing it, so the picture never shifts as an
+              // agent starts and stops working. Input stays live — this informs, it does not lock.
+              <div className="-translate-x-1/2 pointer-events-none absolute top-3 left-1/2 z-10 flex items-center gap-2 rounded-full bg-white px-3 py-1.5 font-medium text-neutral-900 text-xs shadow-lg">
+                <span className="size-2 shrink-0 animate-pulse rounded-full bg-orange-500" />
+                {t('simulatorAgentDriving')}
+              </div>
+            )}
             <SimulatorScreen
               key={udid}
               subscribeFrames={subscribeFrames}

--- a/packages/presentation/i18n/src/locales/en.ts
+++ b/packages/presentation/i18n/src/locales/en.ts
@@ -388,6 +388,7 @@ export const en = {
       simulatorRotate: 'Rotate',
       simulatorHome: 'Home',
       simulatorLock: 'Lock screen',
+      simulatorAgentDriving: 'An agent is using this device',
       simulatorBooted: 'Booted',
       simulatorShutdown: 'Shut down device',
       simulatorDetach: 'Detach simulator',

--- a/packages/presentation/i18n/src/locales/zh-cn.ts
+++ b/packages/presentation/i18n/src/locales/zh-cn.ts
@@ -377,6 +377,7 @@ export const zhCN = {
       simulatorRotate: '旋转',
       simulatorHome: '主屏幕',
       simulatorLock: '锁屏',
+      simulatorAgentDriving: 'Agent 正在使用此设备',
       simulatorBooted: '已启动',
       simulatorShutdown: '关闭设备',
       simulatorDetach: '断开画面',


### PR DESCRIPTION
CODE-417. While an agent drives the device, the panel now floats an "An agent is using this device" badge over the stage, so a co-driving user can tell whose taps are landing. **Stacked on #273 (CODE-416).**

## This turned out to be panel-only

The issue was written assuming engine work — distinguishing MCP-sourced commands from panel-sourced ones, plus a new `simulator.agent-activity` wire push and a version bump. **None of that was needed: the feed already exists**, shipped with the built-in MCP server in CODE-395.

- `simulator.activity` is already a wire variant: `{ sessionId, udid?, tool, phase: 'started' | 'settled' }`.
- It is emitted **only** from `apps/daemon/src/sim/mcp-endpoint.ts`, so it is agent activity by construction — no source tagging required. Every tool call wraps its emission in `try/finally`, so `settled` cannot be dropped.
- `client.subscribeSimulatorActivity` was already exposed.

The type's own comment reads *"the panel's 'agent is driving this device' badge"* — this was left as a hook for exactly this feature. So: **no wire change, no version bump, no engine change.** I corrected the issue description accordingly.

## Implementation

`useSimulatorAgentActivity(client, udid)` tracks in-flight depth rather than a boolean — tools overlap, so the badge must clear on the *last* settle, not the first — and lingers ~1.2s after the depth hits zero, because agents drive a device as a burst of short calls and instant clearing would strobe the badge between consecutive taps. Activity for other devices, and device-less tools like `sim_list_devices`, are ignored.

The badge floats (`absolute`, `pointer-events-none`) so the picture never shifts as an agent starts and stops, and **input stays live** — it informs, it does not lock the user out.

## Verification

- Three unit tests cover the logic that could actually be wrong: the linger, overlapping tools (first settle must not clear), and the udid/device-less filtering.
- `pnpm check:ci` and `pnpm test` green; the desktop E2E deep pass still green (regression only).

**Honest gap:** the badge is not driven end-to-end in E2E. Raising real activity needs an actual MCP tool call, which requires the daemon's per-session MCP token — not reachable from the harness. The logic is unit-tested and the feed it consumes is already exercised by the MCP integration tests, but a live agent-drives-device visual check is still worth doing by hand.