### PR TITLE
feat(engine): reclaim an idle detached simulator the engine booted

### DIFF
--- a/apps/desktop/e2e/simulator-panel.e2e.mts
+++ b/apps/desktop/e2e/simulator-panel.e2e.mts
@@ -8,6 +8,7 @@
 
 import type { ChildProcess } from 'node:child_process';
 import { execFileSync, spawn } from 'node:child_process';
+import { once } from 'node:events';
 import {
   existsSync,
   mkdirSync,
@@ -70,6 +71,13 @@ function bootedUdids(): string[] {
   } catch {
     return [];
   }
+}
+
+/** Poll the host until `udid`'s booted-ness matches `want`; simctl state changes are not instant. */
+async function waitForBooted(udid: string, want: boolean, message: string): Promise<void> {
+  const deadline = Date.now() + 60000;
+  while (bootedUdids().includes(udid) !== want && Date.now() < deadline) await wait(500);
+  if (bootedUdids().includes(udid) !== want) fail(message);
 }
 
 function piOnPath(): boolean {
@@ -142,12 +150,55 @@ async function waitForDownload(dir: string, pattern: RegExp, label: string): Pro
   fail(`${label} never landed in ${dir}`);
 }
 
+/** The claim session + device the CODE-419 reclaim check reuses, so it never fights an existing claim. */
+interface ReclaimTarget {
+  sessionId: string;
+  udid: string;
+}
+
+/**
+ * CODE-419's acceptance, end to end: a device the *engine* booted must not outlive the daemon.
+ * Shuts the host device down, boots it back through the wire so the engine owns it, then drains
+ * the daemon and checks the host. A user-booted device would still be running at this point —
+ * that asymmetry is the whole feature, so the check is only meaningful with an engine boot.
+ */
+async function assertShutdownReclaim(daemon: ChildProcess, target: ReclaimTarget): Promise<void> {
+  const { sessionId, udid } = target;
+  await wireRequest({
+    kind: 'simulator.shutdown',
+    clientReqId: 'e2e-reclaim-shutdown',
+    sessionId,
+    udid,
+  });
+  await waitForBooted(udid, false, 'the device never shut down before the reclaim check');
+
+  const booted = await wireRequest({
+    kind: 'simulator.boot',
+    clientReqId: 'e2e-reclaim-boot',
+    sessionId,
+    udid,
+  });
+  if (booted.kind !== 'request.succeeded') {
+    fail(`engine boot for the reclaim check failed: ${JSON.stringify(booted)}`);
+  }
+  await waitForBooted(udid, true, 'the engine never booted the device for the reclaim check');
+
+  daemon.kill('SIGTERM');
+  await once(daemon, 'exit');
+  await waitForBooted(udid, false, 'the daemon exited leaving the device it booted running');
+  console.log('daemon shutdown reclaimed the device the engine booted');
+
+  // Leave the host as we found it, so the next run still has its booted-device precondition.
+  spawn('xcrun', ['simctl', 'boot', udid], { stdio: 'ignore', detached: true }).unref();
+}
+
 async function run(
   win: Page,
   chatRoot: string,
   deepPass: boolean,
   downloadDir: string,
-): Promise<void> {
+): Promise<ReclaimTarget | null> {
+  let reclaimTarget: ReclaimTarget | null = null;
   await win
     .locator('button[aria-label="Toggle side panel"]:visible')
     .first()
@@ -496,6 +547,8 @@ async function run(
       // CoreSimulator finishes tearing the device down, and blocking this event loop while
       // Playwright holds its connection to Electron shows up later as a spurious "target closed".
       spawn('xcrun', ['simctl', 'boot', bootedUdid], { stdio: 'ignore', detached: true }).unref();
+      // Reuse this session for the reclaim check: a second session would be refused the device.
+      reclaimTarget = { sessionId, udid: bootedUdid };
 
       const tapShot = join(tmpdir(), `linkcode-e2e-simulator-tap-${process.pid}.png`);
       await win.screenshot({ path: tapShot });
@@ -517,6 +570,7 @@ async function run(
     fail('the + menu did not return after removing the section');
   }
   console.log('simulator section closed; + menu restored');
+  return reclaimTarget;
 }
 
 async function main(): Promise<void> {
@@ -595,14 +649,17 @@ async function main(): Promise<void> {
     win.on('console', (message) => {
       if (message.type() === 'error') console.error(`renderer console: ${message.text()}`);
     });
+    let reclaimTarget: ReclaimTarget | null = null;
     try {
-      await run(win, chatRoot, deepPass, downloadDir);
+      reclaimTarget = await run(win, chatRoot, deepPass, downloadDir);
     } catch (error) {
       const shot = join(tmpdir(), `linkcode-e2e-simulator-${process.pid}.png`);
       await win.screenshot({ path: shot }).catch(noop);
       console.error(`screenshot: ${shot}`);
       throw error;
     }
+    // Last, because it ends the daemon: nothing above may depend on it afterwards.
+    if (reclaimTarget !== null) await assertShutdownReclaim(daemon, reclaimTarget);
     passed = true;
     console.log('PASS');
   } finally {

--- a/packages/host/engine/src/__tests__/simulator-service.test.ts
+++ b/packages/host/engine/src/__tests__/simulator-service.test.ts
@@ -148,6 +148,63 @@ describe('SimulatorService', () => {
     expect(service.ownerOf('A')).toBeUndefined();
   });
 
+  it('does not push out a running reclaim window when a deferred stop arrives', async () => {
+    const backend = fakeBackend([device('A', 'Shutdown')]);
+    const service = new SimulatorService(backend, { idleReclaimMs: 1000 });
+
+    await service.boot(S1, 'A');
+    service.releaseSession(S1);
+    await vi.advanceTimersByTimeAsync(600);
+    // The panel's stop lands after the session already stopped. Restarting the clock here would
+    // defer the reclaim every time a late stop trickles in, so the window must keep running.
+    await service.streamStop(S1, 'A');
+
+    await vi.advanceTimersByTimeAsync(400);
+    expect(backend.shutdownDevice).toHaveBeenCalledWith('A');
+  });
+
+  it('reclaims a service-booted device left detached, while its session stays alive', async () => {
+    const backend = fakeBackend([device('A', 'Shutdown')]);
+    const service = new SimulatorService(backend, { idleReclaimMs: 1000 });
+
+    await service.boot(S1, 'A');
+    await service.streamStart(S1, 'A');
+    // Detach: the panel stops watching, but the session lives on and keeps the device.
+    await service.streamStop(S1, 'A');
+    expect(service.ownerOf('A')).toBe(S1);
+
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(backend.shutdownDevice).toHaveBeenCalledWith('A');
+    expect(service.ownerOf('A')).toBeUndefined();
+  });
+
+  it('does not expire a detached device an agent is still driving', async () => {
+    const backend = fakeBackend([device('A', 'Shutdown')]);
+    const service = new SimulatorService(backend, { idleReclaimMs: 1000 });
+
+    await service.boot(S1, 'A');
+    await service.streamStop(S1, 'A');
+    // An agent tool call mid-window is exactly the case the idle clock must yield to.
+    await vi.advanceTimersByTimeAsync(600);
+    await service.screenshot(S1, 'A');
+
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(backend.shutdownDevice).not.toHaveBeenCalled();
+    expect(service.ownerOf('A')).toBe(S1);
+  });
+
+  it('never arms an idle reclaim for a detached device the user booted', async () => {
+    const backend = fakeBackend([device('A', 'Booted')]);
+    const service = new SimulatorService(backend, { idleReclaimMs: 1000 });
+
+    await service.boot(S1, 'A');
+    await service.streamStop(S1, 'A');
+
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(backend.shutdownDevice).not.toHaveBeenCalled();
+    expect(service.ownerOf('A')).toBe(S1);
+  });
+
   it('never shuts down a device the user booted', async () => {
     const backend = fakeBackend([device('A', 'Booted')]);
     const service = new SimulatorService(backend, { idleReclaimMs: 1000 });

--- a/packages/host/engine/src/simulator/service.ts
+++ b/packages/host/engine/src/simulator/service.ts
@@ -50,10 +50,11 @@ interface DeviceClaim {
  * reaching around this layer would bypass ownership and consent.
  *
  * Ownership model (mirrors the reference implementation): a device belongs to the session that
- * first drives it, and concurrent sessions never share one. When the owning session stops, a
- * device this service booted idles for {@link IDLE_RECLAIM_MS} — resuming work re-claims it in
- * place — then is shut down and freed. Devices the user booted are released immediately and
- * never shut down by the engine.
+ * first drives it, and concurrent sessions never share one. When the owning session stops — or the
+ * panel detaches, leaving nobody watching — a device this service booted idles for
+ * {@link IDLE_RECLAIM_MS}, then is shut down and freed; resuming work re-claims it in place.
+ * Devices the user booted are released immediately and never shut down by the engine, so a
+ * simulator started from Simulator.app or Xcode outlives us untouched.
  */
 export class SimulatorService {
   private readonly claims = new Map<string, DeviceClaim>();
@@ -252,8 +253,14 @@ export class SimulatorService {
    * device stays stuck until the daemon restarts. Only the current owner stops the stream; for a
    * stale session it is a no-op that never touches another session's claim. */
   async streamStop(sessionId: SessionId, udid: string): Promise<void> {
-    if (this.claims.get(udid)?.sessionId !== sessionId) return;
-    return this.backend.streamStop(udid);
+    const claim = this.claims.get(udid);
+    if (claim?.sessionId !== sessionId) return;
+    await this.backend.streamStop(udid);
+    // Detaching (CODE-416) leaves the device booted and still owned — the session lives on and an
+    // agent may keep driving it. But nothing is watching any more, so start the idle clock: a
+    // device we booted should not linger unattended. Any later operation on it disarms this again,
+    // so a device an agent is still working never expires out from under it.
+    if (claim.bootedByService) this.armIdleReclaim(udid, claim);
   }
 
   /**
@@ -349,7 +356,19 @@ export class SimulatorService {
       this.drop(udid);
       return;
     }
-    if (claim.idleTimer) clearTimeout(claim.idleTimer);
+    this.armIdleReclaim(udid, claim);
+  }
+
+  /**
+   * Start the clock after which a device we booted is shut down and freed. Only ever called for
+   * service-booted devices — a device the user booted is never ours to end.
+   *
+   * A clock already counting down is left alone rather than restarted: the triggers overlap (a
+   * session stop and the deferred stream stop that follows it), and each one restarting the window
+   * would keep pushing the reclaim out.
+   */
+  private armIdleReclaim(udid: string, claim: DeviceClaim): void {
+    if (claim.idleTimer) return;
     claim.idleTimer = setTimeout(() => {
       // Shut the device down before releasing its claim: dropping first opens a window where
       // another session claims and boots the same udid while this shutdown is still in flight,


### PR DESCRIPTION
Closes CODE-419.

## What I found before writing anything

Most of this issue was already built. `SimulatorService` has tracked boot origin (`bootedByService`) since CODE-394, never reclaims a device the user booted, and already reclaims on engine shutdown and on session stop/delete — sessions have no separate "archive" concept, so `session.delete` → teardown → `releaseSession` covers that bullet.

Exactly one trigger from the issue was missing: **detach**.

## The change

`streamStop` now starts the idle clock for a device the engine booted. Detaching (CODE-416) leaves the device booted and still owned — the session lives on and an agent may keep driving it — but nothing is watching any more, so a device we booted shouldn't linger unattended. Any later operation on it disarms the clock, so a device an agent is still working never expires out from under it.

One subtlety worth naming: the arm is **non-restarting**. The triggers overlap (a session stop, then the deferred stream stop that follows it), and if each restarted the window a trickle of late stops would defer the reclaim indefinitely.

Reclaim stays best-effort and single-shot — no retry storm, per the issue.

## Verification

`pnpm check:ci` green. Four new unit tests: detach reclaims a service-booted device while its session lives on; an agent's mid-window tool call keeps it alive; a user-booted device never arms; and a deferred stop does not push out a running window.

More importantly, **the issue's acceptance criterion now runs in `e2e:simulator`** against a real device: it shuts the host device down, boots it back *through the wire* so the engine owns it, drains the daemon with SIGTERM, and asserts `xcrun simctl list devices booted` no longer has it. This is the part unit tests can't reach — that SIGTERM actually reaches the engine finalizer in a real daemon. Passing:

```
daemon shutdown reclaimed the device the engine booted
PASS
```

(The `ERR_CONNECTION_REFUSED` renderer lines just before it are the app noticing the daemon we deliberately killed.)

## Note on the suite

`pnpm test` has a pre-existing load-sensitive flake unrelated to this change — `engine/tests/integration/run-command.test.ts > stops the process before reporting a typed timeout` spawns a real process against the 5s default timeout. It failed once in four runs here and passes in 411ms in isolation. Not touched by this PR, but worth a `testTimeout` bump on its own sometime.