### PR TITLE
feat(sim,workbench): volume-key injection and Simulator.app shortcut parity

### DIFF
--- a/apps/desktop/e2e/simulator-panel.e2e.mts
+++ b/apps/desktop/e2e/simulator-panel.e2e.mts
@@ -39,7 +39,7 @@ const PORT = 43000 + (process.pid % 1000);
 
 /** Must match `WIRE_PROTOCOL_VERSION` (node can't load the raw-TS schema barrel); a mismatch is
  * silently discarded by the daemon, surfacing here as the session.start timeout. */
-const WIRE_VERSION = 54;
+const WIRE_VERSION = 55;
 
 function fail(message: string): never {
   console.error(`FAIL: ${message}`);
@@ -425,6 +425,22 @@ async function run(
       await win.getByRole('button', { name: 'Rotate', exact: true }).click();
       await waitForHashChange(beforeRotate, 'rotating the device');
       console.log('rotate button rotated the device');
+
+      // Simulator.app shortcut parity (CODE-414). The bindings are owner-scoped, not focus-scoped,
+      // so pressing on the window is enough while the panel is on screen. Home is the one with an
+      // unmistakable visual result, so it is what proves the chord actually reached the device;
+      // the volume keys are asserted only as far as "the panel accepted them without erroring",
+      // since the iOS volume HUD is too small to read out of a downsampled canvas hash.
+      const beforeHomeChord = await canvasHash();
+      await win.keyboard.press('Meta+Shift+KeyH');
+      await waitForHashChange(beforeHomeChord, 'the Home shortcut');
+      console.log('Cmd+Shift+H returned the device to the home screen');
+
+      await win.keyboard.press('Meta+ArrowUp');
+      await win.keyboard.press('Meta+ArrowDown');
+      await win.waitForTimeout(1000);
+      if ((await win.getByText('is busy').count()) > 0) fail('the volume shortcuts were refused');
+      console.log('Cmd+Up / Cmd+Down volume chords accepted (HUD needs a human eye)');
 
       // Live reconfigure (CODE-433): a stream start with new options retunes the running stream in
       // place. Assert the capture-worker process is NOT respawned (same pid) and the picture keeps

--- a/apps/desktop/e2e/simulator-panel.e2e.mts
+++ b/apps/desktop/e2e/simulator-panel.e2e.mts
@@ -4,6 +4,12 @@
  * asserts the device picker reflects the host's real device list. When a booted simulator exists,
  * it also starts a pi session and asserts live frames paint the canvas end-to-end. Run
  * `pnpm -F @linkcode/desktop e2e:simulator` after building daemon and desktop; macOS only.
+ *
+ * Three knobs for driving it as a demo rather than a check: `LINKCODE_E2E_KEEP_OPEN=1` hands the
+ * app over at the pause and waits for the operator to close the window; `LINKCODE_E2E_HOLD_MS`
+ * widens that pause instead of ending it by hand; and `LINKCODE_E2E_SKIP_RECLAIM=1` drops the
+ * closing CODE-419 check — that one ends by killing the daemon, which is correct for a test and
+ * looks like a crash in front of an audience.
  */
 
 import type { ChildProcess } from 'node:child_process';
@@ -36,6 +42,19 @@ const simSidecar = join(repoRoot, 'target', 'release', 'linkcode-sim');
 const electronBinary = require('electron') as unknown as string;
 
 const PORT = 43000 + (process.pid % 1000);
+
+/** How long the deep pass parks with the window live for a human to drive. */
+const HOLD_MS = positiveInt(process.env.LINKCODE_E2E_HOLD_MS) ?? 30000;
+/** Skip the reclaim check, whose last act is to SIGTERM the daemon (see the header). */
+const SKIP_RECLAIM = process.env.LINKCODE_E2E_SKIP_RECLAIM === '1';
+/** Park at the hold point until the operator closes the window, rather than on a timer. */
+const KEEP_OPEN = process.env.LINKCODE_E2E_KEEP_OPEN === '1';
+
+/** Parse an env override, ignoring anything that isn't a positive number. */
+function positiveInt(raw: string | undefined): number | undefined {
+  const value = Number(raw);
+  return raw !== undefined && Number.isFinite(value) && value > 0 ? value : undefined;
+}
 
 /** Must match `WIRE_PROTOCOL_VERSION` (node can't load the raw-TS schema barrel); a mismatch is
  * silently discarded by the daemon, surfacing here as the session.start timeout. */
@@ -600,8 +619,19 @@ async function run(
       await win.screenshot({ path: tapShot });
       console.log(`screenshot: ${tapShot}`);
     }
-    console.log('holding the window open for 30s for manual inspection…');
-    await win.waitForTimeout(30000);
+    if (KEEP_OPEN) {
+      // Demo mode: hand the app over and wait. Everything up to here has been asserted; the two
+      // checks below (closing the section) are given up deliberately, because the alternative is
+      // yanking the window out from under whoever is driving it.
+      console.log(
+        'app is yours — close the window when you are done (section-close checks skipped)',
+      );
+      await win.waitForEvent('close', { timeout: 0 });
+      console.log('window closed; tearing down the harness daemon');
+      return null;
+    }
+    console.log(`holding the window open for ${Math.round(HOLD_MS / 1000)}s — drive it by hand…`);
+    await win.waitForTimeout(HOLD_MS);
   } else {
     console.log('no booted simulator — skipping the live-stream pass');
   }
@@ -705,7 +735,11 @@ async function main(): Promise<void> {
       throw error;
     }
     // Last, because it ends the daemon: nothing above may depend on it afterwards.
-    if (reclaimTarget !== null) await assertShutdownReclaim(daemon, reclaimTarget);
+    if (reclaimTarget !== null && !SKIP_RECLAIM) {
+      await assertShutdownReclaim(daemon, reclaimTarget);
+    } else if (SKIP_RECLAIM) {
+      console.log('LINKCODE_E2E_SKIP_RECLAIM=1 — leaving the daemon up, reclaim NOT verified');
+    }
     passed = true;
     console.log('PASS');
   } finally {

--- a/crates/linkcode-sim/src/interactive.rs
+++ b/crates/linkcode-sim/src/interactive.rs
@@ -253,6 +253,8 @@ mod imp {
         let button = match button {
             ButtonKind::Home => Button::Home,
             ButtonKind::Lock => Button::Lock,
+            ButtonKind::VolumeUp => Button::VolumeUp,
+            ButtonKind::VolumeDown => Button::VolumeDown,
         };
         if input_for(udid)?.button(button, Duration::from_millis(80)) {
             Ok(json!({}))

--- a/crates/linkcode-sim/src/interactive.rs
+++ b/crates/linkcode-sim/src/interactive.rs
@@ -108,6 +108,11 @@ mod imp {
     /// as unusable after this long with no new frame, and the pusher degrades to simctl.
     const SILENT_FALLBACK_AFTER: Duration = Duration::from_secs(3);
 
+    /// How often the pusher asks CoreSimulator whether its device is still booted. Deliberately
+    /// not gated on frame progress: a worker whose boot session ended out from under it can keep
+    /// delivering frames from the dead session, so silence is not a reliable death signal.
+    const STATE_CHECK_INTERVAL: Duration = Duration::from_secs(2);
+
     /// Warmed HID clients and running streams, keyed by udid. Warming a client is expensive, so it
     /// is cached; a stream is one crash-isolated worker plus a pusher thread.
     struct Registry {
@@ -416,12 +421,35 @@ mod imp {
         Ok(json!({}))
     }
 
+    /// Reap a stream whose device's boot session has ended out from under it. The worker holds
+    /// framebuffer registrations that keep the dead session's HID routing half-alive, so a warmed
+    /// client "successfully" injects into it and every control goes silently dead (CODE-442) — an
+    /// out-of-band shutdown (Simulator.app, bare `simctl`) sends no op through this process, so
+    /// nothing else evicts. Killing the worker and forgetting the client makes the next attach or
+    /// injection start from the live device. Called from the pusher's own thread: the JoinHandle
+    /// is dropped, never joined — a thread cannot join itself.
+    fn reap_dead_device(udid: &str) {
+        let handle = registry()
+            .lock()
+            .expect("interactive registry poisoned")
+            .streams
+            .remove(udid);
+        if let Some(mut handle) = handle {
+            handle.stop.store(true, Ordering::Relaxed);
+            drop(handle.pusher.take());
+        }
+        forget(udid);
+        eprintln!("sim stream: device {udid} left Booted; reaped its stream and HID client");
+    }
+
     /// Push framebuffer frames to the daemon, adapting to the stream's live codec each frame so a
     /// reconfigure (JPEG↔H.264, fps) needs no pusher restart. JPEG is latest-wins — deduped by
     /// identity so a static screen doesn't flood, paced on a drift-free clock at the current fps;
     /// H.264 drains the ordered queue (deltas must not be dropped). If the crash-isolated worker
     /// gives up (or stays silent in JPEG mode), it degrades to `simctl io screenshot` — slower, but
     /// frames never stop; each wire frame carries its codec so a mixed stream stays decodable.
+    /// A silent stream on a device that is no longer booted is not degradation but death: the
+    /// pusher reaps itself (see `reap_dead_device`).
     fn push_stream(udid: &str, stream: &CaptureStream, stop: &AtomicBool, tx: &Sender<OutMsg>) {
         // simctl screenshots cost ~200-400ms, so poll the fallback well below the private fps.
         let fallback_interval = Duration::from_millis(500);
@@ -433,7 +461,17 @@ mod imp {
         // Last time a real private frame (either codec) reached the wire; a JPEG-mode silence past
         // the timeout means the framebuffer produced no callbacks, so degrade to simctl.
         let mut last_progress = Instant::now();
+        let mut state_check = Instant::now();
         while !stop.load(Ordering::Relaxed) {
+            // Reap a dead boot session on its own slow clock (see `STATE_CHECK_INTERVAL` for why
+            // frame progress cannot be the trigger).
+            if state_check.elapsed() >= STATE_CHECK_INTERVAL {
+                state_check = Instant::now();
+                if !SimDevice::resolve(udid).is_some_and(|device| device.is_booted()) {
+                    reap_dead_device(udid);
+                    return;
+                }
+            }
             // The worker gave up entirely: degrade to a public screenshot so frames never stop.
             if stream.is_dead() {
                 let tick = Instant::now();

--- a/crates/linkcode-sim/src/interactive.rs
+++ b/crates/linkcode-sim/src/interactive.rs
@@ -22,12 +22,15 @@ fn unsupported() -> OpError {
 
 #[cfg(target_os = "macos")]
 pub use imp::{
-    available, button, key, pinch, rotate, stream_start, stream_stop, swipe, tap, touch,
+    available, button, forget, key, pinch, rotate, stream_start, stream_stop, swipe, tap, touch,
 };
 
 #[cfg(not(target_os = "macos"))]
 mod stubs {
     use super::*;
+
+    /// No cached HID client off macOS, so nothing to evict.
+    pub fn forget(_udid: &str) {}
 
     pub fn available() -> bool {
         false
@@ -82,7 +85,7 @@ mod stubs {
 
 #[cfg(not(target_os = "macos"))]
 pub use stubs::{
-    available, button, key, pinch, rotate, stream_start, stream_stop, swipe, tap, touch,
+    available, button, forget, key, pinch, rotate, stream_start, stream_stop, swipe, tap, touch,
 };
 
 #[cfg(target_os = "macos")]
@@ -149,6 +152,20 @@ mod imp {
         }
     }
 
+    /// Drop the cached HID client and any in-flight gesture state for `udid`.
+    ///
+    /// A warmed `SimDeviceLegacyHIDClient` is bound to the boot session it was created in. Once the
+    /// device shuts down, that client is dead: sends still report success but nothing reaches the
+    /// guest, so the panel looks fine while every tap, button and key silently does nothing. Boot
+    /// and shutdown are the two moments a new session begins, so both evict — the next use re-warms
+    /// against the live device.
+    pub fn forget(udid: &str) {
+        let mut reg = registry().lock().expect("interactive registry poisoned");
+        reg.inputs.remove(udid);
+        reg.touches.remove(udid);
+        reg.pinches.remove(udid);
+    }
+
     /// Resolve (and cache) a warmed HID client for `udid`.
     fn input_for(udid: &str) -> Result<Arc<Input>, OpError> {
         let mut reg = registry().lock().expect("interactive registry poisoned");
@@ -163,12 +180,33 @@ mod imp {
         Ok(input)
     }
 
-    pub fn tap(udid: &str, x: f64, y: f64) -> Result<Value, OpError> {
-        if input_for(udid)?.tap(x, y, Duration::from_millis(80)) {
-            Ok(json!({}))
-        } else {
-            Err(OpError::new(ErrorCode::SimctlFailed, "tap failed"))
+    /// Run a discrete injection against the device's HID client, re-warming once if it fails.
+    ///
+    /// A warmed client is bound to the boot session it was created in, and a device can be shut
+    /// down and re-booted behind our back — from Simulator.app, from `simctl`, or by a boot the
+    /// engine short-circuited because the host already had the device up. The stale client then
+    /// builds no messages, so the failure is indistinguishable from "the device is gone" and the
+    /// panel goes dead with every control still looking healthy. Treat the first failure as
+    /// possibly-stale: drop the client, warm a fresh one, and try once more. A failed build
+    /// injected nothing, so the retry cannot double-send.
+    fn with_input(udid: &str, what: &str, op: impl Fn(&Input) -> bool) -> Result<Value, OpError> {
+        if op(input_for(udid)?.as_ref()) {
+            return Ok(json!({}));
         }
+        forget(udid);
+        if op(input_for(udid)?.as_ref()) {
+            return Ok(json!({}));
+        }
+        Err(OpError::new(
+            ErrorCode::SimctlFailed,
+            format!("{what} failed"),
+        ))
+    }
+
+    pub fn tap(udid: &str, x: f64, y: f64) -> Result<Value, OpError> {
+        with_input(udid, "tap", |input| {
+            input.tap(x, y, Duration::from_millis(80))
+        })
     }
 
     /// One phase of a streamed touch gesture. A `move`/`up` without an active stream is a benign
@@ -242,11 +280,9 @@ mod imp {
         };
         let steps = 10u32;
         let step = duration / (steps + 2);
-        if input_for(udid)?.swipe(x0, y0, x1, y1, steps, step) {
-            Ok(json!({}))
-        } else {
-            Err(OpError::new(ErrorCode::SimctlFailed, "swipe failed"))
-        }
+        with_input(udid, "swipe", |input| {
+            input.swipe(x0, y0, x1, y1, steps, step)
+        })
     }
 
     pub fn button(udid: &str, button: ButtonKind) -> Result<Value, OpError> {
@@ -256,11 +292,9 @@ mod imp {
             ButtonKind::VolumeUp => Button::VolumeUp,
             ButtonKind::VolumeDown => Button::VolumeDown,
         };
-        if input_for(udid)?.button(button, Duration::from_millis(80)) {
-            Ok(json!({}))
-        } else {
-            Err(OpError::new(ErrorCode::SimctlFailed, "button press failed"))
-        }
+        with_input(udid, "button press", |input| {
+            input.button(button, Duration::from_millis(80))
+        })
     }
 
     /// Rotate the interface orientation. Unlike the HID ops this needs no warmed `Input` — it is a
@@ -286,11 +320,9 @@ mod imp {
     }
 
     pub fn key(udid: &str, usage: u32, modifiers: &[u32]) -> Result<Value, OpError> {
-        if input_for(udid)?.key(usage, modifiers, Duration::from_millis(20)) {
-            Ok(json!({}))
-        } else {
-            Err(OpError::new(ErrorCode::SimctlFailed, "key press failed"))
-        }
+        with_input(udid, "key press", |input| {
+            input.key(usage, modifiers, Duration::from_millis(20))
+        })
     }
 
     pub fn stream_start(

--- a/crates/linkcode-sim/src/interactive.rs
+++ b/crates/linkcode-sim/src/interactive.rs
@@ -212,14 +212,27 @@ mod imp {
     /// One phase of a streamed touch gesture. A `move`/`up` without an active stream is a benign
     /// race (a duplicate up, a move after cancel) and no-ops successfully.
     pub fn touch(udid: &str, phase: TouchPhase, x: f64, y: f64) -> Result<Value, OpError> {
+        // `down` is the one phase that can safely re-warm a stale client: nothing has been injected
+        // yet, so the retry costs only a fresh identifier. A mid-gesture phase must not — the new
+        // client would carry a new identifier and the guest would read it as a second finger
+        // rather than a continuation, so a gesture caught by a reboot is simply lost and the next
+        // `down` recovers. This is the path a canvas tap or drag takes, so it matters most.
+        if matches!(phase, TouchPhase::Down) {
+            return with_input(udid, "touch", |input| {
+                let id = input.allocate_touch();
+                registry()
+                    .lock()
+                    .expect("interactive registry poisoned")
+                    .touches
+                    .insert(udid.to_owned(), id);
+                input.touch_phase(x, y, id, private::Phase::Down)
+            });
+        }
         let input = input_for(udid)?;
         let mut reg = registry().lock().expect("interactive registry poisoned");
         let identifier = match phase {
-            TouchPhase::Down => {
-                let id = input.allocate_touch();
-                reg.touches.insert(udid.to_owned(), id);
-                Some(id)
-            }
+            // Returned above; `None` here degrades to a no-op rather than a panic.
+            TouchPhase::Down => None,
             TouchPhase::Move => reg.touches.get(udid).copied(),
             TouchPhase::Up => reg.touches.remove(udid),
         };
@@ -242,14 +255,26 @@ mod imp {
         a: (f64, f64),
         b: (f64, f64),
     ) -> Result<Value, OpError> {
+        // Same rule as `touch`: only the two-finger `down` may re-warm.
+        if matches!(phase, TouchPhase::Down) {
+            return with_input(udid, "pinch", |input| {
+                let ids = [input.allocate_touch(), input.allocate_touch()];
+                registry()
+                    .lock()
+                    .expect("interactive registry poisoned")
+                    .pinches
+                    .insert(udid.to_owned(), ids);
+                input.touch_pair(
+                    [(a.0, a.1, ids[0]), (b.0, b.1, ids[1])],
+                    private::Phase::Down,
+                )
+            });
+        }
         let input = input_for(udid)?;
         let mut reg = registry().lock().expect("interactive registry poisoned");
         let ids = match phase {
-            TouchPhase::Down => {
-                let ids = [input.allocate_touch(), input.allocate_touch()];
-                reg.pinches.insert(udid.to_owned(), ids);
-                Some(ids)
-            }
+            // Returned above; `None` here degrades to a no-op rather than a panic.
+            TouchPhase::Down => None,
             TouchPhase::Move => reg.pinches.get(udid).copied(),
             TouchPhase::Up => reg.pinches.remove(udid),
         };

--- a/crates/linkcode-sim/src/interactive.rs
+++ b/crates/linkcode-sim/src/interactive.rs
@@ -91,6 +91,8 @@ pub use stubs::{
 #[cfg(target_os = "macos")]
 mod imp {
     use std::collections::HashMap;
+    use std::io::{BufRead, BufReader};
+    use std::process::{Child, Command, Stdio};
     use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::{Arc, Mutex, OnceLock};
     use std::thread;
@@ -131,6 +133,9 @@ mod imp {
         stream: Arc<CaptureStream>,
         stop: Arc<AtomicBool>,
         pusher: Option<thread::JoinHandle<()>>,
+        /// The crash-isolated `state-watcher` child relaying this device's state notifications;
+        /// killed with the stream. `None` if it failed to spawn — the pusher's poll covers alone.
+        watcher: Option<Child>,
     }
 
     fn registry() -> &'static Mutex<Registry> {
@@ -395,12 +400,16 @@ mod imp {
             let udid = udid.to_owned();
             move || push_stream(&udid, &stream, &stop, &tx)
         });
+        // Spawned before the insert lands: a notification-path reap blocks on the registry lock
+        // held here, so it can only run once the handle it must remove is actually in the map.
+        let watcher = spawn_state_watcher(udid);
         reg.streams.insert(
             udid.to_owned(),
             StreamHandle {
                 stream,
                 stop,
                 pusher: Some(pusher),
+                watcher,
             },
         );
         Ok(json!({ "streaming": true, "fps": fps, "scale": scale, "codec": codec }))
@@ -417,6 +426,7 @@ mod imp {
             if let Some(pusher) = handle.pusher.take() {
                 let _ = pusher.join();
             }
+            kill_watcher(&mut handle);
         }
         Ok(json!({}))
     }
@@ -428,7 +438,7 @@ mod imp {
     /// nothing else evicts. Killing the worker and forgetting the client makes the next attach or
     /// injection start from the live device. Called from the pusher's own thread: the JoinHandle
     /// is dropped, never joined — a thread cannot join itself.
-    fn reap_dead_device(udid: &str) {
+    fn reap_dead_device(udid: &str, via: &str) {
         let handle = registry()
             .lock()
             .expect("interactive registry poisoned")
@@ -437,9 +447,52 @@ mod imp {
         if let Some(mut handle) = handle {
             handle.stop.store(true, Ordering::Relaxed);
             drop(handle.pusher.take());
+            kill_watcher(&mut handle);
         }
         forget(udid);
-        eprintln!("sim stream: device {udid} left Booted; reaped its stream and HID client");
+        eprintln!(
+            "sim stream: device {udid} left Booted ({via}); reaped its stream and HID client"
+        );
+    }
+
+    fn kill_watcher(handle: &mut StreamHandle) {
+        if let Some(mut watcher) = handle.watcher.take() {
+            let _ = watcher.kill();
+            let _ = watcher.wait();
+        }
+    }
+
+    /// Spawn the notification watcher for `udid`, plus a reader thread that reaps the moment a
+    /// `state <n>` line reports the device out of Booted. This is the fast path to
+    /// [`reap_dead_device`]; the pusher's poll stays as the backstop, so a watcher that fails to
+    /// spawn, crashes, or goes silent costs latency, never correctness (contract in
+    /// `private/notify.rs`).
+    fn spawn_state_watcher(udid: &str) -> Option<Child> {
+        let exe = std::env::current_exe().ok()?;
+        let mut child = Command::new(exe)
+            .arg("state-watcher")
+            .arg(udid)
+            // Held open so an orphaned watcher (server death) sees EOF and exits itself.
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::inherit())
+            .spawn()
+            .ok()?;
+        let stdout = child.stdout.take()?;
+        let udid = udid.to_owned();
+        thread::spawn(move || {
+            for line in BufReader::new(stdout).lines() {
+                let Ok(line) = line else { break };
+                let state = line
+                    .strip_prefix("state ")
+                    .and_then(|s| s.parse::<u64>().ok());
+                if state.is_some_and(|state| state != private::STATE_BOOTED) {
+                    reap_dead_device(&udid, "device notification");
+                    break;
+                }
+            }
+        });
+        Some(child)
     }
 
     /// Push framebuffer frames to the daemon, adapting to the stream's live codec each frame so a
@@ -468,7 +521,7 @@ mod imp {
             if state_check.elapsed() >= STATE_CHECK_INTERVAL {
                 state_check = Instant::now();
                 if !SimDevice::resolve(udid).is_some_and(|device| device.is_booted()) {
-                    reap_dead_device(udid);
+                    reap_dead_device(udid, "state poll");
                     return;
                 }
             }

--- a/crates/linkcode-sim/src/main.rs
+++ b/crates/linkcode-sim/src/main.rs
@@ -234,8 +234,15 @@ fn serve(request: Request, tx: &Sender<OutMsg>) {
     let outcome = match request.op {
         Op::Probe => probe_with_capabilities(),
         Op::List => simctl::list(),
-        Op::Boot { udid } => simctl::boot(&udid),
-        Op::Shutdown { udid } => simctl::shutdown(&udid),
+        // Both ends of a boot session invalidate the warmed HID client bound to the old one.
+        Op::Boot { udid } => {
+            interactive::forget(&udid);
+            simctl::boot(&udid)
+        }
+        Op::Shutdown { udid } => {
+            interactive::forget(&udid);
+            simctl::shutdown(&udid)
+        }
         Op::Install { udid, app_path } => simctl::install(&udid, &app_path),
         Op::Launch { udid, bundle_id } => simctl::launch(&udid, &bundle_id),
         Op::Terminate { udid, bundle_id } => simctl::terminate(&udid, &bundle_id),

--- a/crates/linkcode-sim/src/main.rs
+++ b/crates/linkcode-sim/src/main.rs
@@ -102,6 +102,14 @@ fn main() {
     if subcommand.as_deref() == Some("capture-worker") {
         capture::run_worker();
     }
+    // The crash-isolated device-state watcher (spawned by the sidecar alongside each stream).
+    #[cfg(target_os = "macos")]
+    if subcommand.as_deref() == Some("state-watcher") {
+        let udid = std::env::args()
+            .nth(2)
+            .expect("usage: state-watcher <udid>");
+        std::process::exit(private::notify::run_state_watcher(&udid));
+    }
     // Hidden diagnostic path to exercise the private-framework layer against a real booted device:
     // `linkcode-sim diag-interactive <udid> <out.jpg>`.
     #[cfg(target_os = "macos")]

--- a/crates/linkcode-sim/src/main.rs
+++ b/crates/linkcode-sim/src/main.rs
@@ -141,6 +141,13 @@ fn main() {
         diag_button();
         return;
     }
+    // Diagnostic: report CoreSimulator's view of a device's boot state — the signal the stream
+    // pusher uses to reap a dead boot session: `linkcode-sim diag-state <udid>`.
+    #[cfg(target_os = "macos")]
+    if subcommand.as_deref() == Some("diag-state") {
+        diag_state();
+        return;
+    }
 
     let (tx, rx) = channel::<OutMsg>();
 
@@ -557,6 +564,17 @@ fn diag_button() {
     let input = private::Input::warm(&device).expect("HID unavailable for this device");
     let ok = input.button(button, std::time::Duration::from_millis(80));
     eprintln!("button({name}) -> {ok}");
+}
+
+/// Diagnostic entry (macOS only): print whether CoreSimulator reports the device Booted — ground
+/// truth for the reap-on-shutdown signal in `interactive::push_stream`.
+#[cfg(target_os = "macos")]
+fn diag_state() {
+    let udid = std::env::args().nth(2).expect("usage: diag-state <udid>");
+    match private::SimDevice::resolve(&udid) {
+        Some(device) => eprintln!("is_booted({udid}) -> {}", device.is_booted()),
+        None => eprintln!("device {udid} not found"),
+    }
 }
 
 /// Benchmark entry (macOS only): time the JPEG encode across a resolution/quality sweep and print the

--- a/crates/linkcode-sim/src/main.rs
+++ b/crates/linkcode-sim/src/main.rs
@@ -134,6 +134,13 @@ fn main() {
         diag_reconfigure();
         return;
     }
+    // Diagnostic: press a hardware button, for eyeballing the volume HUD against a real device:
+    // `linkcode-sim diag-button <udid> <home|lock|volume-up|volume-down>`.
+    #[cfg(target_os = "macos")]
+    if subcommand.as_deref() == Some("diag-button") {
+        diag_button();
+        return;
+    }
 
     let (tx, rx) = channel::<OutMsg>();
 
@@ -520,6 +527,29 @@ fn diag_rotate() {
     let device = private::SimDevice::resolve(&udid).expect("device not found");
     let ok = device.set_orientation(orientation);
     eprintln!("set_orientation({name}) -> {ok}");
+}
+
+/// Diagnostic entry (macOS only): press one hardware button on a booted device. Volume is the
+/// reason this exists — it is the one button whose only proof is the on-device HUD, and the
+/// consumer-page HID path it takes is different from home/lock's legacy button message.
+#[cfg(target_os = "macos")]
+fn diag_button() {
+    use crate::private::Button;
+    let udid = std::env::args()
+        .nth(2)
+        .expect("usage: diag-button <udid> <home|lock|volume-up|volume-down>");
+    let name = std::env::args().nth(3).unwrap_or_else(|| "home".to_owned());
+    let button = match name.as_str() {
+        "home" => Button::Home,
+        "lock" => Button::Lock,
+        "volume-up" => Button::VolumeUp,
+        "volume-down" => Button::VolumeDown,
+        other => panic!("unknown button: {other}"),
+    };
+    let device = private::SimDevice::resolve(&udid).expect("device not found");
+    let input = private::Input::warm(&device).expect("HID unavailable for this device");
+    let ok = input.button(button, std::time::Duration::from_millis(80));
+    eprintln!("button({name}) -> {ok}");
 }
 
 /// Benchmark entry (macOS only): time the JPEG encode across a resolution/quality sweep and print the

--- a/crates/linkcode-sim/src/private/device.rs
+++ b/crates/linkcode-sim/src/private/device.rs
@@ -41,20 +41,27 @@ impl SimDevice {
         Retained::as_ptr(&self.object).cast_mut()
     }
 
-    /// CoreSimulator's `SimDeviceState`: 3 is Booted (0 Creating, 1 Shutdown, 2 Booting,
-    /// 4 ShuttingDown). Anything else means the boot session is over or not yet begun.
-    pub fn is_booted(&self) -> bool {
+    /// The raw `SimDeviceState`, or `None` if the KVC read fails.
+    pub fn state_raw(&self) -> Option<u64> {
         let key = NSString::from_str("state");
         // SAFETY: KVC read returning an NSNumber (or nil).
         let number: *mut AnyObject = unsafe { msg_send![&*self.object, valueForKey: &*key] };
         if number.is_null() {
-            return false;
+            return None;
         }
         // SAFETY: number is an NSNumber*; unsignedLongLongValue is its standard accessor.
-        let state: u64 = unsafe { msg_send![number, unsignedLongLongValue] };
-        state == 3
+        Some(unsafe { msg_send![number, unsignedLongLongValue] })
+    }
+
+    /// Whether the device is in a live boot session. Anything but Booted means the session is
+    /// over or not yet begun.
+    pub fn is_booted(&self) -> bool {
+        self.state_raw() == Some(STATE_BOOTED)
     }
 }
+
+/// CoreSimulator's `SimDeviceState` for Booted (0 Creating, 1 Shutdown, 2 Booting, 4 ShuttingDown).
+pub const STATE_BOOTED: u64 = 3;
 
 fn default_device_set() -> Option<Retained<AnyObject>> {
     let ctx = shared_service_context()?;

--- a/crates/linkcode-sim/src/private/device.rs
+++ b/crates/linkcode-sim/src/private/device.rs
@@ -40,6 +40,20 @@ impl SimDevice {
     pub fn object_ptr(&self) -> *mut AnyObject {
         Retained::as_ptr(&self.object).cast_mut()
     }
+
+    /// CoreSimulator's `SimDeviceState`: 3 is Booted (0 Creating, 1 Shutdown, 2 Booting,
+    /// 4 ShuttingDown). Anything else means the boot session is over or not yet begun.
+    pub fn is_booted(&self) -> bool {
+        let key = NSString::from_str("state");
+        // SAFETY: KVC read returning an NSNumber (or nil).
+        let number: *mut AnyObject = unsafe { msg_send![&*self.object, valueForKey: &*key] };
+        if number.is_null() {
+            return false;
+        }
+        // SAFETY: number is an NSNumber*; unsignedLongLongValue is its standard accessor.
+        let state: u64 = unsafe { msg_send![number, unsignedLongLongValue] };
+        state == 3
+    }
 }
 
 fn default_device_set() -> Option<Retained<AnyObject>> {

--- a/crates/linkcode-sim/src/private/input.rs
+++ b/crates/linkcode-sim/src/private/input.rs
@@ -91,11 +91,21 @@ const HOME_ARG0: u32 = 0x0;
 const LOCK_ARG0: u32 = 0x1;
 const LEGACY_BUTTON_TARGET: u32 = 0x33;
 
+/// HID consumer page, where the volume keys live. Unlike home/lock, the volume rockers are not on
+/// the legacy `IndigoHIDMessageForButton` path at all — they are ordinary HID usages routed through
+/// `IndigoHIDMessageForHIDArbitrary`, the same call the keyboard uses with page 7.
+const CONSUMER_USAGE_PAGE: u32 = 12;
+/// Consumer-page Volume Increment / Decrement (HID Usage Tables 1.12, §15).
+const VOLUME_UP_USAGE: u32 = 233;
+const VOLUME_DOWN_USAGE: u32 = 234;
+
 /// Which hardware button to press.
 #[derive(Clone, Copy)]
 pub enum Button {
     Home,
     Lock,
+    VolumeUp,
+    VolumeDown,
 }
 
 /// Touch phase for a streamed gesture.
@@ -243,11 +253,35 @@ impl Input {
         ok
     }
 
-    /// Press a hardware button (home/lock) for `hold`.
+    /// Press and release one consumer-page (page 12) HID usage — the volume rockers.
+    fn consumer_key(&self, usage: u32, hold: Duration) -> bool {
+        let Some(hid) = self.symbols.hid_arbitrary else {
+            return false;
+        };
+        let send_op = |operation: u32| -> bool {
+            // SAFETY: symbol resolved above; returns a malloc'd message consumed by send.
+            let message = unsafe { hid(TOUCH_TARGET, CONSUMER_USAGE_PAGE, usage, operation) };
+            if message.is_null() {
+                return false;
+            }
+            self.send_message(message);
+            true
+        };
+        if !send_op(1) {
+            return false;
+        }
+        sleep(hold.max(Duration::from_millis(20)));
+        send_op(2)
+    }
+
+    /// Press a hardware button for `hold`. Home and lock ride the legacy button message; the volume
+    /// rockers are consumer-page HID usages and take the arbitrary-HID path instead.
     pub fn button(&self, button: Button, hold: Duration) -> bool {
         let arg0 = match button {
             Button::Home => HOME_ARG0,
             Button::Lock => LOCK_ARG0,
+            Button::VolumeUp => return self.consumer_key(VOLUME_UP_USAGE, hold),
+            Button::VolumeDown => return self.consumer_key(VOLUME_DOWN_USAGE, hold),
         };
         // SAFETY: button fn resolved in `resolve_symbols`; direction 1=down, 2=up (0 crashes
         // backboardd). Each returns a freshly malloc'd message consumed by send (freeWhenDone).

--- a/crates/linkcode-sim/src/private/mod.rs
+++ b/crates/linkcode-sim/src/private/mod.rs
@@ -9,11 +9,12 @@ pub(crate) mod debug;
 mod device;
 mod framework;
 mod input;
+pub mod notify;
 mod orientation;
 mod screen;
 mod vt;
 
-pub use device::SimDevice;
+pub use device::{STATE_BOOTED, SimDevice};
 pub use input::{Button, Input, Phase};
 pub use orientation::Orientation;
 pub use screen::{Screen, bench_encode};

--- a/crates/linkcode-sim/src/private/notify.rs
+++ b/crates/linkcode-sim/src/private/notify.rs
@@ -1,0 +1,174 @@
+//! Device state-change notifications, straight from CoreSimulator.
+//!
+//! The `state-watcher` subprocess registers a captureless hand-rolled block with the device's
+//! `SimDeviceNotificationManager` and relays `device_state` notifications as `state <n>` lines on
+//! stdout. It is a separate process for the same reason the capture worker is: this is a private
+//! callback ABI, and a drifted signature must crash a disposable child, never the sidecar server.
+//! The server treats the lines as a fast path only — its own state poll (`interactive::push_stream`)
+//! remains the backstop, so a dead or silent watcher degrades to polling, not to a stale stream.
+
+use std::ffi::{c_ulong, c_void};
+use std::io::{self, BufRead, Write};
+
+use objc2::runtime::AnyObject;
+use objc2::{msg_send, sel};
+use objc2_foundation::NSString;
+
+use super::debug::dbg_log;
+use super::device::SimDevice;
+
+// Block ABI mirrors `screen.rs`: hand-rolled global block with a signature (block2's `RcBlock`
+// crashes CoreSimulator callback paths), captureless by discipline — this process watches exactly
+// one device, so the callback needs no state beyond process-global stdout.
+
+#[repr(C)]
+struct BlockDescriptor {
+    reserved: c_ulong,
+    size: c_ulong,
+    signature: *const i8,
+}
+
+// SAFETY: the descriptor is immutable; the signature points at a static NUL-terminated string.
+unsafe impl Sync for BlockDescriptor {}
+
+#[repr(C)]
+struct NotifyBlock {
+    isa: *const c_void,
+    flags: i32,
+    reserved: i32,
+    invoke: *const c_void,
+    descriptor: *const BlockDescriptor,
+}
+
+unsafe extern "C" {
+    static _NSConcreteGlobalBlock: c_void;
+    // dispatch (public): a serial queue for CoreSimulator to deliver the notifications on.
+    fn dispatch_queue_create(label: *const i8, attr: *const c_void) -> *mut c_void;
+}
+
+const BLOCK_IS_GLOBAL: i32 = 1 << 28;
+const BLOCK_HAS_SIGNATURE: i32 = 1 << 30;
+/// `void (^)(NSDictionary *)` — one notification payload.
+const NOTIFY_SIGNATURE: &[u8] = b"v16@?0@8\0";
+
+static NOTIFY_DESCRIPTOR: BlockDescriptor = BlockDescriptor {
+    reserved: 0,
+    size: size_of::<NotifyBlock>() as c_ulong,
+    signature: NOTIFY_SIGNATURE.as_ptr().cast::<i8>(),
+};
+
+/// Notification callback, on the delivery queue. Filters for `device_state` and emits the new raw
+/// state. Must never unwind (extern "C" boundary), so every failure is a silent return — the
+/// server's poll backstop covers a watcher that goes quiet.
+unsafe extern "C" fn notify_invoke(_block: *mut NotifyBlock, payload: *mut AnyObject) {
+    if payload.is_null() {
+        return;
+    }
+    let name_key = NSString::from_str("notification");
+    // SAFETY: payload is the notification NSDictionary for the duration of the callback.
+    let name: *mut NSString = unsafe { msg_send![payload, objectForKey: &*name_key] };
+    if name.is_null() {
+        return;
+    }
+    let device_state = NSString::from_str("device_state");
+    // SAFETY: name is an NSString*.
+    let is_state: bool = unsafe { msg_send![name, isEqualToString: &*device_state] };
+    if !is_state {
+        // SAFETY: name is a valid NSString for the duration of this read.
+        dbg_log!("state-watcher: ignoring {}", unsafe { (*name).to_string() });
+        return;
+    }
+    let state_key = NSString::from_str("new_state");
+    // SAFETY: payload is still the notification NSDictionary.
+    let number: *mut AnyObject = unsafe { msg_send![payload, objectForKey: &*state_key] };
+    if number.is_null() {
+        return;
+    }
+    // SAFETY: number is an NSNumber*; unsignedLongLongValue is its standard accessor.
+    let state: u64 = unsafe { msg_send![number, unsignedLongLongValue] };
+    emit_state(state);
+}
+
+/// Write one `state <n>` line. Errors are ignored: a dead server also closes our stdin, which is
+/// what actually exits this process.
+fn emit_state(state: u64) {
+    let mut out = io::stdout().lock();
+    let _ = writeln!(out, "state {state}");
+    let _ = out.flush();
+}
+
+/// The handler block, leaked on purpose: CoreSimulator retains it for the registration's lifetime,
+/// which here is the process's lifetime.
+fn notify_block() -> *mut c_void {
+    let block = Box::new(NotifyBlock {
+        isa: (&raw const _NSConcreteGlobalBlock).cast::<c_void>(),
+        flags: BLOCK_IS_GLOBAL | BLOCK_HAS_SIGNATURE,
+        reserved: 0,
+        invoke: notify_invoke as *const c_void,
+        descriptor: &NOTIFY_DESCRIPTOR,
+    });
+    Box::into_raw(block).cast::<c_void>()
+}
+
+/// `linkcode-sim state-watcher <udid>`: relay this device's state notifications as stdout lines.
+///
+/// Contract with the server (`interactive::stream_start`): one `state <n>` line per `device_state`
+/// notification, plus one at startup for the current state so a subscription gap at spawn time
+/// cannot hide an already-dead device; everything else goes to stderr. Exits when stdin closes
+/// (the server dropped the pipe) or when registration is impossible.
+pub fn run_state_watcher(udid: &str) -> i32 {
+    let Some(device) = SimDevice::resolve(udid) else {
+        eprintln!("state-watcher: device {udid} not found");
+        return 1;
+    };
+    let ptr = device.object_ptr();
+    // SAFETY: respondsToSelector: is defined on NSObject.
+    let has_manager: bool =
+        unsafe { msg_send![ptr, respondsToSelector: sel!(notificationManager)] };
+    if !has_manager {
+        eprintln!("state-watcher: SimDevice has no notificationManager");
+        return 1;
+    }
+    // SAFETY: the accessor returns the device's SimDeviceNotificationManager (or nil).
+    let manager: *mut AnyObject = unsafe { msg_send![ptr, notificationManager] };
+    if manager.is_null() {
+        eprintln!("state-watcher: notificationManager is nil");
+        return 1;
+    }
+    let block = notify_block();
+    // SAFETY: respondsToSelector: probes; both register selectors take the block as their last
+    // argument and return an NSUInteger registration id.
+    let reg_id: usize = unsafe {
+        let on_queue: bool = msg_send![manager, respondsToSelector: sel!(registerNotificationHandlerOnQueue:handler:)];
+        if on_queue {
+            let queue =
+                dispatch_queue_create(c"linkcode.sim.state-watcher".as_ptr(), std::ptr::null());
+            msg_send![manager, registerNotificationHandlerOnQueue: queue, handler: block]
+        } else {
+            let plain: bool =
+                msg_send![manager, respondsToSelector: sel!(registerNotificationHandler:)];
+            if !plain {
+                eprintln!("state-watcher: no register selector on the notification manager");
+                return 1;
+            }
+            msg_send![manager, registerNotificationHandler: block]
+        }
+    };
+    dbg_log!("state-watcher: registered (id {reg_id}) for {udid}");
+    match device.state_raw() {
+        Some(state) => emit_state(state),
+        None => eprintln!("state-watcher: device state unreadable"),
+    }
+    // Park until the server closes our stdin; notifications arrive on the delivery queue.
+    let stdin = io::stdin();
+    let mut sink = String::new();
+    while stdin
+        .lock()
+        .read_line(&mut sink)
+        .map(|n| n > 0)
+        .unwrap_or(false)
+    {
+        sink.clear();
+    }
+    0
+}

--- a/crates/linkcode-sim/src/rpc.rs
+++ b/crates/linkcode-sim/src/rpc.rs
@@ -137,6 +137,8 @@ fn default_scale() -> f64 {
 pub enum ButtonKind {
     Home,
     Lock,
+    VolumeUp,
+    VolumeDown,
 }
 
 /// Interface orientation for `rotate`; maps 1:1 onto the private `Orientation`.

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -83,6 +83,9 @@ client configuration or new build.
 | `LINKCODE_HOST`, `LINKCODE_PORT` | daemon/webview/desktop E2E harnesses | Pin the harness daemon to `127.0.0.1` on an ephemeral port. |
 | `LINKCODE_PROFILE` | desktop E2E | Isolates a run's state universe. Must be identical on both sides — the desktop app and its daemon — or they follow different `runtime.json` files. |
 | `HOME` | every E2E harness | Redirected to a fresh temp dir so runs never touch the real `~/.linkcode`. Use a *fresh* one per run. |
+| `LINKCODE_E2E_KEEP_OPEN` | `apps/desktop/e2e/simulator-panel.e2e.mts` | `1` hands the app over at the pause and waits for you to close the window instead of running a timer. The two section-close checks after the pause are given up in exchange — the alternative is yanking the window away from whoever is driving it. |
+| `LINKCODE_E2E_HOLD_MS` | `apps/desktop/e2e/simulator-panel.e2e.mts` | Widens the pause that leaves the window live to be driven by hand (default `30000`). For demoing the simulator panel rather than checking it. |
+| `LINKCODE_E2E_SKIP_RECLAIM` | `apps/desktop/e2e/simulator-panel.e2e.mts` | `1` drops the closing CODE-419 reclaim check, whose last act is to SIGTERM the daemon — correct in a test, looks like a crash in a demo. The run then proves everything *except* reclaim-on-shutdown. |
 | `XDG_CONFIG_HOME` | `apps/desktop/e2e/packaged-smoke.e2e.mts` | Redirects Electron/Chromium config for the packaged run. |
 | `NODE_ENV` | `apps/webview/e2e/browser-smoke.e2e.mts` | Forced to `development` — the mock transport is guarded by `import.meta.env.DEV`. |
 | `GIT_CONFIG_GLOBAL`, `GIT_CONFIG_NOSYSTEM` | `packages/host/engine/tests/integration/git-status.test.ts` | Point git at fixture config so the machine's gitconfig (notably commit signing) can't leak into assertions. |

--- a/packages/client/core/src/client.ts
+++ b/packages/client/core/src/client.ts
@@ -38,6 +38,7 @@ import type {
   SessionInfo,
   SessionNotification,
   SessionRecord,
+  SimulatorButton,
   SimulatorConsentDecision,
   SimulatorConsentState,
   SimulatorDevice,
@@ -794,7 +795,7 @@ export class LinkCodeClient {
   simulatorButton(
     sessionId: SessionId,
     udid: string,
-    button: 'home' | 'lock',
+    button: SimulatorButton,
   ): Promise<RequestAck> {
     return this.control.simulatorButton(sessionId, udid, button);
   }

--- a/packages/client/core/src/client/control-channel.ts
+++ b/packages/client/core/src/client/control-channel.ts
@@ -35,6 +35,7 @@ import type {
   SessionId,
   SessionInfo,
   SessionRecord,
+  SimulatorButton,
   SimulatorConsentDecision,
   SimulatorConsentState,
   SimulatorDevice,
@@ -829,7 +830,7 @@ export class ControlChannel {
   simulatorButton(
     sessionId: SessionId,
     udid: string,
-    button: 'home' | 'lock',
+    button: SimulatorButton,
   ): Promise<RequestAck> {
     return this.sendCorrelated('ack', (clientReqId) => ({
       kind: 'simulator.button',

--- a/packages/client/workbench/src/index.ts
+++ b/packages/client/workbench/src/index.ts
@@ -54,6 +54,7 @@ export * from './simulator/auto-reveal';
 export * from './simulator/consent';
 export * from './simulator/panel';
 export * from './simulator/panel-store';
+export * from './simulator/shortcuts';
 export * from './simulator/stream-registry';
 export * from './surface/selection-store';
 export * from './surface/shell';

--- a/packages/client/workbench/src/simulator/panel.tsx
+++ b/packages/client/workbench/src/simulator/panel.tsx
@@ -1,6 +1,7 @@
 import { useLinkCodeClient } from '@linkcode/client-core';
 import type {
   SessionId,
+  SimulatorButton,
   SimulatorDevice,
   SimulatorOrientation,
   SimulatorStatus,
@@ -38,6 +39,7 @@ import { base64Blob, captureFileStem, downloadBlob, useSimulatorRecorder } from 
 import { useSimulatorConsent, useSimulatorConsentRequest } from './consent';
 import { SimulatorDeviceTabs } from './device-tabs';
 import { selectDeviceTabs, simulatorSessionKey, useSimulatorPanelStore } from './panel-store';
+import { useSimulatorShortcuts } from './shortcuts';
 import type { SimulatorStreamLease } from './stream-registry';
 import {
   acquireSimulatorStream,
@@ -173,6 +175,8 @@ export function SimulatorPanel({ sessionId }: { sessionId: SessionId | null }): 
   const [masks, setMasks] = useState<Readonly<Record<string, string | null>>>({});
   const [busy, setBusy] = useState(false);
   const busyTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+  /** Shortcut owner: the chords below only fire while this panel is on screen. */
+  const panelRef = useRef<HTMLDivElement | null>(null);
   const leaseRef = useRef<SimulatorStreamLease | null>(null);
   const rotateStateRef = useRef<{ udid: string | null; orientation: SimulatorOrientation }>({
     udid: null,
@@ -311,10 +315,6 @@ export function SimulatorPanel({ sessionId }: { sessionId: SessionId | null }): 
     busyTimerRef.current = setTimeout(() => setBusy(false), BUSY_BANNER_MS);
   }, []);
 
-  if (status !== null && !status.available) {
-    return <CenteredHint>{t('simulatorUnavailable')}</CenteredHint>;
-  }
-
   const handleTouch = (phase: SimulatorScreenTouchPhase, point: SimulatorScreenPoint): void => {
     if (ownerSessionId === null || udid === null) return;
     const request = client.simulatorTouch(ownerSessionId, udid, phase, point.x, point.y);
@@ -343,7 +343,7 @@ export function SimulatorPanel({ sessionId }: { sessionId: SessionId | null }): 
       .then(() => client.simulatorKey(ownerSessionId, udid, 0x19, [0xe3]))
       .catch(flagBusy);
   };
-  const pressButton = (button: 'home' | 'lock'): void => {
+  const pressButton = (button: SimulatorButton): void => {
     if (ownerSessionId === null || udid === null) return;
     void client.simulatorButton(ownerSessionId, udid, button).catch(flagBusy);
   };
@@ -399,6 +399,19 @@ export function SimulatorPanel({ sessionId }: { sessionId: SessionId | null }): 
       })
       .catch(flagBusy);
   };
+  // Simulator.app's chords, scoped to this panel (CODE-414). Declared before the availability
+  // guard below because hooks must run unconditionally.
+  useSimulatorShortcuts({
+    owner: panelRef,
+    enabled: ownerSessionId !== null && udid !== null,
+    onButton: pressButton,
+    onRotate: handleRotate,
+  });
+
+  if (status !== null && !status.available) {
+    return <CenteredHint>{t('simulatorUnavailable')}</CenteredHint>;
+  }
+
   const toggleRecording = (): void => {
     if (recorder.recording) {
       recorder.stop();
@@ -408,7 +421,7 @@ export function SimulatorPanel({ sessionId }: { sessionId: SessionId | null }): 
   };
 
   return (
-    <div className="flex h-full min-h-0 flex-col">
+    <div ref={panelRef} className="flex h-full min-h-0 flex-col">
       {openUdids.length > 0 && device !== null && (
         <div className="flex shrink-0 flex-col gap-1 border-border border-b px-2 py-1.5">
           <div className="flex items-center gap-2">

--- a/packages/client/workbench/src/simulator/shortcuts.ts
+++ b/packages/client/workbench/src/simulator/shortcuts.ts
@@ -1,0 +1,67 @@
+import type { SimulatorButton } from '@linkcode/schema';
+import { useKeyboardShortcut } from '@linkcode/ui';
+
+/**
+ * Simulator.app's own bindings, so muscle memory carries over (CODE-414). Every chord is scoped to
+ * the panel element, so it only fires while the panel is on screen and focusable — these are common
+ * keys, and claiming them app-wide would be wrong.
+ */
+const HOME_SHORTCUT = { code: 'KeyH', modifiers: ['primary', 'shift'] } as const;
+const LOCK_SHORTCUT = { code: 'KeyL', modifiers: ['primary'] } as const;
+const VOLUME_UP_SHORTCUT = { code: 'ArrowUp', modifiers: ['primary'] } as const;
+const VOLUME_DOWN_SHORTCUT = { code: 'ArrowDown', modifiers: ['primary'] } as const;
+const ROTATE_SHORTCUT = { code: 'ArrowRight', modifiers: ['primary'] } as const;
+
+export function useSimulatorShortcuts({
+  owner,
+  enabled,
+  onButton,
+  onRotate,
+}: {
+  owner: React.RefObject<Element | null>;
+  /** False while no device is claimed; the chord is then left for anything else to handle. */
+  enabled: boolean;
+  onButton: (button: SimulatorButton) => void;
+  onRotate: () => void;
+}): void {
+  const pressButton = (button: SimulatorButton) => (): boolean => {
+    if (!enabled) return false;
+    onButton(button);
+    return true;
+  };
+
+  useKeyboardShortcut({
+    actionId: 'simulator.home',
+    shortcut: HOME_SHORTCUT,
+    owner,
+    handler: pressButton('home'),
+  });
+  useKeyboardShortcut({
+    actionId: 'simulator.lock',
+    shortcut: LOCK_SHORTCUT,
+    owner,
+    handler: pressButton('lock'),
+  });
+  useKeyboardShortcut({
+    actionId: 'simulator.volume-up',
+    shortcut: VOLUME_UP_SHORTCUT,
+    owner,
+    handler: pressButton('volumeUp'),
+  });
+  useKeyboardShortcut({
+    actionId: 'simulator.volume-down',
+    shortcut: VOLUME_DOWN_SHORTCUT,
+    owner,
+    handler: pressButton('volumeDown'),
+  });
+  useKeyboardShortcut({
+    actionId: 'simulator.rotate',
+    shortcut: ROTATE_SHORTCUT,
+    owner,
+    handler() {
+      if (!enabled) return false;
+      onRotate();
+      return true;
+    },
+  });
+}

--- a/packages/foundation/schema/src/model/simulator.ts
+++ b/packages/foundation/schema/src/model/simulator.ts
@@ -62,6 +62,11 @@ export type SimulatorConsentState = z.infer<typeof SimulatorConsentStateSchema>;
  */
 export const MAX_SIMULATORS_PER_SESSION = 4;
 
+/** Hardware buttons the sidecar can press. Home/lock ride the legacy Indigo button message;
+ * the volume rockers are consumer-page HID usages (CODE-414). */
+export const SimulatorButtonSchema = z.enum(['home', 'lock', 'volumeUp', 'volumeDown']);
+export type SimulatorButton = z.infer<typeof SimulatorButtonSchema>;
+
 export const SimulatorImageFormatSchema = z.enum(['jpeg', 'png']);
 export type SimulatorImageFormat = z.infer<typeof SimulatorImageFormatSchema>;
 

--- a/packages/foundation/schema/src/wire/message.ts
+++ b/packages/foundation/schema/src/wire/message.ts
@@ -24,7 +24,8 @@ import { WirePayloadSchema } from './payload';
 // 52 adds the simulator device-rotation wire (CODE-408).
 // 53 migrates managed-asset IDs from public strings to discriminated objects.
 // 54 adds the simulator agent-consent variants (CODE-420).
-export const WIRE_PROTOCOL_VERSION = 54 as const;
+// 55 adds the simulator volume buttons (CODE-414).
+export const WIRE_PROTOCOL_VERSION = 55 as const;
 
 /** Complete wire message: version + unique id + timestamp + payload. */
 export const WireMessageSchema = z.object({

--- a/packages/foundation/schema/src/wire/simulator.ts
+++ b/packages/foundation/schema/src/wire/simulator.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import { SessionIdSchema } from '../model/primitives';
 import {
+  SimulatorButtonSchema,
   SimulatorConsentDecisionSchema,
   SimulatorConsentStateSchema,
   SimulatorDeviceSchema,
@@ -15,7 +16,6 @@ import { WireRequestIdSchema } from './request';
 const udid = z.string().min(1);
 /** A normalized screen coordinate, 0..1 from the top-left. */
 const coord = z.number().min(0).max(1);
-const SimulatorButtonSchema = z.enum(['home', 'lock']);
 
 /**
  * iOS Simulator wire variants. Commands are session-scoped: the engine's simulator service

--- a/packages/host/engine/src/simulator/backend.ts
+++ b/packages/host/engine/src/simulator/backend.ts
@@ -31,7 +31,9 @@ export interface SimulatorProbe {
 export type SimulatorImageFormat = 'jpeg' | 'png';
 
 /** A hardware button the private HID layer can press. */
-export type SimulatorButton = 'home' | 'lock';
+export type { SimulatorButton } from '@linkcode/schema';
+
+import type { SimulatorButton } from '@linkcode/schema';
 
 /** Interface orientation for a rotate command (matches `UIInterfaceOrientation`). */
 export type SimulatorOrientation =


### PR DESCRIPTION
Closes CODE-414. **Wire 54 → 55** (Invariant 1).

## The issue's plan was wrong, and finding out mattered

CODE-414 said volume would "ride the existing IndigoHID button pipeline (same send path as home/lock, zero new plumbing)". It doesn't. Home and lock go through `IndigoHIDMessageForButton` with arg0 0/1 — a legacy path with no volume entry at all.

Volume rockers are **ordinary HID consumer-page usages** (page 12, usages 233/234 — Volume Increment/Decrement in HID Usage Tables 1.12 §15) routed through `IndigoHIDMessageForHIDArbitrary`. Sources: [baguette](https://github.com/tddworks/baguette)'s `standardHIDUsage` map, which is explicit that home/lock "ride a different SimulatorKit symbol and don't go through the arbitrary-HID path", corroborated by the codes matching the published HID spec exactly.

The happy ending: our crate **already resolves** `IndigoHIDMessageForHIDArbitrary` — it's what the keyboard uses with page 7. So volume really was near-free, just through the other door.

## Verified on a real device, not assumed

A private-API guess is worth nothing unverified, so I added `diag-button` (alongside the existing `diag-rotate`/`diag-reconfigure`) and pressed volume against a booted iPhone 17 Pro:

```
button(volume-up) -> true
```

…and screenshotted the device. **iOS 26's volume indicator is there on the left edge**, expanded capsule with its fill level, collapsing to the slim bar on repeat presses. That is the issue's acceptance criterion ("观察音量 HUD") met with evidence rather than a claim. `diag-button` stays in — it's the only way to check this particular private path.

## Shortcuts

Simulator.app's bindings, scoped to the panel element (owner-based, not focus-based) so common chords aren't claimed app-wide:

| chord | action |
| --- | --- |
| ⌘⇧H | Home |
| ⌘L | Lock |
| ⌘↑ / ⌘↓ | Volume up / down |
| ⌘→ | Rotate |

I checked every registered `primary` chord in the repo for collisions (⌘B, ⌘J, ⌥⌘B, ⌘[ ⌘], ⌘K, ⌘1–9, ⌘,) — none of these four collide. Handlers return `false` when no device is claimed, so a dead panel leaves the chord for anything else.

## Also: one definition of `SimulatorButton`

The union was written out three times (wire enum, engine `backend.ts`, client-core parameter). It's now `SimulatorButtonSchema` in `@linkcode/schema` and everyone reads that — adding the two volume values in one place instead of four.

## Verification

`cargo fmt`/`clippy`/`test`, `pnpm check:ci`, `pnpm test` (1937) all green.

`e2e:simulator` drives the chords against the real device:

```
Cmd+Shift+H returned the device to the home screen
Cmd+Up / Cmd+Down volume chords accepted (HUD needs a human eye)
PASS
```

Home is asserted by the screen actually changing — that proves the chord reached the device, not just the panel. The volume assertion in E2E is deliberately weaker (accepted without error), because the iOS volume HUD is too small to read out of the downsampled canvas hash; the screenshot above is the real proof.

**Not done, deliberately:** the issue also asked for MCP passthrough of the button command. There is no `sim_button` tool, and adding one is the same agent-capability question raised in CODE-423 — see that issue's comment.