### PR TITLE
feat(ui): squircle corner-shape on xl+ radius faces

### DIFF
--- a/packages/presentation/ui/src/styles.css
+++ b/packages/presentation/ui/src/styles.css
@@ -75,8 +75,11 @@
   /* Apple-style continuous corners (UICornerCurve model): only faces with radius ≥ 12px
      (xl/2xl/3xl and their coss-ui-derived inner faces / inset rings) go squircle; smaller
      controls and pills stay circular. Class-substring opt-in — vendored coss-ui can't carry
-     the property itself. clip-path `inset(… round …)` corners (command palette, grouped
-     cards) do not follow corner-shape and keep a circular curve. */
+     the property itself. Substring matching ignores variant conditions: a variant-gated
+     xl class applies squircle even while inactive, which is inert without a radius and
+     imperceptible below the 12px threshold (the only such live face is the 10px popover).
+     clip-path `inset(… round …)` corners (command palette, grouped cards) do not follow
+     corner-shape and keep a circular curve. */
   @supports (corner-shape: squircle) {
     :where(
         [class*="rounded-xl"],
@@ -98,6 +101,13 @@
         [class*="rounded-t-xl"],
         [class*="rounded-t-2xl"]
       )::before {
+      corner-shape: squircle;
+    }
+
+    /* Card-variant tables round their corner cells through logical-corner utilities
+       (`…:rounded-ss-xl` etc.) generated on the table body's class list, so the cells
+       themselves carry no matchable class — bind the curve to them via the carrier. */
+    :where([class*="rounded-ss-xl"]) td {
       corner-shape: squircle;
     }
   }

--- a/packages/presentation/ui/src/styles.css
+++ b/packages/presentation/ui/src/styles.css
@@ -71,6 +71,36 @@
   pre {
     font-family: var(--font-mono);
   }
+
+  /* Apple-style continuous corners (UICornerCurve model): only faces with radius ≥ 12px
+     (xl/2xl/3xl and their coss-ui-derived inner faces / inset rings) go squircle; smaller
+     controls and pills stay circular. Class-substring opt-in — vendored coss-ui can't carry
+     the property itself. clip-path `inset(… round …)` corners (command palette, grouped
+     cards) do not follow corner-shape and keep a circular curve. */
+  @supports (corner-shape: squircle) {
+    :where(
+        [class*="rounded-xl"],
+        [class*="rounded-2xl"],
+        [class*="rounded-3xl"],
+        [class*="rounded-t-xl"],
+        [class*="rounded-t-2xl"],
+        [class*="rounded-b-xl"],
+        [class*="rounded-b-2xl"],
+        [class*="rounded-t-[calc(var(--radius-xl)"],
+        [class*="rounded-t-[calc(var(--radius-2xl)"],
+        [class*="rounded-b-[calc(var(--radius-xl)"],
+        [class*="rounded-b-[calc(var(--radius-2xl)"]
+      ),
+    :where(
+        [class*="rounded-xl"],
+        [class*="rounded-2xl"],
+        [class*="rounded-3xl"],
+        [class*="rounded-t-xl"],
+        [class*="rounded-t-2xl"]
+      )::before {
+      corner-shape: squircle;
+    }
+  }
 }
 
 @layer components {


### PR DESCRIPTION
## Summary

Adopts the native CSS `corner-shape` property (Chromium 139+; our Electron 42 ships Chromium 148) so large surfaces render Apple-style continuous (squircle) corners while small controls keep circular ones.

Curve rule (UICornerCurve model): radius ≥ 12px → `squircle` — i.e. `rounded-xl` (14px), `rounded-2xl` (16px), `rounded-3xl`+ faces, including their `::before` inset rings and coss-ui's derived inner faces (`calc(var(--radius-xl/2xl) - 1px)`). `rounded-lg` (10px) and below, and `rounded-full`, stay `round`.

Implemented as one `@supports (corner-shape: squircle)` block in `packages/presentation/ui/src/styles.css` with class-substring `:where()` selectors (zero specificity): vendored coss-ui cannot carry the property, so it is applied from outside. Shared by the desktop renderer and webview; non-Chromium browsers degrade silently to circular corners.

Known boundary: `clip-path: inset(… round …)` corners (command palette list clip, grouped cards) do not follow `corner-shape` and keep a circular curve there.

## Verification

- E2E probe against the built desktop app (isolated daemon + Playwright `_electron`): computed `corner-shape` = `squircle` on xl+ faces, `round` on lg faces and pills.
- Pixel-diff of the ⌘K palette with the rule on vs forced `round`: the only changed pixels are the corner arcs (outer dialog corner + inner list ring).
- `pnpm check:ci` and `pnpm test` (1933 passed) green.

Closes CODE-449

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Added browser-conditional support for smoother “squircle” corner styling.
  * Preserved existing circular corners for smaller radii and kept clip-path-based inset rounded corners unchanged.
  * Extended squircle styling to corner cells in card/table layouts (where applicable).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->