### PR TITLE
fix(e2e): deterministic maximize checks in the window-bounds suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,7 @@ jobs:
       - name: Install Electron system dependencies
         run: |
           pnpm -F @linkcode/desktop exec playwright-core install-deps chromium
-          sudo apt-get install --no-install-recommends -y openbox
+          sudo apt-get install --no-install-recommends -y openbox x11-utils
 
       - name: Test unpackaged app entry
         run: xvfb-run -a pnpm -F @linkcode/desktop e2e:unpackaged
@@ -124,6 +124,12 @@ jobs:
             openbox >/tmp/linkcode-openbox.log 2>&1 &
             wm_pid=$!
             trap "kill $wm_pid 2>/dev/null || true" EXIT
+            # Maximize needs a managing WM; wait for the EWMH readiness marker instead
+            # of racing openbox startup.
+            for _ in $(seq 1 50); do
+              xprop -root _NET_SUPPORTING_WM_CHECK 2>/dev/null | grep -q "window id" && break
+              sleep 0.2
+            done
             pnpm -F @linkcode/desktop e2e:window-bounds
           '
 

--- a/apps/desktop/e2e/window-bounds.e2e.mts
+++ b/apps/desktop/e2e/window-bounds.e2e.mts
@@ -8,7 +8,7 @@
 import { existsSync, readFileSync, rmSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import { join, resolve } from 'node:path';
-import { noop } from 'foxts/noop';
+import { falseFn, noop, trueFn } from 'foxts/noop';
 import { wait } from 'foxts/wait';
 import { waitFor } from 'foxts/wait-for';
 import type { ElectronApplication } from 'playwright-core';
@@ -110,10 +110,15 @@ async function main(): Promise<void> {
     app = null;
     app = await launch();
     await app.firstWindow();
-    await wait(1000);
-    const maximized = await app.evaluate(({ BrowserWindow }) =>
-      BrowserWindow.getAllWindows()[0].isMaximized(),
-    );
+    // Maximize restore is an async WM round-trip under X11; a fixed sleep + single
+    // sample flakes on CI — poll to a deadline like the pre-close check.
+    const maximized = await waitFor(
+      () => app?.evaluate(({ BrowserWindow }) => BrowserWindow.getAllWindows()[0].isMaximized()),
+      100,
+      AbortSignal.timeout(10000),
+    )
+      .then(trueFn)
+      .catch(falseFn);
     if (!maximized) fail('maximized state did not survive the relaunch');
     console.log('maximized state restored');
 


### PR DESCRIPTION
## Summary

`e2e:window-bounds` flakes on CI with `maximized state did not survive the relaunch` (latest instance: run 30212859266 on #282). Two races, both removed:

1. **No WM-readiness gate**: the workflow backgrounded `openbox` and immediately ran the suite. If Electron maps its window before openbox manages the display, maximize is a no-op. The step now polls the EWMH `_NET_SUPPORTING_WM_CHECK` root property (up to 10s) before starting the suite; `x11-utils` added for `xprop`.
2. **Fixed sleep + single sample**: after the relaunch the spec slept 1000ms and sampled `isMaximized()` once — but maximize restore is an async WM round-trip under X11. It now polls to a 10s deadline with `foxts/waitFor`, mirroring the pre-close check.

No assertion weakened, no retries added — both fixes replace time-based guesses with condition/readiness waits.

## Verification

- `pnpm -F @linkcode/desktop e2e:window-bounds` passes locally (macOS).
- The Linux/openbox path is exercised by this PR's own `Desktop App Entry` job.
- `pnpm check:ci` and `pnpm test` (1939 passed) green.