### PR TITLE
feat(daemon): agent input tools — tap, swipe, text, and named keys (CODE-451)

### DIFF
--- a/apps/daemon/src/__tests__/sim-mcp-endpoint.test.ts
+++ b/apps/daemon/src/__tests__/sim-mcp-endpoint.test.ts
@@ -12,7 +12,9 @@ import { SimulatorMcpEndpoint } from '../sim/mcp-endpoint';
 const S1 = 'session-1' as SessionId;
 const S2 = 'session-2' as SessionId;
 
-function fakeBackend(): SimulatorBackend {
+/** `satisfies` rather than a return annotation: it still checks the full backend contract, but
+ * keeps the inferred mock types so call assertions read the spies directly. */
+function fakeBackend() {
   return {
     probe: vi.fn(() =>
       Promise.resolve({ simctlPath: '/usr/bin/simctl', developerDir: '/dev', interactive: true }),
@@ -50,7 +52,7 @@ function fakeBackend(): SimulatorBackend {
     streamStop: vi.fn(asyncNoop),
     onFrame: vi.fn(() => noop),
     close: vi.fn(noop),
-  };
+  } satisfies SimulatorBackend;
 }
 
 /** Consent pre-granted for the fixture device, so a test exercises the tools and not the gate. */
@@ -101,10 +103,14 @@ describe('SimulatorMcpEndpoint', () => {
       'sim_launch',
       'sim_list_devices',
       'sim_open_url',
+      'sim_press_key',
       'sim_rotate',
       'sim_screenshot',
       'sim_shutdown',
+      'sim_swipe',
+      'sim_tap',
       'sim_terminate',
+      'sim_type_text',
     ]);
 
     const listed = await client.callTool({ name: 'sim_list_devices', arguments: {} });
@@ -123,6 +129,46 @@ describe('SimulatorMcpEndpoint', () => {
     ]);
     expect(activity).toContain('sim_screenshot:started:session-1');
     expect(activity).toContain('sim_screenshot:settled:session-1');
+    await client.close();
+  });
+
+  it('drives input on the normalized coordinate contract', async () => {
+    const backend = fakeBackend();
+    endpoint = await SimulatorMcpEndpoint.create(new SimulatorService(backend), await granted());
+    const client = await connect(urlOf(endpoint.endpointFor(S1)));
+
+    await client.callTool({ name: 'sim_tap', arguments: { udid: 'U-1', x: 0.5, y: 0.25 } });
+    expect(backend.tap).toHaveBeenCalledWith('U-1', 0.5, 0.25);
+
+    await client.callTool({
+      name: 'sim_swipe',
+      arguments: { udid: 'U-1', fromX: 0.5, fromY: 0.8, toX: 0.5, toY: 0.2, durationMs: 300 },
+    });
+    expect(backend.swipe).toHaveBeenCalledWith('U-1', { x: 0.5, y: 0.8 }, { x: 0.5, y: 0.2 }, 300);
+
+    // Passing screenshot pixels is the predictable agent mistake; the schema must reject them
+    // rather than clamp them into a corner tap that looks like it worked.
+    const pixels = await client.callTool({
+      name: 'sim_tap',
+      arguments: { udid: 'U-1', x: 600, y: 1200 },
+    });
+    expect(pixels.isError).toBe(true);
+    expect(backend.tap).toHaveBeenCalledTimes(1);
+    await client.close();
+  });
+
+  it('types through the pasteboard so non-US-layout text works', async () => {
+    const backend = fakeBackend();
+    endpoint = await SimulatorMcpEndpoint.create(new SimulatorService(backend), await granted());
+    const client = await connect(urlOf(endpoint.endpointFor(S1)));
+
+    await client.callTool({ name: 'sim_type_text', arguments: { udid: 'U-1', text: '你好 🎉' } });
+    expect(backend.paste).toHaveBeenCalledWith('U-1', '你好 🎉');
+    // Command+V commits it: the HID key path is a US-layout table that cannot express this text.
+    expect(backend.key).toHaveBeenCalledWith('U-1', 25, [227]);
+
+    await client.callTool({ name: 'sim_press_key', arguments: { udid: 'U-1', key: 'enter' } });
+    expect(backend.key).toHaveBeenLastCalledWith('U-1', 40, []);
     await client.close();
   });
 

--- a/apps/daemon/src/sim/mcp-endpoint.ts
+++ b/apps/daemon/src/sim/mcp-endpoint.ts
@@ -35,6 +35,34 @@ export interface SimulatorMcpNotifications {
 const SERVER_NAME = 'linkcode-sim';
 const RE_MCP_PATH = /^\/mcp\/([\w-]+)$/;
 
+/** HID keyboard usages (page 7) for the keys an agent cannot express as text. Decimal because
+ * Biome lowercases hex literals while the lint rule wants them uppercase. */
+const NAMED_KEY_USAGES = {
+  enter: 40,
+  escape: 41,
+  backspace: 42,
+  tab: 43,
+  space: 44,
+  delete: 76,
+  arrowRight: 79,
+  arrowLeft: 80,
+  arrowDown: 81,
+  arrowUp: 82,
+} as const;
+
+/** `V` held under left-GUI — the paste chord `sim_type_text` commits pasteboard text with. Typing
+ * through the pasteboard rather than per-character HID is what makes non-US-layout text (CJK,
+ * emoji) work at all: the key path is a US-layout table with no way to express them. */
+const PASTE_KEY_USAGE = 25;
+const LEFT_GUI_USAGE = 227;
+
+type NamedKey = keyof typeof NAMED_KEY_USAGES;
+
+const NAMED_KEY_NAMES = Object.keys(NAMED_KEY_USAGES) as [NamedKey, ...NamedKey[]];
+
+/** Normalized screen fraction; the wire's coordinate contract for every pointer op. */
+const COORD = z.number().min(0).max(1);
+
 /**
  * The daemon's built-in simulator MCP endpoint (CODE-395): a loopback HTTP server speaking MCP
  * streamable-HTTP, one session-bound token per LinkCode session. Tools call the engine's
@@ -285,6 +313,75 @@ export class SimulatorMcpEndpoint implements SimulatorMcpProvider {
         run('sim_rotate', udid, async () => {
           await simulators.rotate(sessionId, udid, orientation);
           return `rotated ${udid} to ${orientation}`;
+        }),
+    );
+    server.registerTool(
+      'sim_tap',
+      {
+        description:
+          'Tap a point on a booted iOS Simulator device. Coordinates are NORMALIZED screen fractions (0..1) — 0.5, 0.5 is the centre — NOT pixels, so the size of a screenshot is irrelevant. Screenshot afterwards to confirm what the tap did.',
+        inputSchema: { udid: z.string().min(1), x: COORD, y: COORD },
+      },
+      ({ udid, x, y }) =>
+        run('sim_tap', udid, async () => {
+          await simulators.tap(sessionId, udid, x, y);
+          return `tapped ${x}, ${y}`;
+        }),
+    );
+    server.registerTool(
+      'sim_swipe',
+      {
+        description:
+          'Swipe (drag) between two points on a booted iOS Simulator device — scrolling, paging, pull-to-refresh, edge-swipe back. Coordinates are NORMALIZED screen fractions (0..1), NOT pixels. Note the direction: to scroll DOWN the page, swipe UP (from a larger y to a smaller one), as a finger would.',
+        inputSchema: {
+          udid: z.string().min(1),
+          fromX: COORD,
+          fromY: COORD,
+          toX: COORD,
+          toY: COORD,
+          durationMs: z.number().int().positive().max(10000).optional(),
+        },
+      },
+      ({ udid, fromX, fromY, toX, toY, durationMs }) =>
+        run('sim_swipe', udid, async () => {
+          await simulators.swipe(
+            sessionId,
+            udid,
+            { x: fromX, y: fromY },
+            { x: toX, y: toY },
+            durationMs,
+          );
+          return `swiped ${fromX}, ${fromY} to ${toX}, ${toY}`;
+        }),
+    );
+    server.registerTool(
+      'sim_type_text',
+      {
+        description:
+          'Type text into the focused field of a booted iOS Simulator device. Tap the field first to focus it. Any Unicode works (CJK, emoji) because the text goes through the device pasteboard and is committed with Command+V, so this does not depend on a keyboard layout.',
+        inputSchema: { udid: z.string().min(1), text: z.string().min(1) },
+      },
+      ({ udid, text }) =>
+        run('sim_type_text', udid, async () => {
+          await simulators.paste(sessionId, udid, text);
+          await simulators.key(sessionId, udid, PASTE_KEY_USAGE, [LEFT_GUI_USAGE]);
+          return `typed ${text.length} characters`;
+        }),
+    );
+    server.registerTool(
+      'sim_press_key',
+      {
+        description:
+          'Press one non-text key on a booted iOS Simulator device (Return to submit, Escape to dismiss, Backspace to delete, arrows to move). Use sim_type_text for ordinary text.',
+        inputSchema: {
+          udid: z.string().min(1),
+          key: z.enum(NAMED_KEY_NAMES),
+        },
+      },
+      ({ udid, key }) =>
+        run('sim_press_key', udid, async () => {
+          await simulators.key(sessionId, udid, NAMED_KEY_USAGES[key], []);
+          return `pressed ${key}`;
         }),
     );
     server.registerTool(


### PR DESCRIPTION
Agents could boot, install, launch, screenshot and rotate a simulator — but not touch it. This adds the missing input surface.

## What agents get

| tool | notes |
| --- | --- |
| `sim_tap` | normalized 0..1 coordinates |
| `sim_swipe` | normalized; `durationMs` optional |
| `sim_type_text` | pasteboard + Command+V |
| `sim_press_key` | named keys (enter/escape/backspace/tab/space/delete/arrows) |

No wire change and no sidecar change — `simulator.tap` / `swipe` / `key` / `paste` have been on the wire since the panel shipped; only the MCP exposure was missing.

## Two design calls worth flagging

**Text goes through the pasteboard, not the key path.** The HID key path is a US-layout table with no way to express CJK or emoji. `sim_type_text` sets the device pasteboard and commits with Command+V — the same route the panel uses for IME output — so any Unicode works.

**`sim_key` was split rather than exposed raw.** Raw HID page-7 usage numbers would force an agent to know the US keyboard table. It is now `sim_type_text` for text plus `sim_press_key` for the handful of keys that are not text.

Coordinates are normalized everywhere, and the schema rejects out-of-range values rather than clamping: `sim_screenshot` returns device-native pixels, so passing those pixels back as coordinates is the predictable agent mistake, and a clamp would turn it into a corner tap that looks like it worked.

## Verification

Unit (9 pass in `sim-mcp-endpoint.test.ts`): tool registration, argument mapping, the pasteboard composition, named-key usages, and pixel-coordinate rejection.

Real device (iPhone 17 Pro Max, driven over the wire): tap focused the DuckDuckGo search field, `你好 LinkCode 🎉` typed into it verbatim, Enter navigated, swipe scrolled. Screenshot confirmed the CJK and emoji rendered in the field.

Unblocks CODE-398 (its acceptance needs a tap tool) and CODE-423 (which had no data source without agent-generated touch coordinates).