### PR TITLE
feat(sim,engine,daemon): describe_ui — the guest accessibility tree (CODE-398)

### DIFF
--- a/apps/daemon/src/__tests__/sim-mcp-endpoint.test.ts
+++ b/apps/daemon/src/__tests__/sim-mcp-endpoint.test.ts
@@ -46,6 +46,24 @@ function fakeBackend() {
     swipe: vi.fn(asyncNoop),
     button: vi.fn(asyncNoop),
     rotate: vi.fn(asyncNoop),
+    describeUi: vi.fn(() =>
+      Promise.resolve({
+        role: 'AXApplication',
+        label: 'Fixture',
+        frame: [0, 0, 400, 800] as [number, number, number, number],
+        center: [0.5, 0.5] as [number, number],
+        enabled: true,
+        children: [
+          {
+            role: 'AXButton',
+            label: 'Continue',
+            frame: [100, 400, 200, 40] as [number, number, number, number],
+            center: [0.5, 0.525] as [number, number],
+            enabled: true,
+          },
+        ],
+      }),
+    ),
     streamStart: vi.fn(() =>
       Promise.resolve({ streaming: true as const, fps: 60, scale: 1, codec: 'jpeg' as const }),
     ),
@@ -98,6 +116,7 @@ describe('SimulatorMcpEndpoint', () => {
     const client = await connect(urlOf(entry));
     const tools = await client.listTools();
     expect(tools.tools.map((t) => t.name).sort()).toEqual([
+      'describe_ui',
       'sim_boot',
       'sim_install',
       'sim_launch',
@@ -169,6 +188,28 @@ describe('SimulatorMcpEndpoint', () => {
 
     await client.callTool({ name: 'sim_press_key', arguments: { udid: 'U-1', key: 'enter' } });
     expect(backend.key).toHaveBeenLastCalledWith('U-1', 40, []);
+    await client.close();
+  });
+
+  it('reports the accessibility tree with tap-ready coordinates', async () => {
+    const backend = fakeBackend();
+    endpoint = await SimulatorMcpEndpoint.create(new SimulatorService(backend), await granted());
+    const client = await connect(urlOf(endpoint.endpointFor(S1)));
+
+    const described = await client.callTool({
+      name: 'describe_ui',
+      arguments: { udid: 'U-1', maxDepth: 4, maxNodes: 50 },
+    });
+    expect(backend.describeUi).toHaveBeenCalledWith('U-1', { maxDepth: 4, maxNodes: 50 });
+    expect(described.isError).toBeFalsy();
+
+    // The point of the tool: a centre read off the tree is already in sim_tap's units, so the
+    // find-then-act round trip needs no conversion step an agent could get wrong.
+    const [content] = described.content as Array<{ text: string }>;
+    const tree = JSON.parse(content.text) as { children: Array<{ center: [number, number] }> };
+    const [x, y] = tree.children[0].center;
+    await client.callTool({ name: 'sim_tap', arguments: { udid: 'U-1', x, y } });
+    expect(backend.tap).toHaveBeenCalledWith('U-1', 0.5, 0.525);
     await client.close();
   });
 

--- a/apps/daemon/src/sim/mcp-endpoint.ts
+++ b/apps/daemon/src/sim/mcp-endpoint.ts
@@ -316,6 +316,23 @@ export class SimulatorMcpEndpoint implements SimulatorMcpProvider {
         }),
     );
     server.registerTool(
+      'describe_ui',
+      {
+        description:
+          "Read the frontmost app's accessibility tree from a booted iOS Simulator device: element roles, labels, values and positions. Prefer this over a screenshot for finding and acting on a control — it costs far fewer tokens and gives exact coordinates. Every node carries a `center` as NORMALIZED screen fractions (0..1), which is exactly what sim_tap takes, so you can find a node by its label and tap its centre without knowing the device's size. Screenshot instead when you need to judge how something looks.",
+        inputSchema: {
+          udid: z.string().min(1),
+          maxDepth: z.number().int().nonnegative().max(64).optional(),
+          maxNodes: z.number().int().positive().max(5000).optional(),
+        },
+      },
+      ({ udid, maxDepth, maxNodes }) =>
+        run('describe_ui', udid, async () => {
+          const tree = await simulators.describeUi(sessionId, udid, { maxDepth, maxNodes });
+          return JSON.stringify(tree);
+        }),
+    );
+    server.registerTool(
       'sim_tap',
       {
         description:

--- a/apps/desktop/e2e/simulator-panel.e2e.mts
+++ b/apps/desktop/e2e/simulator-panel.e2e.mts
@@ -58,7 +58,7 @@ function positiveInt(raw: string | undefined): number | undefined {
 
 /** Must match `WIRE_PROTOCOL_VERSION` (node can't load the raw-TS schema barrel); a mismatch is
  * silently discarded by the daemon, surfacing here as the session.start timeout. */
-const WIRE_VERSION = 55;
+const WIRE_VERSION = 56;
 
 function fail(message: string): never {
   console.error(`FAIL: ${message}`);

--- a/crates/linkcode-sim/src/accessibility.rs
+++ b/crates/linkcode-sim/src/accessibility.rs
@@ -1,0 +1,131 @@
+//! The `describe-ui` op: the guest's accessibility tree, read by a disposable child process.
+//!
+//! `AXPTranslator` is a private callback ABI, and this crate's rule for those is settled: they run
+//! where a crash costs one throwaway process, never in the long-lived server (the capture worker
+//! and the device-state watcher follow the same shape). So the server spawns
+//! `linkcode-sim ax-worker <udid>`, which prints one JSON tree on stdout and exits.
+
+use serde_json::{Value, json};
+
+use crate::rpc::{ErrorCode, OpError};
+
+/// Ceiling on how long a tree read may take. The walk is a chain of XPC round-trips into the guest,
+/// so a wedged app shows up as a slow worker rather than an error.
+const WORKER_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+
+#[cfg(target_os = "macos")]
+pub fn describe_ui(udid: &str, max_depth: u32, max_nodes: usize) -> Result<Value, OpError> {
+    use std::io::Read;
+    use std::process::{Command, Stdio};
+
+    let exe = std::env::current_exe()
+        .map_err(|err| OpError::new(ErrorCode::SimctlFailed, format!("no worker path: {err}")))?;
+    let mut child = Command::new(exe)
+        .arg("ax-worker")
+        .arg(udid)
+        .arg(max_depth.to_string())
+        .arg(max_nodes.to_string())
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::inherit())
+        .spawn()
+        .map_err(|err| OpError::new(ErrorCode::SimctlFailed, format!("ax worker failed: {err}")))?;
+
+    // The worker writes one JSON document and exits, so reading to EOF is the whole protocol.
+    let mut stdout = child.stdout.take().expect("stdout was piped");
+    let reader = std::thread::spawn(move || {
+        let mut buffer = String::new();
+        stdout.read_to_string(&mut buffer).map(|_| buffer)
+    });
+
+    let deadline = std::time::Instant::now() + WORKER_TIMEOUT;
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) => {
+                let output = reader
+                    .join()
+                    .map_err(|_| {
+                        OpError::new(ErrorCode::SimctlFailed, "ax worker reader panicked")
+                    })?
+                    .map_err(|err| {
+                        OpError::new(ErrorCode::SimctlFailed, format!("ax worker read: {err}"))
+                    })?;
+                if !status.success() {
+                    // The worker prints its own reason to stderr, which the daemon logs.
+                    return Err(OpError::new(
+                        ErrorCode::SimctlFailed,
+                        format!("ax worker exited with {status}"),
+                    ));
+                }
+                let tree: Value = serde_json::from_str(&output).map_err(|err| {
+                    OpError::new(ErrorCode::SimctlFailed, format!("ax worker output: {err}"))
+                })?;
+                return Ok(json!({ "tree": tree }));
+            }
+            Ok(None) => {
+                if std::time::Instant::now() >= deadline {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    return Err(OpError::new(
+                        ErrorCode::Timeout,
+                        "the accessibility read timed out",
+                    ));
+                }
+                std::thread::sleep(std::time::Duration::from_millis(50));
+            }
+            Err(err) => {
+                return Err(OpError::new(
+                    ErrorCode::SimctlFailed,
+                    format!("ax worker wait: {err}"),
+                ));
+            }
+        }
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+pub fn describe_ui(_udid: &str, _max_depth: u32, _max_nodes: usize) -> Result<Value, OpError> {
+    Err(OpError::new(
+        ErrorCode::XcodeMissing,
+        "accessibility translation is macOS-only",
+    ))
+}
+
+/// `linkcode-sim ax-worker <udid> [maxDepth] [maxNodes]` — print one tree and exit.
+#[cfg(target_os = "macos")]
+pub fn run_worker() -> i32 {
+    use crate::private::ax;
+
+    let mut args = std::env::args().skip(2);
+    let Some(udid) = args.next() else {
+        eprintln!("usage: ax-worker <udid> [maxDepth] [maxNodes]");
+        return 2;
+    };
+    let defaults = ax::WalkLimits::default();
+    let limits = ax::WalkLimits {
+        max_depth: args
+            .next()
+            .and_then(|raw| raw.parse().ok())
+            .unwrap_or(defaults.max_depth),
+        max_nodes: args
+            .next()
+            .and_then(|raw| raw.parse().ok())
+            .unwrap_or(defaults.max_nodes),
+    };
+    match ax::describe(&udid, limits) {
+        Ok(tree) => match serde_json::to_string(&tree) {
+            Ok(json) => {
+                println!("{json}");
+                0
+            }
+            Err(err) => {
+                eprintln!("ax-worker: serialize failed: {err}");
+                1
+            }
+        },
+        Err(message) => {
+            eprintln!("ax-worker: {message}");
+            1
+        }
+    }
+}

--- a/crates/linkcode-sim/src/main.rs
+++ b/crates/linkcode-sim/src/main.rs
@@ -156,6 +156,13 @@ fn main() {
         diag_state();
         return;
     }
+    // Diagnostic: prove the AXPTranslator bridge-token handshake reaches the guest's accessibility
+    // service: `linkcode-sim diag-ax <udid>`.
+    #[cfg(target_os = "macos")]
+    if subcommand.as_deref() == Some("diag-ax") {
+        diag_ax();
+        return;
+    }
 
     let (tx, rx) = channel::<OutMsg>();
 
@@ -572,6 +579,35 @@ fn diag_button() {
     let input = private::Input::warm(&device).expect("HID unavailable for this device");
     let ok = input.button(button, std::time::Duration::from_millis(80));
     eprintln!("button({name}) -> {ok}");
+}
+
+/// Diagnostic entry (macOS only): wire the accessibility translator to a booted device and ask it
+/// for the frontmost application. This is the whole risk of the a11y-tree work in one command —
+/// the bridge-token delegate either reaches the guest's AX service or every query answers nil.
+#[cfg(target_os = "macos")]
+fn diag_ax() {
+    let udid = std::env::args().nth(2).expect("usage: diag-ax <udid>");
+    eprintln!("available: {}", private::ax::available());
+    let Some(translator) = private::ax::install(&udid) else {
+        eprintln!("install failed — no translator (see LINKCODE_SIM_DEBUG=1 for detail)");
+        return;
+    };
+    eprintln!("translator wired, token {:?}", private::ax::token());
+    match private::ax::frontmost_application(&translator, 0) {
+        Some(app) => {
+            // The description is enough to prove the round-trip: a real element prints its class
+            // and address, whereas a failed handshake never gets this far.
+            let description: *mut objc2_foundation::NSString =
+                unsafe { objc2::msg_send![&*app, description] };
+            let text = if description.is_null() {
+                "<no description>".to_owned()
+            } else {
+                unsafe { (*description).to_string() }
+            };
+            eprintln!("frontmostApplication -> {text}");
+        }
+        None => eprintln!("frontmostApplication -> nil (handshake did not reach the guest)"),
+    }
 }
 
 /// Diagnostic entry (macOS only): print whether CoreSimulator reports the device Booted — ground

--- a/crates/linkcode-sim/src/main.rs
+++ b/crates/linkcode-sim/src/main.rs
@@ -12,6 +12,7 @@
     allow(dead_code, unused_imports, unused_variables)
 )]
 
+mod accessibility;
 mod capture;
 mod interactive;
 mod mask;
@@ -101,6 +102,11 @@ fn main() {
     #[cfg(target_os = "macos")]
     if subcommand.as_deref() == Some("capture-worker") {
         capture::run_worker();
+    }
+    // The crash-isolated accessibility reader (spawned per `describe-ui` op).
+    #[cfg(target_os = "macos")]
+    if subcommand.as_deref() == Some("ax-worker") {
+        std::process::exit(accessibility::run_worker());
     }
     // The crash-isolated device-state watcher (spawned by the sidecar alongside each stream).
     #[cfg(target_os = "macos")]
@@ -340,6 +346,11 @@ fn serve(request: Request, tx: &Sender<OutMsg>) {
             codec,
         } => interactive::stream_start(&udid, fps, quality, scale, codec, tx),
         Op::StreamStop { udid } => interactive::stream_stop(&udid),
+        Op::DescribeUi {
+            udid,
+            max_depth,
+            max_nodes,
+        } => accessibility::describe_ui(&udid, max_depth, max_nodes),
     };
     match outcome {
         Ok(result) => send(tx, RESULT, success_body(&request_id, result)),

--- a/crates/linkcode-sim/src/main.rs
+++ b/crates/linkcode-sim/src/main.rs
@@ -593,20 +593,18 @@ fn diag_ax() {
         return;
     };
     eprintln!("translator wired, token {:?}", private::ax::token());
-    match private::ax::frontmost_application(&translator, 0) {
-        Some(app) => {
-            // The description is enough to prove the round-trip: a real element prints its class
-            // and address, whereas a failed handshake never gets this far.
-            let description: *mut objc2_foundation::NSString =
-                unsafe { objc2::msg_send![&*app, description] };
-            let text = if description.is_null() {
-                "<no description>".to_owned()
-            } else {
-                unsafe { (*description).to_string() }
-            };
-            eprintln!("frontmostApplication -> {text}");
-        }
-        None => eprintln!("frontmostApplication -> nil (handshake did not reach the guest)"),
+    let Some(translation) = private::ax::frontmost_application(&translator, 0) else {
+        eprintln!("frontmostApplication -> nil (handshake did not reach the guest)");
+        return;
+    };
+    let Some(element) = private::ax::platform_element(&translator, &translation) else {
+        eprintln!("macPlatformElementFromTranslation -> nil");
+        return;
+    };
+    let tree = private::ax::walk_tree(&element, private::ax::WalkLimits::default());
+    match serde_json::to_string_pretty(&tree) {
+        Ok(json) => println!("{json}"),
+        Err(err) => eprintln!("serialize failed: {err}"),
     }
 }
 

--- a/crates/linkcode-sim/src/private/ax.rs
+++ b/crates/linkcode-sim/src/private/ax.rs
@@ -1,0 +1,402 @@
+//! The in-simulator accessibility tree, via `AXPTranslator`.
+//!
+//! Recipe ported from baguette (Apache-2.0; see crate NOTICE). `AXPTranslator` lives in the
+//! **system** `/System/Library/PrivateFrameworks`, not Xcode's, and is in the dyld shared cache —
+//! so its symbols are invisible to `nm` and only a runtime `dlopen` + `objc_getClass` proves it out.
+//!
+//! The translator is useless on its own: it reaches the guest's AX service by asking a
+//! *bridge-token delegate* for a block that can route an `AXPTranslatorRequest` over the device's
+//! XPC channel. Without that delegate installed, every query returns nil. So this module defines a
+//! delegate class at runtime and installs it — the one place in this crate that declares an
+//! Objective-C class rather than only messaging existing ones.
+
+use std::ffi::{CString, c_ulong, c_void};
+use std::ptr;
+use std::sync::OnceLock;
+use std::sync::atomic::{AtomicPtr, Ordering};
+use std::time::Duration;
+
+use objc2::rc::Retained;
+use objc2::runtime::{AnyClass, AnyObject, ClassBuilder, Sel};
+use objc2::{msg_send, sel};
+use objc2_core_foundation::CGRect;
+use objc2_foundation::NSString;
+
+use super::debug::dbg_log;
+use super::device::SimDevice;
+
+const AXP_FRAMEWORK: &str = "/System/Library/PrivateFrameworks/AccessibilityPlatformTranslation.framework/AccessibilityPlatformTranslation";
+
+/// How long one XPC round-trip to the guest's AX service may take before the dispatcher gives up
+/// and answers with the empty response. The translator issues many sub-requests per tree walk, so
+/// this bounds a hung guest per request, not per walk.
+const XPC_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// The device this process serves, reached by the delegate callback.
+///
+/// The callback runs on AXPTranslator's own thread and must not depend on a captured pointer: the
+/// block we hand back is stored by the framework and invoked later, so it is built captureless and
+/// reads the device from here instead — the same discipline `screen.rs` uses for its framebuffer
+/// callbacks. One `ax-worker` process serves exactly one device, so a single global is precisely
+/// right; it is set by [`install`] and never cleared while the process lives.
+static CURRENT_DEVICE: AtomicPtr<AnyObject> = AtomicPtr::new(ptr::null_mut());
+
+/// The bridge token this process registered. AXPTranslator echoes it back on every callback; a
+/// mismatch means the request belongs to some other registration and is answered empty.
+static CURRENT_TOKEN: OnceLock<String> = OnceLock::new();
+
+// dispatch (public): the delegate's XPC round-trip is synchronous, so it needs its own queue plus a
+// group to park on until the completion handler fires.
+unsafe extern "C" {
+    fn dispatch_queue_create(label: *const i8, attr: *const c_void) -> *mut c_void;
+    fn dispatch_group_create() -> *mut c_void;
+    fn dispatch_group_enter(group: *mut c_void);
+    fn dispatch_group_leave(group: *mut c_void);
+    fn dispatch_group_wait(group: *mut c_void, timeout: u64) -> isize;
+    fn dispatch_time(when: u64, delta: i64) -> u64;
+    fn dispatch_release(object: *mut c_void);
+    static _NSConcreteGlobalBlock: c_void;
+}
+
+/// `DISPATCH_TIME_NOW`.
+const DISPATCH_TIME_NOW: u64 = 0;
+
+/// Load the accessibility framework once. `false` means this host cannot translate at all, which
+/// the caller reports as an unavailable capability rather than an error.
+pub fn available() -> bool {
+    static LOADED: OnceLock<bool> = OnceLock::new();
+    *LOADED.get_or_init(|| {
+        let Ok(path) = CString::new(AXP_FRAMEWORK) else {
+            return false;
+        };
+        // SAFETY: `path` is a valid NUL-terminated C string kept alive across the call.
+        let handle = unsafe { libc::dlopen(path.as_ptr(), libc::RTLD_NOW | libc::RTLD_GLOBAL) };
+        if handle.is_null() {
+            dbg_log!("ax: dlopen failed for {AXP_FRAMEWORK}");
+            return false;
+        }
+        AnyClass::get(c"AXPTranslator").is_some()
+    })
+}
+
+/// Send a parameterless class message that returns an object (`+sharedInstance`, `+emptyResponse`).
+///
+/// # Safety
+/// `sel` must name a class method on `class` taking no arguments and returning an object.
+unsafe fn class_object_message(class: &AnyClass, sel: Sel) -> *mut AnyObject {
+    // SAFETY: forwarded to this function's contract; the receiver is a live class object.
+    unsafe { msg_send![class, performSelector: sel] }
+}
+
+/// The framework's typed empty response, or `NSNull` if it cannot be obtained. AXPTranslator
+/// re-issues a request answered with `NSNull`, so the typed value is strongly preferred.
+fn empty_response() -> *mut AnyObject {
+    let Some(class) = AnyClass::get(c"AXPTranslatorResponse") else {
+        return null_object();
+    };
+    // SAFETY: `+emptyResponse` takes no arguments and returns an autoreleased response object.
+    let response = unsafe { class_object_message(class, sel!(emptyResponse)) };
+    if response.is_null() {
+        null_object()
+    } else {
+        response
+    }
+}
+
+/// `[NSNull null]` — the last-resort answer when even the typed empty response is unavailable.
+fn null_object() -> *mut AnyObject {
+    let Some(class) = AnyClass::get(c"NSNull") else {
+        return ptr::null_mut();
+    };
+    // SAFETY: `+null` is NSNull's standard singleton accessor.
+    unsafe { class_object_message(class, sel!(null)) }
+}
+
+/// Route one `AXPTranslatorRequest` to the guest and block until it answers.
+///
+/// `SimDevice` only exposes the async form, and AXPTranslator calls us synchronously, so the
+/// completion handler parks a dispatch group that this function waits on. A timeout answers empty
+/// rather than hanging the translator's thread forever.
+fn send_request(device: *mut AnyObject, request: *mut AnyObject) -> *mut AnyObject {
+    if device.is_null() {
+        return empty_response();
+    }
+    // SAFETY: respondsToSelector: is defined on NSObject; `device` is the retained SimDevice.
+    let responds: bool = unsafe {
+        msg_send![device, respondsToSelector: sel!(sendAccessibilityRequestAsync:completionQueue:completionHandler:)]
+    };
+    if !responds {
+        dbg_log!("ax: SimDevice has no sendAccessibilityRequestAsync:");
+        return empty_response();
+    }
+
+    // SAFETY: dispatch_group_create/dispatch_queue_create return owned objects released below.
+    let group = unsafe { dispatch_group_create() };
+    let queue = unsafe { dispatch_queue_create(c"linkcode.sim.ax".as_ptr(), ptr::null()) };
+    if group.is_null() || queue.is_null() {
+        return empty_response();
+    }
+    // SAFETY: balanced by the `dispatch_group_leave` in the completion block.
+    unsafe { dispatch_group_enter(group) };
+
+    let mut slot = ResponseSlot {
+        response: ptr::null_mut(),
+        group,
+    };
+    let mut completion = completion_block(&raw mut slot);
+    // SAFETY: the selector's ABI is (request, queue, block); all three outlive the call because we
+    // block on the group below before any of them is dropped.
+    unsafe {
+        let _: () = msg_send![
+            device,
+            sendAccessibilityRequestAsync: request,
+            completionQueue: queue,
+            completionHandler: &raw mut completion as *mut c_void,
+        ];
+    }
+
+    // SAFETY: `dispatch_time` with DISPATCH_TIME_NOW yields an absolute deadline for the wait.
+    let deadline = unsafe { dispatch_time(DISPATCH_TIME_NOW, XPC_TIMEOUT.as_nanos() as i64) };
+    // SAFETY: `group` is live and entered exactly once.
+    let timed_out = unsafe { dispatch_group_wait(group, deadline) } != 0;
+    // SAFETY: both were created by this function and are no longer referenced after the wait.
+    unsafe {
+        dispatch_release(group);
+        dispatch_release(queue);
+    }
+    if timed_out {
+        dbg_log!("ax: XPC request timed out after {}s", XPC_TIMEOUT.as_secs());
+        return empty_response();
+    }
+    if slot.response.is_null() {
+        empty_response()
+    } else {
+        slot.response
+    }
+}
+
+/// Where the completion handler parks its answer. The block writes through a raw pointer to this,
+/// which is sound because `send_request` blocks on `group` until the write has happened.
+struct ResponseSlot {
+    response: *mut AnyObject,
+    group: *mut c_void,
+}
+
+// ── Hand-rolled blocks ──────────────────────────────────────────────────────────────────────────
+//
+// Same layout as `screen.rs`: a global block with a signature, because the framework reads the
+// signature and rejects a signature-less block. The dispatcher's returned block is captureless by
+// design (see `CURRENT_DEVICE`); the XPC completion block is the one exception and carries a single
+// pointer, which is safe only because its creator blocks until it has run.
+
+#[repr(C)]
+struct BlockDescriptor {
+    reserved: c_ulong,
+    size: c_ulong,
+    signature: *const i8,
+}
+
+// SAFETY: descriptors are immutable and their signatures are static NUL-terminated strings.
+unsafe impl Sync for BlockDescriptor {}
+
+#[repr(C)]
+struct CaptureBlock {
+    isa: *const c_void,
+    flags: i32,
+    reserved: i32,
+    invoke: *const c_void,
+    descriptor: *const BlockDescriptor,
+    /// The one captured word; unused by the captureless dispatcher block.
+    context: *mut c_void,
+}
+
+const BLOCK_IS_GLOBAL: i32 = 1 << 28;
+const BLOCK_HAS_SIGNATURE: i32 = 1 << 30;
+
+/// `void (^)(id)` — the XPC completion handler.
+const COMPLETION_SIGNATURE: &[u8] = b"v16@?0@8\0";
+/// `id (^)(id)` — the request router the dispatcher hands back to the translator.
+const ROUTER_SIGNATURE: &[u8] = b"@16@?0@8\0";
+
+static COMPLETION_DESCRIPTOR: BlockDescriptor = BlockDescriptor {
+    reserved: 0,
+    size: size_of::<CaptureBlock>() as c_ulong,
+    signature: COMPLETION_SIGNATURE.as_ptr().cast::<i8>(),
+};
+static ROUTER_DESCRIPTOR: BlockDescriptor = BlockDescriptor {
+    reserved: 0,
+    size: size_of::<CaptureBlock>() as c_ulong,
+    signature: ROUTER_SIGNATURE.as_ptr().cast::<i8>(),
+};
+
+/// The XPC completion handler: store the response and release the waiter.
+unsafe extern "C" fn completion_invoke(block: *mut CaptureBlock, response: *mut AnyObject) {
+    // SAFETY: `context` is the `ResponseSlot` pointer this block was built with, and
+    // `send_request` blocks on the group until this runs, so the slot is still alive.
+    let slot = unsafe { &mut *(*block).context.cast::<ResponseSlot>() };
+    if !response.is_null() {
+        // SAFETY: the response is autoreleased by the sender; retain it to outlive the callback.
+        slot.response = unsafe { msg_send![response, retain] };
+    }
+    // SAFETY: balances the `dispatch_group_enter` in `send_request`.
+    unsafe { dispatch_group_leave(slot.group) };
+}
+
+/// The request router handed back to AXPTranslator: captureless, reads the process-global device.
+unsafe extern "C" fn router_invoke(
+    _block: *mut CaptureBlock,
+    request: *mut AnyObject,
+) -> *mut AnyObject {
+    send_request(CURRENT_DEVICE.load(Ordering::Acquire), request)
+}
+
+fn completion_block(slot: *mut ResponseSlot) -> CaptureBlock {
+    CaptureBlock {
+        isa: (&raw const _NSConcreteGlobalBlock).cast::<c_void>(),
+        flags: BLOCK_IS_GLOBAL | BLOCK_HAS_SIGNATURE,
+        reserved: 0,
+        invoke: completion_invoke as *const c_void,
+        descriptor: &raw const COMPLETION_DESCRIPTOR,
+        context: slot.cast::<c_void>(),
+    }
+}
+
+/// The router block, leaked on purpose: AXPTranslator retains it for as long as it keeps the token.
+fn router_block() -> *mut c_void {
+    let block = Box::new(CaptureBlock {
+        isa: (&raw const _NSConcreteGlobalBlock).cast::<c_void>(),
+        flags: BLOCK_IS_GLOBAL | BLOCK_HAS_SIGNATURE,
+        reserved: 0,
+        invoke: router_invoke as *const c_void,
+        descriptor: &raw const ROUTER_DESCRIPTOR,
+        context: ptr::null_mut(),
+    });
+    Box::into_raw(block).cast::<c_void>()
+}
+
+// ── The runtime-defined delegate ────────────────────────────────────────────────────────────────
+
+/// `-accessibilityTranslationDelegateBridgeCallbackWithToken:` — hand back the router block.
+unsafe extern "C" fn bridge_callback(
+    _this: &AnyObject,
+    _cmd: Sel,
+    token: *mut NSString,
+) -> *mut c_void {
+    if !token_matches(token) {
+        dbg_log!("ax: callback for an unregistered token");
+    }
+    router_block()
+}
+
+/// `-accessibilityTranslationConvertPlatformFrameToSystem:withToken:` — the simulator's frame
+/// space already is the system space here, so this is the identity.
+unsafe extern "C" fn convert_frame(
+    _this: &AnyObject,
+    _cmd: Sel,
+    rect: CGRect,
+    _token: *mut NSString,
+) -> CGRect {
+    rect
+}
+
+/// `-accessibilityTranslationRootParentWithToken:` — no synthetic parent above the app.
+unsafe extern "C" fn root_parent(
+    _this: &AnyObject,
+    _cmd: Sel,
+    _token: *mut NSString,
+) -> *mut AnyObject {
+    ptr::null_mut()
+}
+
+fn token_matches(token: *mut NSString) -> bool {
+    if token.is_null() {
+        return false;
+    }
+    // SAFETY: `token` is a valid NSString for the duration of the callback.
+    let value = unsafe { (*token).to_string() };
+    CURRENT_TOKEN.get().is_some_and(|current| *current == value)
+}
+
+/// Define (once) and instantiate the bridge-token delegate.
+fn dispatcher() -> *mut AnyObject {
+    static CLASS: OnceLock<usize> = OnceLock::new();
+    let class_ptr = *CLASS.get_or_init(|| {
+        let superclass = AnyClass::get(c"NSObject").expect("NSObject is always registered");
+        let mut builder = ClassBuilder::new(c"LinkCodeAXTokenDispatcher", superclass)
+            .expect("the dispatcher class name is unused");
+        // SAFETY: each signature matches the selector AXPTranslator invokes it with — an object
+        // return for the callback, a CGRect in/out for the frame conversion, an object return for
+        // the root parent. Encodings are checked against the runtime by `add_method`.
+        unsafe {
+            builder.add_method(
+                sel!(accessibilityTranslationDelegateBridgeCallbackWithToken:),
+                bridge_callback as unsafe extern "C" fn(_, _, _) -> _,
+            );
+            builder.add_method(
+                sel!(accessibilityTranslationConvertPlatformFrameToSystem:withToken:),
+                convert_frame as unsafe extern "C" fn(_, _, _, _) -> _,
+            );
+            builder.add_method(
+                sel!(accessibilityTranslationRootParentWithToken:),
+                root_parent as unsafe extern "C" fn(_, _, _) -> _,
+            );
+        }
+        ptr::from_ref(builder.register()) as usize
+    });
+    let class = class_ptr as *const AnyClass;
+    // SAFETY: `class` came from `ClassBuilder::register`, which returns a `'static` class.
+    unsafe { msg_send![&*class, new] }
+}
+
+/// Wire the translator to `udid`'s device and return the shared translator.
+///
+/// Installing the delegate is not optional: without it every translator query answers nil, because
+/// the translator has no way to reach the guest's accessibility service.
+pub fn install(udid: &str) -> Option<Retained<AnyObject>> {
+    if !available() {
+        return None;
+    }
+    let device = SimDevice::resolve(udid)?;
+    // Retained for the process's lifetime: the router block reads it on the translator's thread.
+    // SAFETY: `object_ptr` is the live SimDevice; retaining it keeps it valid past this scope.
+    let retained: *mut AnyObject = unsafe { msg_send![device.object_ptr(), retain] };
+    CURRENT_DEVICE.store(retained, Ordering::Release);
+    let token = format!("linkcode-{udid}");
+    let _ = CURRENT_TOKEN.set(token);
+
+    let class = AnyClass::get(c"AXPTranslator")?;
+    // SAFETY: `+sharedInstance` takes no arguments and returns the singleton translator.
+    let translator = unsafe { class_object_message(class, sel!(sharedInstance)) };
+    if translator.is_null() {
+        dbg_log!("ax: +sharedInstance returned nil");
+        return None;
+    }
+    let key = NSString::from_str("bridgeTokenDelegate");
+    let delegate = dispatcher();
+    // SAFETY: KVC write of an object value onto the translator singleton.
+    unsafe {
+        let _: () = msg_send![translator, setValue: delegate, forKey: &*key];
+    }
+    dbg_log!("ax: translator wired for {udid}");
+    // SAFETY: the singleton is owned by the framework; retain it for the returned handle.
+    Some(unsafe { Retained::retain(translator)? })
+}
+
+/// The token this process registered, for the translator entry points that take one.
+pub fn token() -> Option<&'static str> {
+    CURRENT_TOKEN.get().map(String::as_str)
+}
+
+/// The frontmost application element on `display`, or `None` when the translator cannot reach it.
+pub fn frontmost_application(translator: &AnyObject, display: u32) -> Option<Retained<AnyObject>> {
+    let token = NSString::from_str(token()?);
+    // SAFETY: the selector takes (uint32 displayId, NSString *token) and returns an element.
+    let element: *mut AnyObject = unsafe {
+        msg_send![translator, frontmostApplicationWithDisplayId: display, bridgeDelegateToken: &*token]
+    };
+    if element.is_null() {
+        return None;
+    }
+    // SAFETY: the returned element is autoreleased; retain it to outlive the pool.
+    unsafe { Retained::retain(element) }
+}

--- a/crates/linkcode-sim/src/private/ax.rs
+++ b/crates/linkcode-sim/src/private/ax.rs
@@ -555,6 +555,20 @@ fn frame_property(element: &AnyObject) -> [f64; 4] {
     ]
 }
 
+/// Read `udid`'s accessibility tree in this process. Intended for the `ax-worker` child, not the
+/// long-lived server: everything below rides a private callback ABI.
+pub fn describe(udid: &str, limits: WalkLimits) -> Result<AxNode, String> {
+    if !available() {
+        return Err("accessibility translation is unavailable on this host".to_owned());
+    }
+    let translator = install(udid).ok_or("could not wire the accessibility translator")?;
+    let translation = frontmost_application(&translator, 0)
+        .ok_or("no frontmost application (is anything running on the device?)")?;
+    let element = platform_element(&translator, &translation)
+        .ok_or("the translation carried no platform element")?;
+    Ok(walk_tree(&element, limits))
+}
+
 /// Walk the whole tree from the application root.
 ///
 /// The root's own frame is the screen size in points, which is what every node's normalized centre

--- a/crates/linkcode-sim/src/private/ax.rs
+++ b/crates/linkcode-sim/src/private/ax.rs
@@ -139,19 +139,23 @@ fn send_request(device: *mut AnyObject, request: *mut AnyObject) -> *mut AnyObje
     // SAFETY: balanced by the `dispatch_group_leave` in the completion block.
     unsafe { dispatch_group_enter(group) };
 
-    let mut slot = ResponseSlot {
+    // Both the slot and the block live on the heap, not this stack frame: a global block's
+    // `Block_copy` is a no-op returning the same pointer, so the callee holds exactly what we hand
+    // it. If it fired after a stack-allocated pair went out of scope it would write through dead
+    // memory — an intermittent segfault that only shows up when a reply is late.
+    let slot = Box::into_raw(Box::new(ResponseSlot {
         response: ptr::null_mut(),
         group,
-    };
-    let mut completion = completion_block(&raw mut slot);
-    // SAFETY: the selector's ABI is (request, queue, block); all three outlive the call because we
-    // block on the group below before any of them is dropped.
+    }));
+    let completion = Box::into_raw(Box::new(completion_block(slot)));
+    // SAFETY: the selector's ABI is (request, queue, block); the block and its slot are heap-owned
+    // and outlive this call on every path (see the timeout branch below).
     unsafe {
         let _: () = msg_send![
             device,
             sendAccessibilityRequestAsync: request,
             completionQueue: queue,
-            completionHandler: &raw mut completion as *mut c_void,
+            completionHandler: completion.cast::<c_void>(),
         ];
     }
 
@@ -159,24 +163,37 @@ fn send_request(device: *mut AnyObject, request: *mut AnyObject) -> *mut AnyObje
     let deadline = unsafe { dispatch_time(DISPATCH_TIME_NOW, XPC_TIMEOUT.as_nanos() as i64) };
     // SAFETY: `group` is live and entered exactly once.
     let timed_out = unsafe { dispatch_group_wait(group, deadline) } != 0;
-    // SAFETY: both were created by this function and are no longer referenced after the wait.
+    if timed_out {
+        // Deliberately leak the slot, the block and the group. The request is still outstanding, so
+        // a late reply will run the completion handler; freeing any of the three now would turn a
+        // slow guest into a use-after-free. A timeout is rare and the leak is a few words.
+        dbg_log!("ax: XPC request timed out after {}s", XPC_TIMEOUT.as_secs());
+        // SAFETY: the queue is not referenced by the completion handler, only by dispatch itself.
+        unsafe { dispatch_release(queue) };
+        return empty_response();
+    }
+
+    // The handler has run, so nothing else can reach either allocation.
+    // SAFETY: both pointers came from `Box::into_raw` above and are reclaimed exactly once.
+    let response = unsafe {
+        let slot = Box::from_raw(slot);
+        drop(Box::from_raw(completion));
+        slot.response
+    };
+    // SAFETY: created by this function; the handler has finished with the group.
     unsafe {
         dispatch_release(group);
         dispatch_release(queue);
     }
-    if timed_out {
-        dbg_log!("ax: XPC request timed out after {}s", XPC_TIMEOUT.as_secs());
-        return empty_response();
-    }
-    if slot.response.is_null() {
+    if response.is_null() {
         empty_response()
     } else {
-        slot.response
+        response
     }
 }
 
-/// Where the completion handler parks its answer. The block writes through a raw pointer to this,
-/// which is sound because `send_request` blocks on `group` until the write has happened.
+/// Where the completion handler parks its answer. Heap-allocated by `send_request` and reclaimed
+/// there once the handler has run — or leaked on timeout, when the handler may still be pending.
 struct ResponseSlot {
     response: *mut AnyObject,
     group: *mut c_void,
@@ -399,4 +416,218 @@ pub fn frontmost_application(translator: &AnyObject, display: u32) -> Option<Ret
     }
     // SAFETY: the returned element is autoreleased; retain it to outlive the pool.
     unsafe { Retained::retain(element) }
+}
+
+/// Convert a translation object into the readable `AXPMacPlatformElement`. The translator hands
+/// back opaque translations; only the platform element answers the accessibility properties.
+pub fn platform_element(
+    translator: &AnyObject,
+    translation: &AnyObject,
+) -> Option<Retained<AnyObject>> {
+    // SAFETY: the selector takes a translation and returns an autoreleased platform element.
+    let element: *mut AnyObject =
+        unsafe { msg_send![translator, macPlatformElementFromTranslation: translation] };
+    if element.is_null() {
+        return None;
+    }
+    // SAFETY: autoreleased; retained so it outlives the enclosing pool.
+    unsafe { Retained::retain(element) }
+}
+
+/// One node of the guest's accessibility tree, in device points.
+///
+/// Coordinates stay in points here; normalizing against the screen is the caller's job, because
+/// only it knows the device size the agent's tap coordinates are expressed against.
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AxNode {
+    pub role: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub subrole: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub value: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub identifier: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    /// `[x, y, width, height]` in device points.
+    pub frame: [f64; 4],
+    /// The frame's centre as `[x, y]` normalized 0..1 against the screen — the exact shape the
+    /// tap/swipe tools take, so an agent can act on a node without knowing the device's size.
+    /// Absent when the root reported no usable screen size.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub center: Option<[f64; 2]>,
+    pub enabled: bool,
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    pub focused: bool,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub children: Vec<AxNode>,
+}
+
+/// Caps on a serialized tree. A deep SwiftUI hierarchy can run to thousands of nodes, which would
+/// blow an agent's tool-result budget long before it became useful.
+#[derive(Debug, Clone, Copy)]
+pub struct WalkLimits {
+    pub max_depth: u32,
+    pub max_nodes: usize,
+}
+
+impl Default for WalkLimits {
+    fn default() -> Self {
+        Self {
+            max_depth: 24,
+            max_nodes: 800,
+        }
+    }
+}
+
+/// Read a non-empty string property by KVC. `NSNumber` values are coerced so numeric
+/// `accessibilityValue`s (sliders, progress) surface as stable strings.
+fn string_property(element: &AnyObject, key: &str) -> Option<String> {
+    let key = NSString::from_str(key);
+    // SAFETY: KVC read returning any object (or nil).
+    let raw: *mut AnyObject = unsafe { msg_send![element, valueForKey: &*key] };
+    if raw.is_null() {
+        return None;
+    }
+    let string_class = AnyClass::get(c"NSString")?;
+    // SAFETY: isKindOfClass: is defined on NSObject.
+    let is_string: bool = unsafe { msg_send![raw, isKindOfClass: string_class] };
+    let text = if is_string {
+        // SAFETY: `raw` is an NSString for the duration of this read.
+        unsafe { (*raw.cast::<NSString>()).to_string() }
+    } else {
+        let number_class = AnyClass::get(c"NSNumber")?;
+        // SAFETY: isKindOfClass: is defined on NSObject.
+        let is_number: bool = unsafe { msg_send![raw, isKindOfClass: number_class] };
+        if !is_number {
+            return None;
+        }
+        // SAFETY: NSNumber answers `stringValue` with an autoreleased NSString.
+        let value: *mut NSString = unsafe { msg_send![raw, stringValue] };
+        if value.is_null() {
+            return None;
+        }
+        // SAFETY: valid for the duration of this read.
+        unsafe { (*value).to_string() }
+    };
+    if text.is_empty() { None } else { Some(text) }
+}
+
+/// Read a bool property by KVC, falling back when the key is missing or not a number.
+fn bool_property(element: &AnyObject, key: &str, fallback: bool) -> bool {
+    let key = NSString::from_str(key);
+    // SAFETY: KVC read returning any object (or nil).
+    let raw: *mut AnyObject = unsafe { msg_send![element, valueForKey: &*key] };
+    if raw.is_null() {
+        return fallback;
+    }
+    let Some(number_class) = AnyClass::get(c"NSNumber") else {
+        return fallback;
+    };
+    // SAFETY: isKindOfClass: is defined on NSObject.
+    let is_number: bool = unsafe { msg_send![raw, isKindOfClass: number_class] };
+    if !is_number {
+        return fallback;
+    }
+    // SAFETY: NSNumber answers boolValue.
+    unsafe { msg_send![raw, boolValue] }
+}
+
+/// `accessibilityFrame` returns a CGRect, which cannot ride KVC's object return — message it
+/// directly. Elements that do not answer the selector report an empty frame.
+fn frame_property(element: &AnyObject) -> [f64; 4] {
+    // SAFETY: respondsToSelector: is defined on NSObject.
+    let responds: bool =
+        unsafe { msg_send![element, respondsToSelector: sel!(accessibilityFrame)] };
+    if !responds {
+        return [0.0; 4];
+    }
+    // SAFETY: the selector is declared to return a CGRect by value.
+    let rect: CGRect = unsafe { msg_send![element, accessibilityFrame] };
+    [
+        rect.origin.x,
+        rect.origin.y,
+        rect.size.width,
+        rect.size.height,
+    ]
+}
+
+/// Walk the whole tree from the application root.
+///
+/// The root's own frame is the screen size in points, which is what every node's normalized centre
+/// is computed against — so the caller needs no separate notion of how big the device is.
+pub fn walk_tree(root: &AnyObject, limits: WalkLimits) -> AxNode {
+    let screen = frame_property(root);
+    let size = (screen[2] > 0.0 && screen[3] > 0.0).then_some((screen[2], screen[3]));
+    let mut budget = limits.max_nodes;
+    walk(root, limits, &mut budget, size)
+}
+
+/// Walk `element` and its descendants into a serializable tree, stopping at `limits`.
+///
+/// `budget` is shared across the whole walk (not per level), so a wide tree truncates as decisively
+/// as a deep one and the result always fits the caller's cap.
+fn walk(
+    element: &AnyObject,
+    limits: WalkLimits,
+    budget: &mut usize,
+    screen: Option<(f64, f64)>,
+) -> AxNode {
+    let frame = frame_property(element);
+    let node = AxNode {
+        role: string_property(element, "accessibilityRole")
+            .unwrap_or_else(|| "AXUnknown".to_owned()),
+        subrole: string_property(element, "accessibilitySubrole"),
+        label: string_property(element, "accessibilityLabel"),
+        value: string_property(element, "accessibilityValue"),
+        identifier: string_property(element, "accessibilityIdentifier"),
+        title: string_property(element, "accessibilityTitle"),
+        frame,
+        center: screen.map(|(width, height)| {
+            [
+                ((frame[0] + frame[2] / 2.0) / width).clamp(0.0, 1.0),
+                ((frame[1] + frame[3] / 2.0) / height).clamp(0.0, 1.0),
+            ]
+        }),
+        enabled: bool_property(element, "accessibilityEnabled", true)
+            || bool_property(element, "isAccessibilityEnabled", false),
+        focused: bool_property(element, "isAccessibilityFocused", false)
+            || bool_property(element, "accessibilityFocused", false),
+        children: Vec::new(),
+    };
+    *budget = budget.saturating_sub(1);
+    if limits.max_depth == 0 || *budget == 0 {
+        return node;
+    }
+
+    let key = NSString::from_str("accessibilityChildren");
+    // SAFETY: KVC read returning an NSArray (or nil).
+    let raw: *mut AnyObject = unsafe { msg_send![element, valueForKey: &*key] };
+    if raw.is_null() {
+        return node;
+    }
+    // SAFETY: `raw` is an NSArray; count is its standard accessor.
+    let count: usize = unsafe { msg_send![raw, count] };
+    let deeper = WalkLimits {
+        max_depth: limits.max_depth - 1,
+        ..limits
+    };
+    let mut node = node;
+    for index in 0..count {
+        if *budget == 0 {
+            break;
+        }
+        // SAFETY: index < count.
+        let child: *mut AnyObject = unsafe { msg_send![raw, objectAtIndex: index] };
+        if child.is_null() {
+            continue;
+        }
+        // SAFETY: the child is owned by the array, which outlives this loop.
+        node.children
+            .push(walk(unsafe { &*child }, deeper, budget, screen));
+    }
+    node
 }

--- a/crates/linkcode-sim/src/private/mod.rs
+++ b/crates/linkcode-sim/src/private/mod.rs
@@ -5,6 +5,7 @@
 //! frameworks resolved, and the sidecar falls back to public `simctl` (screenshot polling, no touch)
 //! when they don't — so an Xcode without SimulatorKit is view-only, not broken.
 
+pub mod ax;
 pub(crate) mod debug;
 mod device;
 mod framework;

--- a/crates/linkcode-sim/src/rpc.rs
+++ b/crates/linkcode-sim/src/rpc.rs
@@ -119,6 +119,24 @@ pub enum Op {
     },
     /// Stop a running framebuffer stream.
     StreamStop { udid: String },
+    /// Read the guest's accessibility tree (private API; P2). Served by a short-lived worker
+    /// process, so a drifted `AXPTranslator` ABI cannot take the sidecar down with it.
+    DescribeUi {
+        udid: String,
+        /// Deepest level to descend; `0` reports only the application root.
+        #[serde(default = "default_ax_depth")]
+        max_depth: u32,
+        /// Ceiling on total nodes, so a deep SwiftUI hierarchy cannot blow the caller's budget.
+        #[serde(default = "default_ax_nodes")]
+        max_nodes: usize,
+    },
+}
+
+fn default_ax_depth() -> u32 {
+    24
+}
+fn default_ax_nodes() -> usize {
+    800
 }
 
 fn default_fps() -> u32 {

--- a/packages/client/core/src/client.ts
+++ b/packages/client/core/src/client.ts
@@ -357,6 +357,9 @@ export class LinkCodeClient {
       case 'simulator.screenshotted':
         this.pending.resolve('simulatorScreenshot', p.replyTo, { format: p.format, data: p.data });
         break;
+      case 'simulator.described-ui':
+        this.pending.resolve('simulatorDescribeUi', p.replyTo, p.tree);
+        break;
       case 'simulator.devices.changed':
         for (const cb of this.simulatorDevicesChangedSubs) cb(p.devices);
         break;

--- a/packages/client/core/src/client/control-channel.ts
+++ b/packages/client/core/src/client/control-channel.ts
@@ -35,6 +35,7 @@ import type {
   SessionId,
   SessionInfo,
   SessionRecord,
+  SimulatorAxNode,
   SimulatorButton,
   SimulatorConsentDecision,
   SimulatorConsentState,
@@ -661,6 +662,23 @@ export class ControlChannel {
       sessionId,
       udid,
       format,
+    }));
+  }
+
+  /** Resolves with the frontmost app's accessibility tree. Node centres are normalized 0..1, the
+   * same scale {@link simulatorTap} takes, so a caller can act on a node it found by label. */
+  simulatorDescribeUi(
+    sessionId: SessionId,
+    udid: string,
+    limits?: { maxDepth?: number; maxNodes?: number },
+  ): Promise<SimulatorAxNode> {
+    return this.sendCorrelated('simulatorDescribeUi', (clientReqId) => ({
+      kind: 'simulator.describe-ui',
+      clientReqId,
+      sessionId,
+      udid,
+      maxDepth: limits?.maxDepth,
+      maxNodes: limits?.maxNodes,
     }));
   }
 

--- a/packages/client/core/src/client/pending-registry.ts
+++ b/packages/client/core/src/client/pending-registry.ts
@@ -19,6 +19,7 @@ import type {
   SessionId,
   SessionInfo,
   SessionRecord,
+  SimulatorAxNode,
   SimulatorConsentState,
   SimulatorDevice,
   SimulatorImageFormat,
@@ -100,6 +101,7 @@ export interface PendingValueMap {
   simulatorList: SimulatorDevice[];
   simulatorLaunch: number | null;
   simulatorScreenshot: { format: SimulatorImageFormat; data: string };
+  simulatorDescribeUi: SimulatorAxNode;
   simulatorScreenMask: string;
   simulatorConsentGet: SimulatorConsentState;
   simulatorStreamStart: { fps: number; scale: number; codec: SimulatorStreamCodec };
@@ -151,6 +153,7 @@ export class PendingRegistry {
     simulatorList: new Map(),
     simulatorLaunch: new Map(),
     simulatorScreenshot: new Map(),
+    simulatorDescribeUi: new Map(),
     simulatorScreenMask: new Map(),
     simulatorConsentGet: new Map(),
     simulatorStreamStart: new Map(),

--- a/packages/foundation/schema/src/model/simulator.ts
+++ b/packages/foundation/schema/src/model/simulator.ts
@@ -89,3 +89,39 @@ export const SimulatorOrientationSchema = z.enum([
   'landscapeRight',
 ]);
 export type SimulatorOrientation = z.infer<typeof SimulatorOrientationSchema>;
+
+/** One node of the guest's accessibility tree.
+ *
+ * `frame` is `[x, y, width, height]` in device points, faithful to what the guest reports;
+ * `center` is that frame's centre normalized 0..1, which is the scale every pointer command takes
+ * — so a client can act on a node without knowing the device's pixel size. The recursion needs an
+ * explicit interface: zod cannot infer a self-referential shape. */
+export interface SimulatorAxNode {
+  role: string;
+  subrole?: string;
+  label?: string;
+  value?: string;
+  identifier?: string;
+  title?: string;
+  frame: [number, number, number, number];
+  center?: [number, number];
+  enabled: boolean;
+  focused?: boolean;
+  children?: SimulatorAxNode[];
+}
+
+export const SimulatorAxNodeSchema: z.ZodType<SimulatorAxNode> = z.lazy(() =>
+  z.object({
+    role: z.string(),
+    subrole: z.string().optional(),
+    label: z.string().optional(),
+    value: z.string().optional(),
+    identifier: z.string().optional(),
+    title: z.string().optional(),
+    frame: z.tuple([z.number(), z.number(), z.number(), z.number()]),
+    center: z.tuple([z.number(), z.number()]).optional(),
+    enabled: z.boolean(),
+    focused: z.boolean().optional(),
+    children: z.array(SimulatorAxNodeSchema).optional(),
+  }),
+);

--- a/packages/foundation/schema/src/wire/message.ts
+++ b/packages/foundation/schema/src/wire/message.ts
@@ -25,7 +25,7 @@ import { WirePayloadSchema } from './payload';
 // 53 migrates managed-asset IDs from public strings to discriminated objects.
 // 54 adds the simulator agent-consent variants (CODE-420).
 // 55 adds the simulator volume buttons (CODE-414).
-export const WIRE_PROTOCOL_VERSION = 55 as const;
+export const WIRE_PROTOCOL_VERSION = 56 as const;
 
 /** Complete wire message: version + unique id + timestamp + payload. */
 export const WireMessageSchema = z.object({

--- a/packages/foundation/schema/src/wire/simulator.ts
+++ b/packages/foundation/schema/src/wire/simulator.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import { SessionIdSchema } from '../model/primitives';
 import {
+  SimulatorAxNodeSchema,
   SimulatorButtonSchema,
   SimulatorConsentDecisionSchema,
   SimulatorConsentStateSchema,
@@ -239,6 +240,22 @@ export const simulatorWireVariants = [
     udid,
     usage: z.number().int().nonnegative(),
     modifiers: z.array(z.number().int().nonnegative()).max(8),
+  }),
+  /** Read the frontmost app's accessibility tree. Costs a chain of XPC round-trips into the guest,
+   * so it is a request/reply command rather than anything stream-shaped. */
+  z.object({
+    kind: z.literal('simulator.describe-ui'),
+    clientReqId: WireRequestIdSchema,
+    sessionId: SessionIdSchema,
+    udid,
+    maxDepth: z.number().int().nonnegative().max(64).optional(),
+    maxNodes: z.number().int().positive().max(5000).optional(),
+  }),
+  z.object({
+    kind: z.literal('simulator.described-ui'),
+    replyTo: WireRequestIdSchema,
+    udid,
+    tree: SimulatorAxNodeSchema,
   }),
   z.object({
     kind: z.literal('simulator.stream.start'),

--- a/packages/host/engine/src/__tests__/simulator-request-handler.test.ts
+++ b/packages/host/engine/src/__tests__/simulator-request-handler.test.ts
@@ -43,6 +43,13 @@ function fakeBackend() {
     swipe: vi.fn(asyncNoop),
     button: vi.fn(asyncNoop),
     rotate: vi.fn(asyncNoop),
+    describeUi: vi.fn(() =>
+      Promise.resolve({
+        role: 'AXApplication',
+        frame: [0, 0, 400, 800] as [number, number, number, number],
+        enabled: true,
+      }),
+    ),
     streamStart: vi.fn(() =>
       Promise.resolve({ streaming: true as const, fps: 60, scale: 1, codec: 'jpeg' as const }),
     ),

--- a/packages/host/engine/src/__tests__/simulator-service.test.ts
+++ b/packages/host/engine/src/__tests__/simulator-service.test.ts
@@ -40,6 +40,13 @@ function fakeBackend(devices: SimulatorDeviceInfo[]) {
     swipe: vi.fn(asyncNoop),
     button: vi.fn(asyncNoop),
     rotate: vi.fn(asyncNoop),
+    describeUi: vi.fn(() =>
+      Promise.resolve({
+        role: 'AXApplication',
+        frame: [0, 0, 400, 800] as [number, number, number, number],
+        enabled: true,
+      }),
+    ),
     streamStart: vi.fn(() =>
       Promise.resolve<Awaited<ReturnType<SimulatorBackend['streamStart']>>>({
         streaming: true,

--- a/packages/host/engine/src/simulator/backend.ts
+++ b/packages/host/engine/src/simulator/backend.ts
@@ -45,6 +45,31 @@ export type SimulatorOrientation =
 /** One phase of a streamed touch gesture (one `down`, moves, one `up` per gesture). */
 export type SimulatorTouchPhase = 'down' | 'move' | 'up';
 
+/** One node of the guest's accessibility tree.
+ *
+ * `frame` is `[x, y, width, height]` in device points; `center` is that frame's centre normalized
+ * 0..1 against the screen — the same scale the pointer commands take, so a caller can act on a
+ * node without knowing the device's size. */
+export interface SimulatorAxNode {
+  role: string;
+  subrole?: string;
+  label?: string;
+  value?: string;
+  identifier?: string;
+  title?: string;
+  frame: [number, number, number, number];
+  center?: [number, number];
+  enabled: boolean;
+  focused?: boolean;
+  children?: SimulatorAxNode[];
+}
+
+/** Caps on a tree read; omitted fields fall back to the backend's defaults. */
+export interface SimulatorAxLimits {
+  maxDepth?: number;
+  maxNodes?: number;
+}
+
 /** A normalized (0..1) point on the device screen. */
 export interface SimulatorPoint {
   x: number;
@@ -113,6 +138,8 @@ export interface SimulatorBackend {
   rotate(udid: string, orientation: SimulatorOrientation): Promise<void>;
   /** Press one keyboard key (HID usage on page 7) with modifier usages held around it. */
   key(udid: string, usage: number, modifiers: number[]): Promise<void>;
+  /** The frontmost app's accessibility tree (private API; macOS only). */
+  describeUi(udid: string, limits?: SimulatorAxLimits): Promise<SimulatorAxNode>;
   /** Start streaming `udid`'s framebuffer; frames arrive via {@link onFrame} listeners. */
   streamStart(udid: string, options?: SimulatorStreamOptions): Promise<SimulatorStreamStartResult>;
   /** Stop a running framebuffer stream. */

--- a/packages/host/engine/src/simulator/request-handler.ts
+++ b/packages/host/engine/src/simulator/request-handler.ts
@@ -31,6 +31,7 @@ type SimulatorRequest = Extract<
       | 'simulator.button'
       | 'simulator.rotate'
       | 'simulator.key'
+      | 'simulator.describe-ui'
       | 'simulator.stream.start'
       | 'simulator.stream.stop'
       | 'simulator.consent.get'
@@ -141,6 +142,27 @@ export class SimulatorRequestHandler {
             await simulators.openUrl(payload.sessionId, payload.udid, payload.url);
             this.responder.sendSuccess(payload.clientReqId);
           }),
+        );
+      case 'simulator.describe-ui':
+        return this.withSimulators(payload.clientReqId, (simulators) =>
+          simulatorOperation(
+            'simulator.describe-ui',
+            'Failed to read the accessibility tree',
+            async () => {
+              const tree = await simulators.describeUi(payload.sessionId, payload.udid, {
+                maxDepth: payload.maxDepth,
+                maxNodes: payload.maxNodes,
+              });
+              this.transport.send(
+                createWireMessage({
+                  kind: 'simulator.described-ui',
+                  replyTo: payload.clientReqId,
+                  udid: payload.udid,
+                  tree,
+                }),
+              );
+            },
+          ),
         );
       case 'simulator.screenshot':
         return this.withSimulators(payload.clientReqId, (simulators) =>

--- a/packages/host/engine/src/simulator/service.ts
+++ b/packages/host/engine/src/simulator/service.ts
@@ -5,6 +5,8 @@ import { extractErrorMessage } from 'foxts/extract-error-message';
 import { noop } from 'foxts/noop';
 import { RequestError } from '../failure';
 import type {
+  SimulatorAxLimits,
+  SimulatorAxNode,
   SimulatorBackend,
   SimulatorButton,
   SimulatorDeviceInfo,
@@ -235,6 +237,14 @@ export class SimulatorService {
   async key(sessionId: SessionId, udid: string, usage: number, modifiers: number[]): Promise<void> {
     this.claim(sessionId, udid);
     return this.backend.key(udid, usage, modifiers);
+  }
+
+  async describeUi(
+    sessionId: SessionId,
+    udid: string,
+    limits?: SimulatorAxLimits,
+  ): Promise<SimulatorAxNode> {
+    return this.withClaim(sessionId, udid, () => this.backend.describeUi(udid, limits));
   }
 
   /** Start streaming a device's framebuffer for a session, claiming it. */

--- a/packages/host/engine/src/wire/request-router.ts
+++ b/packages/host/engine/src/wire/request-router.ts
@@ -147,6 +147,7 @@ export class WireRequestRouter {
       case 'simulator.swipe':
       case 'simulator.button':
       case 'simulator.rotate':
+      case 'simulator.describe-ui':
       case 'simulator.stream.start':
       case 'simulator.stream.stop': {
         return this.handlers.simulator.handle(p);

--- a/packages/host/sim/src/client.ts
+++ b/packages/host/sim/src/client.ts
@@ -16,6 +16,8 @@ import {
   writeFrame,
 } from './codec';
 import type {
+  SimAxLimits,
+  SimAxNode,
   SimButton,
   SimDevice,
   SimImageFormat,
@@ -26,6 +28,7 @@ import type {
   SimTouchPhase,
 } from './schema';
 import {
+  SimDescribeUiResultSchema,
   SimLaunchResultSchema,
   SimListResultSchema,
   SimProbeSchema,
@@ -203,6 +206,19 @@ export class SimSidecarClient {
   /** Press one keyboard key (HID usage on page 7) with modifier usages held around it. */
   async key(udid: string, usage: number, modifiers: number[]): Promise<void> {
     await this.call('key', { udid, usage, modifiers });
+  }
+
+  /** The frontmost app's accessibility tree (private API; macOS only).
+   *
+   * Served by a short-lived worker process inside the sidecar, so a drifted `AXPTranslator` cannot
+   * take the sidecar down — a failure surfaces as this call rejecting, not as a dead sidecar. */
+  async describeUi(udid: string, limits?: SimAxLimits): Promise<SimAxNode> {
+    const result = await this.call('describeUi', {
+      udid,
+      maxDepth: limits?.maxDepth,
+      maxNodes: limits?.maxNodes,
+    });
+    return SimDescribeUiResultSchema.parse(result).tree;
   }
 
   /**

--- a/packages/host/sim/src/index.ts
+++ b/packages/host/sim/src/index.ts
@@ -1,6 +1,8 @@
 export type { SimFrameListener, SimStreamFrame, SimStreamOptions } from './client';
 export { SimSidecarClient, SimSidecarError } from './client';
 export type {
+  SimAxLimits,
+  SimAxNode,
   SimButton,
   SimDevice,
   SimErrorCode,

--- a/packages/host/sim/src/schema.ts
+++ b/packages/host/sim/src/schema.ts
@@ -35,6 +35,50 @@ export type SimDevice = z.infer<typeof SimDeviceSchema>;
 
 export const SimListResultSchema = z.object({ devices: z.array(SimDeviceSchema) });
 
+/** One node of the guest's accessibility tree.
+ *
+ * `frame` is in device points, faithful to what the guest reports; `center` is the same point
+ * normalized 0..1 against the screen, which is the scale every pointer command takes — so a caller
+ * can act on a node without knowing the device's size. The recursion is typed by hand because zod
+ * cannot infer a self-referential shape. */
+export interface SimAxNode {
+  role: string;
+  subrole?: string;
+  label?: string;
+  value?: string;
+  identifier?: string;
+  title?: string;
+  frame: [number, number, number, number];
+  center?: [number, number];
+  enabled: boolean;
+  focused?: boolean;
+  children?: SimAxNode[];
+}
+
+export const SimAxNodeSchema: z.ZodType<SimAxNode> = z.lazy(() =>
+  z.object({
+    role: z.string(),
+    subrole: z.string().optional(),
+    label: z.string().optional(),
+    value: z.string().optional(),
+    identifier: z.string().optional(),
+    title: z.string().optional(),
+    frame: z.tuple([z.number(), z.number(), z.number(), z.number()]),
+    center: z.tuple([z.number(), z.number()]).optional(),
+    enabled: z.boolean(),
+    focused: z.boolean().optional(),
+    children: z.array(SimAxNodeSchema).optional(),
+  }),
+);
+
+export const SimDescribeUiResultSchema = z.object({ tree: SimAxNodeSchema });
+
+/** Caps on a tree read. Omitted fields fall back to the sidecar's own defaults. */
+export interface SimAxLimits {
+  maxDepth?: number;
+  maxNodes?: number;
+}
+
 export const SimProbeSchema = z.object({
   simctlPath: z.string(),
   developerDir: z.string(),


### PR DESCRIPTION
Stacked on #284 (CODE-451), whose `sim_tap` is what makes this tool actionable.

Agents could only see a simulator by screenshotting it. This adds `describe_ui`: the frontmost app's accessibility tree, with coordinates an agent can act on directly.

## Why it needed a runtime-defined Objective-C class

`AXPTranslator` reaches the guest's accessibility service only through a *bridge-token delegate* — without one installed, every query answers nil. That delegate is a class the framework messages, so this is the first place in the crate that **declares** an Objective-C class (`ClassBuilder`) rather than only messaging existing ones. Its callback hands back a block that routes each `AXPTranslatorRequest` over the device's XPC channel; `SimDevice` exposes only the async form while the translator calls us synchronously, so the router blocks on a dispatch group.

Two blocks with deliberately different rules: the **router is captureless** (the framework stores it and calls it later on its own thread, so the device is read from a process global — the discipline `screen.rs` established), while the XPC completion block carries one pointer, which is sound only because its creator blocks until it has run.

## Crash isolation, not optimism

The tree read runs in a throwaway `ax-worker` process, the same shape as the capture worker and the state watcher. A drifted private ABI then costs one child, never the sidecar.

That was not hypothetical: an intermittent SIGSEGV showed up during verification. The completion block and its response slot were **stack**-allocated, and a global block's `Block_copy` returns the same pointer — so on a late reply the callee wrote through a dead frame and released an already-freed group. Both now live on the heap, and a timeout **deliberately leaks** them rather than freeing memory a still-pending reply will touch. 12 consecutive runs clean afterwards.

## Coordinates

The root `AXApplication` frame is the screen size in points, so normalization needs nothing external. Each node reports `frame` in points (faithful to the guest) plus `center` normalized 0..1 — exactly `sim_tap`'s units, so find-by-label then tap needs no conversion an agent could get wrong.

Depth and node caps are enforced with a budget shared across the whole walk, so a wide tree truncates as decisively as a deep one.

## Verification

Unit: the MCP tool's argument mapping and the find-then-tap round trip on a fixture tree.

Real device, over the wire: `simulator.describe-ui` returned a 4-node tree, `maxNodes: 4` truncated as asked, and tapping the reported centre of the node labelled `Retry` changed the screen. An earlier run against a richer screen found `More sign-in options` and its tap opened the real iOS auth sheet — the screenshot confirmed it hit that exact control.

Wire bumped to 56.