### PR TITLE
feat(schema,daemon,ui): show where an agent is touching the device (CODE-423)

### DIFF
--- a/apps/daemon/src/sim/mcp-endpoint.ts
+++ b/apps/daemon/src/sim/mcp-endpoint.ts
@@ -17,12 +17,16 @@ import { noop } from 'foxts/noop';
 import { z } from 'zod';
 import { logger } from '../logger';
 
-/** `simulator.activity` broadcast hook — the panel's "agent is driving this device" badge. */
+/** `simulator.activity` broadcast hook — the panel's "agent is driving this device" badge, and the
+ * pointer it draws when the tool acted on a specific spot. */
 export type SimulatorActivityNotify = (activity: {
   sessionId: SessionId;
   udid?: string;
   tool: string;
   phase: 'started' | 'settled';
+  /** Normalized 0..1 point the tool acted on; absent for tools without one. */
+  x?: number;
+  y?: number;
 }) => void;
 
 /** Broadcast hooks the daemon wires to the hub. `devicesChanged` mirrors the wire handler's
@@ -191,10 +195,12 @@ export class SimulatorMcpEndpoint implements SimulatorMcpProvider {
       tool: string,
       udid: string | undefined,
       op: () => Promise<string>,
+      /** Where the tool acts, for the panel's pointer; omitted by tools without a single point. */
+      at?: { x: number; y: number },
     ): Promise<{ content: [{ type: 'text'; text: string }]; isError?: true }> => {
       // Announced before the consent gate on purpose: a tool suspended waiting for the user is
       // exactly when the panel should be showing this device.
-      this.notify?.activity?.({ sessionId, udid, tool, phase: 'started' });
+      this.notify?.activity?.({ sessionId, udid, tool, phase: 'started', x: at?.x, y: at?.y });
       try {
         await this.consent.require(sessionId, udid, tool);
         return { content: [{ type: 'text', text: await op() }] };
@@ -204,7 +210,7 @@ export class SimulatorMcpEndpoint implements SimulatorMcpProvider {
           isError: true,
         };
       } finally {
-        this.notify?.activity?.({ sessionId, udid, tool, phase: 'settled' });
+        this.notify?.activity?.({ sessionId, udid, tool, phase: 'settled', x: at?.x, y: at?.y });
       }
     };
 
@@ -340,10 +346,15 @@ export class SimulatorMcpEndpoint implements SimulatorMcpProvider {
         inputSchema: { udid: z.string().min(1), x: COORD, y: COORD },
       },
       ({ udid, x, y }) =>
-        run('sim_tap', udid, async () => {
-          await simulators.tap(sessionId, udid, x, y);
-          return `tapped ${x}, ${y}`;
-        }),
+        run(
+          'sim_tap',
+          udid,
+          async () => {
+            await simulators.tap(sessionId, udid, x, y);
+            return `tapped ${x}, ${y}`;
+          },
+          { x, y },
+        ),
     );
     server.registerTool(
       'sim_swipe',
@@ -360,16 +371,22 @@ export class SimulatorMcpEndpoint implements SimulatorMcpProvider {
         },
       },
       ({ udid, fromX, fromY, toX, toY, durationMs }) =>
-        run('sim_swipe', udid, async () => {
-          await simulators.swipe(
-            sessionId,
-            udid,
-            { x: fromX, y: fromY },
-            { x: toX, y: toY },
-            durationMs,
-          );
-          return `swiped ${fromX}, ${fromY} to ${toX}, ${toY}`;
-        }),
+        run(
+          'sim_swipe',
+          udid,
+          async () => {
+            await simulators.swipe(
+              sessionId,
+              udid,
+              { x: fromX, y: fromY },
+              { x: toX, y: toY },
+              durationMs,
+            );
+            return `swiped ${fromX}, ${fromY} to ${toX}, ${toY}`;
+          },
+          // The origin: where the finger lands is where the pointer should appear.
+          { x: fromX, y: fromY },
+        ),
     );
     server.registerTool(
       'sim_type_text',

--- a/apps/desktop/e2e/simulator-panel.e2e.mts
+++ b/apps/desktop/e2e/simulator-panel.e2e.mts
@@ -58,7 +58,7 @@ function positiveInt(raw: string | undefined): number | undefined {
 
 /** Must match `WIRE_PROTOCOL_VERSION` (node can't load the raw-TS schema barrel); a mismatch is
  * silently discarded by the daemon, surfacing here as the session.start timeout. */
-const WIRE_VERSION = 56;
+const WIRE_VERSION = 57;
 
 function fail(message: string): never {
   console.error(`FAIL: ${message}`);

--- a/packages/client/core/src/client.ts
+++ b/packages/client/core/src/client.ts
@@ -118,6 +118,9 @@ type SimulatorActivityCb = (activity: {
   udid?: string;
   tool: string;
   phase: 'started' | 'settled';
+  /** Normalized 0..1 point the tool acted on; absent for tools without a single point. */
+  x?: number;
+  y?: number;
 }) => void;
 type SimulatorConsentRequiredCb = (request: {
   sessionId: SessionId;
@@ -365,7 +368,14 @@ export class LinkCodeClient {
         break;
       case 'simulator.activity':
         for (const cb of this.simulatorActivitySubs) {
-          cb({ sessionId: p.sessionId, udid: p.udid, tool: p.tool, phase: p.phase });
+          cb({
+            sessionId: p.sessionId,
+            udid: p.udid,
+            tool: p.tool,
+            phase: p.phase,
+            x: p.x,
+            y: p.y,
+          });
         }
         break;
       case 'simulator.consent.state':

--- a/packages/client/workbench/src/simulator/__tests__/agent-activity.test.ts
+++ b/packages/client/workbench/src/simulator/__tests__/agent-activity.test.ts
@@ -23,8 +23,11 @@ function fakeClient(): SimulatorActivityClient & { emit: (activity: Activity) =>
   };
 }
 
-const started = (udid: string | undefined, tool = 'sim_tap'): Activity =>
-  ({ sessionId: 's1', udid, tool, phase: 'started' }) as Activity;
+const started = (
+  udid: string | undefined,
+  tool = 'sim_tap',
+  at?: { x: number; y: number },
+): Activity => ({ sessionId: 's1', udid, tool, phase: 'started', ...at }) as Activity;
 const settled = (udid: string | undefined, tool = 'sim_tap'): Activity =>
   ({ sessionId: 's1', udid, tool, phase: 'settled' }) as Activity;
 
@@ -40,18 +43,18 @@ describe('useSimulatorAgentActivity', () => {
   it('lights while a tool runs and clears after the linger', () => {
     const client = fakeClient();
     const { result } = renderHook(() => useSimulatorAgentActivity(client, 'U-1'));
-    expect(result.current).toBe(false);
+    expect(result.current.active).toBe(false);
 
     client.emit(started('U-1'));
-    expect(result.current).toBe(true);
+    expect(result.current.active).toBe(true);
 
     client.emit(settled('U-1'));
     // Still lit: the linger is what keeps a burst of taps from strobing the badge.
-    expect(result.current).toBe(true);
+    expect(result.current.active).toBe(true);
     act(() => {
       vi.advanceTimersByTime(2000);
     });
-    expect(result.current).toBe(false);
+    expect(result.current.active).toBe(false);
   });
 
   it('stays lit until the last overlapping tool settles', () => {
@@ -65,13 +68,13 @@ describe('useSimulatorAgentActivity', () => {
       vi.advanceTimersByTime(2000);
     });
     // One tool is still running, so the first settle must not clear the badge.
-    expect(result.current).toBe(true);
+    expect(result.current.active).toBe(true);
 
     client.emit(settled('U-1', 'sim_screenshot'));
     act(() => {
       vi.advanceTimersByTime(2000);
     });
-    expect(result.current).toBe(false);
+    expect(result.current.active).toBe(false);
   });
 
   it('ignores activity for other devices and device-less tools', () => {
@@ -80,6 +83,24 @@ describe('useSimulatorAgentActivity', () => {
 
     client.emit(started('U-2'));
     client.emit(started(undefined, 'sim_list_devices'));
-    expect(result.current).toBe(false);
+    expect(result.current.active).toBe(false);
+  });
+
+  it('tracks the point a pointer tool acted on, and expires it', () => {
+    const client = fakeClient();
+    const { result } = renderHook(() => useSimulatorAgentActivity(client, 'U-1'));
+    expect(result.current.point).toBeNull();
+
+    client.emit(started('U-1', 'sim_tap', { x: 0.25, y: 0.75 }));
+    expect(result.current.point).toEqual({ x: 0.25, y: 0.75 });
+
+    // A pointless tool between two taps must not blink the pointer away — only time clears it.
+    client.emit(started('U-1', 'sim_screenshot'));
+    expect(result.current.point).toEqual({ x: 0.25, y: 0.75 });
+
+    act(() => {
+      vi.advanceTimersByTime(3000);
+    });
+    expect(result.current.point).toBeNull();
   });
 });

--- a/packages/client/workbench/src/simulator/agent-activity.ts
+++ b/packages/client/workbench/src/simulator/agent-activity.ts
@@ -9,16 +9,29 @@ export type SimulatorActivityClient = Pick<LinkCodeClient, 'subscribeSimulatorAc
  * short calls, so clearing instantly would strobe the badge between consecutive taps. */
 const LINGER_MS = 1200;
 
+/** How long the pointer stays on the last spot an agent touched. Long enough to be seen between
+ * calls in a burst, short enough that it does not linger over a screen the agent has moved on from. */
+const POINTER_MS = 2000;
+
+/** What the panel knows about an agent driving this device. */
+export interface SimulatorAgentActivity {
+  /** An agent tool is in flight (or just settled) on this device. */
+  active: boolean;
+  /** The last point an agent acted on, normalized 0..1, or `null` when nothing recent. */
+  point: { x: number; y: number } | null;
+}
+
 /**
- * Whether an agent is currently driving `udid`, from the daemon's `simulator.activity` broadcast.
- * That feed originates only in the built-in simulator MCP server, so it is agent activity by
- * construction — the user's own taps in this panel never raise it.
+ * Whether an agent is currently driving `udid` and where it last touched, from the daemon's
+ * `simulator.activity` broadcast. That feed originates only in the built-in simulator MCP server,
+ * so it is agent activity by construction — the user's own taps in this panel never raise it.
  */
 export function useSimulatorAgentActivity(
   client: SimulatorActivityClient,
   udid: string | null,
-): boolean {
+): SimulatorAgentActivity {
   const [active, setActive] = useState(false);
+  const [point, setPoint] = useState<{ x: number; y: number } | null>(null);
 
   useEffect(() => {
     if (udid === null) return;
@@ -27,9 +40,18 @@ export function useSimulatorAgentActivity(
     // cannot leak a permanently-lit badge.
     let inflight = 0;
     let clearTimer: ReturnType<typeof setTimeout> | undefined;
+    let pointTimer: ReturnType<typeof setTimeout> | undefined;
     const unsubscribe = client.subscribeSimulatorActivity((activity) => {
       // Device-less tools (listing devices, probing) are not "driving this device".
       if (activity.udid !== udid) return;
+      // Only the pointer tools carry a point; everything else leaves the last one alone rather
+      // than clearing it, so a screenshot between two taps does not blink the pointer away.
+      if (activity.x !== undefined && activity.y !== undefined) {
+        const at = { x: activity.x, y: activity.y };
+        setPoint(at);
+        clearTimeout(pointTimer);
+        pointTimer = setTimeout(() => setPoint(null), POINTER_MS);
+      }
       if (activity.phase === 'started') {
         inflight += 1;
         clearTimeout(clearTimer);
@@ -45,9 +67,11 @@ export function useSimulatorAgentActivity(
     return () => {
       unsubscribe();
       clearTimeout(clearTimer);
+      clearTimeout(pointTimer);
       setActive(false);
+      setPoint(null);
     };
   }, [client, udid]);
 
-  return active;
+  return { active, point };
 }

--- a/packages/client/workbench/src/simulator/panel.tsx
+++ b/packages/client/workbench/src/simulator/panel.tsx
@@ -301,7 +301,7 @@ export function SimulatorPanel({ sessionId }: { sessionId: SessionId | null }): 
     [client, udid],
   );
   const measuredFps = useReceivedFps(subscribeFrames, showFps && canStream);
-  const agentDriving = useSimulatorAgentActivity(client, udid);
+  const agentActivity = useSimulatorAgentActivity(client, udid);
   const consent = useSimulatorConsent(client);
   const consentRequest = useSimulatorConsentRequest(client);
   const agentAccess = udid === null ? undefined : consent.decisionFor(udid);
@@ -540,7 +540,7 @@ export function SimulatorPanel({ sessionId }: { sessionId: SessionId | null }): 
           // The stage stays near-black in both themes (video-player convention) so the streamed
           // frame carries the contrast; everything on it uses fixed neutrals, not theme tokens.
           <div className="absolute inset-2 overflow-hidden rounded-lg bg-neutral-950">
-            {agentDriving && (
+            {agentActivity.active && (
               // Floats over the stage rather than displacing it, so the picture never shifts as an
               // agent starts and stops working. Input stays live — this informs, it does not lock.
               <div className="-translate-x-1/2 pointer-events-none absolute top-3 left-1/2 z-10 flex items-center gap-2 rounded-full bg-white px-3 py-1.5 font-medium text-neutral-900 text-xs shadow-lg">
@@ -557,6 +557,7 @@ export function SimulatorPanel({ sessionId }: { sessionId: SessionId | null }): 
               onText={handleText}
               maskPng={masks[udid] ?? null}
               onScreenCanvas={setScreenCanvas}
+              agentPointer={agentActivity.point}
               placeholder={
                 <span className="text-neutral-400 text-sm">{t('simulatorConnecting')}</span>
               }

--- a/packages/foundation/schema/src/wire/message.ts
+++ b/packages/foundation/schema/src/wire/message.ts
@@ -25,7 +25,7 @@ import { WirePayloadSchema } from './payload';
 // 53 migrates managed-asset IDs from public strings to discriminated objects.
 // 54 adds the simulator agent-consent variants (CODE-420).
 // 55 adds the simulator volume buttons (CODE-414).
-export const WIRE_PROTOCOL_VERSION = 56 as const;
+export const WIRE_PROTOCOL_VERSION = 57 as const;
 
 /** Complete wire message: version + unique id + timestamp + payload. */
 export const WireMessageSchema = z.object({

--- a/packages/foundation/schema/src/wire/simulator.ts
+++ b/packages/foundation/schema/src/wire/simulator.ts
@@ -51,6 +51,11 @@ export const simulatorWireVariants = [
     udid: z.string().min(1).optional(),
     tool: z.string(),
     phase: z.enum(['started', 'settled']),
+    /** Where on the screen the tool acted, normalized 0..1 — present only for the pointer tools,
+     * so the panel can show *where* an agent is working and not merely that it is. A swipe reports
+     * its origin. Absent for everything that has no single point (boot, screenshot, describe_ui). */
+    x: coord.optional(),
+    y: coord.optional(),
   }),
   // ── Agent consent (CODE-420) ──
   // Device-scoped, not turn-scoped: an agent's first tool call on an unknown device suspends

--- a/packages/presentation/ui/src/shell/simulator/simulator-screen.tsx
+++ b/packages/presentation/ui/src/shell/simulator/simulator-screen.tsx
@@ -66,9 +66,41 @@ export interface SimulatorScreenProps {
    * surface a recorder captures. Pass a **stable** callback (a `useState` setter or `useCallback`):
    * a fresh identity each render would detach and re-attach the ref. */
   onScreenCanvas?: (canvas: HTMLCanvasElement | null) => void;
+  /** Where an agent last acted, in the same normalized [0,1] space {@link onTouch} reports — drawn
+   * as a pointer so a co-driving user can see *where* the agent is working. `null` draws nothing. */
+  agentPointer?: SimulatorScreenPoint | null;
   /** Shown centered until the first frame arrives. */
   placeholder?: React.ReactNode;
   className?: string;
+}
+
+/** The agent's touch point: a large arrow that reads as deliberately not the user's own cursor —
+ * white fill with a brand-orange edge, matching the "agent is driving" badge's dot, over a pulse
+ * that draws the eye to a spot that may be off-screen-of-attention. */
+function AgentPointer({ point }: { point: SimulatorScreenPoint }): React.ReactNode {
+  return (
+    <div
+      className="pointer-events-none absolute"
+      style={{ left: `${point.x * 100}%`, top: `${point.y * 100}%` }}
+    >
+      <span className="-translate-x-1/2 -translate-y-1/2 absolute block size-10 animate-ping rounded-full bg-orange-500/30" />
+      {/* The tip sits exactly on the point; the body hangs down-right the way a cursor does. */}
+      <svg
+        viewBox="0 0 24 24"
+        className="absolute size-7 drop-shadow-lg"
+        aria-hidden="true"
+        focusable="false"
+      >
+        <path
+          d="M3 2 L3 20 L8 15.5 L11 22 L14.5 20.5 L11.5 14 L18 13.5 Z"
+          fill="#FFFFFF"
+          stroke="#F97316"
+          strokeWidth="1.75"
+          strokeLinejoin="round"
+        />
+      </svg>
+    </div>
+  );
 }
 
 /**
@@ -87,6 +119,7 @@ export function SimulatorScreen({
   onText,
   maskPng,
   onScreenCanvas,
+  agentPointer = null,
   placeholder,
   className,
 }: SimulatorScreenProps): React.ReactNode {
@@ -360,6 +393,21 @@ export function SimulatorScreen({
           onPointerCancel={handlePointerCancel}
           onWheel={handleWheel}
         />
+        {agentPointer !== null && layout !== null && (
+          // Shares the screen canvas's inset box, so the same normalized coordinates the input
+          // path produces land on the same pixels here — no second mapping to keep in sync.
+          <div
+            className="pointer-events-none absolute"
+            style={{
+              left: `${layout.inset.left * 100}%`,
+              top: `${layout.inset.top * 100}%`,
+              width: `${layout.inset.width * 100}%`,
+              height: `${layout.inset.height * 100}%`,
+            }}
+          >
+            <AgentPointer point={agentPointer} />
+          </div>
+        )}
       </div>
       {/* Off-screen editable that owns keyboard focus: ASCII keydowns become HID key presses,
           IME/non-ASCII commits become pasteboard text. A tap on the canvas focuses it. App-level


### PR DESCRIPTION
Stacked on #295 (CODE-398). The badge from CODE-417 says an agent is driving; this says *where*.

## One channel, not a second one

`simulator.activity` already carries every agent tool call, so it gains two optional fields (`x`, `y`, normalized 0..1) rather than a parallel variant. Only the pointer tools populate them — `sim_tap` reports its point, `sim_swipe` its origin, and everything without a single point (boot, screenshot, `describe_ui`) leaves them absent.

**The throttling the issue asked for turned out to be unnecessary.** It was written assuming agents stream touch phases, so a drag's `move` flood would need ~10-15 Hz sampling. What CODE-451 actually gave agents is discrete calls: one `sim_tap`, one `sim_swipe`. One event per action, nothing to throttle.

A tool with no point deliberately does **not** clear the pointer — otherwise a screenshot between two taps would blink it away. Only time clears it (2s).

## Coordinates map by construction

The overlay shares the screen canvas's exact inset expression and places the pointer at `x*100%` / `y*100%` inside it. That is the same normalized space the input path produces, so there is no second mapping that can drift out of sync with the first — including after a rotation, which changes the framebuffer's aspect and therefore the inset both layers read.

The pointer is a white arrow with a brand-orange edge over a pulse, matching the badge's dot — deliberately unlike the user's own cursor, so co-driving never leaves you wondering which pointer is yours.

## Verification, and its limit

Unit: the activity hook's new point tracking — set on a pointer tool, **left alone** by a pointless tool in between, expired by time.

**Not verified: the pointer rendered on screen by a real agent.** Seeing it end-to-end needs an actual `sim_tap` through the MCP endpoint, whose token is minted per session and handed only to the agent — unreachable from a test harness, and driving a real agent to choose the tool is nondeterministic. The placement rests on sharing one expression with the canvas rather than on an observed screenshot. Worth a human look when someone next has an agent driving a device.