### PR TITLE
feat(sim,engine,workbench): guide setup instead of reporting simulators unavailable (CODE-422)

### DIFF
--- a/apps/daemon/src/__tests__/sim-mcp-endpoint.test.ts
+++ b/apps/daemon/src/__tests__/sim-mcp-endpoint.test.ts
@@ -46,6 +46,7 @@ function fakeBackend() {
     swipe: vi.fn(asyncNoop),
     button: vi.fn(asyncNoop),
     rotate: vi.fn(asyncNoop),
+    installRuntime: vi.fn(asyncNoop),
     describeUi: vi.fn(() =>
       Promise.resolve({
         role: 'AXApplication',

--- a/apps/desktop/e2e/simulator-panel.e2e.mts
+++ b/apps/desktop/e2e/simulator-panel.e2e.mts
@@ -58,7 +58,7 @@ function positiveInt(raw: string | undefined): number | undefined {
 
 /** Must match `WIRE_PROTOCOL_VERSION` (node can't load the raw-TS schema barrel); a mismatch is
  * silently discarded by the daemon, surfacing here as the session.start timeout. */
-const WIRE_VERSION = 57;
+const WIRE_VERSION = 58;
 
 function fail(message: string): never {
   console.error(`FAIL: ${message}`);

--- a/crates/linkcode-sim/src/main.rs
+++ b/crates/linkcode-sim/src/main.rs
@@ -262,6 +262,7 @@ fn serve(request: Request, tx: &Sender<OutMsg>) {
     let outcome = match request.op {
         Op::Probe => probe_with_capabilities(),
         Op::List => simctl::list(),
+        Op::InstallRuntime => simctl::install_runtime(),
         // Both ends of a boot session invalidate the warmed HID client bound to the old one.
         Op::Boot { udid } => {
             interactive::forget(&udid);

--- a/crates/linkcode-sim/src/rpc.rs
+++ b/crates/linkcode-sim/src/rpc.rs
@@ -119,6 +119,8 @@ pub enum Op {
     },
     /// Stop a running framebuffer stream.
     StreamStop { udid: String },
+    /// Start the iOS runtime download and return immediately (see `simctl::install_runtime`).
+    InstallRuntime,
     /// Read the guest's accessibility tree (private API; P2). Served by a short-lived worker
     /// process, so a drifted `AXPTranslator` ABI cannot take the sidecar down with it.
     DescribeUi {

--- a/crates/linkcode-sim/src/simctl.rs
+++ b/crates/linkcode-sim/src/simctl.rs
@@ -28,6 +28,7 @@ const DEFAULT_TIMEOUT: Duration = Duration::from_secs(60);
 /// environment it was launched from. `/usr/bin/xcrun` ships with macOS itself, not Xcode.
 const XCRUN: &str = "/usr/bin/xcrun";
 const XCODE_SELECT: &str = "/usr/bin/xcode-select";
+const XCODEBUILD: &str = "/usr/bin/xcodebuild";
 
 /// One available simulator device, flattened from `simctl list -j`.
 #[derive(Serialize)]
@@ -64,7 +65,67 @@ pub fn probe() -> Result<Value, OpError> {
         // inject touches. Report it so clients gate the live panel instead of mounting a stream that
         // only ever fails. The private layer resolves exactly when interactive drive is possible.
         "interactive": interactive_supported(),
+        // What is still missing, so a client can guide the user step by step instead of saying
+        // "unavailable". `null` once devices exist.
+        "blocker": setup_blocker(),
     }))
+}
+
+/// The next thing standing between this host and a usable simulator, or `None` when nothing is.
+///
+/// Only reachable once `xcrun --find simctl` has succeeded, so "no Xcode" is already ruled out by
+/// the caller — the remaining gap is a missing runtime, or a runtime with no device created
+/// against it. Both are recoverable by the user without reinstalling anything.
+fn setup_blocker() -> Option<&'static str> {
+    let runtimes = run_ok(simctl(["list", "-j", "runtimes"]), DEFAULT_TIMEOUT).ok();
+    let devices = run_ok(
+        simctl(["list", "-j", "devices", "available"]),
+        DEFAULT_TIMEOUT,
+    )
+    .ok();
+    classify_setup(runtimes.as_deref(), devices.as_deref())
+}
+
+/// Pure classification over the two `simctl list` payloads, so the branches this host cannot reach
+/// (no runtime, no devices) are still covered by tests.
+fn classify_setup(runtimes_json: Option<&str>, devices_json: Option<&str>) -> Option<&'static str> {
+    if !has_ios_runtime(runtimes_json) {
+        return Some("runtime");
+    }
+    if !has_any_device(devices_json) {
+        return Some("devices");
+    }
+    None
+}
+
+/// Whether any *usable* iOS runtime is installed. A bare Xcode ships without one, and an
+/// interrupted download leaves an entry whose `isAvailable` is false — listed, but unable to boot.
+fn has_ios_runtime(raw: Option<&str>) -> bool {
+    let Some(parsed) = raw.and_then(|raw| serde_json::from_str::<Value>(raw).ok()) else {
+        return false;
+    };
+    parsed["runtimes"].as_array().is_some_and(|runtimes| {
+        runtimes.iter().any(|runtime| {
+            runtime["identifier"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("SimRuntime.iOS")
+                && runtime["isAvailable"].as_bool().unwrap_or(false)
+        })
+    })
+}
+
+/// Whether at least one device exists to boot. A runtime install creates the standard set, but a
+/// user who deleted them all lands here with a runtime and nothing to run on it.
+fn has_any_device(raw: Option<&str>) -> bool {
+    let Some(parsed) = raw.and_then(|raw| serde_json::from_str::<Value>(raw).ok()) else {
+        return false;
+    };
+    parsed["devices"].as_object().is_some_and(|by_runtime| {
+        by_runtime
+            .values()
+            .any(|list| list.as_array().is_some_and(|entries| !entries.is_empty()))
+    })
 }
 
 /// Whether this host can drive simulators interactively (framebuffer stream + HID), which requires
@@ -77,6 +138,26 @@ fn interactive_supported() -> bool {
 #[cfg(not(target_os = "macos"))]
 fn interactive_supported() -> bool {
     false
+}
+
+/// Start `xcodebuild -downloadPlatform iOS` and return as soon as it is running.
+///
+/// Deliberately fire-and-forget: the download is tens of minutes and many gigabytes, so holding a
+/// request open for it would blow every deadline in the stack and give the caller nothing to show
+/// meanwhile. Callers observe progress by re-probing until the runtime appears — the same signal
+/// that tells them the user finished the step by hand in Xcode instead.
+pub fn install_runtime() -> Result<Value, OpError> {
+    let mut command = apple_tool(XCODEBUILD);
+    command.args(["-downloadPlatform", "iOS"]);
+    // Detached from this request: nothing reads its output, and the child must outlive the reply.
+    command
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    let child = command
+        .spawn()
+        .map_err(|err| OpError::new(ErrorCode::XcodeMissing, format!("xcodebuild: {err}")))?;
+    Ok(json!({ "started": true, "pid": child.id() }))
 }
 
 /// List available devices with their runtime names.
@@ -411,6 +492,50 @@ fn parse_device_list(devices_json: &str, runtimes_json: &str) -> Result<Vec<Devi
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    const RUNTIMES_OK: &str = r#"{"runtimes":[{"identifier":"com.apple.CoreSimulator.SimRuntime.iOS-26-5","isAvailable":true}]}"#;
+    const DEVICES_OK: &str =
+        r#"{"devices":{"com.apple.CoreSimulator.SimRuntime.iOS-26-5":[{"udid":"U-1"}]}}"#;
+
+    #[test]
+    fn a_provisioned_host_has_no_blocker() {
+        assert_eq!(classify_setup(Some(RUNTIMES_OK), Some(DEVICES_OK)), None);
+    }
+
+    #[test]
+    fn a_bare_xcode_reports_the_missing_runtime() {
+        let empty = r#"{"runtimes":[]}"#;
+        assert_eq!(
+            classify_setup(Some(empty), Some(DEVICES_OK)),
+            Some("runtime")
+        );
+    }
+
+    #[test]
+    fn an_interrupted_runtime_download_still_reports_runtime() {
+        // Listed but unusable: `isAvailable` false means it cannot boot anything, so treating it as
+        // installed would strand the user on a checklist that says everything is done.
+        let broken = r#"{"runtimes":[{"identifier":"com.apple.CoreSimulator.SimRuntime.iOS-26-5","isAvailable":false}]}"#;
+        assert_eq!(
+            classify_setup(Some(broken), Some(DEVICES_OK)),
+            Some("runtime")
+        );
+    }
+
+    #[test]
+    fn a_runtime_without_devices_reports_devices() {
+        let none = r#"{"devices":{"com.apple.CoreSimulator.SimRuntime.iOS-26-5":[]}}"#;
+        assert_eq!(
+            classify_setup(Some(RUNTIMES_OK), Some(none)),
+            Some("devices")
+        );
+    }
+
+    #[test]
+    fn unreadable_output_is_treated_as_missing_rather_than_ready() {
+        assert_eq!(classify_setup(None, None), Some("runtime"));
+        assert_eq!(classify_setup(Some("not json"), None), Some("runtime"));
+    }
 
     const DEVICES: &str = r#"{
         "devices": {

--- a/packages/client/core/src/client.ts
+++ b/packages/client/core/src/client.ts
@@ -38,6 +38,7 @@ import type {
   SessionInfo,
   SessionNotification,
   SessionRecord,
+  SimulatorAxNode,
   SimulatorButton,
   SimulatorConsentDecision,
   SimulatorConsentState,
@@ -727,6 +728,20 @@ export class LinkCodeClient {
 
   simulatorOpenUrl(sessionId: SessionId, udid: string, url: string): Promise<RequestAck> {
     return this.control.simulatorOpenUrl(sessionId, udid, url);
+  }
+
+  /** Start the iOS runtime download; resolves once it is running, not once it finishes. */
+  simulatorInstallRuntime(): Promise<RequestAck> {
+    return this.control.simulatorInstallRuntime();
+  }
+
+  /** The frontmost app's accessibility tree; node centres are in {@link simulatorTap}'s units. */
+  simulatorDescribeUi(
+    sessionId: SessionId,
+    udid: string,
+    limits?: { maxDepth?: number; maxNodes?: number },
+  ): Promise<SimulatorAxNode> {
+    return this.control.simulatorDescribeUi(sessionId, udid, limits);
   }
 
   simulatorScreenshot(

--- a/packages/client/core/src/client/control-channel.ts
+++ b/packages/client/core/src/client/control-channel.ts
@@ -665,6 +665,15 @@ export class ControlChannel {
     }));
   }
 
+  /** Start the iOS runtime download. Resolves once it is running, not once it finishes — poll
+   * {@link simulatorStatus} until the blocker clears to follow progress. */
+  simulatorInstallRuntime(): Promise<RequestAck> {
+    return this.sendCorrelated('ack', (clientReqId) => ({
+      kind: 'simulator.install-runtime',
+      clientReqId,
+    }));
+  }
+
   /** Resolves with the frontmost app's accessibility tree. Node centres are normalized 0..1, the
    * same scale {@link simulatorTap} takes, so a caller can act on a node it found by label. */
   simulatorDescribeUi(

--- a/packages/client/workbench/src/simulator/panel.tsx
+++ b/packages/client/workbench/src/simulator/panel.tsx
@@ -39,6 +39,7 @@ import { base64Blob, captureFileStem, downloadBlob, useSimulatorRecorder } from 
 import { useSimulatorConsent, useSimulatorConsentRequest } from './consent';
 import { SimulatorDeviceTabs } from './device-tabs';
 import { selectDeviceTabs, simulatorSessionKey, useSimulatorPanelStore } from './panel-store';
+import { SimulatorSetupChecklist } from './setup-checklist';
 import { useSimulatorShortcuts } from './shortcuts';
 import type { SimulatorStreamLease } from './stream-registry';
 import {
@@ -54,6 +55,10 @@ import {
 } from './stream-settings-store';
 
 const BUSY_BANNER_MS = 3000;
+
+/** How often to re-probe while the host is still missing a provisioning step. Slow on purpose: the
+ * thing being waited on is a multi-gigabyte download or a human in Xcode, not a fast operation. */
+const SETUP_REPROBE_MS = 5000;
 
 /** Stable empty list, so the no-device case never re-keys the background-stream effect. */
 const EMPTY_UDIDS: readonly string[] = [];
@@ -163,6 +168,8 @@ export function SimulatorPanel({ sessionId }: { sessionId: SessionId | null }): 
   const t = useTranslations('workbench.panel');
   const client = useLinkCodeClient();
   const [status, setStatus] = useState<SimulatorStatus | null>(null);
+  /** True between clicking "download the runtime" and the runtime appearing in a later probe. */
+  const [installingRuntime, setInstallingRuntime] = useState(false);
   const [devices, setDevices] = useState<SimulatorDevice[] | null>(null);
   // Open devices live in the store, not here: agent activity can open one before this component
   // ever mounts (CODE-418), and the cap is per thread, so the strip counts the way the host does.
@@ -193,14 +200,21 @@ export function SimulatorPanel({ sessionId }: { sessionId: SessionId | null }): 
 
   useEffect(
     (signal) => {
-      void client
-        .simulatorStatus()
-        .then((value) => {
-          if (!signal.aborted) setStatus(value);
-        })
-        .catch(() => {
-          if (!signal.aborted) setStatus({ available: false });
-        });
+      const probe = (): void => {
+        void client
+          .simulatorStatus()
+          .then((value) => {
+            if (!signal.aborted) setStatus(value);
+          })
+          .catch(() => {
+            if (!signal.aborted) setStatus({ available: false });
+          });
+      };
+      probe();
+      // While the host is still being provisioned, keep asking: a step finished in Xcode (or by the
+      // download this panel started) should tick itself off without the user restarting anything.
+      // The engine only caches a fully-ready probe, so this really does re-read the host.
+      const reprobe = setInterval(probe, SETUP_REPROBE_MS);
       void client
         .simulatorList()
         .then((value) => {
@@ -211,6 +225,7 @@ export function SimulatorPanel({ sessionId }: { sessionId: SessionId | null }): 
         });
       const unsubscribe = client.subscribeSimulatorDevicesChanged(setDevices);
       return () => {
+        clearInterval(reprobe);
         unsubscribe();
         clearTimeout(busyTimerRef.current);
       };
@@ -408,8 +423,23 @@ export function SimulatorPanel({ sessionId }: { sessionId: SessionId | null }): 
     onRotate: handleRotate,
   });
 
-  if (status !== null && !status.available) {
-    return <CenteredHint>{t('simulatorUnavailable')}</CenteredHint>;
+  // A host that cannot run a device yet gets the step-by-step checklist rather than a dead end —
+  // `blocker` says which of the three things is missing, and the re-probe above ticks them off.
+  if (status !== null && (!status.available || status.blocker !== undefined)) {
+    return (
+      <SimulatorSetupChecklist
+        status={status}
+        installing={installingRuntime}
+        onInstallRuntime={
+          status.blocker === 'runtime'
+            ? () => {
+                setInstallingRuntime(true);
+                void client.simulatorInstallRuntime().catch(() => setInstallingRuntime(false));
+              }
+            : undefined
+        }
+      />
+    );
   }
 
   const toggleRecording = (): void => {

--- a/packages/client/workbench/src/simulator/setup-checklist.tsx
+++ b/packages/client/workbench/src/simulator/setup-checklist.tsx
@@ -1,0 +1,85 @@
+import type { SimulatorStatus } from '@linkcode/schema';
+import { cn } from '@linkcode/ui';
+import { Button } from 'coss-ui/components/button';
+import { CheckIcon, CircleDashedIcon } from 'lucide-react';
+import { useTranslations } from 'use-intl';
+
+/** The provisioning steps, in the order they must happen. */
+const STEPS = ['xcode', 'runtime', 'devices'] as const;
+
+/**
+ * What a host still needs before it can run a simulator, as a checklist that ticks itself off.
+ *
+ * The panel re-probes on a timer while this is showing, so a step finished in Xcode (or by the
+ * download button) marks itself done without a restart — the alternative, a single "unavailable"
+ * line, leaves a user with no idea which of three different things is missing.
+ */
+export function SimulatorSetupChecklist({
+  status,
+  onInstallRuntime,
+  installing,
+}: {
+  status: SimulatorStatus;
+  /** Starts the iOS runtime download; absent while one is already running. */
+  onInstallRuntime?: () => void;
+  installing: boolean;
+}): React.ReactNode {
+  const t = useTranslations('workbench.panel');
+  // Everything before the blocker is finished by definition: the host could not have reported
+  // "no runtime" without Xcode being present to answer.
+  const blocking = status.blocker ?? null;
+  const blockedAt = blocking === null ? STEPS.length : STEPS.indexOf(blocking);
+
+  return (
+    <div className="flex h-full flex-col items-center justify-center gap-4 p-6 text-sm">
+      <p className="text-center font-medium">{t('simulatorSetupTitle')}</p>
+      <ol className="flex w-full max-w-xs flex-col gap-2.5">
+        {STEPS.map((step, index) => {
+          const done = index < blockedAt;
+          const current = index === blockedAt;
+          return (
+            <li
+              key={step}
+              className={cn(
+                'flex items-start gap-2.5',
+                !done && !current && 'text-muted-foreground/60',
+              )}
+            >
+              <StepIcon done={done} />
+              <div className="flex flex-col gap-1">
+                <span className={cn(done && 'text-muted-foreground line-through')}>
+                  {t(`simulatorSetupStep.${step}`)}
+                </span>
+                {current && step === 'runtime' && onInstallRuntime !== undefined && (
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    disabled={installing}
+                    onClick={onInstallRuntime}
+                  >
+                    {installing ? t('simulatorSetupDownloading') : t('simulatorSetupDownload')}
+                  </Button>
+                )}
+              </div>
+            </li>
+          );
+        })}
+      </ol>
+      {/* The download is tens of minutes and many gigabytes, so say so before it is started
+          rather than leaving a button that looks instant. */}
+      {blocking === 'runtime' && (
+        <p className="max-w-xs text-center text-muted-foreground text-xs">
+          {t('simulatorSetupDownloadHint')}
+        </p>
+      )}
+      {status.reason !== undefined && blocking === 'xcode' && (
+        <p className="max-w-xs text-center text-muted-foreground text-xs">{status.reason}</p>
+      )}
+    </div>
+  );
+}
+
+function StepIcon({ done }: { done: boolean }): React.ReactNode {
+  if (done) return <CheckIcon className="mt-0.5 size-4 shrink-0 text-emerald-500" />;
+  return <CircleDashedIcon className="mt-0.5 size-4 shrink-0" />;
+}

--- a/packages/foundation/schema/src/model/simulator.ts
+++ b/packages/foundation/schema/src/model/simulator.ts
@@ -30,6 +30,13 @@ export const SimulatorStatusSchema = z.object({
   interactive: z.boolean().optional(),
   /** Why unavailable (e.g. Xcode missing); present when not available. */
   reason: z.string().optional(),
+  /** The next thing the user must do before a device can run, so a client can guide them step by
+   * step instead of reporting a dead end. Absent once a device exists.
+   *
+   * `xcode` — no Xcode or its command-line tools; `runtime` — Xcode, but no usable iOS runtime (a
+   * bare install ships without one, and an interrupted download leaves an unusable entry);
+   * `devices` — a runtime, but every device was deleted. */
+  blocker: z.enum(['xcode', 'runtime', 'devices']).optional(),
 });
 export type SimulatorStatus = z.infer<typeof SimulatorStatusSchema>;
 

--- a/packages/foundation/schema/src/wire/message.ts
+++ b/packages/foundation/schema/src/wire/message.ts
@@ -25,7 +25,7 @@ import { WirePayloadSchema } from './payload';
 // 53 migrates managed-asset IDs from public strings to discriminated objects.
 // 54 adds the simulator agent-consent variants (CODE-420).
 // 55 adds the simulator volume buttons (CODE-414).
-export const WIRE_PROTOCOL_VERSION = 57 as const;
+export const WIRE_PROTOCOL_VERSION = 58 as const;
 
 /** Complete wire message: version + unique id + timestamp + payload. */
 export const WireMessageSchema = z.object({

--- a/packages/foundation/schema/src/wire/simulator.ts
+++ b/packages/foundation/schema/src/wire/simulator.ts
@@ -33,6 +33,13 @@ export const simulatorWireVariants = [
     replyTo: WireRequestIdSchema,
     status: SimulatorStatusSchema,
   }),
+  /** Start the iOS runtime download (`xcodebuild -downloadPlatform iOS`). Fire-and-forget: it runs
+   * for tens of minutes and many gigabytes, so the reply only says it started — progress is
+   * observed by re-probing `simulator.status` until the runtime appears. */
+  z.object({
+    kind: z.literal('simulator.install-runtime'),
+    clientReqId: WireRequestIdSchema,
+  }),
   z.object({ kind: z.literal('simulator.list'), clientReqId: WireRequestIdSchema }),
   z.object({
     kind: z.literal('simulator.listed'),

--- a/packages/host/engine/src/__tests__/simulator-request-handler.test.ts
+++ b/packages/host/engine/src/__tests__/simulator-request-handler.test.ts
@@ -43,6 +43,7 @@ function fakeBackend() {
     swipe: vi.fn(asyncNoop),
     button: vi.fn(asyncNoop),
     rotate: vi.fn(asyncNoop),
+    installRuntime: vi.fn(asyncNoop),
     describeUi: vi.fn(() =>
       Promise.resolve({
         role: 'AXApplication',

--- a/packages/host/engine/src/__tests__/simulator-service.test.ts
+++ b/packages/host/engine/src/__tests__/simulator-service.test.ts
@@ -40,6 +40,7 @@ function fakeBackend(devices: SimulatorDeviceInfo[]) {
     swipe: vi.fn(asyncNoop),
     button: vi.fn(asyncNoop),
     rotate: vi.fn(asyncNoop),
+    installRuntime: vi.fn(asyncNoop),
     describeUi: vi.fn(() =>
       Promise.resolve({
         role: 'AXApplication',

--- a/packages/host/engine/src/simulator/backend.ts
+++ b/packages/host/engine/src/simulator/backend.ts
@@ -26,6 +26,8 @@ export interface SimulatorProbe {
   /** Whether the host can stream a framebuffer and inject HID input (private SimulatorKit layer),
    * not just run public simctl commands. */
   interactive: boolean;
+  /** What still stands between this host and a runnable device; absent once one exists. */
+  blocker?: 'runtime' | 'devices' | null;
 }
 
 export type SimulatorImageFormat = 'jpeg' | 'png';
@@ -140,6 +142,8 @@ export interface SimulatorBackend {
   key(udid: string, usage: number, modifiers: number[]): Promise<void>;
   /** The frontmost app's accessibility tree (private API; macOS only). */
   describeUi(udid: string, limits?: SimulatorAxLimits): Promise<SimulatorAxNode>;
+  /** Start the iOS runtime download; resolves once it is running, not once it completes. */
+  installRuntime(): Promise<void>;
   /** Start streaming `udid`'s framebuffer; frames arrive via {@link onFrame} listeners. */
   streamStart(udid: string, options?: SimulatorStreamOptions): Promise<SimulatorStreamStartResult>;
   /** Stop a running framebuffer stream. */

--- a/packages/host/engine/src/simulator/request-handler.ts
+++ b/packages/host/engine/src/simulator/request-handler.ts
@@ -32,6 +32,7 @@ type SimulatorRequest = Extract<
       | 'simulator.rotate'
       | 'simulator.key'
       | 'simulator.describe-ui'
+      | 'simulator.install-runtime'
       | 'simulator.stream.start'
       | 'simulator.stream.stop'
       | 'simulator.consent.get'
@@ -142,6 +143,17 @@ export class SimulatorRequestHandler {
             await simulators.openUrl(payload.sessionId, payload.udid, payload.url);
             this.responder.sendSuccess(payload.clientReqId);
           }),
+        );
+      case 'simulator.install-runtime':
+        return this.withSimulators(payload.clientReqId, (simulators) =>
+          simulatorOperation(
+            'simulator.install-runtime',
+            'Failed to start the iOS runtime download',
+            async () => {
+              await simulators.installRuntime();
+              this.responder.sendSuccess(payload.clientReqId);
+            },
+          ),
         );
       case 'simulator.describe-ui':
         return this.withSimulators(payload.clientReqId, (simulators) =>

--- a/packages/host/engine/src/simulator/service.ts
+++ b/packages/host/engine/src/simulator/service.ts
@@ -28,6 +28,8 @@ export interface SimulatorHostStatus {
    * only when available. Clients gate the live panel on it. */
   interactive?: boolean;
   reason?: string;
+  /** The next step the user must take before a device can run; absent once one exists. */
+  blocker?: 'xcode' | 'runtime' | 'devices';
 }
 
 /** At most four simulator panes per session; the panel reads the same constant for its tab cap. */
@@ -92,12 +94,32 @@ export class SimulatorService {
   async status(): Promise<SimulatorHostStatus> {
     if (this.probedStatus) return this.probedStatus;
     try {
-      const probe = await this.backend.probe();
-      this.probedStatus = { available: true, ...probe };
-      return this.probedStatus;
+      // `blocker` is nullable off the sidecar (JSON `null` = nothing missing) but optional on the
+      // wire, so it is normalized here rather than teaching every consumer both spellings.
+      const { blocker, ...probe } = await this.backend.probe();
+      const status: SimulatorHostStatus = {
+        available: true,
+        ...probe,
+        ...(blocker && { blocker }),
+      };
+      // Only a fully-provisioned host is cached. A probe can succeed while the setup is still
+      // incomplete (Xcode without an iOS runtime), and caching that would freeze the client's
+      // checklist on a step the user is in the middle of finishing.
+      if (!blocker) this.probedStatus = status;
+      return status;
     } catch (error) {
-      return { available: false, reason: extractErrorMessage(error) ?? 'probe failed' };
+      return {
+        available: false,
+        reason: extractErrorMessage(error) ?? 'probe failed',
+        blocker: 'xcode',
+      };
     }
+  }
+
+  /** Start the iOS runtime download. Resolves once it is running: the download is tens of minutes
+   * and many gigabytes, so callers watch {@link status} for the runtime to appear instead. */
+  installRuntime(): Promise<void> {
+    return this.backend.installRuntime();
   }
 
   /** Read-only; claims are not required to look. */

--- a/packages/host/engine/src/wire/request-router.ts
+++ b/packages/host/engine/src/wire/request-router.ts
@@ -148,6 +148,7 @@ export class WireRequestRouter {
       case 'simulator.button':
       case 'simulator.rotate':
       case 'simulator.describe-ui':
+      case 'simulator.install-runtime':
       case 'simulator.stream.start':
       case 'simulator.stream.stop': {
         return this.handlers.simulator.handle(p);

--- a/packages/host/sim/src/client.ts
+++ b/packages/host/sim/src/client.ts
@@ -109,6 +109,11 @@ export class SimSidecarClient {
     return SimProbeSchema.parse(await this.call('probe', {}));
   }
 
+  /** Start the iOS runtime download; resolves as soon as it is running, not when it finishes. */
+  async installRuntime(): Promise<void> {
+    await this.call('installRuntime', {});
+  }
+
   async list(): Promise<SimDevice[]> {
     return SimListResultSchema.parse(await this.call('list', {})).devices;
   }

--- a/packages/host/sim/src/schema.ts
+++ b/packages/host/sim/src/schema.ts
@@ -85,6 +85,8 @@ export const SimProbeSchema = z.object({
   /** Whether the private SimulatorKit layer (framebuffer stream + HID) is reachable; simctl alone
    * is not enough to co-drive a device. Defaulted so an older sidecar reads as non-interactive. */
   interactive: z.boolean().default(false),
+  /** What still stands between this host and a runnable device; absent once one exists. */
+  blocker: z.enum(['runtime', 'devices']).nullish(),
 });
 export type SimProbe = z.infer<typeof SimProbeSchema>;
 

--- a/packages/presentation/i18n/src/locales/en.ts
+++ b/packages/presentation/i18n/src/locales/en.ts
@@ -376,6 +376,16 @@ export const en = {
       simulatorSelectDevice: 'Select a device',
       simulatorNoDevices: 'No simulator devices found',
       simulatorUnavailable: 'iOS Simulator is not available on this host',
+      simulatorSetupTitle: 'A few steps left before simulators work',
+      simulatorSetupStep: {
+        xcode: 'Install Xcode and its command-line tools',
+        runtime: 'Install an iOS runtime',
+        devices: 'Create a simulator device',
+      },
+      simulatorSetupDownload: 'Download the iOS runtime',
+      simulatorSetupDownloading: 'Downloading…',
+      simulatorSetupDownloadHint:
+        'Several gigabytes and usually tens of minutes. Leave this panel open — the steps tick themselves off.',
       simulatorNonInteractive:
         "This host can list simulators but can't stream their screen (SimulatorKit unavailable)",
       simulatorNoSession: 'Select a thread to drive the simulator',

--- a/packages/presentation/i18n/src/locales/zh-cn.ts
+++ b/packages/presentation/i18n/src/locales/zh-cn.ts
@@ -366,6 +366,16 @@ export const zhCN = {
       simulatorSelectDevice: '选择设备',
       simulatorNoDevices: '未发现模拟器设备',
       simulatorUnavailable: '此主机不支持 iOS 模拟器',
+      simulatorSetupTitle: '还差几步就能用模拟器',
+      simulatorSetupStep: {
+        xcode: '安装 Xcode 及其命令行工具',
+        runtime: '安装 iOS 运行时',
+        devices: '创建一台模拟器设备',
+      },
+      simulatorSetupDownload: '下载 iOS 运行时',
+      simulatorSetupDownloading: '正在下载…',
+      simulatorSetupDownloadHint:
+        '下载体积数 GB、通常要几十分钟；可以留着这个面板，装好会自动打勾。',
       simulatorNonInteractive: '此主机能列出模拟器，但缺少 SimulatorKit，无法实时串流画面',
       simulatorNoSession: '选择一个线程后即可操控模拟器',
       simulatorBoot: '启动',


### PR DESCRIPTION
Stacked on #297 (CODE-423). A host that cannot run a simulator used to get one line — "not supported on this host" — with no indication which of three different things was missing.

## What the probe can now tell apart

`blocker` is `xcode` (no Xcode or its command-line tools), `runtime` (Xcode, but no usable iOS runtime), `devices` (a runtime, but every device was deleted), or absent once one exists.

Two details the classification gets right that a naive check would not: a runtime whose download was interrupted is **listed but unusable** (`isAvailable: false`), so treating it as installed would strand the user on a checklist claiming they were done; and unreadable `simctl` output is treated as *missing*, never as ready.

## The cache had to change, or the checklist could never tick

`status()` cached any successful probe. But a probe **succeeds** on a bare Xcode with no runtime — `simctl` exists, it just has nothing to run — so the old cache would have frozen `blocker: 'runtime'` forever and the checklist would never have advanced. Now only a fully-provisioned probe is cached; anything short of that is re-read.

The panel re-probes every 5s while a blocker is showing. Slow on purpose: what it is waiting on is a multi-gigabyte download or a human in Xcode.

## The download is fire-and-forget by necessity

`xcodebuild -downloadPlatform iOS` runs for tens of minutes and many gigabytes. Holding a request open for it would blow every deadline in the stack and still show the user nothing, so the op returns as soon as the child is running and progress is observed through the same re-probe that already watches for a hand-installed runtime. The hint text says the size and duration up front rather than offering a button that looks instant.

## Verification, and what could not be verified

Verified: the classification, with fixtures for **every branch including the ones this machine cannot reach** — bare Xcode, interrupted download, runtime-without-devices, unreadable output (5 unit tests). The probe reports `blocker: null` on this fully-provisioned host. `e2e:simulator` PASS, which is the regression that matters here: the panel gained an early return, and the provisioned path must still behave exactly as before.

**Not verified: the guided flow on a host that is actually missing something, and the download button.** This machine has Xcode with iOS 26.5 installed, and reaching the states the checklist exists for would mean uninstalling the user's runtime — a multi-gigabyte, destructive change to their working environment. The checklist rendering is driven entirely by `status.blocker`, so its states are reachable in review by faking that field, but nobody has watched a real `xcodebuild -downloadPlatform` run through this path. Worth confirming on a fresh machine before relying on it.

Wire bumped to 58.