### PR TITLE
feat(sim,engine,daemon): shake a device without reversing the motion payload (CODE-409)

### DIFF
--- a/apps/daemon/src/__tests__/sim-mcp-endpoint.test.ts
+++ b/apps/daemon/src/__tests__/sim-mcp-endpoint.test.ts
@@ -46,6 +46,7 @@ function fakeBackend() {
     swipe: vi.fn(asyncNoop),
     button: vi.fn(asyncNoop),
     rotate: vi.fn(asyncNoop),
+    shake: vi.fn(asyncNoop),
     installRuntime: vi.fn(asyncNoop),
     describeUi: vi.fn(() =>
       Promise.resolve({
@@ -126,6 +127,7 @@ describe('SimulatorMcpEndpoint', () => {
       'sim_press_key',
       'sim_rotate',
       'sim_screenshot',
+      'sim_shake',
       'sim_shutdown',
       'sim_swipe',
       'sim_tap',

--- a/apps/daemon/src/sim/mcp-endpoint.ts
+++ b/apps/daemon/src/sim/mcp-endpoint.ts
@@ -419,6 +419,19 @@ export class SimulatorMcpEndpoint implements SimulatorMcpProvider {
         }),
     );
     server.registerTool(
+      'sim_shake',
+      {
+        description:
+          "Shake a booted iOS Simulator device. Apps use the shake gesture for 'undo typing' prompts, bug reporters, and — in React Native / Expo apps — to open the developer menu. This is not a touch, so it needs no coordinates.",
+        inputSchema: { udid: z.string().min(1) },
+      },
+      ({ udid }) =>
+        run('sim_shake', udid, async () => {
+          await simulators.shake(sessionId, udid);
+          return `shook ${udid}`;
+        }),
+    );
+    server.registerTool(
       'sim_screenshot',
       {
         description:

--- a/apps/desktop/e2e/wire-version.mts
+++ b/apps/desktop/e2e/wire-version.mts
@@ -11,4 +11,4 @@
  * A stale value does not fail loudly: the socket still completes, then every frame is silently
  * discarded at the transport, so a driving script looks connected while the device never moves.
  */
-export const WIRE_VERSION = 58;
+export const WIRE_VERSION = 59;

--- a/crates/linkcode-sim/src/interactive.rs
+++ b/crates/linkcode-sim/src/interactive.rs
@@ -22,7 +22,8 @@ fn unsupported() -> OpError {
 
 #[cfg(target_os = "macos")]
 pub use imp::{
-    available, button, forget, key, pinch, rotate, stream_start, stream_stop, swipe, tap, touch,
+    available, button, forget, key, pinch, rotate, shake, stream_start, stream_stop, swipe, tap,
+    touch,
 };
 
 #[cfg(not(target_os = "macos"))]
@@ -31,6 +32,10 @@ mod stubs {
 
     /// No cached HID client off macOS, so nothing to evict.
     pub fn forget(_udid: &str) {}
+
+    pub fn shake(_udid: &str) -> Result<Value, OpError> {
+        Err(unsupported())
+    }
 
     pub fn available() -> bool {
         false
@@ -85,7 +90,8 @@ mod stubs {
 
 #[cfg(not(target_os = "macos"))]
 pub use stubs::{
-    available, button, forget, key, pinch, rotate, stream_start, stream_stop, swipe, tap, touch,
+    available, button, forget, key, pinch, rotate, shake, stream_start, stream_stop, swipe, tap,
+    touch,
 };
 
 #[cfg(target_os = "macos")]
@@ -114,6 +120,9 @@ mod imp {
     /// not gated on frame progress: a worker whose boot session ended out from under it can keep
     /// delivering frames from the dead session, so silence is not a reliable death signal.
     const STATE_CHECK_INTERVAL: Duration = Duration::from_secs(2);
+
+    /// The notification UIKit turns into a shake gesture inside the guest.
+    const SHAKE_NOTIFICATION: &str = "com.apple.UIKit.SimulatorShake";
 
     /// Warmed HID clients and running streams, keyed by udid. Warming a client is expensive, so it
     /// is cached; a stream is one crash-isolated worker plus a pusher thread.
@@ -211,6 +220,25 @@ mod imp {
             ErrorCode::SimctlFailed,
             format!("{what} failed"),
         ))
+    }
+
+    /// Shake the device.
+    ///
+    /// Not an HID injection at all: UIKit inside the guest listens for a Darwin notification, which
+    /// is the same route Simulator.app's own Device ▸ Shake takes. That makes this the one gesture
+    /// that needs no warmed HID client — and so no re-warm dance either.
+    pub fn shake(udid: &str) -> Result<Value, OpError> {
+        let device = SimDevice::resolve(udid).ok_or_else(|| {
+            OpError::new(ErrorCode::SimctlFailed, format!("device {udid} not found"))
+        })?;
+        if device.post_darwin_notification(SHAKE_NOTIFICATION) {
+            Ok(json!({}))
+        } else {
+            Err(OpError::new(
+                ErrorCode::SimctlFailed,
+                "the device refused the shake notification",
+            ))
+        }
     }
 
     pub fn tap(udid: &str, x: f64, y: f64) -> Result<Value, OpError> {

--- a/crates/linkcode-sim/src/main.rs
+++ b/crates/linkcode-sim/src/main.rs
@@ -334,6 +334,7 @@ fn serve(request: Request, tx: &Sender<OutMsg>) {
         } => interactive::swipe(&udid, x0, y0, x1, y1, duration_ms),
         Op::Button { udid, button } => interactive::button(&udid, button),
         Op::Rotate { udid, orientation } => interactive::rotate(&udid, orientation),
+        Op::Shake { udid } => interactive::shake(&udid),
         Op::Key {
             udid,
             usage,

--- a/crates/linkcode-sim/src/private/device.rs
+++ b/crates/linkcode-sim/src/private/device.rs
@@ -41,6 +41,19 @@ impl SimDevice {
         Retained::as_ptr(&self.object).cast_mut()
     }
 
+    /// Post a Darwin notification into the guest.
+    ///
+    /// This is how Simulator.app's own Device menu drives the gestures that have no HID
+    /// representation — its `simulateShake` posts `com.apple.UIKit.SimulatorShake` and UIKit inside
+    /// the guest turns it into a shake. Far simpler than the Indigo motion path, which would need a
+    /// hand-reversed CoreMotion payload to say the same thing.
+    pub fn post_darwin_notification(&self, name: &str) -> bool {
+        let name = NSString::from_str(name);
+        let mut error: *mut AnyObject = ptr::null_mut();
+        // SAFETY: the selector takes an NSString and an `(NSError**)` out-param, returning BOOL.
+        unsafe { msg_send![&*self.object, postDarwinNotification: &*name, error: &mut error] }
+    }
+
     /// The raw `SimDeviceState`, or `None` if the KVC read fails.
     pub fn state_raw(&self) -> Option<u64> {
         let key = NSString::from_str("state");

--- a/crates/linkcode-sim/src/rpc.rs
+++ b/crates/linkcode-sim/src/rpc.rs
@@ -119,6 +119,8 @@ pub enum Op {
     },
     /// Stop a running framebuffer stream.
     StreamStop { udid: String },
+    /// Shake the device (a Darwin notification, not an HID event).
+    Shake { udid: String },
     /// Start the iOS runtime download and return immediately (see `simctl::install_runtime`).
     InstallRuntime,
     /// Read the guest's accessibility tree (private API; P2). Served by a short-lived worker

--- a/packages/client/core/src/client.ts
+++ b/packages/client/core/src/client.ts
@@ -730,6 +730,11 @@ export class LinkCodeClient {
     return this.control.simulatorOpenUrl(sessionId, udid, url);
   }
 
+  /** Shake the device (undo-typing prompts, React Native's dev menu). */
+  simulatorShake(sessionId: SessionId, udid: string): Promise<RequestAck> {
+    return this.control.simulatorShake(sessionId, udid);
+  }
+
   /** Start the iOS runtime download; resolves once it is running, not once it finishes. */
   simulatorInstallRuntime(): Promise<RequestAck> {
     return this.control.simulatorInstallRuntime();

--- a/packages/client/core/src/client/control-channel.ts
+++ b/packages/client/core/src/client/control-channel.ts
@@ -665,6 +665,16 @@ export class ControlChannel {
     }));
   }
 
+  /** Shake the device — the gesture apps use for "undo typing" and, in React Native, the dev menu. */
+  simulatorShake(sessionId: SessionId, udid: string): Promise<RequestAck> {
+    return this.sendCorrelated('ack', (clientReqId) => ({
+      kind: 'simulator.shake',
+      clientReqId,
+      sessionId,
+      udid,
+    }));
+  }
+
   /** Start the iOS runtime download. Resolves once it is running, not once it finishes — poll
    * {@link simulatorStatus} until the blocker clears to follow progress. */
   simulatorInstallRuntime(): Promise<RequestAck> {

--- a/packages/foundation/schema/src/wire/message.ts
+++ b/packages/foundation/schema/src/wire/message.ts
@@ -25,7 +25,7 @@ import { WirePayloadSchema } from './payload';
 // 53 migrates managed-asset IDs from public strings to discriminated objects.
 // 54 adds the simulator agent-consent variants (CODE-420).
 // 55 adds the simulator volume buttons (CODE-414).
-export const WIRE_PROTOCOL_VERSION = 58 as const;
+export const WIRE_PROTOCOL_VERSION = 59 as const;
 
 /** Complete wire message: version + unique id + timestamp + payload. */
 export const WireMessageSchema = z.object({

--- a/packages/foundation/schema/src/wire/simulator.ts
+++ b/packages/foundation/schema/src/wire/simulator.ts
@@ -234,6 +234,14 @@ export const simulatorWireVariants = [
     udid,
     button: SimulatorButtonSchema,
   }),
+  /** Shake the device. Not HID and not a GSEvent: UIKit inside the guest listens for a Darwin
+   * notification, which is the route Simulator.app's own Device menu takes. */
+  z.object({
+    kind: z.literal('simulator.shake'),
+    clientReqId: WireRequestIdSchema,
+    sessionId: SessionIdSchema,
+    udid,
+  }),
   /** Rotate the device's interface orientation (a GraphicsServices GSEvent, not HID). A guest app
    * that doesn't support the target orientation silently keeps its frame — not observable here. */
   z.object({

--- a/packages/host/engine/src/__tests__/simulator-request-handler.test.ts
+++ b/packages/host/engine/src/__tests__/simulator-request-handler.test.ts
@@ -209,6 +209,25 @@ describe('simulator wire requests', () => {
     await h.engine.stop();
   });
 
+  it('routes a shake request through the wire router to the backend', async () => {
+    const backend = fakeBackend();
+    const h = harness(backend);
+    await h.engine.start();
+    const s1 = await h.startSession('s1');
+
+    // Same guard as rotate: `simulator.shake` carries no coordinates, so a missing entry in the
+    // router's simulator group is invisible except as a reply that never arrives.
+    await h.inject({
+      kind: 'simulator.shake',
+      clientReqId: 'shk',
+      sessionId: s1,
+      udid: 'U-1',
+    });
+    expect(h.reply('shk')).toMatchObject({ kind: 'request.succeeded' });
+    expect(backend.shake).toHaveBeenCalledWith('U-1');
+    await h.engine.stop();
+  });
+
   it('start subscribes frames and fans them out session-scoped; stop unsubscribes', async () => {
     const backend = fakeBackend();
     const h = harness(backend);

--- a/packages/host/engine/src/__tests__/simulator-request-handler.test.ts
+++ b/packages/host/engine/src/__tests__/simulator-request-handler.test.ts
@@ -43,6 +43,7 @@ function fakeBackend() {
     swipe: vi.fn(asyncNoop),
     button: vi.fn(asyncNoop),
     rotate: vi.fn(asyncNoop),
+    shake: vi.fn(asyncNoop),
     installRuntime: vi.fn(asyncNoop),
     describeUi: vi.fn(() =>
       Promise.resolve({

--- a/packages/host/engine/src/__tests__/simulator-service.test.ts
+++ b/packages/host/engine/src/__tests__/simulator-service.test.ts
@@ -40,6 +40,7 @@ function fakeBackend(devices: SimulatorDeviceInfo[]) {
     swipe: vi.fn(asyncNoop),
     button: vi.fn(asyncNoop),
     rotate: vi.fn(asyncNoop),
+    shake: vi.fn(asyncNoop),
     installRuntime: vi.fn(asyncNoop),
     describeUi: vi.fn(() =>
       Promise.resolve({

--- a/packages/host/engine/src/simulator/backend.ts
+++ b/packages/host/engine/src/simulator/backend.ts
@@ -138,6 +138,8 @@ export interface SimulatorBackend {
   button(udid: string, button: SimulatorButton): Promise<void>;
   /** Rotate the interface orientation (GraphicsServices GSEvent; macOS only). */
   rotate(udid: string, orientation: SimulatorOrientation): Promise<void>;
+  /** Shake the device (a Darwin notification UIKit turns into the gesture; macOS only). */
+  shake(udid: string): Promise<void>;
   /** Press one keyboard key (HID usage on page 7) with modifier usages held around it. */
   key(udid: string, usage: number, modifiers: number[]): Promise<void>;
   /** The frontmost app's accessibility tree (private API; macOS only). */

--- a/packages/host/engine/src/simulator/request-handler.ts
+++ b/packages/host/engine/src/simulator/request-handler.ts
@@ -30,6 +30,7 @@ type SimulatorRequest = Extract<
       | 'simulator.swipe'
       | 'simulator.button'
       | 'simulator.rotate'
+      | 'simulator.shake'
       | 'simulator.key'
       | 'simulator.describe-ui'
       | 'simulator.install-runtime'
@@ -265,6 +266,13 @@ export class SimulatorRequestHandler {
         return this.withSimulators(payload.clientReqId, (simulators) =>
           simulatorOperation('simulator.button', 'Failed to press button', async () => {
             await simulators.button(payload.sessionId, payload.udid, payload.button);
+            this.responder.sendSuccess(payload.clientReqId);
+          }),
+        );
+      case 'simulator.shake':
+        return this.withSimulators(payload.clientReqId, (simulators) =>
+          simulatorOperation('simulator.shake', 'Failed to shake device', async () => {
+            await simulators.shake(payload.sessionId, payload.udid);
             this.responder.sendSuccess(payload.clientReqId);
           }),
         );

--- a/packages/host/engine/src/simulator/service.ts
+++ b/packages/host/engine/src/simulator/service.ts
@@ -256,6 +256,11 @@ export class SimulatorService {
     return this.backend.rotate(udid, orientation);
   }
 
+  async shake(sessionId: SessionId, udid: string): Promise<void> {
+    this.claim(sessionId, udid);
+    return this.backend.shake(udid);
+  }
+
   async key(sessionId: SessionId, udid: string, usage: number, modifiers: number[]): Promise<void> {
     this.claim(sessionId, udid);
     return this.backend.key(udid, usage, modifiers);

--- a/packages/host/engine/src/wire/request-router.ts
+++ b/packages/host/engine/src/wire/request-router.ts
@@ -147,6 +147,7 @@ export class WireRequestRouter {
       case 'simulator.swipe':
       case 'simulator.button':
       case 'simulator.rotate':
+      case 'simulator.shake':
       case 'simulator.describe-ui':
       case 'simulator.install-runtime':
       case 'simulator.stream.start':

--- a/packages/host/sim/src/client.ts
+++ b/packages/host/sim/src/client.ts
@@ -203,6 +203,11 @@ export class SimSidecarClient {
     await this.call('button', { udid, button });
   }
 
+  /** Shake the device (a Darwin notification UIKit turns into the gesture; macOS only). */
+  async shake(udid: string): Promise<void> {
+    await this.call('shake', { udid });
+  }
+
   /** Rotate the interface orientation (GraphicsServices GSEvent; macOS only). */
   async rotate(udid: string, orientation: SimOrientation): Promise<void> {
     await this.call('rotate', { udid, orientation });


### PR DESCRIPTION
The issue budgeted its main effort for reverse-engineering the ~140-byte CoreMotion payload `IndigoHIDMessageForDeviceMotionLiteEvent` copies, and flagged that as the risk. **Shake needs none of it.**

## How Apple's own UI does it

`Simulator.app`'s Device ▸ Shake resolves to a `simulateShake` that bridges one string — `com.apple.UIKit.SimulatorShake` — and hands it to the device. `SimDevice` answers `postDarwinNotification:error:` directly; UIKit inside the guest listens for that name and raises the shake. So shake is a **notification, not an HID event** — the same shape of discovery as rotation turning out to be a GSEvent rather than an Indigo message.

That also makes it the one gesture with no warmed HID client behind it, so none of the staleness machinery from CODE-442 applies to it.

Checked first, and worth recording: `simctl` has no public shake or motion subcommand, so the private path is the only one.

## What this does not do

**Tilt is deliberately not implemented.** Gravity and attitude still need the reversed CoreMotion struct, and nothing on the notification path expresses them. The issue anticipated this ("若 RE 成本过高，可先只做 shake") and shake is what its acceptance criterion asks for. A follow-up can take on the payload if a gravity-driven app ever needs it — the forensics are recorded in the issue.

## Verification

Real device, three levels:

1. **Feasibility probe** — typed into a field, posted the notification: the guest's Expo dev menu opened, which is exactly what a React Native app shows on shake. That screenshot is what proved the notification is a real shake and not an unrelated repaint.
2. **Sidecar op** — a framed `shake` request returned `ok` and the screen changed.
3. **Over the wire** — `simulator.shake` → `request.succeeded`, screen changed.

`describe_ui` (CODE-398) was what located the text field for step 1 — the first time one of these tools was useful for building the next.

Agents get `sim_shake`, described so they know when to reach for it (undo-typing prompts, bug reporters, RN dev menu) and that it takes no coordinates. Wire bumped to 59.