### PR TITLE
fix(sim): honor the HID send verdict instead of assuming every injection landed

### DIFF
--- a/crates/linkcode-sim/src/interactive.rs
+++ b/crates/linkcode-sim/src/interactive.rs
@@ -210,13 +210,23 @@ mod imp {
     /// possible at all — while the verdict was being discarded, a stale client reported a clean
     /// success for every injection and the panel went dead with all its controls looking healthy
     /// (CODE-442). Treat the first failure as possibly-stale: drop the client, warm a fresh one,
-    /// and try once more. A failed send means the port was unusable, so nothing was delivered and
-    /// the retry cannot double-send.
+    /// and try once more. A *refused* send names an unusable port, so nothing was delivered and the
+    /// retry cannot double-send — but a send that was never acknowledged at all proves nothing, so
+    /// that one retires the client without repeating the injection.
     fn with_input(udid: &str, what: &str, op: impl Fn(&Input) -> bool) -> Result<Value, OpError> {
-        if op(input_for(udid)?.as_ref()) {
+        let input = input_for(udid)?;
+        if op(input.as_ref()) {
             return Ok(json!({}));
         }
+        let stalled = input.is_stalled();
+        drop(input);
         forget(udid);
+        if stalled {
+            return Err(OpError::new(
+                ErrorCode::SimctlFailed,
+                format!("{what} was never acknowledged; the HID client has been dropped"),
+            ));
+        }
         eprintln!("sim input: {what} on {udid} found a dead HID session; re-warming the client");
         if op(input_for(udid)?.as_ref()) {
             return Ok(json!({}));

--- a/crates/linkcode-sim/src/interactive.rs
+++ b/crates/linkcode-sim/src/interactive.rs
@@ -173,11 +173,12 @@ mod imp {
 
     /// Drop the cached HID client and any in-flight gesture state for `udid`.
     ///
-    /// A warmed `SimDeviceLegacyHIDClient` is bound to the boot session it was created in. Once the
-    /// device shuts down, that client is dead: sends still report success but nothing reaches the
-    /// guest, so the panel looks fine while every tap, button and key silently does nothing. Boot
-    /// and shutdown are the two moments a new session begins, so both evict — the next use re-warms
-    /// against the live device.
+    /// A warmed `SimDeviceLegacyHIDClient` is bound to the boot session it was created in, and its
+    /// mach port dies with that session. A dead client cannot be revived in place, so eviction is
+    /// the only recovery. Boot and shutdown are the two moments a new session begins, so both evict
+    /// — the next use re-warms against the live device. This is the cheap path, not the safety net:
+    /// an out-of-band reboot sends no op through this process, and `Input`'s own dead-port detection
+    /// is what covers that.
     pub fn forget(udid: &str) {
         let mut reg = registry().lock().expect("interactive registry poisoned");
         reg.inputs.remove(udid);
@@ -203,16 +204,20 @@ mod imp {
     ///
     /// A warmed client is bound to the boot session it was created in, and a device can be shut
     /// down and re-booted behind our back — from Simulator.app, from `simctl`, or by a boot the
-    /// engine short-circuited because the host already had the device up. The stale client then
-    /// builds no messages, so the failure is indistinguishable from "the device is gone" and the
-    /// panel goes dead with every control still looking healthy. Treat the first failure as
-    /// possibly-stale: drop the client, warm a fresh one, and try once more. A failed build
-    /// injected nothing, so the retry cannot double-send.
+    /// engine short-circuited because the host already had the device up. Building messages against
+    /// the stale client keeps working; only the *send* fails, and SimulatorKit reports that per
+    /// message as a dead mach port. `Input` waits for that verdict, which is what makes this retry
+    /// possible at all — while the verdict was being discarded, a stale client reported a clean
+    /// success for every injection and the panel went dead with all its controls looking healthy
+    /// (CODE-442). Treat the first failure as possibly-stale: drop the client, warm a fresh one,
+    /// and try once more. A failed send means the port was unusable, so nothing was delivered and
+    /// the retry cannot double-send.
     fn with_input(udid: &str, what: &str, op: impl Fn(&Input) -> bool) -> Result<Value, OpError> {
         if op(input_for(udid)?.as_ref()) {
             return Ok(json!({}));
         }
         forget(udid);
+        eprintln!("sim input: {what} on {udid} found a dead HID session; re-warming the client");
         if op(input_for(udid)?.as_ref()) {
             return Ok(json!({}));
         }
@@ -459,13 +464,14 @@ mod imp {
         Ok(json!({}))
     }
 
-    /// Reap a stream whose device's boot session has ended out from under it. The worker holds
-    /// framebuffer registrations that keep the dead session's HID routing half-alive, so a warmed
-    /// client "successfully" injects into it and every control goes silently dead (CODE-442) — an
-    /// out-of-band shutdown (Simulator.app, bare `simctl`) sends no op through this process, so
-    /// nothing else evicts. Killing the worker and forgetting the client makes the next attach or
-    /// injection start from the live device. Called from the pusher's own thread: the JoinHandle
-    /// is dropped, never joined — a thread cannot join itself.
+    /// Reap a stream whose device's boot session has ended out from under it. A worker outlives the
+    /// session it was opened against and keeps pushing that session's last frames, so the panel
+    /// shows a live-looking picture of a device that is gone — and an out-of-band shutdown
+    /// (Simulator.app, bare `simctl`) sends no op through this process, so nothing else stops it.
+    /// Injection correctness does not rest here: `Input` detects the dead port itself and re-warms
+    /// (CODE-442). This is about not streaming a corpse, and not leaking the worker process with
+    /// it. Called from the pusher's own thread: the JoinHandle is dropped, never joined — a thread
+    /// cannot join itself.
     fn reap_dead_device(udid: &str, via: &str) {
         let handle = registry()
             .lock()

--- a/crates/linkcode-sim/src/private/ax.rs
+++ b/crates/linkcode-sim/src/private/ax.rs
@@ -10,7 +10,7 @@
 //! delegate class at runtime and installs it — the one place in this crate that declares an
 //! Objective-C class rather than only messaging existing ones.
 
-use std::ffi::{CString, c_ulong, c_void};
+use std::ffi::{CString, c_void};
 use std::ptr;
 use std::sync::OnceLock;
 use std::sync::atomic::{AtomicPtr, Ordering};
@@ -22,6 +22,7 @@ use objc2::{msg_send, sel};
 use objc2_core_foundation::CGRect;
 use objc2_foundation::NSString;
 
+use super::block::{self, BlockDescriptor, CaptureBlock};
 use super::debug::dbg_log;
 use super::device::SimDevice;
 
@@ -55,7 +56,6 @@ unsafe extern "C" {
     fn dispatch_group_wait(group: *mut c_void, timeout: u64) -> isize;
     fn dispatch_time(when: u64, delta: i64) -> u64;
     fn dispatch_release(object: *mut c_void);
-    static _NSConcreteGlobalBlock: c_void;
 }
 
 /// `DISPATCH_TIME_NOW`.
@@ -199,52 +199,19 @@ struct ResponseSlot {
     group: *mut c_void,
 }
 
-// ── Hand-rolled blocks ──────────────────────────────────────────────────────────────────────────
+// ── Blocks ──────────────────────────────────────────────────────────────────────────────────────
 //
-// Same layout as `screen.rs`: a global block with a signature, because the framework reads the
-// signature and rejects a signature-less block. The dispatcher's returned block is captureless by
+// Layout and ownership rules live in `block.rs`. The dispatcher's returned block is captureless by
 // design (see `CURRENT_DEVICE`); the XPC completion block is the one exception and carries a single
 // pointer, which is safe only because its creator blocks until it has run.
-
-#[repr(C)]
-struct BlockDescriptor {
-    reserved: c_ulong,
-    size: c_ulong,
-    signature: *const i8,
-}
-
-// SAFETY: descriptors are immutable and their signatures are static NUL-terminated strings.
-unsafe impl Sync for BlockDescriptor {}
-
-#[repr(C)]
-struct CaptureBlock {
-    isa: *const c_void,
-    flags: i32,
-    reserved: i32,
-    invoke: *const c_void,
-    descriptor: *const BlockDescriptor,
-    /// The one captured word; unused by the captureless dispatcher block.
-    context: *mut c_void,
-}
-
-const BLOCK_IS_GLOBAL: i32 = 1 << 28;
-const BLOCK_HAS_SIGNATURE: i32 = 1 << 30;
 
 /// `void (^)(id)` — the XPC completion handler.
 const COMPLETION_SIGNATURE: &[u8] = b"v16@?0@8\0";
 /// `id (^)(id)` — the request router the dispatcher hands back to the translator.
 const ROUTER_SIGNATURE: &[u8] = b"@16@?0@8\0";
 
-static COMPLETION_DESCRIPTOR: BlockDescriptor = BlockDescriptor {
-    reserved: 0,
-    size: size_of::<CaptureBlock>() as c_ulong,
-    signature: COMPLETION_SIGNATURE.as_ptr().cast::<i8>(),
-};
-static ROUTER_DESCRIPTOR: BlockDescriptor = BlockDescriptor {
-    reserved: 0,
-    size: size_of::<CaptureBlock>() as c_ulong,
-    signature: ROUTER_SIGNATURE.as_ptr().cast::<i8>(),
-};
+static COMPLETION_DESCRIPTOR: BlockDescriptor = block::descriptor(COMPLETION_SIGNATURE);
+static ROUTER_DESCRIPTOR: BlockDescriptor = block::descriptor(ROUTER_SIGNATURE);
 
 /// The XPC completion handler: store the response and release the waiter.
 unsafe extern "C" fn completion_invoke(block: *mut CaptureBlock, response: *mut AnyObject) {
@@ -268,26 +235,20 @@ unsafe extern "C" fn router_invoke(
 }
 
 fn completion_block(slot: *mut ResponseSlot) -> CaptureBlock {
-    CaptureBlock {
-        isa: (&raw const _NSConcreteGlobalBlock).cast::<c_void>(),
-        flags: BLOCK_IS_GLOBAL | BLOCK_HAS_SIGNATURE,
-        reserved: 0,
-        invoke: completion_invoke as *const c_void,
-        descriptor: &raw const COMPLETION_DESCRIPTOR,
-        context: slot.cast::<c_void>(),
-    }
+    block::capture_block(
+        completion_invoke as *const c_void,
+        &raw const COMPLETION_DESCRIPTOR,
+        slot.cast::<c_void>(),
+    )
 }
 
 /// The router block, leaked on purpose: AXPTranslator retains it for as long as it keeps the token.
 fn router_block() -> *mut c_void {
-    let block = Box::new(CaptureBlock {
-        isa: (&raw const _NSConcreteGlobalBlock).cast::<c_void>(),
-        flags: BLOCK_IS_GLOBAL | BLOCK_HAS_SIGNATURE,
-        reserved: 0,
-        invoke: router_invoke as *const c_void,
-        descriptor: &raw const ROUTER_DESCRIPTOR,
-        context: ptr::null_mut(),
-    });
+    let block = Box::new(block::capture_block(
+        router_invoke as *const c_void,
+        &raw const ROUTER_DESCRIPTOR,
+        ptr::null_mut(),
+    ));
     Box::into_raw(block).cast::<c_void>()
 }
 

--- a/crates/linkcode-sim/src/private/block.rs
+++ b/crates/linkcode-sim/src/private/block.rs
@@ -1,0 +1,78 @@
+//! The hand-rolled Objective-C block ABI the private frameworks are handed callbacks through.
+//!
+//! block2's `RcBlock` is not usable against these APIs — it crashes the CoreSimulator callback path
+//! (see `screen.rs`) — so every block this crate hands out is built by hand: a **global** block
+//! carrying a signature, which is what the callees accept.
+//!
+//! Two consequences of `BLOCK_IS_GLOBAL` govern how callers must own these:
+//!
+//! * `Block_copy` returns the same pointer rather than copying, so the callee holds exactly the
+//!   allocation the caller handed it — a block built on the stack is a use-after-free waiting for a
+//!   late callback.
+//! * `Block_release` still *reads* the block to discover it is global, and that read can happen
+//!   after the callback has already run. So a block whose callback releases the waiter must not be
+//!   freed by the woken thread; leak it, or keep it alive for the process.
+//!
+//! `screen.rs` keeps a separate, narrower layout: ROCK's XPC delivery zeroes a pointer captured in
+//! the block body, so its callbacks carry no context word at all and reach state through a
+//! process-global instead.
+
+use std::ffi::{c_ulong, c_void};
+
+unsafe extern "C" {
+    static _NSConcreteGlobalBlock: c_void;
+}
+
+const BLOCK_IS_GLOBAL: i32 = 1 << 28;
+const BLOCK_HAS_SIGNATURE: i32 = 1 << 30;
+
+/// A block's descriptor: its size and the Objective-C type encoding of its signature. The callees
+/// read the signature, so a signature-less block is rejected.
+#[repr(C)]
+pub struct BlockDescriptor {
+    reserved: c_ulong,
+    size: c_ulong,
+    signature: *const i8,
+}
+
+// SAFETY: descriptors are immutable and each signature points at a static NUL-terminated string.
+unsafe impl Sync for BlockDescriptor {}
+
+/// A global block carrying one captured word. Callbacks that need no context set it to null.
+#[repr(C)]
+pub struct CaptureBlock {
+    isa: *const c_void,
+    flags: i32,
+    reserved: i32,
+    /// The invoke fn, stored type-erased; the descriptor's signature tells the runtime the real ABI.
+    invoke: *const c_void,
+    descriptor: *const BlockDescriptor,
+    /// The one captured word.
+    pub context: *mut c_void,
+}
+
+/// Build a descriptor for `signature`, which must be a static NUL-terminated type encoding.
+pub const fn descriptor(signature: &'static [u8]) -> BlockDescriptor {
+    BlockDescriptor {
+        reserved: 0,
+        size: size_of::<CaptureBlock>() as c_ulong,
+        signature: signature.as_ptr().cast::<i8>(),
+    }
+}
+
+/// Build a block invoking `invoke` with `context` as its captured word. See the module docs for who
+/// may free the result — usually nobody.
+pub fn capture_block(
+    invoke: *const c_void,
+    descriptor: *const BlockDescriptor,
+    context: *mut c_void,
+) -> CaptureBlock {
+    CaptureBlock {
+        isa: (&raw const _NSConcreteGlobalBlock).cast::<c_void>(),
+        flags: BLOCK_IS_GLOBAL | BLOCK_HAS_SIGNATURE,
+        reserved: 0,
+        invoke,
+        descriptor,
+        context,
+    }
+}

--- a/crates/linkcode-sim/src/private/input.rs
+++ b/crates/linkcode-sim/src/private/input.rs
@@ -19,9 +19,10 @@
 //! Crown/Dial (watch) and returns otherwise. Scrolling on iOS is a touch gesture; the client's
 //! wheel→synthetic-drag translation is the platform-canonical path, not a stopgap.
 
-use std::ffi::{c_ulong, c_void};
+use std::ffi::c_void;
 use std::ptr;
-use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use std::thread::sleep;
 use std::time::Duration;
 
@@ -29,6 +30,7 @@ use objc2::msg_send;
 use objc2::rc::Retained;
 use objc2::runtime::{AnyClass, AnyObject};
 
+use super::block::{self, BlockDescriptor, CaptureBlock};
 use super::device::SimDevice;
 use super::framework;
 
@@ -87,8 +89,6 @@ unsafe extern "C" {
     fn dispatch_group_leave(group: *mut c_void);
     fn dispatch_group_wait(group: *mut c_void, timeout: u64) -> isize;
     fn dispatch_time(when: u64, delta: i64) -> u64;
-    fn dispatch_release(object: *mut c_void);
-    static _NSConcreteGlobalBlock: c_void;
 }
 
 /// `DISPATCH_TIME_NOW`.
@@ -175,10 +175,15 @@ pub struct Input {
     client: Retained<AnyObject>,
     symbols: Symbols,
     touch_counter: AtomicU32,
+    gate: *mut SendGate,
+    completion: *mut CaptureBlock,
+    /// Held across each send and its acknowledgement, so the one gate is never in two sends at
+    /// once. Discrete ops (tap, button, swipe) run on their own request threads.
+    send_lock: Mutex<()>,
 }
 
-// SAFETY: the sidecar serializes input per device; the HID client and C fn pointers are only touched
-// under that serialization.
+// SAFETY: the HID client and C fn pointers are only touched under `send_lock`; the gate is reached
+// only through atomics and outlives every reader, and the block is never written after it is built.
 unsafe impl Send for Input {}
 unsafe impl Sync for Input {}
 
@@ -188,13 +193,25 @@ impl Input {
     pub fn warm(device: &SimDevice) -> Option<Input> {
         let symbols = resolve_symbols()?;
         let client = make_hid_client(device)?;
+        let gate = SendGate::create()?;
         let input = Input {
             client,
             symbols,
             touch_counter: AtomicU32::new(0),
+            gate,
+            completion: Box::into_raw(Box::new(completion_block(gate))),
+            send_lock: Mutex::new(()),
         };
         input.warm_services();
         Some(input)
+    }
+
+    /// Whether a send on this client went unanswered. Such a client is finished — its acknowledgement
+    /// bookkeeping is unbalanced — and, unlike a refused send, an unanswered one is no proof that
+    /// nothing was delivered, so the caller must not repeat the operation on a fresh client.
+    pub fn is_stalled(&self) -> bool {
+        // SAFETY: the gate outlives this `Input` (see `SendGate`).
+        unsafe { &*self.gate }.stalled.load(Ordering::Acquire)
     }
 
     /// Allocate the shared identifier for one caller-driven touch stream (down → moves → up).
@@ -440,135 +457,104 @@ impl Input {
     /// session ended does. Discarding the completion (as this did until CODE-442) turns that into a
     /// silent success: the panel stays lit, every control reports fine, and nothing reaches the
     /// guest. Both of `HIDError`'s cases (`machPortInvalid`, `machPortNotConnected`) mean the mach
-    /// port is unusable, so a failure here is proof that nothing was delivered — which is what lets
-    /// the caller re-warm and retry without risking a double-send.
+    /// port is unusable, so a *refused* send is proof that nothing was delivered — which is what
+    /// lets the caller re-warm and retry without risking a double-send. A send that is never
+    /// answered at all carries no such proof: it retires the client instead ([`Input::is_stalled`]).
     fn send_message(&self, message: *mut c_void) -> bool {
-        // SAFETY: both creators return owned dispatch objects, released on every path below.
-        let group = unsafe { dispatch_group_create() };
-        let queue = unsafe { dispatch_queue_create(c"linkcode.sim.hid".as_ptr(), ptr::null()) };
-        if group.is_null() || queue.is_null() {
+        let _serialized = self.send_lock.lock().expect("hid send lock poisoned");
+        // SAFETY: the gate outlives this `Input` (see `SendGate`).
+        let gate = unsafe { &*self.gate };
+        if gate.stalled.load(Ordering::Acquire) {
             // SAFETY: `message` is the malloc'd buffer the client would have freed for us.
             unsafe { libc::free(message) };
             return false;
         }
+        gate.failed.store(false, Ordering::Relaxed);
         // SAFETY: balanced by the `dispatch_group_leave` in `completion_invoke`.
-        unsafe { dispatch_group_enter(group) };
-        // Slot and block live on the heap, not this stack frame: a global block's `Block_copy` is a
-        // no-op returning the same pointer, so a late completion would write through dead memory
-        // (the same hazard `ax.rs` documents).
-        let slot = Box::into_raw(Box::new(SendSlot {
-            failed: false,
-            group,
-        }));
-        let completion = Box::into_raw(Box::new(completion_block(slot)));
+        unsafe { dispatch_group_enter(gate.group) };
         // SAFETY: the client implements sendWithMessage:freeWhenDone:completionQueue:completion:;
-        // message is a live malloc'd buffer the client frees, and the block outlives the call on
-        // every path (see the timeout branch below).
+        // message is a live malloc'd buffer the client frees, and the block outlives every caller.
         unsafe {
             let _: () = msg_send![
                 &*self.client,
                 sendWithMessage: message,
                 freeWhenDone: true,
-                completionQueue: queue,
-                completion: completion.cast::<c_void>(),
+                completionQueue: gate.queue,
+                completion: self.completion.cast::<c_void>(),
             ];
         }
         // SAFETY: DISPATCH_TIME_NOW plus a delta yields an absolute deadline for the wait.
         let deadline =
             unsafe { dispatch_time(DISPATCH_TIME_NOW, SEND_ACK_TIMEOUT.as_nanos() as i64) };
-        // SAFETY: the group is live and entered exactly once.
-        let timed_out = unsafe { dispatch_group_wait(group, deadline) } != 0;
-        if timed_out {
-            // Deliberately leak the slot, the block and the group: the send is still outstanding,
-            // so freeing them now would turn a stalled acknowledgement into a use-after-free. The
-            // caller drops this client on the failure, so the leak is bounded and one-off.
-            // SAFETY: the queue is referenced by dispatch itself, never by the completion handler.
-            unsafe { dispatch_release(queue) };
+        // SAFETY: the group is live and entered exactly once above.
+        if unsafe { dispatch_group_wait(gate.group, deadline) } != 0 {
+            // The acknowledgement is still outstanding, so the group's count stays unbalanced and
+            // no later wait on it would mean anything. Retire the whole client rather than try to
+            // repair it; `is_stalled` also tells the caller this failure is not safe to retry.
+            gate.stalled.store(true, Ordering::Release);
             return false;
         }
-        // SAFETY: the handler has run, so nothing else can reach either allocation; both came from
-        // `Box::into_raw` above and are reclaimed exactly once.
-        let failed = unsafe {
-            let slot = Box::from_raw(slot);
-            drop(Box::from_raw(completion));
-            slot.failed
-        };
-        // SAFETY: created by this function; the handler has finished with the group.
-        unsafe {
-            dispatch_release(group);
-            dispatch_release(queue);
-        }
-        !failed
+        !gate.failed.load(Ordering::Acquire)
     }
 }
 
-/// Where one send's completion handler parks its verdict.
-struct SendSlot {
-    /// Set when SimulatorKit hands back a non-nil `HIDError`.
-    failed: bool,
+/// The completion side of one client's sends: the queue they are acknowledged on, the group the
+/// sender parks on, and where the handler leaves its verdict.
+///
+/// Allocated once per warmed client and **never freed**, nor is the block built over it. A global
+/// block's `Block_copy` hands back the same pointer, so the callee releases *this* allocation — and
+/// that release can run after the handler has already woken the sender, which would put it on dead
+/// memory. Two small allocations per warmed client is a cheaper price than proving the last release
+/// has happened, and clients are warmed once per device outside the re-warm path.
+struct SendGate {
+    queue: *mut c_void,
     group: *mut c_void,
+    /// Set by the handler when SimulatorKit hands back a `HIDError`.
+    failed: AtomicBool,
+    /// Set when an acknowledgement never arrived; the client is finished at that point.
+    stalled: AtomicBool,
 }
 
-// ── Hand-rolled block ───────────────────────────────────────────────────────────────────────────
-//
-// Same layout as `ax.rs` and `screen.rs`: a global block carrying one captured word, with a
-// signature. block2's `RcBlock` is used nowhere in this crate's private layer — it crashed the
-// callbacks these frameworks invoke (see `screen.rs`), so the recipe is hand-rolled throughout.
-
-#[repr(C)]
-struct BlockDescriptor {
-    reserved: c_ulong,
-    size: c_ulong,
-    /// Objective-C type encoding of the block signature; required with `BLOCK_HAS_SIGNATURE`.
-    signature: *const i8,
+impl SendGate {
+    /// `None` if libdispatch refuses the queue or group, which leaves the client unusable.
+    fn create() -> Option<*mut SendGate> {
+        // SAFETY: both creators return owned dispatch objects; they are never released (see above).
+        let queue = unsafe { dispatch_queue_create(c"linkcode.sim.hid".as_ptr(), ptr::null()) };
+        let group = unsafe { dispatch_group_create() };
+        if queue.is_null() || group.is_null() {
+            return None;
+        }
+        Some(Box::into_raw(Box::new(SendGate {
+            queue,
+            group,
+            failed: AtomicBool::new(false),
+            stalled: AtomicBool::new(false),
+        })))
+    }
 }
-
-// SAFETY: the descriptor is immutable and its signature is a static NUL-terminated string.
-unsafe impl Sync for BlockDescriptor {}
-
-#[repr(C)]
-struct CaptureBlock {
-    isa: *const c_void,
-    flags: i32,
-    reserved: i32,
-    invoke: *const c_void,
-    descriptor: *const BlockDescriptor,
-    /// The one captured word: the [`SendSlot`] this completion writes into.
-    context: *mut c_void,
-}
-
-const BLOCK_IS_GLOBAL: i32 = 1 << 28;
-const BLOCK_HAS_SIGNATURE: i32 = 1 << 30;
 
 /// `void (^)(NSError *)` — `send`'s completion handler, from the Swift signature
 /// `completion: ((Error?) -> ())?`.
 const COMPLETION_SIGNATURE: &[u8] = b"v16@?0@8\0";
 
-static COMPLETION_DESCRIPTOR: BlockDescriptor = BlockDescriptor {
-    reserved: 0,
-    size: size_of::<CaptureBlock>() as c_ulong,
-    signature: COMPLETION_SIGNATURE.as_ptr().cast::<i8>(),
-};
+static COMPLETION_DESCRIPTOR: BlockDescriptor = block::descriptor(COMPLETION_SIGNATURE);
 
-/// Record whether the send errored and release the waiter.
+/// Record whether the send errored, then release the waiter. Ordering matters: the verdict must be
+/// visible before the sender can wake.
 unsafe extern "C" fn completion_invoke(block: *mut CaptureBlock, error: *mut AnyObject) {
-    // SAFETY: `context` is the `SendSlot` pointer this block was built with, and `send_message`
-    // blocks on the group until this runs, so the slot is still alive.
-    let slot = unsafe { &mut *(*block).context.cast::<SendSlot>() };
-    slot.failed = !error.is_null();
+    // SAFETY: `context` is the `SendGate` this block was built with, which outlives every send.
+    let gate = unsafe { &*(*block).context.cast::<SendGate>() };
+    gate.failed.store(!error.is_null(), Ordering::Release);
     // SAFETY: balances the `dispatch_group_enter` in `send_message`.
-    unsafe { dispatch_group_leave(slot.group) };
+    unsafe { dispatch_group_leave(gate.group) };
 }
 
-fn completion_block(slot: *mut SendSlot) -> CaptureBlock {
-    CaptureBlock {
-        isa: (&raw const _NSConcreteGlobalBlock).cast::<c_void>(),
-        flags: BLOCK_IS_GLOBAL | BLOCK_HAS_SIGNATURE,
-        reserved: 0,
-        invoke: completion_invoke as *const c_void,
-        descriptor: &raw const COMPLETION_DESCRIPTOR,
-        context: slot.cast::<c_void>(),
-    }
+fn completion_block(gate: *mut SendGate) -> CaptureBlock {
+    block::capture_block(
+        completion_invoke as *const c_void,
+        &raw const COMPLETION_DESCRIPTOR,
+        gate.cast::<c_void>(),
+    )
 }
 
 /// Patch the two byte slots the trackpad wrapper leaves uninitialised: the touch-target routing tag

--- a/crates/linkcode-sim/src/private/input.rs
+++ b/crates/linkcode-sim/src/private/input.rs
@@ -19,7 +19,7 @@
 //! Crown/Dial (watch) and returns otherwise. Scrolling on iOS is a touch gesture; the client's
 //! wheel→synthetic-drag translation is the platform-canonical path, not a stopgap.
 
-use std::ffi::c_void;
+use std::ffi::{c_ulong, c_void};
 use std::ptr;
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::thread::sleep;
@@ -81,7 +81,25 @@ unsafe extern "C" {
     fn CFRelease(cf: *const c_void);
     fn malloc_size(ptr: *const c_void) -> usize;
     fn mach_absolute_time() -> u64;
+    fn dispatch_queue_create(label: *const i8, attr: *const c_void) -> *mut c_void;
+    fn dispatch_group_create() -> *mut c_void;
+    fn dispatch_group_enter(group: *mut c_void);
+    fn dispatch_group_leave(group: *mut c_void);
+    fn dispatch_group_wait(group: *mut c_void, timeout: u64) -> isize;
+    fn dispatch_time(when: u64, delta: i64) -> u64;
+    fn dispatch_release(object: *mut c_void);
+    static _NSConcreteGlobalBlock: c_void;
 }
+
+/// `DISPATCH_TIME_NOW`.
+const DISPATCH_TIME_NOW: u64 = 0;
+
+/// How long a send waits for SimulatorKit's acknowledgement before giving up on the client.
+/// Measured on a real device the answer lands in ~0.1ms, success or dead-port error alike, so this
+/// is four orders of magnitude of headroom. It is kept this tight because the wait is synchronous
+/// and touch/pinch/key ops run inline on the sidecar's read loop (see `main.rs`) — a generous
+/// timeout would let one unanswered send stall every other request behind it.
+const SEND_ACK_TIMEOUT: Duration = Duration::from_secs(1);
 
 const TRANSDUCER_FINGER: u32 = 2;
 const TOUCH_TARGET: u32 = 0x32;
@@ -148,6 +166,11 @@ const KEYBOARD_USAGE_PAGE: u32 = 7;
 
 /// A warmed HID client bound to one device, plus the resolved private symbols. Created lazily; a
 /// resolution failure means this host cannot inject input (the caller degrades to view-only).
+///
+/// Bound to **one boot session**: the client's mach port dies with the session, and every method
+/// here reports `false` once it does (see [`Input::send_message`]). There is no way to revive one —
+/// `-resetHIDSession` tears a *live* session down rather than re-establishing a dead one — so the
+/// only recovery is to drop the client and warm a new one against the live device.
 pub struct Input {
     client: Retained<AnyObject>,
     symbols: Symbols,
@@ -234,8 +257,7 @@ impl Input {
             if message.is_null() {
                 return false;
             }
-            self.send_message(message);
-            true
+            self.send_message(message)
         };
         for modifier in modifiers {
             if !send_op(*modifier, 1) {
@@ -264,8 +286,7 @@ impl Input {
             if message.is_null() {
                 return false;
             }
-            self.send_message(message);
-            true
+            self.send_message(message)
         };
         if !send_op(1) {
             return false;
@@ -289,14 +310,15 @@ impl Input {
         if down.is_null() {
             return false;
         }
-        self.send_message(down);
+        if !self.send_message(down) {
+            return false;
+        }
         sleep(hold.max(Duration::from_millis(20)));
         let up = unsafe { (self.symbols.button)(arg0, 2, LEGACY_BUTTON_TARGET) };
         if up.is_null() {
             return false;
         }
-        self.send_message(up);
-        true
+        self.send_message(up)
     }
 
     fn next_identifier(&self) -> u32 {
@@ -387,8 +409,7 @@ impl Input {
             return false;
         }
         patch_message(message);
-        self.send_message(message);
-        true
+        self.send_message(message)
     }
 
     fn warm_services(&self) {
@@ -402,26 +423,151 @@ impl Input {
             // SAFETY: service creators take no args and return a malloc'd message consumed by send.
             let message = unsafe { create() };
             if !message.is_null() {
+                // Priming only: a client warmed against a session that is already gone reports the
+                // dead port on the caller's first real injection, which is where the retry lives.
                 self.send_message(message);
                 sleep(Duration::from_millis(20));
             }
         }
     }
 
-    /// Dispatch a malloc'd Indigo message; `freeWhenDone: true` hands ownership to the client.
-    fn send_message(&self, message: *mut c_void) {
-        let null_obj: *mut AnyObject = ptr::null_mut();
+    /// Dispatch a malloc'd Indigo message and wait for SimulatorKit's verdict on it;
+    /// `freeWhenDone: true` hands ownership of the buffer to the client.
+    ///
+    /// `false` means the message reached nobody. The send itself is asynchronous and returns void,
+    /// so the completion handler is the *only* signal that distinguishes a delivered message from
+    /// one dropped on the floor — and dropping it on the floor is exactly what a client whose boot
+    /// session ended does. Discarding the completion (as this did until CODE-442) turns that into a
+    /// silent success: the panel stays lit, every control reports fine, and nothing reaches the
+    /// guest. Both of `HIDError`'s cases (`machPortInvalid`, `machPortNotConnected`) mean the mach
+    /// port is unusable, so a failure here is proof that nothing was delivered — which is what lets
+    /// the caller re-warm and retry without risking a double-send.
+    fn send_message(&self, message: *mut c_void) -> bool {
+        // SAFETY: both creators return owned dispatch objects, released on every path below.
+        let group = unsafe { dispatch_group_create() };
+        let queue = unsafe { dispatch_queue_create(c"linkcode.sim.hid".as_ptr(), ptr::null()) };
+        if group.is_null() || queue.is_null() {
+            // SAFETY: `message` is the malloc'd buffer the client would have freed for us.
+            unsafe { libc::free(message) };
+            return false;
+        }
+        // SAFETY: balanced by the `dispatch_group_leave` in `completion_invoke`.
+        unsafe { dispatch_group_enter(group) };
+        // Slot and block live on the heap, not this stack frame: a global block's `Block_copy` is a
+        // no-op returning the same pointer, so a late completion would write through dead memory
+        // (the same hazard `ax.rs` documents).
+        let slot = Box::into_raw(Box::new(SendSlot {
+            failed: false,
+            group,
+        }));
+        let completion = Box::into_raw(Box::new(completion_block(slot)));
         // SAFETY: the client implements sendWithMessage:freeWhenDone:completionQueue:completion:;
-        // message is a live malloc'd buffer the client frees.
+        // message is a live malloc'd buffer the client frees, and the block outlives the call on
+        // every path (see the timeout branch below).
         unsafe {
             let _: () = msg_send![
                 &*self.client,
                 sendWithMessage: message,
                 freeWhenDone: true,
-                completionQueue: null_obj,
-                completion: null_obj,
+                completionQueue: queue,
+                completion: completion.cast::<c_void>(),
             ];
         }
+        // SAFETY: DISPATCH_TIME_NOW plus a delta yields an absolute deadline for the wait.
+        let deadline =
+            unsafe { dispatch_time(DISPATCH_TIME_NOW, SEND_ACK_TIMEOUT.as_nanos() as i64) };
+        // SAFETY: the group is live and entered exactly once.
+        let timed_out = unsafe { dispatch_group_wait(group, deadline) } != 0;
+        if timed_out {
+            // Deliberately leak the slot, the block and the group: the send is still outstanding,
+            // so freeing them now would turn a stalled acknowledgement into a use-after-free. The
+            // caller drops this client on the failure, so the leak is bounded and one-off.
+            // SAFETY: the queue is referenced by dispatch itself, never by the completion handler.
+            unsafe { dispatch_release(queue) };
+            return false;
+        }
+        // SAFETY: the handler has run, so nothing else can reach either allocation; both came from
+        // `Box::into_raw` above and are reclaimed exactly once.
+        let failed = unsafe {
+            let slot = Box::from_raw(slot);
+            drop(Box::from_raw(completion));
+            slot.failed
+        };
+        // SAFETY: created by this function; the handler has finished with the group.
+        unsafe {
+            dispatch_release(group);
+            dispatch_release(queue);
+        }
+        !failed
+    }
+}
+
+/// Where one send's completion handler parks its verdict.
+struct SendSlot {
+    /// Set when SimulatorKit hands back a non-nil `HIDError`.
+    failed: bool,
+    group: *mut c_void,
+}
+
+// ── Hand-rolled block ───────────────────────────────────────────────────────────────────────────
+//
+// Same layout as `ax.rs` and `screen.rs`: a global block carrying one captured word, with a
+// signature. block2's `RcBlock` is used nowhere in this crate's private layer — it crashed the
+// callbacks these frameworks invoke (see `screen.rs`), so the recipe is hand-rolled throughout.
+
+#[repr(C)]
+struct BlockDescriptor {
+    reserved: c_ulong,
+    size: c_ulong,
+    /// Objective-C type encoding of the block signature; required with `BLOCK_HAS_SIGNATURE`.
+    signature: *const i8,
+}
+
+// SAFETY: the descriptor is immutable and its signature is a static NUL-terminated string.
+unsafe impl Sync for BlockDescriptor {}
+
+#[repr(C)]
+struct CaptureBlock {
+    isa: *const c_void,
+    flags: i32,
+    reserved: i32,
+    invoke: *const c_void,
+    descriptor: *const BlockDescriptor,
+    /// The one captured word: the [`SendSlot`] this completion writes into.
+    context: *mut c_void,
+}
+
+const BLOCK_IS_GLOBAL: i32 = 1 << 28;
+const BLOCK_HAS_SIGNATURE: i32 = 1 << 30;
+
+/// `void (^)(NSError *)` — `send`'s completion handler, from the Swift signature
+/// `completion: ((Error?) -> ())?`.
+const COMPLETION_SIGNATURE: &[u8] = b"v16@?0@8\0";
+
+static COMPLETION_DESCRIPTOR: BlockDescriptor = BlockDescriptor {
+    reserved: 0,
+    size: size_of::<CaptureBlock>() as c_ulong,
+    signature: COMPLETION_SIGNATURE.as_ptr().cast::<i8>(),
+};
+
+/// Record whether the send errored and release the waiter.
+unsafe extern "C" fn completion_invoke(block: *mut CaptureBlock, error: *mut AnyObject) {
+    // SAFETY: `context` is the `SendSlot` pointer this block was built with, and `send_message`
+    // blocks on the group until this runs, so the slot is still alive.
+    let slot = unsafe { &mut *(*block).context.cast::<SendSlot>() };
+    slot.failed = !error.is_null();
+    // SAFETY: balances the `dispatch_group_enter` in `send_message`.
+    unsafe { dispatch_group_leave(slot.group) };
+}
+
+fn completion_block(slot: *mut SendSlot) -> CaptureBlock {
+    CaptureBlock {
+        isa: (&raw const _NSConcreteGlobalBlock).cast::<c_void>(),
+        flags: BLOCK_IS_GLOBAL | BLOCK_HAS_SIGNATURE,
+        reserved: 0,
+        invoke: completion_invoke as *const c_void,
+        descriptor: &raw const COMPLETION_DESCRIPTOR,
+        context: slot.cast::<c_void>(),
     }
 }
 

--- a/crates/linkcode-sim/src/private/mod.rs
+++ b/crates/linkcode-sim/src/private/mod.rs
@@ -6,6 +6,7 @@
 //! when they don't — so an Xcode without SimulatorKit is view-only, not broken.
 
 pub mod ax;
+mod block;
 pub(crate) mod debug;
 mod device;
 mod framework;


### PR DESCRIPTION
Closes the residual form of CODE-442 — the one the earlier fix did not cover, where a long-lived
sidecar keeps reporting `ok` for injections that reach nobody. It also corrects the root cause that
issue recorded.

## What is actually wrong

`sendWithMessage:freeWhenDone:completionQueue:completion:` is asynchronous and returns void. We
passed `nil` for both the queue and the completion, so the verdict was thrown away — and the verdict
is the *only* thing that distinguishes a delivered message from one dropped on the floor.

SimulatorKit has been reporting the failure all along. A client is bound to one boot session; once
that session ends, every send comes back with `HIDError.machPortInvalid`, in about 0.1 ms. Nobody
was listening, so the sidecar answered `ok: true` and the panel stayed lit with every control dead.

## Correction to the recorded root cause

CODE-442's accepted explanation was that a capture worker's framebuffer registrations keep a dead
session's HID routing "half-alive", making injections succeed silently. That is wrong. Measured
against a real device with a live zombie worker held across a shutdown+boot:

| | stale client | fresh client, same process, zombie worker still running |
| --- | --- | --- |
| completion | `machPortInvalid` | `nil` (success) |
| screen | unchanged | changed |

The worker poisons nothing. The stream-reaping fix worked because it happens to call `forget()`;
eviction was the effective ingredient, not the worker kill. With no stream there was nothing to
evict, which is exactly why the residual form survived.

Two further findings, both negative, both recorded in code comments so nobody re-treads them:
`-resetHIDSession` **breaks a healthy client** (`machPortNotConnected` afterwards) rather than
reviving a dead one, and the `sessionResetHandler` on the 4-argument initialiser never fired — not
on shutdown, not on reboot.

## The fix

`send_message` now hands SimulatorKit a real completion handler and waits for it. Every injection
path returns that verdict, so `with_input`'s existing re-warm-and-retry — which until now could
never trigger, because a build-success was reported as an op-success — finally does its job. Both
`HIDError` cases mean the mach port is unusable, so a failure proves nothing was delivered and the
retry cannot double-send.

This is one mechanism covering every path: panel shutdown, `simctl`, Simulator.app, an engine boot
short-circuited because the host already had the device up, with or without a stream. The reaper
stays, with its comment corrected to say what it actually earns — not streaming a corpse, and not
leaking the worker process.

## Verification

A/B through the real framed-stdio protocol, one long-lived sidecar, device rebooted entirely out of
band, no capture stream anywhere:

| | pre-fix | fixed |
| --- | --- | --- |
| inject after the out-of-band reboot | `ok: true`, screen unchanged | `ok: true`, screen changed, one re-warm logged |
| inject again | `ok: true`, screen unchanged | lands, no re-warm needed — the fresh client stuck |

Also verified on a real device: the panel's own streamed `touch` (down → up, where only `down` may
re-warm) lands after an out-of-band reboot; with a live stream, frames keep flowing, the
notification-path reaper still fires, re-attach spawns a fresh worker+watcher pair, and
`streamStop` leaves no processes behind. `diag-button` became a truthful oracle in the process — it
now answers `false` on a shut-down device instead of `true`.

Gates: `cargo fmt`/`clippy`/`test`, `pnpm check:ci` (0 errors), `pnpm test` (1943 passed).

`e2e:simulator` was **not** run: it drives `bootedUdids()[0]`, and its reclaim step shuts that
device down and reboots it — the host's first booted device is one another session is actively
driving. The stream/reap/inject regression above covers the surfaces this change touches.

No wire change.
