### PR TITLE
fix(mobile): polyfill AbortSignal#throwIfAborted for Hermes (CODE-466)

### DIFF
--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -1,3 +1,5 @@
+import '../runtime/polyfills';
+
 import { BottomSheetModalProvider } from '@gorhom/bottom-sheet';
 import { sanitizeSentryTransaction } from '@linkcode/common/sentry';
 import type { TelemetryConfig } from '@linkcode/common/telemetry-config';

--- a/apps/mobile/src/runtime/__tests__/polyfills.test.ts
+++ b/apps/mobile/src/runtime/__tests__/polyfills.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, expect, it } from 'vitest';
+import { installPolyfills } from '../polyfills';
+
+// Held as a property descriptor: a bare method reference trips @typescript-eslint/unbound-method.
+const native = Object.getOwnPropertyDescriptor(AbortSignal.prototype, 'throwIfAborted');
+
+afterEach(() => {
+  if (native) Object.defineProperty(AbortSignal.prototype, 'throwIfAborted', native);
+});
+
+it('installs throwIfAborted when the runtime lacks it (Hermes, CODE-466)', () => {
+  // @ts-expect-error -- simulate Hermes, which has no throwIfAborted
+  delete AbortSignal.prototype.throwIfAborted;
+  installPolyfills();
+
+  const fresh = new AbortController();
+  expect(() => fresh.signal.throwIfAborted()).not.toThrow();
+
+  const aborted = new AbortController();
+  const reason = new Error('stop');
+  aborted.abort(reason);
+  expect(() => aborted.signal.throwIfAborted()).toThrow(reason);
+});
+
+it('throws even when the signal was aborted without a reason', () => {
+  // @ts-expect-error -- simulate Hermes, which has no throwIfAborted
+  delete AbortSignal.prototype.throwIfAborted;
+  installPolyfills();
+
+  const controller = new AbortController();
+  controller.abort();
+  // Node fills in an AbortError reason; the polyfill's own fallback covers a runtime that leaves
+  // `reason` undefined. Either way the call must throw.
+  expect(() => controller.signal.throwIfAborted()).toThrow();
+});
+
+it('leaves a native implementation in place', () => {
+  installPolyfills();
+  expect(Object.getOwnPropertyDescriptor(AbortSignal.prototype, 'throwIfAborted')?.value).toBe(
+    native?.value,
+  );
+});

--- a/apps/mobile/src/runtime/__tests__/polyfills.test.ts
+++ b/apps/mobile/src/runtime/__tests__/polyfills.test.ts
@@ -22,16 +22,27 @@ it('installs throwIfAborted when the runtime lacks it (Hermes, CODE-466)', () =>
   expect(() => aborted.signal.throwIfAborted()).toThrow(reason);
 });
 
-it('throws even when the signal was aborted without a reason', () => {
+it('falls back to an AbortError when the signal was aborted without a reason', () => {
   // @ts-expect-error -- simulate Hermes, which has no throwIfAborted
   delete AbortSignal.prototype.throwIfAborted;
   installPolyfills();
 
   const controller = new AbortController();
   controller.abort();
-  // Node fills in an AbortError reason; the polyfill's own fallback covers a runtime that leaves
-  // `reason` undefined. Either way the call must throw.
-  expect(() => controller.signal.throwIfAborted()).toThrow();
+  // Node fills in an AbortError reason. RN 0.86's `abort-controller` has no `reason` at all, which
+  // is the case the fallback exists for, so strip it to reach that branch.
+  Object.defineProperty(controller.signal, 'reason', { value: undefined });
+
+  let thrown: unknown;
+  try {
+    controller.signal.throwIfAborted();
+  } catch (error) {
+    thrown = error;
+  }
+  expect(thrown).toBeInstanceOf(DOMException);
+  expect((thrown as DOMException).name).toBe('AbortError');
+  // Node's own reason reads "This operation was aborted", so the wording pins the fallback branch.
+  expect((thrown as DOMException).message).toBe('The operation was aborted.');
 });
 
 it('leaves a native implementation in place', () => {

--- a/apps/mobile/src/runtime/polyfills.ts
+++ b/apps/mobile/src/runtime/polyfills.ts
@@ -1,0 +1,21 @@
+/**
+ * Runtime gaps in Hermes that shared code relies on. Imported first from the root layout so
+ * everything below the app entry sees the patched globals.
+ *
+ * `AbortSignal#throwIfAborted`: Hermes ships `AbortSignal.any` but not this method (checked on
+ * RN 0.86). `foxts/async-retry` calls it on entry, which made every `ConnectionController`
+ * recovery attempt throw synchronously before dialing — the app could never reach a host
+ * (CODE-466). The guard keeps a future native implementation in charge once Hermes grows one.
+ */
+export function installPolyfills(): void {
+  if (!AbortSignal.prototype.throwIfAborted) {
+    AbortSignal.prototype.throwIfAborted = function throwIfAborted(this: AbortSignal): void {
+      if (this.aborted) {
+        // Spec: throw the abort reason. An aborted-without-reason signal still must throw.
+        throw this.reason ?? new Error('Aborted');
+      }
+    };
+  }
+}
+
+installPolyfills();

--- a/apps/mobile/src/runtime/polyfills.ts
+++ b/apps/mobile/src/runtime/polyfills.ts
@@ -2,17 +2,20 @@
  * Runtime gaps in Hermes that shared code relies on. Imported first from the root layout so
  * everything below the app entry sees the patched globals.
  *
- * `AbortSignal#throwIfAborted`: Hermes ships `AbortSignal.any` but not this method (checked on
- * RN 0.86). `foxts/async-retry` calls it on entry, which made every `ConnectionController`
- * recovery attempt throw synchronously before dialing — the app could never reach a host
- * (CODE-466). The guard keeps a future native implementation in charge once Hermes grows one.
+ * `AbortSignal#throwIfAborted`: the Abort API comes from RN, not Hermes — RN 0.86 injects the 2019
+ * `abort-controller` package, which lacks the method and drops `abort(reason)`, and Expo's winter
+ * runtime fills in only the `timeout`/`any` statics. `foxts/async-retry` calls it on entry, which
+ * made every `ConnectionController` recovery attempt throw synchronously before dialing — the app
+ * could never reach a host (CODE-466). RN 0.87 ships a real implementation, which the guard defers
+ * to; CODE-477 deletes this file on the Expo SDK 58 bump.
  */
 export function installPolyfills(): void {
   if (!AbortSignal.prototype.throwIfAborted) {
     AbortSignal.prototype.throwIfAborted = function throwIfAborted(this: AbortSignal): void {
       if (this.aborted) {
-        // Spec: throw the abort reason. An aborted-without-reason signal still must throw.
-        throw this.reason ?? new Error('Aborted');
+        // RN 0.86 never populates `reason`, so the fallback is the live path there; it mirrors the
+        // shape Expo's winter runtime falls back to, so callers only ever see an `AbortError`.
+        throw this.reason ?? new DOMException('The operation was aborted.', 'AbortError');
       }
     };
   }


### PR DESCRIPTION
## Summary

- Polyfill `AbortSignal.prototype.throwIfAborted` for Hermes in the mobile runtime.
- Load the polyfill from the Expo Router root layout before the connection runtime is used.
- Preserve a future native implementation and cover the fallback behavior with unit tests.

`foxts/async-retry` calls `throwIfAborted()` before each `ConnectionController` recovery attempt. Hermes in React Native 0.86 does not provide that method, so mobile host connections failed synchronously before dialing (CODE-466).

## Verification

Local verification requested by `lucas77778`, on Node 26.3.0 after merging current `master`:

- `pnpm format:check` — passed.
- `pnpm lint:ci` with the CI-equivalent single-threaded lint configuration — passed with no errors.
- `pnpm typecheck` — passed.
- `pnpm test` — passed: 257 files passed, 3 skipped; 2,076 tests passed, 5 skipped.
- `pnpm -F @linkcode/mobile smoke:export` — passed for Android and iOS; both outputs were Hermes bytecode bundles and included the required Expo Router modules.
- The earlier CI `Mobile Native Bundles`, desktop, webview, Rust, and CodeQL jobs passed.

The original CI TypeScript job stopped in ESLint with a worker heap OOM before typecheck/tests. Current `master` was merged in commit `3cc966bd`, bringing in the CI fix that uses a 6144 MB heap and single-threaded `pnpm lint:ci`; the push triggered a fresh CI run.

Runtime device verification remains outstanding: the Linux orb has no Android emulator/ADB and cannot run the iOS simulator, so a real Hermes connection to a host was not claimed.

## Checklist

- [ ] `pnpm check:ci` and `pnpm test` both pass (plus `cargo fmt` / `clippy` / `test` for Rust changes)
  - `pnpm test` and the current CI gate (`format:check`, `lint:ci`, `typecheck`) passed; the local convenience `check:ci` still invokes concurrent lint and OOMs in this orb.
- [ ] The affected surface was run and the change observed working
  - Android/iOS production exports passed; device-level host connection verification is still required.
- [x] If a wire message changed: `WIRE_PROTOCOL_VERSION` is bumped (not applicable; no wire change)
- [x] New code and assets are original work, or their origin and license compatibility are noted above
- [x] Docs and comments are updated where behavior changed