### PR TITLE
ci(lint): fix the intermittent ESLint worker OOM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,21 +56,26 @@ jobs:
         with:
           rustflags: '' # keep build.rustflags; the -D warnings default belongs to the Rust job's clippy call
 
+      # Before `pnpm install`, so the hashFiles globs below cannot reach into node_modules.
+      #
+      # eslint validates a cached entry against that file's own content only, so a cross-file type
+      # change would leave an unchanged file's cached result in place — a type-aware rule such as
+      # no-floating-promises can start applying to a caller nobody edited, and `tsc` does not
+      # reject that code either. The key therefore covers every lint-visible input at once and
+      # there are deliberately no restore-keys: a prefix match would reintroduce exactly that hole.
+      # The cost is that this only hits on commits touching no lintable source (docs, Rust,
+      # workflows); a run that changes any of them re-lints from cold, which is the correct answer.
+      - name: Restore ESLint cache
+        uses: actions/cache@v6
+        with:
+          path: .eslintcache
+          key: eslint-${{ runner.os }}-${{ hashFiles('**/*.ts', '**/*.tsx', '**/*.mts', '**/*.cts', '**/*.js', '**/*.jsx', '**/*.mjs', '**/*.cjs', '**/tsconfig*.json', 'eslint.config.cjs', 'pnpm-lock.yaml') }}
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
       - name: Check formatting and imports
         run: pnpm format:check
-
-      # Keyed by run so every run writes a fresh entry; restore-keys pick the newest prior one.
-      # eslint invalidates each entry itself on a content, config, eslint- or node-version change,
-      # so the key deliberately does not try to encode those.
-      - name: Restore ESLint cache
-        uses: actions/cache@v6
-        with:
-          path: .eslintcache
-          key: eslint-${{ runner.os }}-${{ github.run_id }}
-          restore-keys: eslint-${{ runner.os }}-
 
       # `lint:ci`, not `lint`: multithread linting duplicates the typescript-eslint program per
       # worker instead of splitting it, which OOMs a 2-worker runner (CODE-468).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,9 @@ permissions:
   contents: read
 
 env:
-  NODE_OPTIONS: --max-old-space-size=4096
+  # Typed linting needs one TS program set in a single heap: `lint:ci` runs eslint with
+  # `--concurrency=off`, and a cold cache still walks the whole repo, which does not fit in 4096.
+  NODE_OPTIONS: --max-old-space-size=6144
 
 jobs:
   typescript:
@@ -60,8 +62,20 @@ jobs:
       - name: Check formatting and imports
         run: pnpm format:check
 
+      # Keyed by run so every run writes a fresh entry; restore-keys pick the newest prior one.
+      # eslint invalidates each entry itself on a content, config, eslint- or node-version change,
+      # so the key deliberately does not try to encode those.
+      - name: Restore ESLint cache
+        uses: actions/cache@v6
+        with:
+          path: .eslintcache
+          key: eslint-${{ runner.os }}-${{ github.run_id }}
+          restore-keys: eslint-${{ runner.os }}-
+
+      # `lint:ci`, not `lint`: multithread linting duplicates the typescript-eslint program per
+      # worker instead of splitting it, which OOMs a 2-worker runner (CODE-468).
       - name: Lint
-        run: pnpm lint
+        run: pnpm lint:ci
 
       - name: Typecheck
         run: pnpm typecheck

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ expo-export/
 # turbo
 .turbo/
 
+# eslint (`lint:ci` only — see .github/workflows/ci.yml)
+.eslintcache
+
 # expo / react-native
 .expo/
 .expo-shared/

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "dev": "turbo run dev",
     "typecheck": "tsc --build --noEmit",
     "lint": "eslint --concurrency=auto --format=sukka .",
+    "lint:ci": "eslint --concurrency=off --cache --cache-strategy content --format=sukka .",
     "lint:fix": "eslint --concurrency=auto --format=sukka --fix .",
     "format": "biome check --write .",
     "format:check": "biome check .",

--- a/packages/host/assets/src/pi-closure.gen.ts
+++ b/packages/host/assets/src/pi-closure.gen.ts
@@ -242,6 +242,13 @@ const packages: NpmClosure['packages'] = [
     path: 'node_modules/@google/genai',
   },
   {
+    name: 'ws',
+    version: '8.21.0',
+    integrity:
+      'sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==',
+    path: 'node_modules/@google/genai/node_modules/ws',
+  },
+  {
     name: '@hono/node-server',
     version: '1.19.14',
     integrity:
@@ -350,6 +357,13 @@ const packages: NpmClosure['packages'] = [
     integrity:
       'sha512-W8pX7zHxjJvMIpw8JMxeJEleapXX0Q9NPszdNzqkM3MIEoIGPObdodujj+WHteXEvGfaP/AMwlNyRfEzSY6dQQ==',
     path: 'node_modules/@mistralai/mistralai',
+  },
+  {
+    name: 'ws',
+    version: '8.21.0',
+    integrity:
+      'sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==',
+    path: 'node_modules/@mistralai/mistralai/node_modules/ws',
   },
   {
     name: '@modelcontextprotocol/sdk',
@@ -1255,6 +1269,13 @@ const packages: NpmClosure['packages'] = [
     path: 'node_modules/openai',
   },
   {
+    name: 'ws',
+    version: '8.21.0',
+    integrity:
+      'sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==',
+    path: 'node_modules/openai/node_modules/ws',
+  },
+  {
     name: 'p-retry',
     version: '4.6.2',
     integrity:
@@ -1571,9 +1592,9 @@ const packages: NpmClosure['packages'] = [
   },
   {
     name: 'ws',
-    version: '8.21.0',
+    version: '8.21.1',
     integrity:
-      'sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==',
+      'sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==',
     path: 'node_modules/ws',
   },
   {


### PR DESCRIPTION
Closes CODE-463's blocker. Fixes CODE-468.

## Why CI kept dying

`pnpm lint` runs `eslint --concurrency=auto`. `auto` resolves to `os.availableParallelism() >> 1`, and ESLint creates those workers with **no `resourceLimits`**, so each inherits the main thread's heap ceiling. On a public-repo `ubuntu-latest` (4 vCPU / 16 GB) that is exactly **2 workers**, each capped at the workflow's `--max-old-space-size=4096`.

Every worker builds its own typescript-eslint project-service programs, so the type graph is duplicated per worker rather than split across them. Two workers each need more than 4 GB, and the job sat just under that cliff — which is why it was intermittent (12 failures / 2 successes since 09:00, including a cargo-only bump that passed while its neighbours failed) rather than a clean break. It stayed green on dev machines only because a high-core box resolves `auto` to many more workers, each with a smaller share.

## Measured on this repo

| `--concurrency` | `--max-old-space-size` | result | wall | peak RSS |
| --- | --- | --- | --- | --- |
| off | 4096 | **OOM** | 42 s† | 4.9 GB |
| **off** | **6144** | **pass** | **54 s** | **6.2 GB** |
| 2 (= CI's `auto`) | 4096 | **OOM** | 49 s† | 9.5 GB |
| 2 | 6144 | pass | 40 s | 11.7 GB |
| 4 | 4096 | pass | 33 s | 18.0 GB |
| 8 | 4096 | pass | 31 s | 32.6 GB |

† died mid-run. The CI failure reproduces locally at `--concurrency=2`.

Lowering concurrency is not the fix and raising it does not fit: total RSS scales with worker count because each worker re-materializes the programs, so 16 GB cannot host more than 2 workers, while 2 workers each need more ceiling than they have. Single-threaded also uses *less* total CPU here (78 s user vs 107–158 s for 2 workers) — the duplicated program building outweighs the parallelism. This matches typescript-eslint's own guidance to disable concurrency for typed linting and lean on `--cache` instead.

## What changed

- **`lint:ci`** — a new script, `eslint --concurrency=off --cache --cache-strategy content`. `pnpm lint` / `lint:fix` keep `--concurrency=auto`, so local behavior is untouched; only the workflow's Lint step switches.
- **`--cache-strategy content` is load-bearing.** The default `metadata` strategy keys on mtime+size, and a fresh checkout rewrites every mtime, so it would score a 0 % hit rate in CI. Verified: after `touch`-ing every `.ts`/`.tsx` in the repo, a warm run still finished in 2.25 s.
- **`actions/cache` on `.eslintcache`**, keyed per run with a `restore-keys` prefix so each run restores the newest prior entry and writes a fresh one.
- **`NODE_OPTIONS` 4096 → 6144.** Still required: a cold cache walks the whole repo, and single-threaded at 4096 OOMs. It is a ceiling, not an allocation, so other jobs are unaffected in practice.

Cold vs warm, both at the CI ceiling: **53.7 s / 6.2 GB** → **2.4 s / 0.44 GB**, same 344 findings.

## Cache correctness

ESLint invalidates an entry when the file's content hash changes or when its resolved config hash changes — and that config hash folds in the ESLint and Node versions — so the cache key deliberately doesn't try to encode any of that. Verified by adding a `debugger;` to a cached file: the cached run reported 345 problems / 1 error, matching an uncached control run of the same file.

One real limitation to be aware of: the cache tracks each file's own content, **not cross-file type dependencies**. With type-aware rules, editing file A can change what a rule should report in an unchanged file B, and B's entry stays valid. `pnpm typecheck` runs uncached in the same job, so genuine type breakage is still caught; what could be missed is a type-derived *lint* finding in a file nobody touched. Worth revisiting if that ever bites.

## Second, unrelated breakage in the same job

With Lint fixed, the job runs far enough to reach `Test`, which then failed on `packages/host/assets` — the committed pi closure manifest no longer matched the lockfile after `chore(deps): bump ws from 7.5.11 to 8.21.1 (#289)`. Lint was failing first and short-circuiting the job, so this never surfaced on CI. Regenerated via `pnpm -F @linkcode/assets run generate:pi-closure` (second commit); the real diff is three nested `ws@8.21.0` entries.

## Verification

`pnpm check:ci` exit 0 and `pnpm test` 2056 passed / 5 skipped, both after the regeneration. The cache behavior above was driven directly rather than inferred.
