### PR TITLE
fix(workbench,ui): scope the new-session agent catalog to the selected workspace

### DIFF
--- a/apps/desktop/e2e/new-session-policy.e2e.mts
+++ b/apps/desktop/e2e/new-session-policy.e2e.mts
@@ -1,0 +1,135 @@
+/**
+ * New-session approval-policy default E2E (CODE-467): boots an isolated daemon + the built desktop
+ * app against a fake HOME whose chat workspace declares `permissions.defaultMode: "plan"`, then
+ * asserts the new-session page advertises Plan mode.
+ *
+ * The catalog request is what this guards: it must carry the selected workspace's cwd, or
+ * claude-code's `startCatalog` cannot read that settings file and the picker falls back to "Ask
+ * permissions" while the started session would actually run in Plan mode. No agent CLI is needed —
+ * `startCatalog` only reads the workspace's settings. Run `pnpm -F @linkcode/desktop
+ * e2e:new-session-policy` after building daemon and desktop.
+ */
+
+import type { ChildProcess } from 'node:child_process';
+import { spawn } from 'node:child_process';
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { falseFn, noop } from 'foxts/noop';
+import { wait } from 'foxts/wait';
+import type { ElectronApplication, Page } from 'playwright-core';
+import { _electron } from 'playwright-core';
+
+const require = createRequire(import.meta.url);
+const desktopDir = resolve(import.meta.dirname, '..');
+const daemonDir = resolve(desktopDir, '../daemon');
+const electronBinary = require('electron') as unknown as string;
+
+const PORT = 43000 + (process.pid % 1000);
+// Both sides must agree, or the app resolves a different userData universe than the daemon's HOME
+// and reads a real dev profile's persisted provider instead of this run's.
+const PROFILE = `e2e-policy-${process.pid}`;
+const RE_PLAN_MODE = /Plan mode/;
+
+function fail(message: string): never {
+  console.error(`FAIL: ${message}`);
+  process.exit(1);
+}
+
+async function waitForDaemon(): Promise<void> {
+  const deadline = Date.now() + 30000;
+  while (Date.now() < deadline) {
+    try {
+      await fetch(`http://127.0.0.1:${PORT}/socket.io/?EIO=4&transport=polling`);
+      return;
+    } catch {
+      await wait(250);
+    }
+  }
+  fail(`daemon did not come up on port ${PORT}`);
+}
+
+async function run(win: Page): Promise<void> {
+  // A fresh profile opens straight onto the new-session page.
+  await win.getByText('What should we build?').waitFor({ state: 'visible', timeout: 30000 });
+  await win.waitForTimeout(2000);
+
+  // The chip is the approval-policy trigger specifically, so this cannot pass on the words
+  // appearing anywhere else on the page.
+  const policyChip = win.getByRole('button', { name: RE_PLAN_MODE });
+  if (!(await policyChip.isVisible().catch(falseFn))) {
+    const labels = await win
+      .getByRole('button')
+      .evaluateAll((nodes) => nodes.map((node) => node.textContent?.trim() ?? ''));
+    console.error('composer controls:', JSON.stringify(labels.filter(Boolean)));
+    fail(
+      'the new-session composer does not advertise Plan mode — the agent catalog was fetched without the workspace cwd',
+    );
+  }
+  console.log('approval-policy picker resolved the workspace default: Plan mode');
+}
+
+async function main(): Promise<void> {
+  if (!existsSync(join(daemonDir, 'dist/index.js'))) {
+    fail('apps/daemon/dist is missing — run `pnpm -F @linkcode/daemon build` first');
+  }
+  if (!existsSync(join(desktopDir, 'out/main/index.js'))) {
+    fail('apps/desktop/out is missing — run `pnpm -F @linkcode/desktop build` first');
+  }
+
+  const home = mkdtempSync(join(tmpdir(), 'linkcode-e2e-home-'));
+  const userData = mkdtempSync(join(tmpdir(), 'linkcode-e2e-userdata-'));
+
+  // The daemon-owned chat workspace is the new-session page's default selection; declaring a
+  // non-default tier here is what the picker has to discover.
+  const chatRoot = join(home, 'LinkCode');
+  mkdirSync(join(chatRoot, '.claude'), { recursive: true });
+  writeFileSync(
+    join(chatRoot, '.claude', 'settings.json'),
+    `${JSON.stringify({ permissions: { defaultMode: 'plan' } }, null, 2)}\n`,
+  );
+
+  let daemon: ChildProcess | null = null;
+  let app: ElectronApplication | null = null;
+  let passed = false;
+  try {
+    daemon = spawn(process.execPath, ['dist/index.js'], {
+      cwd: daemonDir,
+      env: { ...process.env, HOME: home, LINKCODE_PORT: String(PORT), LINKCODE_PROFILE: PROFILE },
+      stdio: 'ignore',
+    });
+    await waitForDaemon();
+    console.log(`daemon up on :${PORT} (HOME=${home})`);
+
+    app = await _electron.launch({
+      executablePath: electronBinary,
+      args: [desktopDir, `--user-data-dir=${userData}`, '--use-mock-keychain'],
+      env: { ...process.env, HOME: home, LINKCODE_PROFILE: PROFILE },
+    });
+
+    const win = await app.firstWindow();
+    try {
+      await run(win);
+    } catch (error) {
+      const shot = join(tmpdir(), `linkcode-e2e-new-session-policy-${process.pid}.png`);
+      await win.screenshot({ path: shot }).catch(noop);
+      console.error(`screenshot: ${shot}`);
+      throw error;
+    }
+    passed = true;
+    console.log('PASS');
+  } finally {
+    await app?.close().catch(noop);
+    daemon?.kill('SIGTERM');
+    if (passed) {
+      rmSync(home, { recursive: true, force: true });
+      rmSync(userData, { recursive: true, force: true });
+    } else {
+      console.error(`kept for debugging: HOME=${home} userData=${userData}`);
+      process.exitCode = 1;
+    }
+  }
+}
+
+void main();

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -19,6 +19,7 @@
     "e2e:packaged": "pnpm run package:devshell && pnpm run e2e:packaged:smoke",
     "e2e:notifications": "node e2e/notifications.e2e.mts",
     "e2e:file-tree": "node e2e/file-tree.e2e.mts",
+    "e2e:new-session-policy": "node e2e/new-session-policy.e2e.mts",
     "e2e:simulator": "node e2e/simulator-panel.e2e.mts",
     "e2e:thread-menu": "node e2e/thread-menu.e2e.mts",
     "e2e:window-bounds": "node e2e/window-bounds.e2e.mts",

--- a/apps/desktop/src/renderer/src/shell/desktop-shell.tsx
+++ b/apps/desktop/src/renderer/src/shell/desktop-shell.tsx
@@ -67,6 +67,8 @@ export function DesktopShell({
   chatWorkspace,
   activeSession,
   draft,
+  newSessionWorkspaceId,
+  onNewSessionWorkspaceChange,
   runtimeCues,
   attachmentSupport,
   agentCatalogs,
@@ -392,6 +394,8 @@ export function DesktopShell({
           draft={draft}
           workspaces={workspaces}
           chatWorkspace={chatWorkspace}
+          workspaceId={newSessionWorkspaceId}
+          onWorkspaceChange={onNewSessionWorkspaceChange}
           runtimeCues={runtimeCues}
           attachmentSupport={attachmentSupport}
           agentCatalogs={agentCatalogs}

--- a/packages/client/workbench/src/surface/__tests__/use-agent-catalogs.test.ts
+++ b/packages/client/workbench/src/surface/__tests__/use-agent-catalogs.test.ts
@@ -1,0 +1,50 @@
+// @vitest-environment jsdom
+
+import { renderHook } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { useAgentStartCatalogs } from '../use-agent-catalogs';
+
+const tayoriMock = vi.hoisted(() => ({ params: [] as unknown[] }));
+
+vi.mock('../../runtime/tayori', () => ({
+  useData(_operation: unknown, params: unknown) {
+    tayoriMock.params.push(params);
+    return { data: undefined };
+  },
+}));
+
+afterEach(() => {
+  tayoriMock.params.length = 0;
+});
+
+describe('useAgentStartCatalogs', () => {
+  it('scopes every agent catalog request to the selected workspace', () => {
+    renderHook(() => useAgentStartCatalogs('/repo/app'));
+
+    // The cwd is what lets an adapter resolve the tier a session would really start under —
+    // claude-code reads `permissions.defaultMode` from the workspace's own settings.
+    expect(tayoriMock.params).toEqual([
+      { agentKind: 'claude-code', cwd: '/repo/app' },
+      { agentKind: 'codex', cwd: '/repo/app' },
+      { agentKind: 'opencode', cwd: '/repo/app' },
+      { agentKind: 'pi', cwd: '/repo/app' },
+      { agentKind: 'grok-build', cwd: '/repo/app' },
+    ]);
+  });
+
+  it('follows a workspace switch rather than capturing the first cwd', () => {
+    const { rerender } = renderHook(({ cwd }: { cwd: string }) => useAgentStartCatalogs(cwd), {
+      initialProps: { cwd: '/repo/app' },
+    });
+    tayoriMock.params.length = 0;
+    rerender({ cwd: '/repo/other' });
+
+    expect(tayoriMock.params).toEqual([
+      { agentKind: 'claude-code', cwd: '/repo/other' },
+      { agentKind: 'codex', cwd: '/repo/other' },
+      { agentKind: 'opencode', cwd: '/repo/other' },
+      { agentKind: 'pi', cwd: '/repo/other' },
+      { agentKind: 'grok-build', cwd: '/repo/other' },
+    ]);
+  });
+});

--- a/packages/client/workbench/src/surface/use-agent-catalogs.ts
+++ b/packages/client/workbench/src/surface/use-agent-catalogs.ts
@@ -2,12 +2,20 @@ import type { AgentKind, AgentStartCatalog } from '@linkcode/schema';
 import { getAgentCatalog } from '@linkcode/sdk';
 import { useData } from '../runtime/tayori';
 
-export function useAgentStartCatalogs(): Partial<Record<AgentKind, AgentStartCatalog>> {
-  const claude = useData(getAgentCatalog, { agentKind: 'claude-code' });
-  const codex = useData(getAgentCatalog, { agentKind: 'codex' });
-  const opencode = useData(getAgentCatalog, { agentKind: 'opencode' });
-  const pi = useData(getAgentCatalog, { agentKind: 'pi' });
-  const grok = useData(getAgentCatalog, { agentKind: 'grok-build' });
+/**
+ * Pre-session capability catalogs, scoped to the workspace the new-session surface has selected.
+ *
+ * `cwd` is load-bearing: an adapter resolves its default approval tier from the workspace
+ * (claude-code reads `permissions.defaultMode` out of `.claude/settings*.json`), so a cwd-less
+ * request reports the generic fallback and the picker would name a tier the session would not
+ * actually start in. Each cwd is its own tayori key, so switching workspaces refetches.
+ */
+export function useAgentStartCatalogs(cwd?: string): Partial<Record<AgentKind, AgentStartCatalog>> {
+  const claude = useData(getAgentCatalog, { agentKind: 'claude-code', cwd });
+  const codex = useData(getAgentCatalog, { agentKind: 'codex', cwd });
+  const opencode = useData(getAgentCatalog, { agentKind: 'opencode', cwd });
+  const pi = useData(getAgentCatalog, { agentKind: 'pi', cwd });
+  const grok = useData(getAgentCatalog, { agentKind: 'grok-build', cwd });
   return {
     ...(claude.data && { 'claude-code': claude.data }),
     ...(codex.data && { codex: codex.data }),

--- a/packages/client/workbench/src/surface/use-agent-catalogs.ts
+++ b/packages/client/workbench/src/surface/use-agent-catalogs.ts
@@ -10,12 +10,18 @@ import { useData } from '../runtime/tayori';
  * request reports the generic fallback and the picker would name a tier the session would not
  * actually start in. Each cwd is its own tayori key, so switching workspaces refetches.
  */
+// Opt out of the provider-wide keepPreviousData, same reason as the seeded conversation: these
+// results are identity-scoped, so on a workspace switch the previous workspace's catalog would
+// keep answering — forever if the new request fails — and re-create the very mismatch this
+// scoping removes.
+const SCOPED = { keepPreviousData: false } as const;
+
 export function useAgentStartCatalogs(cwd?: string): Partial<Record<AgentKind, AgentStartCatalog>> {
-  const claude = useData(getAgentCatalog, { agentKind: 'claude-code', cwd });
-  const codex = useData(getAgentCatalog, { agentKind: 'codex', cwd });
-  const opencode = useData(getAgentCatalog, { agentKind: 'opencode', cwd });
-  const pi = useData(getAgentCatalog, { agentKind: 'pi', cwd });
-  const grok = useData(getAgentCatalog, { agentKind: 'grok-build', cwd });
+  const claude = useData(getAgentCatalog, { agentKind: 'claude-code', cwd }, SCOPED);
+  const codex = useData(getAgentCatalog, { agentKind: 'codex', cwd }, SCOPED);
+  const opencode = useData(getAgentCatalog, { agentKind: 'opencode', cwd }, SCOPED);
+  const pi = useData(getAgentCatalog, { agentKind: 'pi', cwd }, SCOPED);
+  const grok = useData(getAgentCatalog, { agentKind: 'grok-build', cwd }, SCOPED);
   return {
     ...(claude.data && { 'claude-code': claude.data }),
     ...(codex.data && { codex: codex.data }),

--- a/packages/client/workbench/src/surface/workbench.tsx
+++ b/packages/client/workbench/src/surface/workbench.tsx
@@ -104,6 +104,13 @@ export interface WorkbenchProps {
   shellComponent?: WorkbenchShellComponent;
 }
 
+/** A new-session workspace choice, tagged with the resolved workspace it was made against so a
+ * draft opened from another entry point cannot inherit it. */
+interface NewSessionWorkspacePick {
+  forInitial: WorkspaceId | null;
+  picked: WorkspaceId;
+}
+
 /**
  * The workbench feature surface: session inbox + conversation stream + composer. Assumes the data
  * plane is already mounted above it — wrap in `WorkbenchProviders` and mount as a feature page.
@@ -113,33 +120,41 @@ export function Workbench({
 }: WorkbenchProps): React.ReactNode {
   const rootRef = useRef<HTMLDivElement>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [workspacePick, setWorkspacePick] = useState<NewSessionWorkspacePick | null>(null);
   function handleError(err: unknown): void {
     setErrorMessage(extractErrorMessage(err));
   }
 
-  const rawSessions = useWorkbenchSessions(handleError);
   // Leaving the current surface drops its error state: a stale failure must not follow the user
   // to another thread or the new-thread page (CODE-239). `create` clears at submit time instead.
+  // The new-session workspace pick goes with it: the shells remount the draft page per entry
+  // point, which resets its other picks, so an abandoned workspace must not outlive it either.
+  function leaveSurface(): void {
+    setErrorMessage(null);
+    setWorkspacePick(null);
+  }
+
+  const rawSessions = useWorkbenchSessions(handleError);
   const sessions: WorkbenchSessions = {
     ...rawSessions,
     select(id) {
-      setErrorMessage(null);
+      leaveSurface();
       rawSessions.select(id);
     },
     startDraft(workspaceId) {
-      setErrorMessage(null);
+      leaveSurface();
       rawSessions.startDraft(workspaceId);
     },
     goBack() {
-      setErrorMessage(null);
+      leaveSurface();
       rawSessions.goBack();
     },
     goForward() {
-      setErrorMessage(null);
+      leaveSurface();
       rawSessions.goForward();
     },
     close(id) {
-      setErrorMessage(null);
+      leaveSurface();
       rawSessions.close(id);
     },
   };
@@ -158,6 +173,8 @@ export function Workbench({
         conversation={conversation}
         errorMessage={errorMessage}
         ShellComponent={ShellComponent}
+        workspacePick={workspacePick}
+        onWorkspacePick={setWorkspacePick}
         onClearError={() => setErrorMessage(null)}
         onError={handleError}
       />
@@ -171,6 +188,8 @@ interface WorkbenchSessionSurfaceProps {
   conversation: Conversation;
   errorMessage: string | null;
   ShellComponent: WorkbenchShellComponent;
+  workspacePick: NewSessionWorkspacePick | null;
+  onWorkspacePick: (pick: NewSessionWorkspacePick) => void;
   onClearError: () => void;
   onError: (err: unknown) => void;
 }
@@ -180,6 +199,8 @@ function WorkbenchSessionSurface({
   conversation,
   errorMessage,
   ShellComponent,
+  workspacePick,
+  onWorkspacePick,
   onClearError,
   onError,
 }: WorkbenchSessionSurfaceProps): React.ReactNode {
@@ -514,14 +535,10 @@ function WorkbenchSessionSurface({
       }
     : null;
 
-  // The new-session page's workspace lives here rather than in the surface because the catalogs
-  // below are scoped by its cwd — two copies would let the picker advertise a default the session
-  // would not start in. A pick belongs to the draft it was made in: reopening the page against a
-  // different resolved workspace starts from that one instead of inheriting the stale pick.
-  const [workspacePick, setWorkspacePick] = useState<{
-    forInitial: WorkspaceId | null;
-    picked: WorkspaceId;
-  } | null>(null);
+  // The new-session page's workspace is owned above rather than by the surface because the
+  // catalogs below are scoped by its cwd — two copies would let them drift and advertise a default
+  // the session would not start in. The pick is tagged with the workspace it was resolved against,
+  // and leaving the surface clears it (see `leaveSurface`), so a later draft never inherits it.
   const newSessionWorkspaceId =
     workspacePick?.forInitial === initialWorkspaceId ? workspacePick.picked : initialWorkspaceId;
   const agentCatalogs = useAgentStartCatalogs(
@@ -529,7 +546,7 @@ function WorkbenchSessionSurface({
   );
 
   function handleNewSessionWorkspaceChange(workspaceId: WorkspaceId): void {
-    setWorkspacePick({ forInitial: initialWorkspaceId, picked: workspaceId });
+    onWorkspacePick({ forInitial: initialWorkspaceId, picked: workspaceId });
   }
 
   function handleRespond(requestId: string, decision: PermissionDecision): void {

--- a/packages/client/workbench/src/surface/workbench.tsx
+++ b/packages/client/workbench/src/surface/workbench.tsx
@@ -209,7 +209,6 @@ function WorkbenchSessionSurface({
   const active = sessions.active;
   const { mentionItems, onMentionQueryChange } = useFileMentionSource();
   const newSessionDefaultModels = useConfiguredDefaultModels();
-  const agentCatalogs = useAgentStartCatalogs();
   const sdkClient = useWorkbenchSdkClient();
   const activeSessionId = sessions.activeId;
   // Announce observation of the focused session so the daemon replays buffered per-session state
@@ -484,7 +483,10 @@ function WorkbenchSessionSurface({
   // The chat workspace is a fixed system entry (the sidebar's "Chats" section, not a Projects
   // group) — split out so the new-session picker offers it as its own "Chat" entry.
   const allWorkspaces = workspaces ?? [];
-  const workspaceIds = new Set(allWorkspaces.map((workspace) => workspace.workspaceId));
+  const workspacesById = new Map(
+    allWorkspaces.map((workspace) => [workspace.workspaceId, workspace] as const),
+  );
+  const workspaceIds = new Set(workspacesById.keys());
   let chatWorkspace: WorkspaceRecord | null = null;
   const projectWorkspaces: WorkspaceRecord[] = [];
   for (const workspace of allWorkspaces) {
@@ -511,6 +513,24 @@ function WorkbenchSessionSurface({
         initialProvider: lastProvider ?? 'claude-code',
       }
     : null;
+
+  // The new-session page's workspace lives here rather than in the surface because the catalogs
+  // below are scoped by its cwd — two copies would let the picker advertise a default the session
+  // would not start in. A pick belongs to the draft it was made in: reopening the page against a
+  // different resolved workspace starts from that one instead of inheriting the stale pick.
+  const [workspacePick, setWorkspacePick] = useState<{
+    forInitial: WorkspaceId | null;
+    picked: WorkspaceId;
+  } | null>(null);
+  const newSessionWorkspaceId =
+    workspacePick?.forInitial === initialWorkspaceId ? workspacePick.picked : initialWorkspaceId;
+  const agentCatalogs = useAgentStartCatalogs(
+    newSessionWorkspaceId === null ? undefined : workspacesById.get(newSessionWorkspaceId)?.cwd,
+  );
+
+  function handleNewSessionWorkspaceChange(workspaceId: WorkspaceId): void {
+    setWorkspacePick({ forInitial: initialWorkspaceId, picked: workspaceId });
+  }
 
   function handleRespond(requestId: string, decision: PermissionDecision): void {
     if (!sessions.activeId || respondingRequestIds.has(requestId)) return;
@@ -569,6 +589,8 @@ function WorkbenchSessionSurface({
       chatWorkspace={chatWorkspace}
       activeSession={active}
       draft={draft}
+      newSessionWorkspaceId={newSessionWorkspaceId}
+      onNewSessionWorkspaceChange={handleNewSessionWorkspaceChange}
       newSessionDefaultModels={newSessionDefaultModels}
       agentCatalogs={agentCatalogs}
       newSessionPreferredModels={newSessionPreferredModels}

--- a/packages/presentation/ui/src/shell/__tests__/new-session-surface.test.tsx
+++ b/packages/presentation/ui/src/shell/__tests__/new-session-surface.test.tsx
@@ -3,8 +3,10 @@
 import { WorkspaceIdSchema } from '@linkcode/schema';
 import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { useState } from 'react';
 import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
-import { NewSessionSurface } from '../new-session-surface';
+import type { NewSessionSurfaceProps } from '../new-session-surface';
+import { NewSessionSurface as ControlledNewSessionSurface } from '../new-session-surface';
 import {
   composerText,
   pressInComposer,
@@ -41,6 +43,27 @@ const RE_PI_SONNET = /Pi Sonnet/;
 const RE_GPT_56_SOL = /GPT-5.6-Sol/;
 const RE_APPROVAL_DEFAULT = /Default/;
 const RE_ACCEPT_EDITS = /Accept edits/;
+const RE_PROJECT_WORKSPACE = /app/;
+
+type StandaloneProps = Omit<NewSessionSurfaceProps, 'workspaceId' | 'onWorkspaceChange'> &
+  Partial<Pick<NewSessionSurfaceProps, 'onWorkspaceChange'>>;
+
+/** The surface takes its workspace as a controlled prop so the workbench can scope the agent
+ * catalogs to the same cwd. These cases exercise the surface standalone, so this stands in for the
+ * workbench and holds the selection; `onWorkspaceChange` still reaches a case that passes one. */
+function NewSessionSurface({ onWorkspaceChange, ...props }: StandaloneProps): React.ReactNode {
+  const [workspaceId, setWorkspaceId] = useState(props.draft.initialWorkspaceId);
+  return (
+    <ControlledNewSessionSurface
+      {...props}
+      workspaceId={workspaceId}
+      onWorkspaceChange={(next) => {
+        setWorkspaceId(next);
+        onWorkspaceChange?.(next);
+      }}
+    />
+  );
+}
 
 describe('NewSessionSurface', () => {
   it.each(['claude-code', 'codex', 'opencode', 'pi'] as const)(
@@ -612,6 +635,40 @@ describe('NewSessionSurface', () => {
 
     await waitFor(() =>
       expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({ model: 'claude-opus-4-8' })),
+    );
+  });
+
+  it('reports a workspace switch upward instead of holding the selection itself', async () => {
+    const user = userEvent.setup();
+    const onWorkspaceChange = vi.fn();
+    const project = {
+      workspaceId: WorkspaceIdSchema.parse('workspace-2'),
+      cwd: '/repo/app',
+      kind: 'project' as const,
+      createdAt: 2,
+      lastUsedAt: 2,
+    };
+    render(
+      <NewSessionSurface
+        chatWorkspace={CHAT_WORKSPACE}
+        draft={{ initialProvider: 'claude-code', initialWorkspaceId: CHAT_WORKSPACE.workspaceId }}
+        mentionItems={[]}
+        onMentionQueryChange={vi.fn()}
+        onRegisterWorkspace={vi.fn().mockResolvedValue(CHAT_WORKSPACE)}
+        onSubmit={vi.fn().mockResolvedValue(undefined)}
+        onWorkspaceChange={onWorkspaceChange}
+        workspaces={[project]}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'chooseWorkspace' }));
+    await user.click(await screen.findByRole('menuitemradio', { name: RE_PROJECT_WORKSPACE }));
+
+    // The workbench needs the pick because it scopes the agent-catalog request by the same cwd.
+    expect(onWorkspaceChange).toHaveBeenCalledWith(project.workspaceId);
+    // And the surface renders whatever workspace it is handed back, not a private copy.
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'chooseWorkspace' }).textContent).toContain('app'),
     );
   });
 

--- a/packages/presentation/ui/src/shell/new-session-surface.tsx
+++ b/packages/presentation/ui/src/shell/new-session-surface.tsx
@@ -71,6 +71,11 @@ export interface NewSessionSurfaceProps {
   /** Project workspaces offered by the picker; the chat workspace arrives separately. */
   workspaces: WorkspaceRecord[];
   chatWorkspace: WorkspaceRecord | null;
+  /** The selected workspace. Controlled by the workbench, which needs that same cwd to scope the
+   * agent catalogs it feeds back in through `agentCatalogs` — a second copy of this state here
+   * would let the two drift and show a default the session would not start in. */
+  workspaceId: WorkspaceId | null;
+  onWorkspaceChange: (workspaceId: WorkspaceId) => void;
   className?: string;
   topContent?: React.ReactNode;
   /** Runtime availability per agent (CODE-112): a cue renders the onboarding card for the picked
@@ -130,6 +135,8 @@ export function NewSessionSurface({
   draft,
   workspaces,
   chatWorkspace,
+  workspaceId,
+  onWorkspaceChange,
   className,
   topContent,
   runtimeCues,
@@ -152,7 +159,6 @@ export function NewSessionSurface({
 }: NewSessionSurfaceProps): React.ReactNode {
   const t = useTranslations('workbench.newSession');
   const [provider, setProvider] = useState(draft.initialProvider);
-  const [workspaceId, setWorkspaceId] = useState(draft.initialWorkspaceId);
   const [selectedModels, setSelectedModels] = useState<Partial<Record<AgentKind, string | null>>>(
     {},
   );
@@ -276,7 +282,7 @@ export function NewSessionSurface({
 
   function handleWorkspaceChange(nextWorkspaceId: WorkspaceId): void {
     onMentionQueryChange(undefined, null);
-    setWorkspaceId(nextWorkspaceId);
+    onWorkspaceChange(nextWorkspaceId);
   }
 
   return (

--- a/packages/presentation/ui/src/shell/shell-frame.tsx
+++ b/packages/presentation/ui/src/shell/shell-frame.tsx
@@ -4,6 +4,7 @@ import type {
   QuestionOutcome,
   SessionId,
   SessionInfo,
+  WorkspaceId,
   WorkspaceRecord,
 } from '@linkcode/schema';
 import type { ConversationViewModel } from '../chat';
@@ -41,6 +42,10 @@ export interface ShellFrameProps
   activeSession: SessionInfo | null;
   /** Non-null while the new-session page is up — it replaces the conversation column. */
   draft: NewSessionDraft | null;
+  /** The new-session page's selected workspace, owned by the workbench so the same cwd scopes
+   * `agentCatalogs`. */
+  newSessionWorkspaceId: WorkspaceId | null;
+  onNewSessionWorkspaceChange: (workspaceId: WorkspaceId) => void;
   /** Agent runtime availability cues: the new-session page's onboarding flow (CODE-112) and the
    * active session's needs-login recovery card (CODE-172). */
   runtimeCues?: AgentRuntimeCues;
@@ -112,6 +117,8 @@ export function ShellFrame({
   chatWorkspace,
   activeSession,
   draft,
+  newSessionWorkspaceId,
+  onNewSessionWorkspaceChange,
   runtimeCues,
   attachmentSupport,
   agentCatalogs,
@@ -199,6 +206,8 @@ export function ShellFrame({
             draft={draft}
             workspaces={workspaces}
             chatWorkspace={chatWorkspace}
+            workspaceId={newSessionWorkspaceId}
+            onWorkspaceChange={onNewSessionWorkspaceChange}
             runtimeCues={runtimeCues}
             attachmentSupport={attachmentSupport}
             agentCatalogs={agentCatalogs}


### PR DESCRIPTION
Closes CODE-467. Follow-up to CODE-463 / #305, raised in that PR's review.

## The bug

`useAgentStartCatalogs()` requested every pre-session catalog with `{ agentKind }` and no `cwd`, even though the wire variant, the SDK operation and the engine handler all already accepted one. claude-code's `startCatalog` resolves its `defaultPolicyId` by reading `permissions.defaultMode` out of the workspace's `.claude/settings*.json`, so without a cwd it reported the generic `default` tier and the New Task composer advertised **Ask permissions** for a workspace configured as **Plan mode**.

Only the display was wrong — #305 already stopped the surface from submitting the catalog default as an explicit pick, so the session itself still started in the right tier. The picker just named a different one.

## Why it needed more than passing an argument

The cwd lives in the selected workspace, and that selection was `useState` inside `new-session-surface.tsx` (`packages/presentation/ui`), while the catalog fetch lives in `workbench.tsx` (`packages/client/workbench`). UI cannot call tayori, so the selection is now lifted:

- `NewSessionSurface` takes `workspaceId` + `onWorkspaceChange` as controlled props instead of holding the selection.
- `workbench.tsx` owns it, keyed to the draft it was made in — reopening the page against a different resolved workspace starts from that one rather than inheriting a stale pick. Both derivations are pure; no effect watches anything.
- `useAgentStartCatalogs(cwd)` passes it through, so each workspace is its own tayori key and switching refetches.

A second copy of the selection would have let the two drift back apart, which is the failure mode this is fixing.

The workspace lookup went from `Array#find` to a `Map` built alongside the existing id `Set` (one pass instead of two) — `sukka/react-no-performance-impacting-array-find` rejects a find in the render phase.

## Verification

Driven in the real app, not just typechecked. New E2E `apps/desktop/e2e/new-session-policy.e2e.mts` (`pnpm -F @linkcode/desktop e2e:new-session-policy`) boots an isolated daemon + the built desktop app against a fake HOME whose chat workspace declares `permissions.defaultMode: "plan"`, and asserts the composer's approval-policy chip specifically:

```
daemon up on :43558 (HOME=/tmp/linkcode-e2e-home-qZFh2T)
approval-policy picker resolved the workspace default: Plan mode
PASS
```

I also confirmed it fails for the right reason: reverting just the cwd argument and rebuilding turns the chip back into the old symptom —

```
composer controls: [...,"Sign in to Claude Code","Ask permissions","Sonnet 5·Default",...]
FAIL: the new-session composer does not advertise Plan mode — the agent catalog was fetched without the workspace cwd
```

It needs no agent CLI: `startCatalog` only reads the workspace's settings file.

Unit coverage alongside it: the catalog request carries the cwd for all five agent kinds and follows a workspace switch rather than capturing the first cwd; the surface reports a switch upward instead of holding the selection itself. `pnpm check:ci` exit 0, `pnpm test` 2076 passed / 5 skipped.

The existing surface tests render `NewSessionSurface` standalone in 22 places, so they go through a small test-local wrapper that plays the workbench's part and holds the selection — no behavioral change to those cases.
