### PR TITLE
fix(ui): soften continuous corners to superellipse(1.1)

### DIFF
--- a/packages/presentation/ui/src/styles.css
+++ b/packages/presentation/ui/src/styles.css
@@ -104,14 +104,18 @@
   }
 
   /* Apple-style continuous corners (UICornerCurve model): only faces with radius ≥ 12px
-     (xl/2xl/3xl and their coss-ui-derived inner faces / inset rings) go squircle; smaller
-     controls and pills stay circular. Class-substring opt-in — vendored coss-ui can't carry
-     the property itself. Substring matching ignores variant conditions: a variant-gated
-     xl class applies squircle even while inactive, which is inert without a radius and
-     imperceptible below the 12px threshold (the only such live face is the 10px popover).
-     clip-path `inset(… round …)` corners (command palette, grouped cards) do not follow
-     corner-shape and keep a circular curve. */
-  @supports (corner-shape: squircle) {
+     (xl/2xl/3xl and their coss-ui-derived inner faces / inset rings) get the continuous
+     curve; smaller controls and pills stay circular. superellipse(1.1), not the squircle
+     keyword: iOS's continuous corner (figma smoothing 0.6) is shape-wise almost a circle —
+     squircle (= superellipse(2)) halves the apex cut-in, reading as a much smaller radius.
+     1.1 keeps ~94% of the perceived radius with a hint of the smoothed transition.
+     Class-substring opt-in — vendored coss-ui can't carry the property itself. Substring
+     matching ignores variant conditions: a variant-gated xl class applies the curve even
+     while inactive, which is inert without a radius and imperceptible below the 12px
+     threshold (the only such live face is the 10px popover). clip-path `inset(… round …)`
+     corners (command palette, grouped cards) do not follow corner-shape and keep a
+     circular curve. */
+  @supports (corner-shape: superellipse(1.1)) {
     :where(
         [class*="rounded-xl"],
         [class*="rounded-2xl"],
@@ -132,14 +136,14 @@
         [class*="rounded-t-xl"],
         [class*="rounded-t-2xl"]
       )::before {
-      corner-shape: squircle;
+      corner-shape: superellipse(1.1);
     }
 
     /* Card-variant tables round their corner cells through logical-corner utilities
        (`…:rounded-ss-xl` etc.) generated on the table body's class list, so the cells
        themselves carry no matchable class — bind the curve to them via the carrier. */
     :where([class*="rounded-ss-xl"]) td {
-      corner-shape: squircle;
+      corner-shape: superellipse(1.1);
     }
   }
 }


### PR DESCRIPTION
Closes CODE-474. Follow-up to CODE-449 (#282).

## Problem

`corner-shape: squircle` (= `superellipse(2)`) cuts into the 45° apex only 54% as deep as a circular corner at the same `border-radius` — rounded-xl 12px reads as ≈6.5px, 2xl 16px as ≈8.7px, 3xl 24px as ≈13px. The whole app visibly lost corner roundness.

## Evidence

Pixel-level XOR fit inside our own Electron, reference = `figma-squircle@1.1.0` at `cornerSmoothing: 0.6` (the `--smoothing-ios` token in the apple-graph library these corners were adopted from):

| curve | XOR vs iOS reference (px²) |
|---|---|
| `round` = `superellipse(1.00)` | **509** (0.3% of the corner box) |
| `superellipse(1.10)` | 1644 |
| `superellipse(1.50)` | 5489 |
| `squircle` = `superellipse(2.00)` | 8697 (17× round) |

iOS's continuous corner is shape-wise almost a circle; its character comes from curvature-transition smoothing (G2), which the superellipse family cannot express — any smoothing there is paid for with a shallower apex. Even `superellipse(1.01)` is farther from the Apple curve than plain `round`.

## Change

`superellipse(1.1)` (decision: keep a hint of the continuous transition; the strictly-faithful answer would be `round`). Keeps ~94% of the perceived radius — 0.7px shallower at 12px, imperceptible — while the `@supports` gate now tests the exact value in use. Fractional `superellipse()` support and the `squircle ≡ superellipse(2)` / `round ≡ superellipse(1)` mapping were verified empirically in the bundled Chromium.