### PR TITLE
chore: trim verbose comments across the codebase

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,12 @@ When asked to plan, the plan must be fully resolved before implementation begins
 - Only change what is explicitly requested. Do not "improve", restructure, replace, or simplify adjacent code you weren't asked to touch. Reducing your edit to a reasonable scope helps you stay focused.
   - **NEVER re-create a file from scratch. NEVER use `sed`/`awk` to edit a file. Always use targeted, localized edits.** This avoids introducing unrequested changes or silently dropping things that were already there.
 - Commit messages: `type(scope): summary` (e.g. `fix(transport): drop stale ack on reconnect`). **No `Co-Authored-By` lines.** Keep them simple. If you feel the need to explain something in a commit message, **don't** — put the explanation in a code comment instead.
+- **Comments: constraint or trap only, 1–2 lines max.** A comment earns its place by stating a non-obvious constraint, a verified trap, or a "why" the code alone cannot convey. Delete everything else:
+  - No `CODE-xxx` issue references — traceability belongs in commits and PR descriptions.
+  - No version changelogs above constants — git log is the history.
+  - No narration of what the code does — well-named identifiers already say it.
+  - No cookie-cutter TODOs — one tracked issue replaces N scattered copies.
+  - Design rationale longer than two lines belongs in the owning `AGENTS.md`, not inline.
 - Keep each commit atomic — compilable and runnable. Target ~200 lines changed (excluding generated files); hard limit 400. Don't make commits too small either — group related changes into one coherent commit. Commit along the way, not all at the end.
 - **Formatter, linter, type checker, and tests must pass before commit** — `pnpm check:ci` (= `format:check` + `lint` + `typecheck`) **and** `pnpm test` (Invariant 4: they remain separate commands). Pre-commit hooks don't cover everything.
 - Use the package manager for dependency changes (`pnpm add`), not manual manifest edits. Cut releases via the repo's release flow (Invariant 5); never hand-tag or hand-edit workspace versions.

--- a/apps/daemon/src/index.ts
+++ b/apps/daemon/src/index.ts
@@ -57,16 +57,12 @@ import { resolveSimSidecarPath } from './sim/backend';
 import { SimulatorMcpEndpoint } from './sim/mcp-endpoint';
 import { createWorkspaceStore } from './workspace-store';
 
-// After an uncaught exception the process state (live sessions, mid-writes) is untrustworthy —
-// die loudly rather than keep serving clients from an unknown state.
+// State is untrustworthy after an uncaught exception — die rather than serve from unknown state.
 process.on('uncaughtException', (err) => {
   logger.fatal({ err }, 'Uncaught exception');
   process.exit(1);
 });
 
-// An unhandled rejection is scoped to one async operation — the rest of the daemon stays
-// coherent, so log instead of exiting. Reaching here means a fire-and-forget path missed its
-// `.catch`; fix that path.
 process.on('unhandledRejection', (reason) => {
   logger.error({ err: reason }, 'Unhandled rejection');
 });
@@ -89,7 +85,6 @@ class BoundListeners extends Context.Service<BoundListeners, readonly DaemonList
   'daemon/BoundListeners',
 ) {}
 
-// A failing finalizer must not change the shutdown outcome; log and move on.
 function finalize(run: () => void | Promise<void>): Effect.Effect<void> {
   return Effect.tryPromise({ try: async () => run(), catch: (cause) => cause }).pipe(
     Effect.catchCause((cause) =>
@@ -102,10 +97,7 @@ function finalize(run: () => void | Promise<void>): Effect.Effect<void> {
   );
 }
 
-// Explicit exits everywhere, not exitCode+return: under utilityProcess the parent IPC channel
-// keeps the event loop alive forever, so a natural exit never happens and the supervisor never
-// hears it. runMain's onExit only skips process.exit for a signal-less code 0, which the
-// never-completing program cannot produce.
+// Explicit process.exit: utilityProcess IPC keeps the event loop alive, preventing natural exit.
 const teardown: Runtime.Teardown = (exit, onExit) => {
   if (Exit.isSuccess(exit)) {
     onExit(0);
@@ -126,39 +118,21 @@ const teardown: Runtime.Teardown = (exit, onExit) => {
   onExit(1);
 };
 
-/**
- * Link Code daemon — the standalone local host process: one shared `Engine` behind a fan-out
- * `Hub`, exposing configured listeners to clients. Real agents live here — they spawn CLI
- * subprocesses and hold credentials, so they cannot run inside a browser tab.
- *
- * Boot/shutdown is an Effect layer graph (CODE-244): acquisition order Shared → Engine →
- * Listeners → lifecycle (runtime file, then uplink), finalizers in reverse. Signals interrupt
- * the root fiber at any boot phase, unwinding exactly the layers that were acquired.
- */
+/** Link Code daemon — local host process: Engine behind a fan-out Hub, serving agents to clients. */
 async function main(): Promise<void> {
-  // Resolved before anything (subcommands included) touches state paths: an invalid
-  // LINKCODE_PROFILE or LINKCODE_CHANNEL must abort here, not mid-command or as a daemon that
-  // silently landed in the default universe.
   const profile = daemonProfile();
   const channel = daemonChannel();
 
-  // Subcommands run and exit instead of booting the host (a running daemon
-  // picks the new sign-in state up on its next restart).
   const command = process.argv[2];
   if (command === 'login') return runLoginCommand();
   if (command === 'logout') return runLogoutCommand();
 
-  // Before the engine starts: agent adapters spawn vendored CLI binaries that resolve inside the
-  // desktop app's asar (no-op outside Electron — see asar-spawn.ts).
   installAsarSpawnFix();
 
   const SharedLive = Layer.effect(
     Shared,
     Effect.gen(function* () {
       const config = loadConfig();
-      // One daemon per universe (channel × profile) — a second instance would share this
-      // universe's daemon.db and split sessions. Daemons of other channels/profiles live in
-      // sibling state dirs and are not visible here.
       const running = yield* Effect.promise(findRunningDaemon);
       if (running) {
         const urls = running.listeners.map((listener) => listener.url).join(', ');
@@ -182,12 +156,7 @@ async function main(): Promise<void> {
       yield* Effect.addFinalizer(() =>
         Effect.promise(() => Sentry.close(DRAIN_TIMEOUT_MS)).pipe(Effect.ignore),
       );
-      // Engine.stop() also closes the hub via transport.close(); Hub.close is idempotent, so the
-      // late double-close here matches the old stopAll behavior.
       yield* Effect.addFinalizer(() => finalize(() => hub.close()));
-      // Written by the engine's script service, read by every listener's reverse proxy. Preview
-      // traffic bypasses daemon auth by decision — the loopback bind is the boundary; remote
-      // exposure is the tunnel's job.
       const previewRoutes = new PreviewRouteRegistry();
       return { config, identity, hub, previewRoutes };
     }),
@@ -197,11 +166,7 @@ async function main(): Promise<void> {
     Effect.gen(function* () {
       const { config, hub, previewRoutes } = yield* Shared;
       const store = createProviderConfigStore(config.providers ?? {}, config.accounts ?? []);
-      // Managed assets (CODE-111): GC superseded versions before anything can spawn, then feed the
-      // store into spawn resolution — managed wins over detected as soon as an install lands.
       const assets = new AssetManager();
-      // Prior managed install = standing consent to keep that agent current (CODE-221). Snapshot
-      // before GC removes superseded versions.
       const consentedAgents = consentedManagedAgents(assets);
       const gc = assets.gcAtBoot();
       if (gc.removed.length > 0) {
@@ -218,7 +183,6 @@ async function main(): Promise<void> {
         const name = ManagedAgentAssetNameSchema.safeParse(kind);
         return name.success ? assets.managedBinary(managedAgentAssetId(name.data)) : undefined;
       });
-      // In-process agents (pi) import a managed closure entry instead of spawning (CODE-219).
       agentRuntimeProber.setManagedEntryResolver((kind) => {
         const name = ManagedAgentAssetNameSchema.safeParse(kind);
         if (!name.success) return;
@@ -227,23 +191,12 @@ async function main(): Promise<void> {
         const version = assets.wantedVersionOf(id);
         return path && version ? { path, version } : undefined;
       });
-      // Probed once per boot (user-installed CLIs self-update, so results must not outlive a
-      // boot); fills the adapters' spawn-path resolution and is served on `agent-runtime.list`.
-      // Deliberately not awaited (CODE-225): collect() spawns agent CLIs (`--version`, `auth
-      // status`) that take seconds on a cold machine — listener bind must not wait on them, or
-      // every client sits on ECONNREFUSED for the whole probe. The engine seeds from the promise.
+      // Not awaited: CLI probes are slow; listeners must bind without waiting.
       const agentRuntimesReady = agentRuntimeProber.collect();
-      // Absent (not a rejecting stub) off macOS or unconfigured: the engine then has no
-      // simulator surface at all, which is what the capability gate reads. The daemon owns the
-      // service (not just the sidecar client) so the MCP endpoint and the engine share one
-      // device-claims registry.
       const simSidecarPath = resolveSimSidecarPath();
       const simulators = simSidecarPath
         ? new SimulatorService(new SimSidecarClient(simSidecarPath))
         : undefined;
-      // Decisions persist in config.json, so a grant outlives the session that earned it. The ask
-      // hook reports whether anyone is attached: with no client there is nobody to answer, and
-      // suspending the agent for two minutes would just look like a hang.
       const simulatorConsent = new SimulatorConsentService({
         load: () => Promise.resolve(config.simulatorConsent),
         save: (state) => Promise.resolve(saveSimulatorConsent(state)),
@@ -307,9 +260,6 @@ async function main(): Promise<void> {
       const EngineReady = Layer.effectDiscard(
         Effect.gen(function* () {
           const engine = yield* EngineService;
-          // Refresh consented managed installs in the background — boot never waits on a download.
-          // Rides the probe promise (CODE-225); yielding the service first guarantees the engine's
-          // asset subscription sees the whole install lifecycle.
           void agentRuntimesReady
             .then((agentRuntimes) => {
               for (const kind of agentsToRefresh(consentedAgents, agentRuntimes, assets)) {

--- a/apps/daemon/tsup.config.ts
+++ b/apps/daemon/tsup.config.ts
@@ -7,35 +7,22 @@ export default defineConfig({
   format: ['esm'],
   target: 'node24',
   clean: true,
-  // Desktop packaging copies only index.js into the asar (electron.vite.config.ts
-  // bundle-daemon-artifact); a split bundle boots to ERR_MODULE_NOT_FOUND on the missing chunk-*.js.
+  // Desktop packaging copies only index.js; a split bundle misses chunk-*.js.
   splitting: false,
-  // Stamps the channel into the bundle (CODE-460): a built daemon is a release artifact, while
-  // running the TS source leaves this undefined so `daemonChannel()` defaults to development. The
-  // desktop supervisor's LINKCODE_CHANNEL still outranks it — the devshell pack ships this very
-  // bundle inside a development shell.
+  // Stamp the channel into the bundle (CODE-460).
   define: { 'process.env.LINKCODE_BUILD_CHANNEL': JSON.stringify('release') },
-  // Inlined CJS deps call `require()`; esbuild's ESM output has none, so provide one or boot dies
-  // with "Dynamic require of ... is not supported". The private alias avoids redeclaring a bundled
-  // module's own preserved `import { createRequire }` (the banner is prepended after esbuild).
+  // Provide require() for inlined CJS deps (esbuild ESM has none).
   banner: {
     js: "import { createRequire as __linkcodeCreateRequire } from 'node:module'; const require = __linkcodeCreateRequire(import.meta.url);",
   },
-  // Workspace packages are exported as TS source and must be bundled in. drizzle-orm is bundled
-  // too (it's pure JS and daemon-only, and lives in devDependencies): keeping it external would
-  // put its whole 15 MB dual-format dist into both deploy closures (desktop asar + standalone)
-  // when the bundle only uses the better-sqlite3 dialect.
-  // effect + its daemon integrations follow the same pattern: pure JS, daemon-only,
-  // devDependencies, bundled in so neither deploy closure has to carry them (CODE-244).
+  // Workspace TS source + daemon-only pure-JS deps (drizzle-orm, effect) must be bundled in.
   noExternal: [
     /^@linkcode\//,
     'drizzle-orm',
     /^effect(\/|$)/,
     /^@effect\/(?:opentelemetry|platform-node)(\/|$)/,
   ],
-  // The agent SDKs are pulled in (lazily) via @linkcode/agent-adapter, but must stay external: several
-  // ship platform-specific native binaries / spawn subprocesses and break if bundled. They load from
-  // node_modules at runtime. `ws` (via @linkcode/transport/server) is externalized for the same reason.
+  // Agent SDKs ship native binaries and break if bundled; ws likewise.
   external: [
     '@anthropic-ai/claude-agent-sdk',
     '@openai/codex',

--- a/apps/desktop/src/main/daemon-supervisor.ts
+++ b/apps/desktop/src/main/daemon-supervisor.ts
@@ -8,14 +8,7 @@ import { CHANNEL, PROFILE } from './constants';
 import { watchDaemonRuntime } from './daemon-discovery';
 import { getSettings } from './settings';
 
-/**
- * Supervises the bundled daemon (out/daemon/index.mjs): forks it under Electron's Node via
- * `utilityProcess`, started on app-ready, SIGTERMed on quit; closing windows leaves it running.
- * It only spawns — the one-daemon-per-universe contract lives in the daemon itself
- * (apps/daemon/src/runtime.ts): an external daemon makes the child exit
- * DAEMON_EXIT_ALREADY_RUNNING and the supervisor stands down; which daemon clients dial is
- * discovery's job (runtime.json).
- */
+/** Supervises the bundled daemon: fork via utilityProcess, SIGTERM on quit, respawn on crash. */
 
 const RESPAWN_DELAY_MS = 1000;
 /** A child that lived at least this long resets the crash-loop counter. */
@@ -47,9 +40,7 @@ export function startDaemonSupervisor(): void {
     const proc = child;
     if (draining || proc === null) return;
     draining = true;
-    // Electron destroys its utility processes as the browser exits, so quitting straight after
-    // the SIGTERM truncates the daemon's drain — it dies mid-shutdown, leaving runtime.json
-    // behind and its session writes unfinished. Hold the quit until the child is actually gone.
+    // Hold quit until daemon exits; Electron kills utilities on browser exit.
     event.preventDefault();
     const deadline = setTimeout(() => {
       log.warn('[linkcode/desktop] daemon did not drain in time; quitting anyway');
@@ -94,8 +85,6 @@ function spawnDaemon(): void {
   if (quitting || !isDaemonManaged()) return;
   const startedAt = Date.now();
   const env: Record<string, string | undefined> = { ...process.env };
-  // The child must live in the desktop's resolved universe: a `--profile` switch outranks any
-  // inherited LINKCODE_PROFILE, and the default universe must not leak a stray env value through.
   if (PROFILE === undefined) delete env.LINKCODE_PROFILE;
   else env.LINKCODE_PROFILE = PROFILE;
   // The channel cannot be inferred by the child: the devshell pack bundles a daemon stamped
@@ -115,9 +104,6 @@ function spawnDaemon(): void {
   // Same DSN the Electron main process inlined at build time (signed builds only). Publishable id.
   const sentryDsn = import.meta.env.MAIN_VITE_SENTRY_DSN;
   if (sentryDsn) env.LINKCODE_SENTRY_DSN = sentryDsn;
-  // Agent CLI binaries need no env here: the daemon owns its managed-asset store
-  // (@linkcode/assets, CODE-111) and resolves spawn paths managed → detected on its own.
-
   const daemonDir = join(__dirname, '../daemon');
   const instrument = join(daemonDir, 'instrument.mjs');
   // Preload Sentry before any daemon module loads (same contract as `node --import` standalone).

--- a/apps/desktop/src/renderer/src/cloud-auth/store.ts
+++ b/apps/desktop/src/renderer/src/cloud-auth/store.ts
@@ -45,10 +45,6 @@ export const useCloudAuthStore = create<CloudAuthState>((set, get) => {
     publishUser,
     signIn() {
       set({ authenticating: true });
-      // Re-assert the deep-link scheme before the browser handoff so the OAuth callback routes
-      // back to THIS app; `allSettled` lets a failed re-assert still proceed to sign-in.
-      // requestAuth resolves once the system browser has the sign-in URL — clear the flag on that
-      // handoff, otherwise abandoning the browser leaves no callback and the button stays disabled.
       void Promise.allSettled([cloudDataBridge.claimDeepLink()])
         .then(() => traceRendererIpc('cloud.auth.request', () => window.requestAuth()))
         .finally(() => set({ authenticating: false }));

--- a/apps/desktop/src/renderer/src/shell/browser/browser-webview-pane.tsx
+++ b/apps/desktop/src/renderer/src/shell/browser/browser-webview-pane.tsx
@@ -201,11 +201,7 @@ export function BrowserWebviewPane({
     };
   }, [webview, t, tabId]);
 
-  // Pause any playing media when the pane is hidden (panel collapsed or another section shown),
-  // so a preview stops instead of playing audio out of sight. Paused, not resumed — the user
-  // restarts it on their next visit.
-  // Gated on `dom-ready`: the resident webview normally mounts hidden, and calling guest methods
-  // before attachment can throw synchronously. A guest that never became ready has nothing playing.
+  // Pause playing media when the pane is hidden; gated on dom-ready to avoid pre-attachment throws.
   useLayoutEffect(() => {
     if (webview === null || !guestReady) return;
     const isVisible = (): boolean => {

--- a/apps/desktop/vite.main.config.ts
+++ b/apps/desktop/vite.main.config.ts
@@ -38,11 +38,6 @@ export default defineConfig({
     assetPlugin(),
     {
       name: 'bundle-daemon-artifact',
-      // The daemon ships inside the desktop app (CODE-86): consume apps/daemon/dist (turbo `^build`
-      // orders it) so bundling stays owned by the daemon; its runtime externals resolve from asar
-      // node_modules through the @linkcode/daemon dependency edge. instrument.js ships too (Sentry
-      // error reporting); it loads `@sentry/profiling-node` only via createRequire so a missing
-      // native profiler under Electron is a soft miss, not a boot crash.
       closeBundle() {
         const dist = resolve(__dirname, '../daemon/dist/index.js');
         if (!existsSync(dist)) {

--- a/apps/desktop/vite.shared.ts
+++ b/apps/desktop/vite.shared.ts
@@ -10,10 +10,7 @@ import { dependencies } from './package.json';
 export const NODE_TARGET = 'node24.18';
 export const CHROME_TARGET = 'chrome150';
 
-// Workspace packages export raw TS, so they must be bundled into main/preload: a require left in
-// the bundle resolves to .ts under app.asar/node_modules and crashes on launch
-// (ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING). Derived from package.json so a new workspace
-// import can never be missed; everything else in `dependencies` stays external.
+// Workspace TS packages must be bundled; externalizing them crashes on asar .ts require.
 const ELECTRON_SUBPATH_RE = /^electron\/.+/;
 
 export function nodeExternals(alsoBundle: readonly string[] = []): Array<string | RegExp> {

--- a/packages/client/core/src/client/control-channel.ts
+++ b/packages/client/core/src/client/control-channel.ts
@@ -592,10 +592,6 @@ export class ControlChannel {
     }));
   }
 
-  // iOS Simulator (CODE-394). Commands are session-scoped: the engine claims the device for
-  // `sessionId` (ownership/cap rules) before touching it. Gate the whole surface on
-  // `simulatorStatus().available`.
-
   simulatorStatus(): Promise<SimulatorStatus> {
     return this.sendCorrelated('simulatorStatus', (clientReqId) => ({
       kind: 'simulator.status',

--- a/packages/client/core/tests/integration/conversation-store.test.ts
+++ b/packages/client/core/tests/integration/conversation-store.test.ts
@@ -92,8 +92,6 @@ describe('createConversationStore', () => {
     close();
   });
 
-  // CODE-35: a transcript snapshot can never contain ephemeral events (permission asks, status,
-  // stop, errors) — a mid-turn seed read whose uptoSeq passes them must not erase them.
   it('keeps ephemeral live events that fall inside the snapshot cut', async () => {
     const { client, send, close } = await harness();
     const announce: AgentEvent = {
@@ -133,9 +131,6 @@ describe('createConversationStore', () => {
     close();
   });
 
-  // CODE-272: mid-turn, the transcript lags the live stream — the in-flight reply has no
-  // transcript row yet, so a reseed (focus/reconnect revalidation) must keep its live chunks
-  // even though they fall inside the cut, or the rendered answer collapses to a suffix.
   it('keeps live chunks of a streaming message the snapshot has not flushed yet', async () => {
     const { client, send, close } = await harness();
     const chunk = (text: string): AgentEvent => ({
@@ -163,8 +158,6 @@ describe('createConversationStore', () => {
     close();
   });
 
-  // CODE-328: once history flushes a completed block under the same provider id, a reseed must
-  // replace its buffered live chunks rather than render the transcript row beside a second copy.
   it('deduplicates live chunks that the snapshot covers by message id', async () => {
     const { client, send, close } = await harness();
     const chunk = (text: string): AgentEvent => ({

--- a/packages/client/workbench/src/history/use-provider-history.ts
+++ b/packages/client/workbench/src/history/use-provider-history.ts
@@ -58,7 +58,6 @@ export async function importHistoryGroup({
   if (inFlight.has(inFlightKey)) return null;
   inFlight.add(inFlightKey);
   try {
-    // session.import registers each successful entry's cwd as a project in the engine (CODE-345).
     const settled: Array<PromiseSettledResult<SessionId>> = [];
     for (let start = 0; start < entries.length; start += GROUP_IMPORT_CONCURRENCY) {
       const batch = entries.slice(start, start + GROUP_IMPORT_CONCURRENCY);

--- a/packages/client/workbench/src/simulator/panel.tsx
+++ b/packages/client/workbench/src/simulator/panel.tsx
@@ -171,8 +171,6 @@ export function SimulatorPanel({ sessionId }: { sessionId: SessionId | null }): 
   /** True between clicking "download the runtime" and the runtime appearing in a later probe. */
   const [installingRuntime, setInstallingRuntime] = useState(false);
   const [devices, setDevices] = useState<SimulatorDevice[] | null>(null);
-  // Open devices live in the store, not here: agent activity can open one before this component
-  // ever mounts (CODE-418), and the cap is per thread, so the strip counts the way the host does.
   const sessionKey = simulatorSessionKey(sessionId);
   const tabs = useSimulatorPanelStore((state) => selectDeviceTabs(state, sessionKey));
   const openDevice = useSimulatorPanelStore((state) => state.openDevice);
@@ -421,8 +419,6 @@ export function SimulatorPanel({ sessionId }: { sessionId: SessionId | null }): 
       recorder.start(screenCanvas, captureFileStem(device.name));
     }
   };
-  // Simulator.app's chords, scoped to this panel (CODE-414). Declared before the availability
-  // guard below because hooks must run unconditionally.
   useSimulatorShortcuts({
     owner: panelRef,
     enabled: ownerSessionId !== null && udid !== null,

--- a/packages/client/workbench/src/surface/use-workbench-sessions.ts
+++ b/packages/client/workbench/src/surface/use-workbench-sessions.ts
@@ -209,8 +209,7 @@ export function useWorkbenchSessions(onError: (err: unknown) => void): Workbench
       agent_kind: opts.kind,
       duration_ms: Date.now() - startedAt,
     });
-    // The list must contain the new session before selection flips: otherwise `active` falls
-    // back to the previous session for a render and its conversation flashes (CODE-103).
+    // Mutate before selecting to avoid a flash of the previous session.
     await mutate().catch(noop);
     recordNavigation(from, { surface: 'thread', sessionId });
     // setSelectedId atomically exits the draft (see the selection store).

--- a/packages/client/workbench/src/surface/workbench.tsx
+++ b/packages/client/workbench/src/surface/workbench.tsx
@@ -125,10 +125,6 @@ export function Workbench({
     setErrorMessage(extractErrorMessage(err));
   }
 
-  // Leaving the current surface drops its error state: a stale failure must not follow the user
-  // to another thread or the new-thread page (CODE-239). `create` clears at submit time instead.
-  // The new-session workspace pick goes with it: the shells remount the draft page per entry
-  // point, which resets its other picks, so an abandoned workspace must not outlive it either.
   function leaveSurface(): void {
     setErrorMessage(null);
     setWorkspacePick(null);

--- a/packages/foundation/schema/src/wire/message.ts
+++ b/packages/foundation/schema/src/wire/message.ts
@@ -8,26 +8,7 @@ import { WirePayloadSchema } from './payload';
  * sending and after receiving (docs/ARCHITECTURE.md, Transport & wire protocol).
  */
 
-// 39 disambiguates a parallel double-bump: #186 (CODE-142) and #189 (CODE-219) both shipped as
-// "38" with different schemas, so a build from between their merges shares a number with a
-// schema it does not speak.
-// 43 combines 42's agent.catalog/agent.cataloged with CODE-316's parallel 42 bump for
-// file.host/file.hosted, keeping every distinct schema on a distinct protocol version.
-// 44 adds the simulator.* variants (CODE-394).
-// 45 adds the simulator.activity broadcast (CODE-395).
-// 46 adds the simulator interactive + framebuffer-stream variants (CODE-397).
-// 47 adds the simulator screen-mask wire (CODE-397).
-// 48 adds the H.264 stream codec plumbing (CODE-397).
-// 49 adds streamed touch, wheel scroll, and HID keyboard input (CODE-397).
-// 50 adds two-finger pinch and IME pasteboard input (CODE-397).
-// 51 adds the simulator interactive-capability flag to the status wire (CODE-397).
-// 52 adds the simulator device-rotation wire (CODE-408).
-// 53 migrates managed-asset IDs from public strings to discriminated objects.
-// 54 adds the simulator agent-consent variants (CODE-420).
-// 55 adds the simulator volume buttons (CODE-414).
-// 60 adds provider/model-specific reasoning-effort metadata and Codex's distinct `ultra` level.
-// 61 adds the browser broker variants (CODE-267).
-// 62 carries project cwd on history reads so provider-local environment resolution stays coherent.
+// Bump on every wire schema change; mismatched peers silently discard all frames (Invariant 1).
 export const WIRE_PROTOCOL_VERSION = 62 as const;
 
 /** Complete wire message: version + unique id + timestamp + payload. */

--- a/packages/foundation/schema/src/wire/simulator.ts
+++ b/packages/foundation/schema/src/wire/simulator.ts
@@ -64,10 +64,7 @@ export const simulatorWireVariants = [
     x: coord.optional(),
     y: coord.optional(),
   }),
-  // ── Agent consent (CODE-420) ──
-  // Device-scoped, not turn-scoped: an agent's first tool call on an unknown device suspends
-  // while the user decides, which the agent-turn approval channel cannot express (it cancels its
-  // open asks whenever a turn goes idle). Decisions persist across sessions and daemon restarts.
+  // ── Agent consent ──
   z.object({ kind: z.literal('simulator.consent.get'), clientReqId: WireRequestIdSchema }),
   z.object({
     kind: z.literal('simulator.consent.state'),
@@ -173,9 +170,7 @@ export const simulatorWireVariants = [
     data: z.string(),
   }),
 
-  // ── Interactive control + framebuffer streaming (CODE-397; private-API, macOS host only) ──
-  // Void commands reply with the generic `request.succeeded`/`request.failed`. Coordinates are
-  // normalized 0..1, so a downscaled stream needs no adjustment.
+  // ── Interactive control + framebuffer streaming (macOS host only) ──
   z.object({
     kind: z.literal('simulator.tap'),
     clientReqId: WireRequestIdSchema,

--- a/packages/foundation/transport/src/transport.ts
+++ b/packages/foundation/transport/src/transport.ts
@@ -62,14 +62,7 @@ export class Listeners<T> {
   }
 }
 
-/**
- * Base for the four wire-carried `Transport` implementations (ws / ws-server / socket-io /
- * socket-io-server): factors out the listener bookkeeping and the deferred `emitClosed` arming
- * they all repeat. Binding timing is the load-bearing difference:
- * client transports create their socket in an overridden `connect()` and arm `emitClosed` there;
- * server-side connections already hold a live socket at construction, so they arm it in their
- * constructor and keep the inherited default `connect()`.
- */
+/** Base for the four wire-carried Transport implementations, factoring out listener bookkeeping. */
 export abstract class WireConnection implements Transport {
   protected readonly inbound = new Listeners<ValidatedWireMessage>();
   protected readonly closed = new Listeners<void>();
@@ -86,9 +79,6 @@ export abstract class WireConnection implements Transport {
   /** Push the message onto the underlying socket (or drop it if it isn't ready). */
   protected abstract sendBytes(msg: ValidatedWireMessage): void;
 
-  // No zod parse on send: the ValidatedWireMessage brand is the proof (minted only by
-  // createWireMessage / parseWireMessage), so a per-frame parse here would only re-check it
-  // (CODE-231). LocalTransport keeps its send-side parse to catch schema drift in tests.
   send(msg: ValidatedWireMessage): void {
     this.sendBytes(msg);
   }

--- a/packages/host/agent-adapter/src/native/claude-code.ts
+++ b/packages/host/agent-adapter/src/native/claude-code.ts
@@ -777,30 +777,17 @@ export class ClaudeCodeAdapter extends BaseAgentAdapter {
         // Bundled pair staged by the packaged host, else a detected user install (runtime-probe);
         // undefined in dev/standalone daemons, where the SDK resolves its own platform package.
         pathToClaudeCodeExecutable: agentRuntimeProber.resolveBinary('claude-code'),
-        // `options.effort` becomes `--effort`, which outranks flag-settings for the process's whole
-        // lifetime — passing it pins the level and makes every later applyFlagSettings switch a
-        // silent no-op. Only `max` goes in here (the flag-settings key rejects it); other levels
-        // apply through the switchable channel right after creation.
+        // Only `max` here — it pins the level; other levels switch live via applyFlagSettings.
         effort: this.effort === 'max' ? 'max' : undefined,
         includePartialMessages: true,
-        // Forward subagent text/thinking (tool_use/tool_result already flow by default) so the
-        // client can render the nested transcript; all subagent frames carry parent_tool_use_id.
         forwardSubagentText: true,
-        // Opus 4.6+ models default `thinking.display` to 'omitted' at the API — thinking blocks
-        // arrive with EMPTY text (signature only), so no thought event would ever carry content
-        // (CODE-273). The TUI shows thinking because interactive mode requests summaries; SDK mode
-        // must ask explicitly. Ride the raw `--thinking-display` flag rather than the typed
-        // `options.thinking`, which would also pin `--thinking adaptive` and override the CLI's
-        // per-model thinking resolution (verified live on the 0.3.206 × 2.1.212 pair).
+        // Raw flag, not options.thinking — the typed option would also pin --thinking adaptive.
         extraArgs: { 'thinking-display': 'summarized' },
         // Read-only Stop hook reflecting the resolved effort (see `reflectEffortHook`).
         hooks: { Stop: [{ hooks: [reflectCurrentQueryEffort] }] },
         canUseTool: this.canUseTool,
-        // Resolved in onStart via `settingsDefaultMode` — the SDK-driven CLI does not apply
-        // settings.json itself. `undefined` = no pick anywhere; the CLI then starts in 'default'.
         permissionMode: this.approvalPolicy,
-        // Gate flag only — the effective mode stays `permissionMode` above. It must be set at
-        // startup for a later live switch to 'bypassPermissions' to be accepted at all.
+        // Gate for later live switch to bypassPermissions; must be set at startup.
         allowDangerouslySkipPermissions: true,
         resume,
         additionalDirectories: opts.additionalDirectories,
@@ -1377,8 +1364,6 @@ export class ClaudeCodeAdapter extends BaseAgentAdapter {
     this.cancelling = false;
     this.turnActive = false;
     if (msg.subtype === 'success') {
-      // A 401 comes back as a `success` result carrying `api_error_status` (CODE-75) — surface it
-      // as a non-recoverable auth error driving the daemon's login re-probe, not usage + a phantom stop.
       if (msg.api_error_status === 401) {
         this.emitError(
           'Claude authentication failed — sign in to Claude',
@@ -1822,8 +1807,6 @@ export function createClaudeHistoryEventMapper(
       announced.set(toolCall.toolCallId, toolCall);
       return { historyId, itemId: toolCall.toolCallId, ts, event: { type: 'tool-call', toolCall } };
     };
-    // A compaction's swapped-in summary is stored as a user row; replaying it as a user prompt
-    // would fake a giant user turn (CODE-141). It becomes the compaction marker in place instead.
     const compaction = message.type === 'user' ? compactions?.get(message.uuid) : undefined;
     if (compaction) {
       const summary = plainTextContent(
@@ -1857,8 +1840,6 @@ export function createClaudeHistoryEventMapper(
         lastModel = model;
         events.push({ historyId, ts, event: { type: 'model-update', model } });
       }
-      // Thinking replays under the provider message id used by the live stream. Pre-CODE-273
-      // transcripts store empty thinking text; the helper's empty-drop rule skips those.
       for (const block of blocks) {
         if (!isThinkingBlock(block)) continue;
         const thought = thoughtHistoryEvent(

--- a/packages/host/agent-adapter/src/native/pi/adapter.ts
+++ b/packages/host/agent-adapter/src/native/pi/adapter.ts
@@ -236,9 +236,6 @@ export class PiAdapter extends BaseAgentAdapter {
     if (opts.mcpServers?.length) {
       throw new Error('pi: MCP servers are not supported');
     }
-    // Managed closure entry first (the packaged source, CODE-219), then node_modules
-    // self-resolution (dev/standalone). The entry import is type-erased by the dynamic path;
-    // the closure manifest is lockfile-generated, so its bytes match the compiled-against types.
     const generation = ++this.lifecycle;
     const pi = await this.importSdk();
     if (opts.approvalPolicyId) {

--- a/packages/host/agent-adapter/src/probe/claude-code.ts
+++ b/packages/host/agent-adapter/src/probe/claude-code.ts
@@ -23,11 +23,7 @@ export class ClaudeCodeProbe extends AgentCliProbe {
     return `claude-agent-sdk-${process.platform}-${process.arch}`;
   }
 
-  /**
-   * Login status via `claude auth status --json`. The JSON rides stdout even on a non-zero exit
-   * (signed out), so the payload is parsed regardless of exit code; unparseable output fails open
-   * to `undefined` ("unknown", never blocks). Reads the same keychain/credentials the SDK inherits.
-   */
+  /** Login status via `claude auth status --json`; fails open to `undefined`. */
   override async probeAuth(file: string): Promise<AgentAuthStatus | undefined> {
     let stdout = '';
     try {
@@ -43,9 +39,7 @@ export class ClaudeCodeProbe extends AgentCliProbe {
   }
 }
 
-/** Narrow the `claude auth status --json` payload to the surfaced fields. `undefined` (fail-open)
- * when the output is not JSON or lacks a boolean `loggedIn` — never a false negative that would
- * wrongly block a signed-in user. */
+/** Parse `claude auth status --json`; `undefined` (fail-open) on unparseable output. */
 export function parseClaudeAuthStatus(stdout: string): AgentAuthStatus | undefined {
   let data: unknown;
   try {

--- a/packages/host/agent-adapter/src/probe/prober.ts
+++ b/packages/host/agent-adapter/src/probe/prober.ts
@@ -131,19 +131,12 @@ export class AgentRuntimeProber {
           runtimes[probe.kind] = { status: 'available', source: 'sdk', ...(auth && { auth }) };
           return;
         }
-        // Packaged hosts exclude the platform packages (CODE-114): with no detected install either,
-        // this agent genuinely cannot run — do not advertise it.
         runtimes[probe.kind] = { status: 'missing' };
       }),
     );
     return runtimes;
   }
 
-  /**
-   * pi runs in-process, not as a CLI (CODE-219): a managed closure install is the packaged
-   * source; dev/standalone daemons self-resolve the SDK out of node_modules. Neither present —
-   * a packaged host before the first download — reads as missing so onboarding offers it.
-   */
   private piAvailability(): AgentRuntimeAvailability {
     const managed = this.managedEntryResolver?.('pi');
     if (managed) return { status: 'available', source: 'managed', ...managed };

--- a/packages/host/assets/src/catalog.ts
+++ b/packages/host/assets/src/catalog.ts
@@ -120,8 +120,6 @@ function tectonicArtifact(
   };
 }
 
-// The first-party Anthropic⇄OpenAI translation sidecar (CODE-133). GitHub-release binaries; digests
-// hand-verified against the downloaded v0.5.0-rc2 assets (2026-07-09). No win32-arm64 build (like tectonic).
 const AIGATEWAY_VERSION = '0.5.0-rc2';
 const AIGATEWAY_RELEASE = `https://github.com/arcboxlabs/aigateway/releases/download/v${AIGATEWAY_VERSION}`;
 

--- a/packages/host/engine/src/simulator/service.ts
+++ b/packages/host/engine/src/simulator/service.ts
@@ -294,10 +294,6 @@ export class SimulatorService {
     const claim = this.claims.get(udid);
     if (claim?.sessionId !== sessionId) return;
     await this.backend.streamStop(udid);
-    // Detaching (CODE-416) leaves the device booted and still owned — the session lives on and an
-    // agent may keep driving it. But nothing is watching any more, so start the idle clock: a
-    // device we booted should not linger unattended. Any later operation on it disarms this again,
-    // so a device an agent is still working never expires out from under it.
     if (claim.bootedByService) this.armIdleReclaim(udid, claim);
   }
 

--- a/packages/presentation/ui/src/chat/artifact.tsx
+++ b/packages/presentation/ui/src/chat/artifact.tsx
@@ -5,8 +5,6 @@ import { cn } from '../lib/cn';
 import type { TooltipIconButtonProps } from './tooltip-icon-button';
 import { TooltipIconButton } from './tooltip-icon-button';
 
-// TODO(linkcode-schema): Provisional UI-only artifact metadata, not yet wired to daemon/client schema.
-// Move or replace with @linkcode/schema types when generated artifacts are emitted by the data plane.
 export interface ChatArtifact {
   id: string;
   title: string;

--- a/packages/presentation/ui/src/chat/attachments.tsx
+++ b/packages/presentation/ui/src/chat/attachments.tsx
@@ -8,8 +8,6 @@ import { cn } from '../lib/cn';
 import type { FileIconComponent } from '../lib/file-icon';
 import { fileIconFor } from '../lib/file-icon';
 
-// TODO(linkcode-schema): Provisional UI-only attachment model, not yet wired to daemon/client schema.
-// Move or replace with @linkcode/schema types when uploads/context files are supported by the data plane.
 export interface ChatAttachment {
   id: string;
   name: string;
@@ -21,7 +19,6 @@ export interface ChatAttachment {
   errorMessage?: string;
 }
 
-// TODO(linkcode-schema): Promote the prepared non-image kinds when the data plane supports them.
 export type ChatAttachmentKind =
   | 'audio'
   | 'directory'

--- a/packages/presentation/ui/src/chat/checkpoint.tsx
+++ b/packages/presentation/ui/src/chat/checkpoint.tsx
@@ -4,8 +4,6 @@ import { cn } from '../lib/cn';
 import type { TooltipIconButtonProps } from './tooltip-icon-button';
 import { TooltipIconButton } from './tooltip-icon-button';
 
-// TODO(linkcode-schema): Provisional UI-only checkpoint metadata, not yet wired to daemon/client schema.
-// Move or replace with @linkcode/schema types when restore/checkpoint events exist in the data plane.
 export interface ChatCheckpoint {
   id: string;
   label: string;

--- a/packages/presentation/ui/src/chat/commit.tsx
+++ b/packages/presentation/ui/src/chat/commit.tsx
@@ -9,8 +9,6 @@ import type { ChatDisclosureContentProps } from './disclosure-content';
 import { ChatDisclosureContent } from './disclosure-content';
 import { CHAT_DISCLOSURE_TRIGGER_CLASS_NAME, ChatDisclosureChevron } from './disclosure-header';
 
-// TODO(linkcode-schema): Provisional UI-only commit metadata, not yet wired to daemon/client schema.
-// Move or replace with @linkcode/schema types when git/checkpoint events expose structured commits.
 export interface ChatCommit {
   id: string;
   hash: string;

--- a/packages/presentation/ui/src/chat/context.tsx
+++ b/packages/presentation/ui/src/chat/context.tsx
@@ -12,8 +12,6 @@ import {
 } from 'lucide-react';
 import { cn } from '../lib/cn';
 
-// TODO(linkcode-schema): Provisional UI-only context item, not yet wired to daemon/client schema.
-// Move or replace with @linkcode/schema types when active context/files are emitted by the runtime data plane.
 export interface ChatContextItem {
   id: string;
   label: string;

--- a/packages/presentation/ui/src/chat/inline-citation.tsx
+++ b/packages/presentation/ui/src/chat/inline-citation.tsx
@@ -4,8 +4,6 @@ import { ExternalLinkIcon } from 'lucide-react';
 import { cn } from '../lib/cn';
 import { UrlLinkIcon } from './link-icon';
 
-// TODO(linkcode-schema): Provisional UI-only citation reference, not yet wired to daemon/client schema.
-// Move or replace with @linkcode/schema citation metadata when message content supports citations.
 export interface ChatCitation {
   id: string;
   sourceId: string;

--- a/packages/presentation/ui/src/chat/package-info.tsx
+++ b/packages/presentation/ui/src/chat/package-info.tsx
@@ -3,8 +3,6 @@ import { Card } from 'coss-ui/components/card';
 import { ArrowRightIcon, MinusIcon, PackageIcon, PlusIcon } from 'lucide-react';
 import { cn } from '../lib/cn';
 
-// TODO(linkcode-schema): Provisional UI-only package metadata, not yet wired to daemon/client schema.
-// Move or replace with @linkcode/schema types when package manager tool outputs expose structured package data.
 export interface ChatPackageInfo {
   id: string;
   name: string;

--- a/packages/presentation/ui/src/chat/queue.tsx
+++ b/packages/presentation/ui/src/chat/queue.tsx
@@ -22,8 +22,6 @@ import {
   ChatDisclosureIconSlot,
 } from './disclosure-header';
 
-// TODO(linkcode-schema): Provisional UI-only queue item, not yet wired to daemon/client schema.
-// Move or replace with @linkcode/schema types when queued agent operations are emitted by client-core.
 export interface ChatQueueItem {
   id: string;
   title: string;

--- a/packages/presentation/ui/src/chat/schema-display.tsx
+++ b/packages/presentation/ui/src/chat/schema-display.tsx
@@ -12,8 +12,6 @@ import {
 
 const PATH_PARAM_RE = /\{[^}]+\}/g;
 
-// TODO(linkcode-schema): Provisional UI-only schema endpoint model, not yet wired to daemon/client schema.
-// Move or replace with @linkcode/schema types when tools expose structured API/schema metadata.
 export interface ChatSchemaEndpoint {
   id: string;
   method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';

--- a/packages/presentation/ui/src/chat/snippet.tsx
+++ b/packages/presentation/ui/src/chat/snippet.tsx
@@ -3,8 +3,6 @@ import { cn } from '../lib/cn';
 import type { CopyIconButtonProps } from './copy-icon-button';
 import { CopyIconButton } from './copy-icon-button';
 
-// TODO(linkcode-schema): Provisional UI-only snippet model, not yet wired to daemon/client schema.
-// Move or replace with @linkcode/schema types when tool outputs expose reusable command/code snippets.
 export interface ChatSnippet {
   id: string;
   code: string;

--- a/packages/presentation/ui/src/chat/sources.tsx
+++ b/packages/presentation/ui/src/chat/sources.tsx
@@ -13,8 +13,6 @@ import {
 } from './disclosure-header';
 import { UrlLinkIcon } from './link-icon';
 
-// TODO(linkcode-schema): Provisional UI-only source metadata, not yet wired to daemon/client schema.
-// Move or replace with @linkcode/schema types when assistant messages can emit source/citation metadata.
 export interface ChatSource {
   id: string;
   title: string;

--- a/packages/presentation/ui/src/chat/stack-trace.tsx
+++ b/packages/presentation/ui/src/chat/stack-trace.tsx
@@ -17,8 +17,6 @@ import {
 import type { ParsedStackFrame, ParsedStackTrace } from './stack-trace-parser';
 import { formatStackLocationPart, parseStackTrace } from './stack-trace-parser';
 
-// TODO(linkcode-schema): Provisional UI-only stack trace model, not yet wired to daemon/client schema.
-// Move or replace with @linkcode/schema types when test/tool outputs expose structured stack traces.
 export interface ChatStackTrace {
   id: string;
   trace: string;

--- a/packages/presentation/ui/src/chat/suggestion.tsx
+++ b/packages/presentation/ui/src/chat/suggestion.tsx
@@ -2,8 +2,6 @@ import { Button } from 'coss-ui/components/button';
 import { ScrollArea } from 'coss-ui/components/scroll-area';
 import { cn } from '../lib/cn';
 
-// TODO(linkcode-schema): Provisional UI-only suggested action, not yet wired to daemon/client schema.
-// Move or replace with @linkcode/schema types when daemon/client suggestions are part of the data plane.
 export interface ChatSuggestion {
   id: string;
   label: string;

--- a/packages/presentation/ui/src/chat/task.tsx
+++ b/packages/presentation/ui/src/chat/task.tsx
@@ -19,8 +19,6 @@ import {
   ChatDisclosureIconSlot,
 } from './disclosure-header';
 
-// TODO(linkcode-schema): Provisional UI-only task item, not yet wired to daemon/client schema.
-// Move or replace with @linkcode/schema types when agent task progress is part of the event stream.
 export interface ChatTaskItem {
   id: string;
   title: string;

--- a/packages/presentation/ui/src/chat/test-results.tsx
+++ b/packages/presentation/ui/src/chat/test-results.tsx
@@ -6,8 +6,6 @@ import { cn } from '../lib/cn';
 
 const EMPTY_TEST_RESULTS: readonly ChatTestResult[] = [];
 
-// TODO(linkcode-schema): Provisional UI-only test result model, not yet wired to daemon/client schema.
-// Move or replace with @linkcode/schema types when test tool outputs expose structured results.
 export interface ChatTestResult {
   id: string;
   name: string;

--- a/packages/presentation/ui/src/chat/web-preview.tsx
+++ b/packages/presentation/ui/src/chat/web-preview.tsx
@@ -16,8 +16,6 @@ import { TooltipIconButton } from './tooltip-icon-button';
 
 const EMPTY_WEB_PREVIEW_LOGS: readonly ChatWebPreviewLog[] = [];
 
-// TODO(linkcode-schema): Provisional UI-only web preview data, not yet wired to daemon/client schema.
-// Move or replace with @linkcode/schema types when preview sessions/logs are emitted by the data plane.
 export interface ChatWebPreviewData {
   id: string;
   url: string;

--- a/packages/presentation/ui/src/shell/session-modes.ts
+++ b/packages/presentation/ui/src/shell/session-modes.ts
@@ -1,18 +1,6 @@
 import type { SessionMode } from '@linkcode/schema';
 
-/**
- * Workflow modes — provider-advertised `SessionMode`s, at most one active (`currentModeId`);
- * switching sends `set-mode` and the active mode reflects back via `current-mode-update`.
- * This axis is HOW the agent works, NOT the approval policy (the separate permission/safety axis
- * — `ApprovalPolicyState` in @linkcode/schema). Approval-policy ids (default / acceptEdits /
- * auto / bypassPermissions) stay off this channel even once real modes are advertised.
- * TODO(backend): `SessionModeState.availableModes` is not emitted yet — until then the composer
- * menu shows the stub rows below; delete `STUB_SESSION_MODES` once agents advertise real modes.
- */
-
-// TODO(backend): replace with the agent-advertised mode list from `SessionModeState`.
-// TODO(modes): prevent hardcoded workflow modes once agents reliably advertise capabilities.
-// TODO(i18n): move stub labels/descriptions into i18n after the command-menu copy settles.
+// TODO(backend): replace with agent-advertised modes; move labels to i18n after copy settles.
 export const STUB_SESSION_MODES: SessionMode[] = [
   {
     modeId: 'plan',


### PR DESCRIPTION
## Summary

- Remove the 17-line version changelog above `WIRE_PROTOCOL_VERSION` (replaced with a 1-line invariant note)
- Strip ~20 redundant `CODE-xxx` task references from inline comments (daemon boot, adapter, probes, workbench)
- Delete 17 identical `TODO(linkcode-schema)` boilerplate comments across 16 chat component files
- Collapse 4 stacked TODOs in `session-modes.ts` into one line
- Shorten multi-line implementation notes (tsup, daemon-supervisor, vite configs, transport, cloud-auth, browser-pane, simulator) to 1-line constraint summaries

39 files changed, net −220 lines of comments. Zero code logic changes.

## Test plan

- [x] `pnpm format:check` — passed
- [x] `pnpm typecheck` — passed
- [x] `pnpm test` — 247 suites, 1952 tests passed
- [ ] Lint fails on master (pre-existing CODE-468, 255 warnings / 0 errors) — not introduced by this PR