### PR TITLE
refactor(workbench): make keepPreviousData an opt-in per call site

### DIFF
--- a/packages/client/workbench/src/files/panel.tsx
+++ b/packages/client/workbench/src/files/panel.tsx
@@ -48,6 +48,9 @@ export function FilesPanel({
   const treeRef = useRef<WorkspaceFileTreeHandle>(null);
 
   const { data: treeFiles } = useData(listWorkspaceFiles, cwd === undefined ? null : { cwd }, {
+    // Hold the previous workspace's tree while the next enumeration loads, rather than collapsing
+    // the pane to empty — same call as `files/hooks.ts`, same intent.
+    keepPreviousData: true,
     onSuccess(paths) {
       treeRef.current?.resetPaths(paths);
     },

--- a/packages/client/workbench/src/runtime/provider.tsx
+++ b/packages/client/workbench/src/runtime/provider.tsx
@@ -217,9 +217,13 @@ function WorkbenchSWRConfig({ children }: React.PropsWithChildren): React.ReactN
   const { current: cache } = useSingleton<Cache>(() => new Map());
   const { current: provider } = useSingleton(() => createCacheProvider(cache));
   return (
+    // `keepPreviousData` stays at SWR's own default (off) on purpose. Turning it on here made the
+    // risky option the default: every identity-scoped request — keyed by session, workspace, loop —
+    // would answer with the *previous* identity's data while the new key loads, and forever if that
+    // request fails. A surface that genuinely wants the stale-while-loading behavior asks for it at
+    // its own call site, where the intent is visible.
     <SWRConfig
       value={{
-        keepPreviousData: true,
         onError: handleFetchError,
         provider,
         use: [debugMiddleware],


### PR DESCRIPTION
Closes CODE-475. Fallout from the CODE-467 review: hitting this hazard from scratch made it clear the default is the wrong way round.

## The problem with the global

`WorkbenchSWRConfig` overrode SWR's own default with a provider-wide `keepPreviousData: true`, which makes the risky option the default. Any request keyed by an identity — session, workspace, cwd, loop, schedule — silently answers with the **previous** identity's data while the new key loads, and indefinitely if that request fails, unless someone remembers to opt out.

The call sites already argue against it:

- **7 explicit `keepPreviousData: true`** — `git/hooks.ts` (×3), `automations/{loop,schedule}/hooks.ts`, `files/hooks.ts`, `scripts/hooks.ts`. Every one states its intent locally, so the global bought them nothing.
- **8 explicit `keepPreviousData: false`** — `cloud/im.tsx` (×3), `cloud/hosts.tsx`, `files/mentions.ts`, `surface/use-provider-history.ts`, `surface/use-seeded-conversation.ts`, `surface/use-agent-catalogs.ts`. These exist *only* because the global forced them to be written. `use-seeded-conversation.ts` spells the hazard out: "a conversation must never bleed across sessions, and on a switch it would serve the previous transcript — forever, when there's no historyId yet".

Roughly even, and all of them already declare intent — while everything that says nothing quietly gets the risky behavior.

## Blast radius

`keepPreviousData` only matters when the SWR **key changes**; for a fixed key SWR retains data across revalidation regardless. Of 31 `useData` call sites, all but three pass a fixed `{}` key (no-op under either default) or already set the flag:

| call site | key | effect |
| --- | --- | --- |
| `files/panel.tsx` | `{ cwd }` | wanted the old behavior — now says so explicitly, matching its sibling `files/hooks.ts` |
| `automations/loop/hooks.ts` (`inspectLoop`) | `{ loopId }` | identity-scoped; no longer bleeds the previous loop's inspection |
| `automations/schedule/hooks.ts` (`listScheduleRuns`) | `{ scheduleId }` | identity-scoped; same |

So the only deliberate behavior change is the two detail views, and in both directions it moves toward correctness.

Existing explicit `false` opt-outs stay as-is: redundant now, but still true and carrying their rationale. A later sweep can drop them if the noise bothers anyone.

## Verification

`pnpm check:ci` exit 0, `pnpm test` 2073 passed / 5 skipped.

Note this overlaps conceptually with #318 (CODE-467), which adds one of those `false` opt-outs — the two are independent in file terms and can land in either order.
