### PR TITLE
chore(workbench): drop keepPreviousData opt-outs the new default covers

### DIFF
--- a/packages/client/workbench/src/cloud/hosts.tsx
+++ b/packages/client/workbench/src/cloud/hosts.tsx
@@ -35,7 +35,6 @@ export function useCloudHosts(accountKey: string | null | undefined): SWRRespons
     {
       revalidateOnFocus: true,
       refreshInterval: 30000,
-      keepPreviousData: false,
     },
   );
 }

--- a/packages/client/workbench/src/cloud/im.tsx
+++ b/packages/client/workbench/src/cloud/im.tsx
@@ -109,7 +109,7 @@ export function useCloudImOverview(
   return useSWR<CloudImOverview>(
     accountKey && source ? [IM_OVERVIEW_KEY, accountKey] : null,
     source ? source.overview : null,
-    { revalidateOnFocus: true, keepPreviousData: false },
+    { revalidateOnFocus: true },
   );
 }
 
@@ -134,7 +134,7 @@ export function useCloudImPreferences(
   return useSWR<CloudImPreferences>(
     accountKey && source ? [IM_PREFERENCES_KEY, accountKey] : null,
     source ? source.preferences : null,
-    { revalidateOnFocus: true, keepPreviousData: false },
+    { revalidateOnFocus: true },
   );
 }
 

--- a/packages/client/workbench/src/files/__tests__/mentions.test.ts
+++ b/packages/client/workbench/src/files/__tests__/mentions.test.ts
@@ -29,10 +29,11 @@ beforeEach(() => {
     (_operation: unknown, request: MentionRequest | null, options?: MentionDataOptions) => {
       if (!request) return { data: [{ path: 'src/stale.ts' }] };
       const nextData = [{ path: request.cwd === '/project-a' ? 'src/a.ts' : 'src/b.ts' }];
+      // Mirrors the provider: keepPreviousData is off unless a call site opts in.
       const keepsPreviousWorkspace =
         previousData !== undefined &&
         previousCwd !== request.cwd &&
-        options?.keepPreviousData !== false;
+        options?.keepPreviousData === true;
       const data = keepsPreviousWorkspace ? previousData : nextData;
       previousData = nextData;
       previousCwd = request.cwd;

--- a/packages/client/workbench/src/files/mentions.ts
+++ b/packages/client/workbench/src/files/mentions.ts
@@ -60,16 +60,13 @@ export function useFileMentionSource(): FileMentionSource {
     });
   };
 
+  // A suggestion belongs to its request cwd — never opt this into keepPreviousData: after a
+  // draft/session switch it would offer the previous workspace's paths for insertion.
   const { data } = useData(
     suggestWorkspaceFiles,
     effectiveQuery === null || live.cwd === undefined
       ? null
       : { cwd: live.cwd, query: effectiveQuery, limit: MENTION_SUGGEST_LIMIT },
-    {
-      // A suggestion belongs to its request cwd. Global keepPreviousData would briefly expose the
-      // previous workspace's paths after a draft/session switch, where they could be inserted.
-      keepPreviousData: false,
-    },
   );
 
   const mentionItems = useMemo<MentionItem[]>(

--- a/packages/client/workbench/src/history/__tests__/use-provider-history.test.ts
+++ b/packages/client/workbench/src/history/__tests__/use-provider-history.test.ts
@@ -51,8 +51,9 @@ beforeEach(() => {
       if (!('agentKind' in request)) return { mutate: vi.fn() };
       const response = responses.get(request.agentKind) ?? {};
       const changedProvider = previousKind !== undefined && previousKind !== request.agentKind;
+      // Mirrors the provider: keepPreviousData is off unless a call site opts in.
       const data =
-        changedProvider && response.data === undefined && options?.keepPreviousData !== false
+        changedProvider && response.data === undefined && options?.keepPreviousData === true
           ? previousData
           : response.data;
 
@@ -97,11 +98,10 @@ describe('useProviderHistory', () => {
 
     expect(result.current.entries).toEqual([]);
     expect(result.current.loadError).toBe(unavailable);
-    expect(useDataMock).toHaveBeenCalledWith(
-      expect.anything(),
-      { agentKind: 'pi', opts: { limit: 200 } },
-      { keepPreviousData: false },
-    );
+    expect(useDataMock).toHaveBeenCalledWith(expect.anything(), {
+      agentKind: 'pi',
+      opts: { limit: 200 },
+    });
   });
 
   it('keeps late results scoped to their provider during rapid switches and restores its cache', () => {

--- a/packages/client/workbench/src/history/use-provider-history.ts
+++ b/packages/client/workbench/src/history/use-provider-history.ts
@@ -81,16 +81,12 @@ export async function importHistoryGroup({
 
 /** Global (cwd-less) provider history for one agent kind, plus the import mutation. */
 export function useProviderHistory(kind: AgentKind): ProviderHistory {
-  const { data, isLoading, error, mutate } = useData(
-    listHistory,
-    {
-      agentKind: kind,
-      opts: { limit: HISTORY_PAGE_LIMIT },
-    },
-    // Provider history is identity-scoped: retaining the previous key's rows would label one
-    // agent's sessions as another agent's while the next scan is pending or unavailable.
-    { keepPreviousData: false },
-  );
+  // Identity-scoped by agent kind — never opt this into keepPreviousData: retaining the previous
+  // key's rows labels one agent's sessions as another's while the next scan is pending.
+  const { data, isLoading, error, mutate } = useData(listHistory, {
+    agentKind: kind,
+    opts: { limit: HISTORY_PAGE_LIMIT },
+  });
   const importMutation = useMutation(importSession);
   const pendingImportsRef = useRef(new Map<string, Promise<SessionId>>());
   const pendingGroupsRef = useRef(new Set<string>());

--- a/packages/client/workbench/src/surface/use-seeded-conversation.ts
+++ b/packages/client/workbench/src/surface/use-seeded-conversation.ts
@@ -58,9 +58,8 @@ export function useSeededConversation(
       fallbackData: active?.historyId
         ? loadPersistedSeed(active.kind, active.historyId)
         : undefined,
-      // Opt out of keepPreviousData: a conversation must never bleed across sessions, and on a
-      // switch it would serve the previous transcript — forever, when there's no historyId yet.
-      keepPreviousData: false,
+      // Never opt this into keepPreviousData: a conversation must not bleed across sessions, and
+      // on a switch it would serve the previous transcript — forever, with no historyId yet.
     },
   );
   return useConversation(active?.sessionId ?? null, seed);


### PR DESCRIPTION
Follow-up to #321. With `keepPreviousData` back at SWR's own default, the six explicit `false` opt-outs are no-ops — they only ever existed to defend against the global that #321 removed.

Removes the option at `cloud/im.tsx` (×3), `cloud/hosts.tsx`, `files/mentions.ts`, `history/use-provider-history.ts` and `surface/use-seeded-conversation.ts`.

The **rationale** stays, reworded as a caution, at the three sites where opting in would cause real damage and someone might be tempted: mentions would offer the previous workspace's paths for insertion, provider history would label one agent's sessions as another's, and a conversation would serve the previous transcript — forever, when there is no historyId yet. Those comments no longer reference a global that no longer exists.

## One thing that had to change with it

Two test doubles encoded the *old* default and only passed before because the call sites still said `false`:

```ts
options?.keepPreviousData !== false   // → === true
```

`files/__tests__/mentions.test.ts` and `history/__tests__/use-provider-history.test.ts` now mirror the provider: previous data is kept only when a call site opts in. Without this the fakes claim behavior the app no longer has, and both suites go red — which is what caught it here (4 failures before the fix). The `use-provider-history` assertion on the removed option is updated to the two-argument call.

`pnpm check:ci` exit 0, `pnpm test` 2073 passed / 5 skipped.
