### PR TITLE
chore(workbench): drop the last keepPreviousData opt-out

### DIFF
--- a/packages/client/workbench/src/cloud/im.tsx
+++ b/packages/client/workbench/src/cloud/im.tsx
@@ -122,7 +122,7 @@ export function useCloudImBindings(
   return useSWR<CloudImBinding[]>(
     accountKey && source ? [IM_BINDINGS_KEY, accountKey] : null,
     source ? source.bindings : null,
-    { revalidateOnFocus: true, refreshInterval: 30000, keepPreviousData: false },
+    { revalidateOnFocus: true, refreshInterval: 30000 },
   );
 }
 


### PR DESCRIPTION
Follow-up to #323, which missed one.

`cloud/im.tsx` has three `useSWR` calls; the bindings one carries an extra `refreshInterval: 30000` between the two options I matched on, so the edit that cleared the other two skipped it, and the verification grep I ran was truncated by `head` before reaching it. Caught by grepping master after the merge.

`keepPreviousData: false` is now gone repo-wide (SWR's default since #321), and the six deliberate `true` opt-ins are untouched: `git/hooks.ts` (×3), `files/hooks.ts`, `files/panel.tsx`, `scripts/hooks.ts`, `automations/{loop,schedule}/hooks.ts`.

`pnpm check:ci` exit 0, `pnpm test` 2078 passed / 5 skipped.