### PR TITLE
test(mobile): cover the AbortSignal polyfill (CODE-478)

### DIFF
--- a/apps/mobile/src/__tests__/polyfills.test.ts
+++ b/apps/mobile/src/__tests__/polyfills.test.ts
@@ -1,0 +1,82 @@
+import { AbortError } from 'foxts/abort-error';
+import { afterEach, expect, it, vi } from 'vitest';
+
+// Node implements all three, so every case has to hand the module a runtime that doesn't, then put
+// the natives back. Held as descriptors because `reason` is an accessor, not a value.
+const nativeThrowIfAborted = Object.getOwnPropertyDescriptor(
+  AbortSignal.prototype,
+  'throwIfAborted',
+);
+const nativeReason = Object.getOwnPropertyDescriptor(AbortSignal.prototype, 'reason');
+const nativeAbort = Object.getOwnPropertyDescriptor(AbortController.prototype, 'abort');
+
+afterEach(() => {
+  if (nativeThrowIfAborted) {
+    Object.defineProperty(AbortSignal.prototype, 'throwIfAborted', nativeThrowIfAborted);
+  }
+  if (nativeReason) Object.defineProperty(AbortSignal.prototype, 'reason', nativeReason);
+  if (nativeAbort) Object.defineProperty(AbortController.prototype, 'abort', nativeAbort);
+});
+
+/**
+ * The module patches at import time behind a `typeof … !== 'function'` guard, so re-running it needs
+ * a fresh module registry — there is no exported installer to call.
+ */
+async function installOnRuntimeWithoutAbortApi(): Promise<void> {
+  // @ts-expect-error -- simulate RN's `abort-controller`, which has neither member
+  delete AbortSignal.prototype.throwIfAborted;
+  // @ts-expect-error -- same as above: the DOM types declare `reason` as always present
+  delete AbortSignal.prototype.reason;
+  vi.resetModules();
+  await import('../polyfills');
+}
+
+it('installs throwIfAborted on a runtime that lacks it (CODE-462)', async () => {
+  await installOnRuntimeWithoutAbortApi();
+
+  expect(typeof AbortSignal.prototype.throwIfAborted).toBe('function');
+  expect(() => new AbortController().signal.throwIfAborted()).not.toThrow();
+});
+
+it('records the reason RN drops and rethrows it verbatim', async () => {
+  await installOnRuntimeWithoutAbortApi();
+
+  const controller = new AbortController();
+  // Not an Error: `abort()` takes any value, and `ConnectionController` re-throws whatever it gets.
+  const reason = { superseded: true };
+  controller.abort(reason);
+
+  expect(controller.signal.aborted).toBe(true);
+  expect(controller.signal.reason).toBe(reason);
+
+  let thrown: unknown;
+  try {
+    controller.signal.throwIfAborted();
+  } catch (error) {
+    thrown = error;
+  }
+  expect(thrown).toBe(reason);
+});
+
+it('falls back to an AbortError when nothing recorded a reason', async () => {
+  await installOnRuntimeWithoutAbortApi();
+
+  const controller = new AbortController();
+  controller.abort();
+
+  expect(controller.signal.reason).toBeInstanceOf(AbortError);
+  expect(() => controller.signal.throwIfAborted()).toThrow(AbortError);
+});
+
+it('leaves a runtime that already has the Abort API untouched', async () => {
+  vi.resetModules();
+  await import('../polyfills');
+
+  // Whole descriptors: `toEqual` compares the held functions by reference, and reading `.get` off
+  // one would trip @typescript-eslint/unbound-method.
+  expect(Object.getOwnPropertyDescriptor(AbortSignal.prototype, 'throwIfAborted')).toEqual(
+    nativeThrowIfAborted,
+  );
+  expect(Object.getOwnPropertyDescriptor(AbortSignal.prototype, 'reason')).toEqual(nativeReason);
+  expect(Object.getOwnPropertyDescriptor(AbortController.prototype, 'abort')).toEqual(nativeAbort);
+});


### PR DESCRIPTION
## Summary

`apps/mobile/src/polyfills.ts` (CODE-462) is what lets the mobile client open a socket at all, and it had no test. This adds `apps/mobile/src/__tests__/polyfills.test.ts` — four cases in the app's existing vitest project, no production code touched.

The module patches at import time behind `typeof AbortSignal.prototype.throwIfAborted !== "function"`, with no exported installer, so each case hands it a runtime without the API (delete `throwIfAborted` + `reason` off the prototype) and re-runs it through `vi.resetModules()` + dynamic `import()`. `afterEach` puts all three patched globals back, `AbortController.prototype.abort` included.

Cases:

1. `throwIfAborted` is installed when the runtime lacks it, and a live signal does not throw.
2. **The `reason` round-trip** — `abort(reason)` → `signal.reason` → `throwIfAborted()` rethrows the same value by identity, with a non-`Error` reason so a future narrowing would fail here. RN 0.86 discards the argument to `abort(reason)` entirely, and `ConnectionController` re-throws `signal.reason` when a run is superseded, so the symbol-recording wrapper is the only thing keeping that value alive on device.
3. `abort()` with no argument yields a `foxts` `AbortError`, from both `signal.reason` and the throw.
4. A runtime that already has the Abort API is left untouched — descriptor identity for `throwIfAborted`, `reason`, and `abort`. This is the guard that will let CODE-477 delete the module on RN 0.87 / Expo SDK 58 without ceremony.

Salvaged from the closed PR #309 (CODE-466, a duplicate of CODE-462): that branch shipped a second, weaker polyfill; only its test was worth keeping, and it is rewritten here against the surviving module.

## Verification

- `pnpm test polyfills` — 4 passed.
- `pnpm test` — 256 files passed, 3 skipped; 2,082 tests passed, 5 skipped.
- `pnpm format:check`, `pnpm lint` (0 errors), `pnpm typecheck` — all pass.
- **Mutation-checked**, since a test for a polyfill is easy to write vacuously. Removing the `AbortController.prototype.abort` wrapper fails cases 2 and 3 only; forcing the guard always-true fails case 4 only. Both mutations were reverted.

No device run: the change is test-only and the module it covers is unchanged.

## Checklist

- [x] `pnpm check:ci` and `pnpm test` both pass (plus `cargo fmt` / `clippy` / `test` for Rust changes)
- [x] I ran the affected surface and observed the change working — the vitest project, including the two mutation runs above
- [x] If a wire message changed: `WIRE_PROTOCOL_VERSION` is bumped (not applicable)
- [x] New code and assets are my own work, or their origin and license compatibility are noted above
- [x] Docs and comments are updated where behavior changed (no behavior change)