### PR TITLE
ci: prefer pnpm actions cache & parallel steps

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -83,43 +83,45 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.ref }}
 
-      # electron-builder versions artifacts and the updater feed from package.json, not the git
-      # tag — a stale version would ship a release that updaters can't order correctly.
-      - name: Assert package version matches release tag
-        if: ${{ inputs.sign && startsWith(github.ref, 'refs/tags/v') }}
-        shell: bash
-        run: |
-          version="$(jq -r .version "${DESKTOP_DIR}/package.json")"
-          if [ "v${version}" != "${GITHUB_REF_NAME}" ]; then
-            echo "::error::${DESKTOP_DIR}/package.json version (${version}) does not match tag (${GITHUB_REF_NAME})"
-            exit 1
-          fi
+      - parallel:
+          # electron-builder versions artifacts and the updater feed from package.json, not the git
+          # tag — a stale version would ship a release that updaters can't order correctly.
+          - name: Assert package version matches release tag
+            if: ${{ inputs.sign && startsWith(github.ref, 'refs/tags/v') }}
+            shell: bash
+            run: |
+              version="$(jq -r .version "${DESKTOP_DIR}/package.json")"
+              if [ "v${version}" != "${GITHUB_REF_NAME}" ]; then
+                echo "::error::${DESKTOP_DIR}/package.json version (${version}) does not match tag (${GITHUB_REF_NAME})"
+                exit 1
+              fi
 
-      - uses: pnpm/action-setup@v6
-        with:
-          run_install: false
-          cache: true
+          - uses: pnpm/action-setup@v6
+            with:
+              run_install: false
+              cache: true
 
-      - uses: actions/setup-node@v6
-        with:
-          node-version-file: .nvmrc
-          package-manager-cache: false
+          - uses: actions/setup-node@v6
+            with:
+              node-version-file: .nvmrc
+              package-manager-cache: false
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Build workspace
-        run: pnpm turbo run build --filter "${{ env.DESKTOP_PACKAGE }}..."
-        env:
-          # Publishable identifiers inlined only into signed release bundles. These names must
-          # stay declared in apps/desktop/turbo.json `build.env` so Turbo cache keys include them.
-          MAIN_VITE_SENTRY_DSN: ${{ inputs.sign && secrets.SENTRY_DSN_DESKTOP || '' }}
-          RENDERER_VITE_POSTHOG_PROJECT_TOKEN: ${{ inputs.sign && secrets.POSTHOG_PROJECT_TOKEN || '' }}
-          RENDERER_VITE_POSTHOG_HOST: ${{ inputs.sign && secrets.POSTHOG_HOST || '' }}
+      - parallel:
+          - name: Build workspace
+            run: pnpm turbo run build --filter "${{ env.DESKTOP_PACKAGE }}..."
+            env:
+              # Publishable identifiers inlined only into signed release bundles. These names must
+              # stay declared in apps/desktop/turbo.json `build.env` so Turbo cache keys include them.
+              MAIN_VITE_SENTRY_DSN: ${{ inputs.sign && secrets.SENTRY_DSN_DESKTOP || '' }}
+              RENDERER_VITE_POSTHOG_PROJECT_TOKEN: ${{ inputs.sign && secrets.POSTHOG_PROJECT_TOKEN || '' }}
+              RENDERER_VITE_POSTHOG_HOST: ${{ inputs.sign && secrets.POSTHOG_HOST || '' }}
 
-      # The PTY sidecar ships per arch under Resources (extraResources: sidecar/${arch}).
-      - name: Build PTY sidecar (both arches)
-        uses: ./.github/actions/build-sidecar
+          # The PTY sidecar ships per arch under Resources (extraResources: sidecar/${arch}).
+          - name: Build PTY sidecar (both arches)
+            uses: ./.github/actions/build-sidecar
 
       # OIDC exchange for Windows Trusted Signing; Invoke-TrustedSigning (spawned by
       # electron-builder below) picks it up via DefaultAzureCredential's Azure CLI entry.

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -95,15 +95,15 @@ jobs:
             exit 1
           fi
 
-      # pnpm MUST be set up before setup-node so `cache: pnpm` can find the binary.
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v6 # reads version from package.json "packageManager"
+      - uses: pnpm/action-setup@v6
+        with:
+          run_install: false
+          cache: true
 
-      - name: Setup Node
-        uses: actions/setup-node@v7.0.0
+      - uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
-          cache: pnpm
+          package-manager-cache: false
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,17 +39,17 @@ jobs:
     timeout-minutes: 30
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v7
+      - uses: actions/checkout@v7
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@v6
+        with:
+          run_install: false
+          cache: true
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v7.0.0
+      - uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
-          cache: pnpm
+          package-manager-cache: false
 
       - name: Setup Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -119,17 +119,17 @@ jobs:
     timeout-minutes: 30
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v7
+      - uses: actions/checkout@v7
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@v6
+        with:
+          run_install: false
+          cache: true
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v7.0.0
+      - uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
-          cache: pnpm
+          package-manager-cache: false
 
       - name: Setup Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -174,14 +174,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@v6
+        with:
+          run_install: false
+          cache: true
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v7.0.0
+      - uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
-          cache: pnpm
+          package-manager-cache: false
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -211,14 +212,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@v6
+        with:
+          run_install: false
+          cache: true
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v7.0.0
+      - uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
-          cache: pnpm
+          package-manager-cache: false
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,29 +41,42 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: pnpm/action-setup@v6
-        with:
-          run_install: false
-          cache: true
-
-      - uses: actions/setup-node@v6
-        with:
-          node-version-file: .nvmrc
-          package-manager-cache: false
-
       - name: Setup Rust
+        id: setup-rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           rustflags: "" # keep build.rustflags; the -D warnings default belongs to the Rust job's clippy call
+        background: true
 
-      - name: Restore ESLint cache
-        uses: actions/cache@v6
-        with:
-          path: .eslintcache
-          key: eslint-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'pnpm-workspace.yaml', 'package.json', 'apps/*/package.json', 'packages/*/*/package.json', 'tsconfig*.json', 'apps/*/tsconfig.json', 'apps/*/tests/tsconfig.json', 'apps/*/e2e/tsconfig.json', 'packages/*/*/tsconfig.json', 'packages/*/*/tests/tsconfig.json') }}-${{ hashFiles('packages/*/*/src/**') }}-${{ github.sha }}
-          restore-keys: |
-            eslint-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'pnpm-workspace.yaml', 'package.json', 'apps/*/package.json', 'packages/*/*/package.json', 'tsconfig*.json', 'apps/*/tsconfig.json', 'apps/*/tests/tsconfig.json', 'apps/*/e2e/tsconfig.json', 'packages/*/*/tsconfig.json', 'packages/*/*/tests/tsconfig.json') }}-${{ hashFiles('packages/*/*/src/**') }}-
-            eslint-${{ runner.os }}-
+      - parallel:
+          - uses: pnpm/action-setup@v6
+            with:
+              run_install: false
+              cache: true
+
+          - uses: actions/setup-node@v6
+            with:
+              node-version-file: .nvmrc
+              package-manager-cache: false
+
+          # Before `pnpm install`, so the hashFiles globs below cannot reach into node_modules.
+          #
+          # eslint validates a cached entry against that file's own content only, so a cross-file
+          # type change would leave an unchanged file's cached result in place — a type-aware rule
+          # such as no-floating-promises can start applying to a caller nobody edited, and `tsc`
+          # does not reject that code either. The key therefore covers every lint-visible input at
+          # once and there are deliberately no restore-keys: a prefix match would reintroduce
+          # exactly that hole. The cost is that this only hits on commits touching no lintable
+          # source (docs, Rust, workflows); a run that changes any of them re-lints from cold,
+          # which is the correct answer.
+          - name: Restore ESLint cache
+            uses: actions/cache@v6
+            with:
+              path: .eslintcache
+              key: eslint-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'pnpm-workspace.yaml', 'package.json', 'apps/*/package.json', 'packages/*/*/package.json', 'tsconfig*.json', 'apps/*/tsconfig.json', 'apps/*/tests/tsconfig.json', 'apps/*/e2e/tsconfig.json', 'packages/*/*/tsconfig.json', 'packages/*/*/tests/tsconfig.json') }}-${{ hashFiles('packages/*/*/src/**') }}-${{ github.sha }}
+              restore-keys: |
+                eslint-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'pnpm-workspace.yaml', 'package.json', 'apps/*/package.json', 'packages/*/*/package.json', 'tsconfig*.json', 'apps/*/tsconfig.json', 'apps/*/tests/tsconfig.json', 'apps/*/e2e/tsconfig.json', 'packages/*/*/tsconfig.json', 'packages/*/*/tests/tsconfig.json') }}-${{ hashFiles('packages/*/*/src/**') }}-
+                eslint-${{ runner.os }}-
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -83,6 +96,11 @@ jobs:
           restore-keys: |
             tsc-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'tsconfig*.json', 'apps/*/tsconfig.json', 'apps/*/tests/tsconfig.json', 'apps/*/e2e/tsconfig.json', 'packages/*/*/tsconfig.json', 'packages/*/*/tests/tsconfig.json') }}-
             tsc-${{ runner.os }}-
+      - wait: setup-rust
+      - name: Build PTY sidecar for interoperability tests
+        id: build-sidecar
+        run: cargo build --locked -p linkcode-pty
+        background: true
 
       - name: Check formatting and imports
         run: pnpm format:check
@@ -95,8 +113,7 @@ jobs:
       - name: Typecheck
         run: pnpm typecheck
 
-      - name: Build PTY sidecar for interoperability tests
-        run: cargo build --locked -p linkcode-pty
+      - wait: build-sidecar
 
       - name: Test
         env:
@@ -121,20 +138,23 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: pnpm/action-setup@v6
-        with:
-          run_install: false
-          cache: true
-
-      - uses: actions/setup-node@v6
-        with:
-          node-version-file: .nvmrc
-          package-manager-cache: false
-
       - name: Setup Rust
+        id: setup-rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           rustflags: ""
+        background: true
+
+      - parallel:
+          - uses: pnpm/action-setup@v6
+            with:
+              run_install: false
+              cache: true
+
+          - uses: actions/setup-node@v6
+            with:
+              node-version-file: .nvmrc
+              package-manager-cache: false
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -162,6 +182,8 @@ jobs:
             pnpm -F @linkcode/desktop e2e:window-bounds
           '
 
+      - wait: setup-rust
+
       - name: Test unsigned packaged app entry
         run: xvfb-run -a pnpm -F @linkcode/desktop e2e:packaged
 
@@ -174,15 +196,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
-      - uses: pnpm/action-setup@v6
-        with:
-          run_install: false
-          cache: true
+      - parallel:
+          - uses: pnpm/action-setup@v6
+            with:
+              run_install: false
+              cache: true
 
-      - uses: actions/setup-node@v6
-        with:
-          node-version-file: .nvmrc
-          package-manager-cache: false
+          - uses: actions/setup-node@v6
+            with:
+              node-version-file: .nvmrc
+              package-manager-cache: false
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -212,15 +235,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
-      - uses: pnpm/action-setup@v6
-        with:
-          run_install: false
-          cache: true
+      - parallel:
+          - uses: pnpm/action-setup@v6
+            with:
+              run_install: false
+              cache: true
 
-      - uses: actions/setup-node@v6
-        with:
-          node-version-file: .nvmrc
-          package-manager-cache: false
+          - uses: actions/setup-node@v6
+            with:
+              node-version-file: .nvmrc
+              package-manager-cache: false
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -248,11 +272,12 @@ jobs:
         with:
           rustflags: ""
 
-      - name: Format
-        run: cargo fmt --check
+      - parallel:
+          - name: Format
+            run: cargo fmt --check
 
-      - name: Clippy
-        run: cargo clippy --all-targets --locked -- -D warnings
+          - name: Clippy
+            run: cargo clippy --all-targets --locked -- -D warnings
 
       - name: Test
         run: cargo test --locked

--- a/.github/workflows/finalize-releases.yml
+++ b/.github/workflows/finalize-releases.yml
@@ -34,39 +34,40 @@ jobs:
           persist-credentials: false
           sparse-checkout: .github/scripts
 
-      - name: Verify release automation was CI-tested
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        env:
-          TESTED_SHA: ${{ github.event.workflow_run.head_sha }}
-        with:
-          github-token: ${{ github.token }}
-          script: |
-            const path = '.github/scripts/release-automation.cjs'
-            const read = async (ref) => {
-              const response = await github.rest.repos.getContent({
-                ...context.repo,
-                path,
-                ref,
-              })
-              return response.data.sha
-            }
-            const [testedBlob, currentBlob] = await Promise.all([
-              read(process.env.TESTED_SHA),
-              read('master'),
-            ])
-            if (currentBlob !== testedBlob) {
-              throw new Error(`${path} changed after CI-tested release candidate ${process.env.TESTED_SHA}`)
-            }
+      - parallel:
+          - name: Verify release automation was CI-tested
+            uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+            env:
+              TESTED_SHA: ${{ github.event.workflow_run.head_sha }}
+            with:
+              github-token: ${{ github.token }}
+              script: |
+                const path = '.github/scripts/release-automation.cjs'
+                const read = async (ref) => {
+                  const response = await github.rest.repos.getContent({
+                    ...context.repo,
+                    path,
+                    ref,
+                  })
+                  return response.data.sha
+                }
+                const [testedBlob, currentBlob] = await Promise.all([
+                  read(process.env.TESTED_SHA),
+                  read('master'),
+                ])
+                if (currentBlob !== testedBlob) {
+                  throw new Error(`${path} changed after CI-tested release candidate ${process.env.TESTED_SHA}`)
+                }
 
-      - name: Mint release bot token
-        id: release-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
-        with:
-          app-id: ${{ secrets.BOT_APP_ID }}
-          private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
-          permission-contents: write
-          permission-issues: write
-          permission-pull-requests: write
+          - name: Mint release bot token
+            id: release-token
+            uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+            with:
+              app-id: ${{ secrets.BOT_APP_ID }}
+              private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
+              permission-contents: write
+              permission-issues: write
+              permission-pull-requests: write
 
       # Bind release-please to the exact commit that this successful CI run tested. Normal master
       # pushes are no-ops, and release-please may only see this one pending Desktop release PR.

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -56,27 +56,28 @@ jobs:
       BOT_APP_ID: ${{ secrets.BOT_APP_ID }}
       BOT_APP_PRIVATE_KEY: ${{ secrets.BOT_APP_PRIVATE_KEY }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-        with:
-          ref: ${{ inputs.ref || github.ref }}
-          persist-credentials: false
+      - parallel:
+          - name: Checkout
+            uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+            with:
+              ref: ${{ inputs.ref || github.ref }}
+              persist-credentials: false
 
-      - name: Download all build artifacts
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with:
-          pattern: desktop-*
-          merge-multiple: true
-          path: artifacts
+          - name: Download all build artifacts
+            uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+            with:
+              pattern: desktop-*
+              merge-multiple: true
+              path: artifacts
 
-      - name: Resolve tag
-        id: meta
-        run: |
-          if [ "${{ github.event_name }}" = "push" ]; then
-            echo "tag=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
-          else
-            echo "tag=${{ inputs.ref }}" >> "$GITHUB_OUTPUT"
-          fi
+          - name: Resolve tag
+            id: meta
+            run: |
+              if [ "${{ github.event_name }}" = "push" ]; then
+                echo "tag=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+              else
+                echo "tag=${{ inputs.ref }}" >> "$GITHUB_OUTPUT"
+              fi
 
       - name: Verify release-please Release exists
         if: ${{ github.event_name == 'push' }}
@@ -95,48 +96,66 @@ jobs:
               tag: process.env.TAG,
             })
 
-      - name: Publish update feed to R2
-        # The live updater feed (installers + latest*.yml + *.blockmap), public via
-        # https://releases.linkcode.ai — the publish.url baked into shipped apps.
-        # No --delete: prior versions stay for delta updates.
-        if: ${{ github.event_name == 'push' || inputs.dry_run == false }}
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
-          AWS_REGION: auto # R2 ignores region, but the CLI requires one to be set
-          # R2 doesn't implement the CRC32 upload checksums that recent aws-cli sends by default.
-          AWS_REQUEST_CHECKSUM_CALCULATION: WHEN_REQUIRED
-          AWS_RESPONSE_CHECKSUM_VALIDATION: WHEN_REQUIRED
-        run: |
-          aws s3 sync artifacts/ "s3://${R2_BUCKET}/desktop/" \
-            --endpoint-url "https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com" \
-            --no-progress \
-            --exclude "*" \
-            --include "*.dmg" --include "*.zip" --include "*.exe" --include "*.msi" \
-            --include "*.appx" --include "*.AppImage" --include "*.deb" --include "*.rpm" \
-            --include "*.snap" --include "*.yml" --include "*.blockmap"
+      # Upload both copies concurrently, but keep the GitHub Release as a draft until the R2
+      # updater feed and every GitHub asset have finished successfully.
+      - parallel:
+          - name: Publish update feed to R2
+            # The live updater feed (installers + latest*.yml + *.blockmap), public via
+            # https://releases.linkcode.ai — the publish.url baked into shipped apps.
+            # No --delete: prior versions stay for delta updates.
+            if: ${{ github.event_name == 'push' || inputs.dry_run == false }}
+            env:
+              AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+              AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+              AWS_REGION: auto # R2 ignores region, but the CLI requires one to be set
+              # R2 doesn't implement the CRC32 upload checksums that recent aws-cli sends by default.
+              AWS_REQUEST_CHECKSUM_CALCULATION: WHEN_REQUIRED
+              AWS_RESPONSE_CHECKSUM_VALIDATION: WHEN_REQUIRED
+            run: |
+              aws s3 sync artifacts/ "s3://${R2_BUCKET}/desktop/" \
+                --endpoint-url "https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com" \
+                --no-progress \
+                --exclude "*" \
+                --include "*.dmg" --include "*.zip" --include "*.exe" --include "*.msi" \
+                --include "*.appx" --include "*.AppImage" --include "*.deb" --include "*.rpm" \
+                --include "*.snap" --include "*.yml" --include "*.blockmap"
 
-      - name: Create GitHub Release
+          - name: Upload GitHub Release assets
+            id: release-assets
+            if: ${{ github.event_name == 'push' || inputs.dry_run == false }}
+            uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
+            with:
+              tag_name: ${{ steps.meta.outputs.tag }}
+              # release-please creates this draft before the tag push. Keep it private while the
+              # assets upload; the next step publishes this exact release after the parallel wait.
+              draft: true
+              prerelease: ${{ contains(steps.meta.outputs.tag, '-') }} # v1.2.3-beta.1 => prerelease
+              files: |
+                artifacts/*.dmg
+                artifacts/*.zip
+                artifacts/*.exe
+                artifacts/*.msi
+                artifacts/*.appx
+                artifacts/*.AppImage
+                artifacts/*.deb
+                artifacts/*.rpm
+                artifacts/*.snap
+                artifacts/*.yml
+                artifacts/*.blockmap
+
+      - name: Publish GitHub Release
         if: ${{ github.event_name == 'push' || inputs.dry_run == false }}
-        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          RELEASE_ID: ${{ steps.release-assets.outputs.id }}
         with:
-          tag_name: ${{ steps.meta.outputs.tag }}
-          # release-please creates this as a draft before the tag push. action-gh-release reuses
-          # that draft, uploads assets first, then publishes it when draft is false.
-          draft: false
-          prerelease: ${{ contains(steps.meta.outputs.tag, '-') }} # v1.2.3-beta.1 => prerelease
-          files: |
-            artifacts/*.dmg
-            artifacts/*.zip
-            artifacts/*.exe
-            artifacts/*.msi
-            artifacts/*.appx
-            artifacts/*.AppImage
-            artifacts/*.deb
-            artifacts/*.rpm
-            artifacts/*.snap
-            artifacts/*.yml
-            artifacts/*.blockmap
+          github-token: ${{ github.token }}
+          script: |
+            await github.rest.repos.updateRelease({
+              ...context.repo,
+              release_id: Number(process.env.RELEASE_ID),
+              draft: false,
+            })
 
       - name: Mint Homebrew tap token
         # Keep the LinkCode cask in arcboxlabs/homebrew-tap in step with releases so


### PR DESCRIPTION
## Summary

- Prefer `pnpm/actions-setup` cache option over the `actions/setup-node` cache
  - Better store detection
- Enable GitHub's new parallel steps.

## Verification

<!-- How did you prove it works? Commands run, surfaces launched, before/after screenshots for UI changes. -->

## Checklist

- [x] `pnpm check:ci` and `pnpm test` both pass (plus `cargo fmt` / `clippy` / `test` for Rust changes)
- [ ] I ran the affected surface and observed the change working
- [ ] If a wire message changed: `WIRE_PROTOCOL_VERSION` is bumped
- [x] New code and assets are my own work, or their origin and license compatibility are noted above
- [ ] Docs and comments are updated where behavior changed
