### PR TITLE
fix(code-282): ensure scroll to bottom

### DIFF
--- a/packages/presentation/ui/src/chat/conversation-view.tsx
+++ b/packages/presentation/ui/src/chat/conversation-view.tsx
@@ -2,6 +2,7 @@ import type { AgentKind } from '@linkcode/schema';
 import { Spinner } from 'coss-ui/components/spinner';
 import { useState } from 'react';
 import { useTranslations } from 'use-intl';
+import type { StickToBottomContext } from 'use-stick-to-bottom';
 import {
   Conversation,
   ConversationContent,
@@ -23,6 +24,8 @@ export interface ConversationViewProps {
   TerminalBlockComponent?: React.ComponentType<{ terminalId: string }>;
   /** Opens this turn's workspace changes in the host review surface. */
   onReviewChanges?: () => void;
+  /** Receives the conversation scroll controller for composer-driven positioning. */
+  scrollContextRef?: React.Ref<StickToBottomContext>;
 }
 
 /** The centered message stream — the main reading surface. Auto-follows only while pinned to the bottom. */
@@ -33,6 +36,7 @@ export function ConversationView({
   modelName,
   TerminalBlockComponent,
   onReviewChanges,
+  scrollContextRef,
 }: ConversationViewProps): React.ReactNode {
   const t = useTranslations('workbench.conversation');
   const tk = useTranslations('workbench.agentKind');
@@ -73,6 +77,7 @@ export function ConversationView({
 
   return (
     <Conversation
+      contextRef={scrollContextRef}
       style={{
         maskImage:
           'linear-gradient(to bottom, transparent 0, black 24px, black calc(100% - 16px), transparent 100%)',

--- a/packages/presentation/ui/src/shell/__tests__/conversation-surface.test.tsx
+++ b/packages/presentation/ui/src/shell/__tests__/conversation-surface.test.tsx
@@ -1,10 +1,10 @@
 // @vitest-environment jsdom
 
-import { act, cleanup, render, screen } from '@testing-library/react';
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { nullthrow } from 'foxts/guard';
 import type { LexicalEditor } from 'lexical';
 import { getNearestEditorFromDOMNode } from 'lexical';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { PermissionConversationItem } from '../../chat/conversation-prompts';
 import type { ConversationViewModel } from '../../chat/types';
 import type { AgentRuntimeCues } from '../agent-onboarding-card';
@@ -20,8 +20,19 @@ vi.mock('use-intl', () => ({
   useTranslations: () => translateKey,
 }));
 
+const { scrollToBottom } = vi.hoisted(() => ({ scrollToBottom: vi.fn() }));
+
 vi.mock('../../chat/conversation-view', () => ({
-  ConversationView: () => null,
+  ConversationView({
+    scrollContextRef,
+  }: {
+    scrollContextRef?: React.Ref<{ scrollToBottom: typeof scrollToBottom }>;
+  }) {
+    const context = { scrollToBottom };
+    if (typeof scrollContextRef === 'function') scrollContextRef(context);
+    else if (scrollContextRef) scrollContextRef.current = context;
+    return null;
+  },
 }));
 
 const EMPTY_CONVERSATION: ConversationViewModel = {
@@ -57,13 +68,14 @@ const RE_MAX_EFFORT = /Max/;
 function surface(
   runtimeCues?: AgentRuntimeCues,
   conversation: ConversationViewModel = EMPTY_CONVERSATION,
+  onSend = vi.fn(),
 ): React.ReactNode {
   return (
     <ConversationSurface
       conversation={conversation}
       composer={{
         directiveControls: UNSUPPORTED_COMPOSER_DIRECTIVES,
-        onSend: vi.fn(),
+        onSend,
         onStop: vi.fn(),
       }}
       agentKind="claude-code"
@@ -78,6 +90,7 @@ function surface(
 }
 
 afterEach(cleanup);
+beforeEach(() => scrollToBottom.mockClear());
 
 function composerEditor(): LexicalEditor {
   return nullthrow(
@@ -97,6 +110,21 @@ function composerText(): string {
 }
 
 describe('ConversationSurface prompt card', () => {
+  it('scrolls to the latest message once when the composer submits', () => {
+    const onSend = vi.fn();
+    render(surface(undefined, EMPTY_CONVERSATION, onSend));
+    typeInComposer('Take me back to the latest message');
+
+    fireEvent.click(screen.getByRole('button', { name: 'send' }));
+
+    expect(onSend).toHaveBeenCalledExactlyOnceWith([
+      { type: 'text', text: 'Take me back to the latest message' },
+    ]);
+    // The no-options call keeps the library's default escape behavior: a later upward user scroll
+    // cancels sticky following instead of being forced back to the bottom.
+    expect(scrollToBottom).toHaveBeenCalledExactlyOnceWith();
+  });
+
   it('keeps the model unresolved until the adapter reports its concrete value', () => {
     const { rerender } = render(surface());
     expect(screen.getByRole('button', { name: RE_MODEL_DEFAULT })).toBeTruthy();

--- a/packages/presentation/ui/src/shell/composer.tsx
+++ b/packages/presentation/ui/src/shell/composer.tsx
@@ -158,6 +158,8 @@ export interface ComposerProps {
   agentModels?: AgentModelOption[] | null;
   /** A promise defers draft clearing until the caller accepts the submission. */
   onSend: (content: ContentBlock[]) => ComposerSubmissionResult;
+  /** Fires once after a valid prompt, slash command, or shell command is handed to its caller. */
+  onSubmit?: () => void;
   onStop: () => void;
   /** Sends the workflow-mode switch (`set-mode`); the active mode is reflected from the session's
    * `current-mode-update` event, not locally. */
@@ -215,6 +217,7 @@ export function Composer({
   directiveControls,
   agentModels,
   onSend,
+  onSubmit,
   onStop,
   onModeChange,
   onApprovalPolicyChange,
@@ -416,6 +419,7 @@ export function Composer({
       submissionPendingRef.current = false;
       throw error;
     }
+    onSubmit?.();
 
     if (result === undefined) {
       try {

--- a/packages/presentation/ui/src/shell/conversation-surface.tsx
+++ b/packages/presentation/ui/src/shell/conversation-surface.tsx
@@ -1,5 +1,6 @@
 import type { AgentKind, ContentBlock, EffortLevel, QuestionOutcome } from '@linkcode/schema';
 import { useRef } from 'react';
+import type { StickToBottomContext } from 'use-stick-to-bottom';
 import { ArtifactHostActionsProvider } from '../chat/artifacts/context';
 import type { PermissionDecision } from '../chat/conversation-prompts';
 import { selectPendingPromptItems } from '../chat/conversation-prompts';
@@ -107,6 +108,7 @@ export function ConversationSurface({
   onPickAttachmentFiles,
 }: ConversationSurfaceProps): React.ReactNode {
   const composerRef = useRef<ComposerHandle | null>(null);
+  const conversationScrollRef = useRef<StickToBottomContext | null>(null);
   // Only the signed-out cue matters mid-session (the next turn would fail on auth); a missing or
   // unverified CLI stays a new-session concern — this session's process is already running.
   const cue = agentKind === undefined ? undefined : runtimeCues?.[agentKind];
@@ -132,6 +134,7 @@ export function ConversationSurface({
             agentKind={agentKind}
             cwd={cwd}
             modelName={modelName ?? conversation.currentModel ?? undefined}
+            scrollContextRef={conversationScrollRef}
             TerminalBlockComponent={TerminalBlockComponent}
             onReviewChanges={onReviewChanges}
           />
@@ -177,6 +180,11 @@ export function ConversationSurface({
           agentModels={conversation.availableModels}
           directiveControls={composer.directiveControls}
           onSend={composer.onSend}
+          // Scrolls at submit, not acceptance: the jump must feel tied to pressing send, and a
+          // rare rejection isn't worth delaying it on the round-trip.
+          onSubmit={() => {
+            void conversationScrollRef.current?.scrollToBottom();
+          }}
           onStop={composer.onStop}
           onPickAttachmentFiles={onPickAttachmentFiles}
           onModeChange={composer.onModeChange}


### PR DESCRIPTION
## Summary

Fixes CODE-282

Added test case.

## Checklist

- [x] `pnpm check:ci` and `pnpm test` both pass (plus `cargo fmt` / `clippy` / `test` for Rust changes)
- [ ] I ran the affected surface and observed the change working
- [ ] If a wire message changed: `WIRE_PROTOCOL_VERSION` is bumped
- [x] New code and assets are my own work, or their origin and license compatibility are noted above
- [ ] Docs and comments are updated where behavior changed

-----

cc @Zerlight Extra review and testing might be required.