### PR TITLE
fix(ui): keep permission mode visible on new task

### DIFF
--- a/packages/presentation/i18n/src/locales/en.ts
+++ b/packages/presentation/i18n/src/locales/en.ts
@@ -339,6 +339,7 @@ export const en = {
     newSession: {
       heading: 'What should we build?',
       headingIn: 'What should we build in {name}?',
+      permissionMode: 'Permission mode',
       chooseWorkspace: 'Choose a workspace',
       chat: 'Chat',
       noProject: "Don't work in a project",

--- a/packages/presentation/i18n/src/locales/zh-cn.ts
+++ b/packages/presentation/i18n/src/locales/zh-cn.ts
@@ -329,6 +329,7 @@ export const zhCN = {
     newSession: {
       heading: '想构建什么？',
       headingIn: '在 {name} 中构建什么？',
+      permissionMode: '权限模式',
       chooseWorkspace: '选择工作区',
       chat: '聊天',
       noProject: '不使用项目',

--- a/packages/presentation/ui/src/shell/__tests__/new-session-surface.test.tsx
+++ b/packages/presentation/ui/src/shell/__tests__/new-session-surface.test.tsx
@@ -120,6 +120,24 @@ describe('NewSessionSurface', () => {
     },
   );
 
+  it('keeps permission mode visible while the agent catalog is unavailable', () => {
+    render(
+      <NewSessionSurface
+        chatWorkspace={CHAT_WORKSPACE}
+        draft={{ initialProvider: 'claude-code', initialWorkspaceId: CHAT_WORKSPACE.workspaceId }}
+        mentionItems={[]}
+        onMentionQueryChange={vi.fn()}
+        onRegisterWorkspace={vi.fn().mockResolvedValue(CHAT_WORKSPACE)}
+        onSubmit={vi.fn().mockResolvedValue(undefined)}
+        workspaces={[]}
+      />,
+    );
+
+    expect(screen.getByRole<HTMLButtonElement>('button', { name: 'permissionMode' }).disabled).toBe(
+      true,
+    );
+  });
+
   it('names the model selector with its agent, model, and reasoning effort', () => {
     render(
       <NewSessionSurface

--- a/packages/presentation/ui/src/shell/composer.tsx
+++ b/packages/presentation/ui/src/shell/composer.tsx
@@ -8,6 +8,7 @@ import type {
 } from '@linkcode/schema';
 import { MAX_ATTACHMENT_BYTES, MAX_ATTACHMENT_TOTAL_BYTES, textBlock } from '@linkcode/schema';
 import { AutocompletePrimitive } from 'coss-ui/components/autocomplete';
+import { Button } from 'coss-ui/components/button';
 import { Command } from 'coss-ui/components/command';
 import { Frame, FrameFooter } from 'coss-ui/components/frame';
 import { Input } from 'coss-ui/components/input';
@@ -17,6 +18,7 @@ import { extractErrorMessage } from 'foxts/extract-error-message';
 import { falseFn, trueFn } from 'foxts/noop';
 import type { EditorState, LexicalEditor } from 'lexical';
 import { $getSelection, $setSelection, CLEAR_HISTORY_COMMAND } from 'lexical';
+import { ShieldIcon } from 'lucide-react';
 import { AnimatePresence, motion, useReducedMotion } from 'motion/react';
 import { useId, useImperativeHandle, useMemo, useRef, useState } from 'react';
 import { useTranslations } from 'use-intl';
@@ -143,6 +145,9 @@ export interface ComposerProps {
   /** The agent-advertised approval-policy state (the permission/safety axis), reflected from the
    * session's `approval-policy-update` event. Absent or empty hides the policy menu. */
   approvalPolicy?: ApprovalPolicyState | null;
+  /** Keeps the permission-mode affordance visible before a new session has a policy catalog.
+   * Omit for live sessions, where an absent policy means the adapter does not support switching. */
+  approvalPolicyPlaceholder?: string;
   /** The model the session is actually running on, reflected from the session's `model-update`
    * event. `null` until the adapter reports it — the picker then shows a placeholder. */
   currentModel?: string | null;
@@ -210,6 +215,7 @@ export function Composer({
   currentModeId,
   availableModes = STUB_SESSION_MODES,
   approvalPolicy,
+  approvalPolicyPlaceholder,
   currentModel,
   currentEffort,
   directiveControls,
@@ -984,6 +990,20 @@ export function Composer({
                         policies={approvalPolicy.availablePolicies}
                         onSelect={selectPolicy}
                       />
+                    ) : approvalPolicyPlaceholder ? (
+                      <Button
+                        className="text-muted-foreground @max-[480px]/composer:size-8 @max-[480px]/composer:p-0"
+                        disabled
+                        size="sm"
+                        title={approvalPolicyPlaceholder}
+                        type="button"
+                        variant="ghost"
+                      >
+                        <ShieldIcon />
+                        <span className="@max-[480px]/composer:sr-only">
+                          {approvalPolicyPlaceholder}
+                        </span>
+                      </Button>
                     ) : null}
                     {activeMode && onModeChange ? (
                       <SessionModeChip

--- a/packages/presentation/ui/src/shell/new-session-surface.tsx
+++ b/packages/presentation/ui/src/shell/new-session-surface.tsx
@@ -325,6 +325,7 @@ export function NewSessionSurface({
             currentEffort={constrainedEffort}
             agentModels={dynamicModels}
             approvalPolicy={approvalPolicy}
+            approvalPolicyPlaceholder={t('permissionMode')}
             selectableProviders={SELECTABLE_PROVIDERS}
             onSend={handleSend}
             onStop={noop}


### PR DESCRIPTION
## Summary

- keep the Permission mode affordance visible on New Task while the agent catalog is unavailable
- replace the disabled placeholder with the existing agent-advertised policy menu once policies resolve
- preserve live-session behavior and avoid inventing policy IDs for dynamic adapters
- add localized English and Simplified Chinese labels plus component coverage

## Verification

- `pnpm format:check`
- `pnpm typecheck`
- focused ESLint on all changed files (0 errors)
- `pnpm test` — 263 files passed, 2,107 tests passed, 1 skipped
- manual Electron acceptance recording: New Task → Ask permissions menu → Accept edits → selected-state confirmation

> Full-repository ESLint could not complete in the orb because the ESLint process exhausted its heap. Changed-file ESLint completed with no errors.

Linear: [CODE-499](https://linear.app/arcbox/issue/CODE-499/fixui-keep-permission-mode-visible-on-new-task)
