### PR TITLE
fix(release): repair Linux desktop cross-architecture builds

### DIFF
--- a/.github/actions/build-sidecar/action.yml
+++ b/.github/actions/build-sidecar/action.yml
@@ -18,12 +18,12 @@ runs:
         target: ${{ runner.os == 'macOS' && 'x86_64-apple-darwin' || runner.os == 'Windows' && 'aarch64-pc-windows-msvc' || 'aarch64-unknown-linux-gnu' }}
         rustflags: ''
 
-    - name: Install aarch64 cross linker
+    - name: Install aarch64 cross toolchain
       if: runner.os == 'Linux'
       shell: bash
       run: |
         sudo apt-get update -q
-        sudo apt-get install -yq gcc-aarch64-linux-gnu
+        sudo apt-get install -yq g++-aarch64-linux-gnu
 
     # The runner image ships x64-only VC tools; linking aarch64-pc-windows-msvc needs the ARM64
     # component. A no-op when already present.

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -140,13 +140,6 @@ jobs:
           APPLE_API_KEY_BASE64: ${{ secrets.APPLE_API_KEY_BASE64 }}
         run: printf '%s' "$APPLE_API_KEY_BASE64" | base64 --decode > "$RUNNER_TEMP/apple_api_key.p8"
 
-      # Electron 43 / V8 15 headers fail under Ubuntu 22.04's GCC 11; keep the older glibc floor.
-      - name: Use Clang 15 for Linux native modules
-        if: ${{ runner.os == 'Linux' }}
-        run: |
-          echo "CC=clang-15" >> "$GITHUB_ENV"
-          echo "CXX=clang++-15" >> "$GITHUB_ENV"
-
       - name: Package with electron-builder
         working-directory: ${{ env.DESKTOP_DIR }}
         shell: bash # unify quoting across runners for the conditional signing args below
@@ -161,8 +154,17 @@ jobs:
           if [ -n "$MACOS_CSC_LINK" ]; then
             export CSC_LINK="$MACOS_CSC_LINK" CSC_KEY_PASSWORD="$MACOS_CSC_KEY_PASSWORD"
           fi
-          node scripts/package-app.mts ${{ matrix.platform }} --publish never \
-            ${{ (runner.os == 'Windows' && inputs.sign) && format('-c.win.azureSignOptions.publisherName="{0}" -c.win.azureSignOptions.endpoint="{1}" -c.win.azureSignOptions.codeSigningAccountName="{2}" -c.win.azureSignOptions.certificateProfileName="{3}"', env.AZURE_PUBLISHER_NAME, env.AZURE_SIGN_ENDPOINT, env.AZURE_CODE_SIGNING_ACCOUNT, env.AZURE_CERTIFICATE_PROFILE) || '' }}
+          if [ "${{ matrix.platform }}" = linux ]; then
+            # Electron 43 needs Clang 15; the arm64 rebuild also needs an explicit cross target.
+            CC=clang-15 CXX=clang++-15 \
+              node scripts/package-app.mts linux --x64 --publish never
+            CC='clang-15 --target=aarch64-linux-gnu' \
+              CXX='clang++-15 --target=aarch64-linux-gnu' \
+              node scripts/package-app.mts linux --arm64 --publish never
+          else
+            node scripts/package-app.mts ${{ matrix.platform }} --publish never \
+              ${{ (runner.os == 'Windows' && inputs.sign) && format('-c.win.azureSignOptions.publisherName="{0}" -c.win.azureSignOptions.endpoint="{1}" -c.win.azureSignOptions.codeSigningAccountName="{2}" -c.win.azureSignOptions.certificateProfileName="{3}"', env.AZURE_PUBLISHER_NAME, env.AZURE_SIGN_ENDPOINT, env.AZURE_CODE_SIGNING_ACCOUNT, env.AZURE_CERTIFICATE_PROFILE) || '' }}
+          fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -158,9 +158,13 @@ jobs:
             # Electron 43 needs Clang 15; the arm64 rebuild also needs an explicit cross target.
             CC=clang-15 CXX=clang++-15 \
               node scripts/package-app.mts linux --x64 --publish never
+            mv release/linux-unpacked "$RUNNER_TEMP/linkcode-linux-x64-unpacked"
             CC='clang-15 --target=aarch64-linux-gnu' \
               CXX='clang++-15 --target=aarch64-linux-gnu' \
               node scripts/package-app.mts linux --arm64 --publish never
+            # Single-arch Linux builds both use linux-unpacked; preserve the verifier's arch layout.
+            mv release/linux-unpacked release/linux-arm64-unpacked
+            mv "$RUNNER_TEMP/linkcode-linux-x64-unpacked" release/linux-unpacked
           else
             node scripts/package-app.mts ${{ matrix.platform }} --publish never \
               ${{ (runner.os == 'Windows' && inputs.sign) && format('-c.win.azureSignOptions.publisherName="{0}" -c.win.azureSignOptions.endpoint="{1}" -c.win.azureSignOptions.codeSigningAccountName="{2}" -c.win.azureSignOptions.certificateProfileName="{3}"', env.AZURE_PUBLISHER_NAME, env.AZURE_SIGN_ENDPOINT, env.AZURE_CODE_SIGNING_ACCOUNT, env.AZURE_CERTIFICATE_PROFILE) || '' }}

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -141,11 +141,11 @@ jobs:
         run: printf '%s' "$APPLE_API_KEY_BASE64" | base64 --decode > "$RUNNER_TEMP/apple_api_key.p8"
 
       # Electron 43 / V8 15 headers fail under Ubuntu 22.04's GCC 11; keep the older glibc floor.
-      - name: Use Clang for Linux native modules
+      - name: Use Clang 15 for Linux native modules
         if: ${{ runner.os == 'Linux' }}
         run: |
-          echo "CC=clang" >> "$GITHUB_ENV"
-          echo "CXX=clang++" >> "$GITHUB_ENV"
+          echo "CC=clang-15" >> "$GITHUB_ENV"
+          echo "CXX=clang++-15" >> "$GITHUB_ENV"
 
       - name: Package with electron-builder
         working-directory: ${{ env.DESKTOP_DIR }}

--- a/apps/desktop/scripts/package-app.mts
+++ b/apps/desktop/scripts/package-app.mts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /**
  * Package the desktop app from a materialized, single-importer staging directory (CODE-107):
- * `node scripts/package-app.mts [mac|win|linux] [--devshell] [-- <extra electron-builder args>]`.
+ * `node scripts/package-app.mts [mac|win|linux] [--x64|--arm64] [--devshell] [builder args]`.
  *
  * Packing apps/desktop in place fails silently twice under pnpm's hoisted layout: on Windows the
  * @electron/rebuild workspace-root detection misses the repo root, so better-sqlite3 is never
@@ -28,6 +28,7 @@ const HOST_PLATFORM: Partial<Record<NodeJS.Platform, BuilderPlatform>> = {
 };
 const BUILDER_PLATFORMS = ['mac', 'win', 'linux'] as const;
 type BuilderPlatform = (typeof BUILDER_PLATFORMS)[number];
+const BUILDER_ARCHES = ['x64', 'arm64'] as const;
 
 const desktopDir = join(import.meta.dirname, '..');
 const repoRoot = join(desktopDir, '..', '..');
@@ -59,8 +60,14 @@ const devshell = args.includes('--devshell');
 const platform =
   BUILDER_PLATFORMS.find((name) => args.includes(name)) ?? HOST_PLATFORM[process.platform];
 if (!platform) throw new Error(`unsupported host platform ${process.platform}; pass mac|win|linux`);
+const requestedArches = BUILDER_ARCHES.filter((arch) => args.includes(`--${arch}`));
 // Everything the caller passed that isn't ours is forwarded to electron-builder (--publish, signing).
-const passthrough = args.filter((arg) => arg !== '--devshell' && !platformTokens.has(arg));
+const passthrough = args.filter(
+  (arg) =>
+    arg !== '--devshell' &&
+    !platformTokens.has(arg) &&
+    !BUILDER_ARCHES.some((arch) => arg === `--${arch}`),
+);
 
 /** Deploy the production closure into a fresh staging dir, then sync the build outputs into it. */
 function materializeStaging(): void {
@@ -121,11 +128,15 @@ function pruneStaging(): void {
  * resolve an arch that wasn't (CI stages both via `stage-sidecar --all`; a local
  * `stage:host-runtime` stages just the host).
  */
-const KNOWN_ARCHES = new Set(['x64', 'arm64']);
-
 function stagedArches(): string[] {
-  const arches = readdirSync(join(desktopDir, 'sidecar')).filter((name) => KNOWN_ARCHES.has(name));
-  if (arches.length === 0) throw new Error('no staged sidecar arch; run stage:host-runtime first');
+  const staged = readdirSync(join(desktopDir, 'sidecar')).filter((name) =>
+    BUILDER_ARCHES.some((arch) => arch === name),
+  );
+  if (staged.length === 0) throw new Error('no staged sidecar arch; run stage:host-runtime first');
+  const arches = requestedArches.length === 0 ? staged : requestedArches;
+  for (const arch of arches) {
+    if (!staged.includes(arch)) throw new Error(`sidecar/${arch} is not staged`);
+  }
   return arches;
 }
 


### PR DESCRIPTION
## Summary

- pin Linux native module builds to Clang 15 for Electron 43
- rebuild x64 and ARM64 dependencies with architecture-specific compiler targets
- install the ARM64 C++ cross toolchain and preserve both unpacked application layouts

## Root cause

Ubuntu 22's unversioned `clang` resolves to Clang 14, which cannot compile Electron 43's V8 headers using `std::source_location`. Applying one compiler configuration to both targets also produced the wrong native binding architecture, while sequential single-architecture electron-builder invocations reused `linux-unpacked`.

## Impact

Restores verified Linux x64 and ARM64 release artifacts without moving the build to Ubuntu 24 and raising the glibc compatibility baseline.

## Verification

- `pnpm check:ci`
- `pnpm test` — 2103 passed, 5 skipped
- [Build Desktop run 30537813989](https://github.com/arcboxlabs/linkcode/actions/runs/30537813989) — Linux packaging, artifact verification, and upload passed