### PR TITLE
fix(workbench): route input to selected thread

### DIFF
--- a/packages/client/workbench/src/surface/__tests__/active-session-input.test.ts
+++ b/packages/client/workbench/src/surface/__tests__/active-session-input.test.ts
@@ -1,24 +1,42 @@
 import type { AgentInput, SessionId } from '@linkcode/schema';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { submitActiveSessionInput } from '../active-session-input';
+import { useSessionSelectionStore } from '../selection-store';
 
 const sessionId = 'session-1' as SessionId;
 
 describe('submitActiveSessionInput', () => {
+  beforeEach(() => {
+    useSessionSelectionStore.setState({ selectedId: sessionId, draft: null });
+  });
+
   it('propagates correlated input rejection to the caller', async () => {
     const failure = new Error('Session is busy');
     const trigger = vi.fn().mockRejectedValue(failure);
     const input: AgentInput = { type: 'prompt', content: [] };
 
-    await expect(submitActiveSessionInput(sessionId, input, trigger)).rejects.toBe(failure);
+    await expect(submitActiveSessionInput(input, trigger)).rejects.toBe(failure);
     expect(trigger).toHaveBeenCalledWith({ sessionId, input });
   });
 
-  it('rejects without dispatching when the active session is gone', async () => {
+  it('reads the selected session when the input is submitted', async () => {
+    const nextSessionId = 'session-2' as SessionId;
+    const trigger = vi.fn().mockResolvedValue(undefined);
+    const input: AgentInput = { type: 'prompt', content: [] };
+    const submit = (): Promise<void> => submitActiveSessionInput(input, trigger);
+
+    useSessionSelectionStore.getState().setSelectedId(nextSessionId);
+    await submit();
+
+    expect(trigger).toHaveBeenCalledWith({ sessionId: nextSessionId, input });
+  });
+
+  it('rejects without dispatching while the new-session draft is open', async () => {
     const trigger = vi.fn();
+    useSessionSelectionStore.getState().startDraft({ workspaceId: null });
 
     await expect(
-      submitActiveSessionInput(null, { type: 'shell-command', command: 'pwd' }, trigger),
+      submitActiveSessionInput({ type: 'shell-command', command: 'pwd' }, trigger),
     ).rejects.toThrow('No active session');
     expect(trigger).not.toHaveBeenCalled();
   });

--- a/packages/client/workbench/src/surface/active-session-input.ts
+++ b/packages/client/workbench/src/surface/active-session-input.ts
@@ -1,14 +1,13 @@
 import type { AgentInput, SessionId } from '@linkcode/schema';
 import { noop } from 'foxact/noop';
+import { useSessionSelectionStore } from './selection-store';
 
 type InputTrigger = (request: { sessionId: SessionId; input: AgentInput }) => Promise<unknown>;
 
 /** Submit through the correlated request so callers can retain UI state until the host accepts. */
-export function submitActiveSessionInput(
-  sessionId: SessionId | null,
-  input: AgentInput,
-  trigger: InputTrigger,
-): Promise<void> {
+export function submitActiveSessionInput(input: AgentInput, trigger: InputTrigger): Promise<void> {
+  const { selectedId: sessionId, draft } = useSessionSelectionStore.getState();
+  if (draft) return Promise.reject(new Error('No active session'));
   if (!sessionId) return Promise.reject(new Error('No active session'));
   return trigger({ sessionId, input }).then(noop);
 }

--- a/packages/client/workbench/src/surface/workbench.tsx
+++ b/packages/client/workbench/src/surface/workbench.tsx
@@ -313,9 +313,8 @@ function WorkbenchSessionSurface({
   );
 
   function submitActiveInput(input: AgentInput): Promise<void> {
-    const sessionId = sessions.activeId;
-    if (sessionId) onClearError();
-    return submitActiveSessionInput(sessionId, input, turnInputMutation.trigger);
+    onClearError();
+    return submitActiveSessionInput(input, turnInputMutation.trigger);
   }
 
   function handleSend(content: ContentBlock[]): Promise<void> {


### PR DESCRIPTION
## What changed

- Resolve the composer target from the session selection store when the input is submitted.
- Reject submission while the new-thread draft is open.
- Cover a selection change between creating and invoking the submit callback.

## Why

Thread rendering is deferred to support View Transitions. Composer input previously reused the deferred rendered session id, so a prompt submitted during a switch could be dispatched to the previous Thread.

The command target now comes from the immediate selection state while rendering remains deferred.

## Impact

Prompts, slash commands, and shell commands are routed to the Thread selected at submission time across all agent kinds.

## Validation

- `pnpm check:ci`
- `pnpm exec vitest run packages/client/workbench/src/surface/__tests__/active-session-input.test.ts` — 3 passed
- In-app webview mock: created a second Thread in the same project, sent `after-switch`, verified it appeared only in the new Thread and not in the old Thread
- Full `pnpm test`: 2151 passed, 1 skipped, 2 unrelated failures in `packages/host/engine/tests/integration/worktree-service.test.ts` on macOS path canonicalization (`/tmp` vs `/private/tmp`)