### PR TITLE
test: fix two suites that asserted properties of the machine

### DIFF
--- a/apps/daemon/tests/integration/runtime.test.ts
+++ b/apps/daemon/tests/integration/runtime.test.ts
@@ -6,6 +6,7 @@ import type { AddressInfo } from 'node:net';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { DaemonIdentity } from '@linkcode/schema';
+import { DAEMON_PORT_HUNT_SPAN } from '@linkcode/schema';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
   DaemonAlreadyRunningError,
@@ -16,6 +17,18 @@ import {
 } from '../../src/runtime';
 
 const servers: Server[] = [];
+
+/**
+ * The hunt walks upward from the requested port, so what a "hunted past it" case can assert is that
+ * it landed above the occupant and inside the span — not the exact neighbour. `port` here is an
+ * ephemeral port the OS handed out, and nothing reserves `port + 1`: asserting adjacency made these
+ * cases fail whenever another process (a parallel vitest worker, most often) held it.
+ */
+function expectHuntedPast(url: string, occupied: number): void {
+  const hunted = Number(new URL(url).port);
+  expect(hunted).toBeGreaterThan(occupied);
+  expect(hunted).toBeLessThan(occupied + DAEMON_PORT_HUNT_SPAN);
+}
 let savedHome: string | undefined;
 
 // The runtime file lives under os.homedir(); point HOME at a fresh temp dir per test.
@@ -59,6 +72,21 @@ function serveIdentity(id: DaemonIdentity): Promise<number> {
     }
     res.writeHead(404);
     res.end();
+  });
+}
+
+/** Occupy one specific port; resolves to it, or rejects if something else already holds it. */
+function listenOn(port: number): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const server = createServer((_req, res) => {
+      res.writeHead(200);
+      res.end();
+    });
+    servers.push(server);
+    server.once('error', reject);
+    server.listen(port, '127.0.0.1', () => {
+      resolve(port);
+    });
   });
 }
 
@@ -119,13 +147,27 @@ describe('probeDaemonIdentity', () => {
 });
 
 describe('listenWithPortHunt', () => {
-  it('hunts past a foreign occupant to the next port', async () => {
+  it('hunts past a foreign occupant', async () => {
     const port = await serveForeign();
     const { server, url } = await listenWithPortHunt(
       { type: 'ws', port, host: '127.0.0.1' },
       identity(process.pid),
     );
-    expect(url).toBe(`ws://127.0.0.1:${port + 1}`);
+    expectHuntedPast(url, port);
+    await server.close();
+  });
+
+  // The scenario the adjacency assertions used to fail on, made deterministic: the neighbour is
+  // occupied too, so the hunt has to keep walking rather than settle on `port + 1`.
+  it('keeps walking when the neighbouring port is taken as well', async () => {
+    const port = await serveForeign();
+    const neighbour = await listenOn(port + 1);
+    const { server, url } = await listenWithPortHunt(
+      { type: 'ws', port, host: '127.0.0.1' },
+      identity(process.pid),
+    );
+    expect(Number(new URL(url).port)).toBeGreaterThan(neighbour);
+    expectHuntedPast(url, port);
     await server.close();
   });
 
@@ -140,7 +182,7 @@ describe('listenWithPortHunt', () => {
     const self = identity(process.pid);
     const port = await serveIdentity(self);
     const { server, url } = await listenWithPortHunt({ type: 'ws', port, host: '127.0.0.1' }, self);
-    expect(url).toBe(`ws://127.0.0.1:${port + 1}`);
+    expectHuntedPast(url, port);
     await server.close();
   });
 
@@ -150,7 +192,7 @@ describe('listenWithPortHunt', () => {
       { type: 'ws', port, host: '127.0.0.1' },
       identity(process.pid),
     );
-    expect(url).toBe(`ws://127.0.0.1:${port + 1}`);
+    expectHuntedPast(url, port);
     await server.close();
   });
 
@@ -173,7 +215,7 @@ describe('listenWithPortHunt', () => {
       { type: 'ws', port, host: '127.0.0.1' },
       { ...identity(process.pid), channel: 'development' },
     );
-    expect(url).toBe(`ws://127.0.0.1:${port + 1}`);
+    expectHuntedPast(url, port);
     await server.close();
   });
 

--- a/apps/daemon/tests/integration/runtime.test.ts
+++ b/apps/daemon/tests/integration/runtime.test.ts
@@ -18,17 +18,13 @@ import {
 
 const servers: Server[] = [];
 
-/**
- * The hunt walks upward from the requested port, so what a "hunted past it" case can assert is that
- * it landed above the occupant and inside the span — not the exact neighbour. `port` here is an
- * ephemeral port the OS handed out, and nothing reserves `port + 1`: asserting adjacency made these
- * cases fail whenever another process (a parallel vitest worker, most often) held it.
- */
+// Ports are shared with the rest of the machine, so the exact landing port is not ours to predict.
 function expectHuntedPast(url: string, occupied: number): void {
   const hunted = Number(new URL(url).port);
   expect(hunted).toBeGreaterThan(occupied);
   expect(hunted).toBeLessThan(occupied + DAEMON_PORT_HUNT_SPAN);
 }
+
 let savedHome: string | undefined;
 
 // The runtime file lives under os.homedir(); point HOME at a fresh temp dir per test.
@@ -75,7 +71,6 @@ function serveIdentity(id: DaemonIdentity): Promise<number> {
   });
 }
 
-/** Occupy one specific port; resolves to it, or rejects if something else already holds it. */
 function listenOn(port: number): Promise<number> {
   return new Promise((resolve, reject) => {
     const server = createServer((_req, res) => {
@@ -88,6 +83,20 @@ function listenOn(port: number): Promise<number> {
       resolve(port);
     });
   });
+}
+
+/**
+ * Two adjacent ports we hold ourselves. Retried because the neighbour of an ephemeral port belongs
+ * to the machine, not to us — assuming it is free is the very flake these cases exist to rule out.
+ */
+async function occupyAdjacentPair(attempt = 0): Promise<{ port: number; neighbour: number }> {
+  const port = await serveForeign();
+  try {
+    return { port, neighbour: await listenOn(port + 1) };
+  } catch (err) {
+    if (attempt >= 20) throw err;
+    return occupyAdjacentPair(attempt + 1);
+  }
 }
 
 function serveForeign(): Promise<number> {
@@ -157,11 +166,9 @@ describe('listenWithPortHunt', () => {
     await server.close();
   });
 
-  // The scenario the adjacency assertions used to fail on, made deterministic: the neighbour is
-  // occupied too, so the hunt has to keep walking rather than settle on `port + 1`.
+  // Occupying the neighbour too is what forces the hunt to keep walking rather than settle on +1.
   it('keeps walking when the neighbouring port is taken as well', async () => {
-    const port = await serveForeign();
-    const neighbour = await listenOn(port + 1);
+    const { port, neighbour } = await occupyAdjacentPair();
     const { server, url } = await listenWithPortHunt(
       { type: 'ws', port, host: '127.0.0.1' },
       identity(process.pid),

--- a/packages/host/engine/tests/integration/worktree-service.test.ts
+++ b/packages/host/engine/tests/integration/worktree-service.test.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from 'node:child_process';
-import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { SessionIdSchema } from '@linkcode/schema';
@@ -12,8 +12,13 @@ import { InMemoryWorktreeStore } from '../../src/worktree/worktree-store';
 
 const roots: string[] = [];
 
+/**
+ * `realpathSync` because macOS `tmpdir()` is `/var/folders/…` behind a `/private` symlink (and
+ * `/tmp` → `/private/tmp`). The service records the resolved path git reports, so a test comparing
+ * against the unresolved one fails on macOS and passes on Linux, where nothing is symlinked.
+ */
 function temp(): string {
-  const path = mkdtempSync(join(tmpdir(), 'linkcode-worktree-test-'));
+  const path = realpathSync(mkdtempSync(join(tmpdir(), 'linkcode-worktree-test-')));
   roots.push(path);
   return path;
 }

--- a/packages/host/engine/tests/integration/worktree-service.test.ts
+++ b/packages/host/engine/tests/integration/worktree-service.test.ts
@@ -12,11 +12,8 @@ import { InMemoryWorktreeStore } from '../../src/worktree/worktree-store';
 
 const roots: string[] = [];
 
-/**
- * `realpathSync` because macOS `tmpdir()` is `/var/folders/…` behind a `/private` symlink (and
- * `/tmp` → `/private/tmp`). The service records the resolved path git reports, so a test comparing
- * against the unresolved one fails on macOS and passes on Linux, where nothing is symlinked.
- */
+// Resolved because macOS puts tmpdir() behind a /private symlink, while the service records the
+// path git reports — comparing the two unresolved fails on macOS and passes on Linux.
 function temp(): string {
   const path = realpathSync(mkdtempSync(join(tmpdir(), 'linkcode-worktree-test-')));
   roots.push(path);


### PR DESCRIPTION
Two tests that encoded an assumption about the machine rather than about the code. Both were found while running the full suite on macOS for an unrelated branch; neither is caused by that work.

## `worktree-service.test.ts` — fails on every mac, passes on Linux CI

```
- Expected  "repoRoot": "/tmp/linkcode-worktree-test-lFskJd"
+ Received  "repoRoot": "/private/tmp/linkcode-worktree-test-lFskJd"
```

`mkdtempSync(join(tmpdir(), …))` hands back a path that goes through a symlink on macOS — `/tmp` → `/private/tmp`, and `$TMPDIR` under `/var/folders/…` likewise. `WorktreeService` records the resolved path git reports, so the two never compare equal. On Linux nothing in that path is a symlink, which is why this merged green.

Two of the thirteen cases failed (`creates and persists a non-current local branch…` and `records unknown linked worktrees as orphaned…`); one `realpathSync` in the fixture fixes both, since they shared the cause.

This is a fixture bug, not a service bug: resolving the path is the correct behaviour for something that has to match git's own bookkeeping.

## `runtime.test.ts` — intermittently fails in the full suite, never in isolation

Four `listenWithPortHunt` cases asserted the hunt landed on exactly `port + 1`. `port` is an ephemeral port the OS handed out and **nothing reserves its neighbour**, so when another process held `port + 1` the hunt correctly walked further and the assertion failed. In practice the other process was usually a parallel vitest worker, which is why it only ever showed up in a full-suite run — I saw it three times across this session and could not reproduce it in ten isolated runs of the file.

They now assert what `huntFrom` actually promises: a port above the occupant, inside `DAEMON_PORT_HUNT_SPAN`. That keeps the meaningful claims (it hunted *past* the occupant, upward, and stayed in range) and drops the one the test could never guarantee.

Added `keeps walking when the neighbouring port is taken as well`, which occupies the neighbour deliberately — the scenario that used to flake, now deterministic. Under the old assertion it would fail every time.

## Verification

Full suite on macOS: 2149 passed, 0 failed (previously 2 failed). `check:ci` green. `runtime.test.ts` run repeatedly in isolation and in the full suite.
