### PR TITLE
feat(chat): add a conversation minimap for turn navigation

### DIFF
--- a/packages/client/workbench/src/mock/data/long-thread.ts
+++ b/packages/client/workbench/src/mock/data/long-thread.ts
@@ -1,0 +1,64 @@
+import type { AgentEvent, MessageId } from '@linkcode/schema';
+import { textBlock } from '@linkcode/schema';
+
+/** Enough turns to overflow the conversation minimap's rail, which only scrolls past ~38 of them. */
+export const LONG_THREAD_TURNS = 48;
+
+const SUBJECTS = [
+  'the reconnect backoff',
+  'the wire envelope',
+  'the fleet table query',
+  'the PTY sidecar handshake',
+  'the artifact viewer',
+  'the approval policy',
+  'the compaction marker',
+  'the terminal credit window',
+];
+
+const ASKS = [
+  'Walk me through',
+  'What breaks in',
+  'Summarize',
+  'Find the regression in',
+  'Explain the invariant behind',
+];
+
+/**
+ * A long settled transcript, so surfaces that only misbehave at length — the minimap rail, the
+ * virtualizer's windowing — are reachable in dev without a real agent. Turn bodies vary in size on
+ * purpose: a rail whose ticks all look alike hides nothing.
+ */
+export function createLongThreadScript(messageId: (slug: string) => MessageId): AgentEvent[] {
+  const script: AgentEvent[] = [{ type: 'status', status: 'running' }];
+  for (let turn = 0; turn < LONG_THREAD_TURNS; turn++) {
+    const subject = SUBJECTS[turn % SUBJECTS.length];
+    const ask = ASKS[turn % ASKS.length];
+    script.push({
+      type: 'user-message',
+      messageId: messageId(`mock-long-user-${turn}`),
+      content: [textBlock(`${ask} ${subject}.`)],
+    });
+    script.push({
+      type: 'agent-message-chunk',
+      messageId: messageId(`mock-long-reply-${turn}`),
+      content: textBlock(replyBody(turn, subject)),
+    });
+  }
+  script.push({ type: 'stop', stopReason: 'end_turn' });
+  script.push({ type: 'status', status: 'idle' });
+  return script;
+}
+
+function replyBody(turn: number, subject: string): string {
+  const lines = [`Turn ${turn + 1} — notes on ${subject}.`, ''];
+  // Every third turn is a long one, so the rail shows an uneven, realistic rhythm.
+  const paragraphs = turn % 3 === 0 ? 4 : 1;
+  for (let i = 0; i < paragraphs; i++) {
+    lines.push(
+      `${subject} settles once the caller owns the retry budget; paragraph ${i + 1} of turn ${turn + 1} exists to give this reply real height.`,
+      '',
+    );
+  }
+  if (turn % 4 === 0) lines.push('- one', '- two', '- three', '');
+  return lines.join('\n');
+}

--- a/packages/client/workbench/src/mock/data/sessions.ts
+++ b/packages/client/workbench/src/mock/data/sessions.ts
@@ -15,6 +15,8 @@ export interface SeedSession {
   status: SessionStatus;
   ageMs: number;
   showcase?: boolean;
+  /** Seeds a long settled transcript instead of the scripted showcase (see `long-thread.ts`). */
+  longThread?: boolean;
   terminalId?: string;
   resources?: SeedSessionResource[];
 }
@@ -85,6 +87,14 @@ export const SEED_SESSIONS: SeedSession[] = [
         ageMs: 10000,
       },
     ],
+  },
+  {
+    kind: 'claude-code',
+    cwd: '/mock/linkcode',
+    title: 'Long thread · navigation testbed',
+    status: 'idle',
+    ageMs: 8 * 60000,
+    longThread: true,
   },
   {
     kind: 'claude-code',

--- a/packages/client/workbench/src/mock/dev-mock-host.ts
+++ b/packages/client/workbench/src/mock/dev-mock-host.ts
@@ -46,6 +46,7 @@ import { MOCK_COMMAND_CATALOG, mockCommandFixture } from './data/commands';
 import { MOCK_WORKSPACE_FILES, mockFileFixture } from './data/files';
 import { gitFixtureFor } from './data/git';
 import { SEED_HISTORY } from './data/history';
+import { createLongThreadScript } from './data/long-thread';
 import { SEED_MODEL_CATALOGS } from './data/models';
 import {
   CHUNK_LATENCY_MS,
@@ -120,6 +121,8 @@ interface MockSession extends SessionInfo {
   epoch: number;
   showcase?: boolean;
   showcaseSeeded?: boolean;
+  longThread?: boolean;
+  longThreadSeeded?: boolean;
   terminalId?: string;
 }
 
@@ -310,6 +313,7 @@ export class DevMockHost {
         });
         // Start after the list reply so the UI can subscribe before scripted frames arrive.
         this.startShowcase();
+        this.seedLongThreads();
         break;
       case 'session.attach':
         this.attachSession(p.sessionId);
@@ -1156,6 +1160,17 @@ export class DevMockHost {
     session.status = 'idle';
     this.emit(session.sessionId, { type: 'status', status: 'idle' });
     this.sendSuccess(replyTo);
+  }
+
+  /** Emitted in one burst, not streamed: this transcript exists to be long, not to look live. */
+  private seedLongThreads(): void {
+    for (const session of this.sessions.values()) {
+      if (!session.longThread || session.longThreadSeeded) continue;
+      session.longThreadSeeded = true;
+      for (const event of createLongThreadScript((slug) => this.nextMessageId(slug))) {
+        this.emit(session.sessionId, event);
+      }
+    }
   }
 
   private startShowcase(): void {

--- a/packages/presentation/i18n/src/locales/en.ts
+++ b/packages/presentation/i18n/src/locales/en.ts
@@ -132,6 +132,10 @@ export const en = {
       compacting: 'Compacting context…',
       compacted: 'Context compacted',
       compactedTokens: '{pre} → {post} tokens',
+      minimap: {
+        label: 'Conversation navigation',
+        turn: 'Turn {index}',
+      },
     },
     tool: {
       input: 'Input',

--- a/packages/presentation/i18n/src/locales/zh-cn.ts
+++ b/packages/presentation/i18n/src/locales/zh-cn.ts
@@ -128,6 +128,10 @@ export const zhCN = {
       compacting: '正在压缩上下文…',
       compacted: '上下文已压缩',
       compactedTokens: '{pre} → {post} tokens',
+      minimap: {
+        label: '对话导航',
+        turn: '第 {index} 轮',
+      },
     },
     tool: {
       input: '输入',

--- a/packages/presentation/ui/src/chat/__tests__/minimap-geometry.test.ts
+++ b/packages/presentation/ui/src/chat/__tests__/minimap-geometry.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import {
+  fisheyeFactor,
+  fisheyeSize,
+  MINIMAP_FISHEYE_SPREAD,
+  MINIMAP_ROW_HEIGHT,
+  MINIMAP_TURN_TICK,
+  railScrollTopFor,
+} from '../minimap-geometry';
+
+describe('fisheyeFactor', () => {
+  it('peaks under the pointer and dies at the spread', () => {
+    expect(fisheyeFactor(0)).toBe(1);
+    expect(fisheyeFactor(MINIMAP_FISHEYE_SPREAD)).toBe(0);
+    expect(fisheyeFactor(MINIMAP_FISHEYE_SPREAD * 4)).toBe(0);
+  });
+
+  it('is symmetric, so ticks above and below the pointer grow alike', () => {
+    expect(fisheyeFactor(-20)).toBe(fisheyeFactor(20));
+  });
+
+  it('decreases monotonically across the falloff', () => {
+    const samples = [0, 10, 20, 30, 40, 50, 54].map((d) => fisheyeFactor(d));
+    for (let i = 1; i < samples.length; i++) expect(samples[i]).toBeLessThan(samples[i - 1]);
+  });
+
+  it('eases out — the near half of the falloff keeps most of the magnification', () => {
+    expect(fisheyeFactor(MINIMAP_FISHEYE_SPREAD / 2)).toBeGreaterThan(0.5);
+  });
+});
+
+describe('fisheyeSize', () => {
+  it('spans exactly base to peak', () => {
+    expect(fisheyeSize(MINIMAP_TURN_TICK, 0)).toEqual({ width: 12, height: 3 });
+    expect(fisheyeSize(MINIMAP_TURN_TICK, 1)).toEqual({ width: 39, height: 6 });
+  });
+
+  it('interpolates both axes together', () => {
+    expect(fisheyeSize(MINIMAP_TURN_TICK, 0.5)).toEqual({ width: 25.5, height: 4.5 });
+  });
+});
+
+describe('railScrollTopFor', () => {
+  const railHeight = 180; // 10 rows
+
+  it('does not scroll while every turn fits', () => {
+    expect(railScrollTopFor({ start: 0, end: 4 }, 8, railHeight)).toBe(0);
+  });
+
+  it('centers the visible range once the rail overflows', () => {
+    // Rows 20..29 → center at row 25 → 25 * 18 - 90.
+    expect(railScrollTopFor({ start: 20, end: 29 }, 100, railHeight)).toBe(360);
+  });
+
+  it('clamps at both ends instead of overscrolling', () => {
+    expect(railScrollTopFor({ start: 0, end: 3 }, 100, railHeight)).toBe(0);
+    expect(railScrollTopFor({ start: 96, end: 99 }, 100, railHeight)).toBe(
+      100 * MINIMAP_ROW_HEIGHT - railHeight,
+    );
+  });
+});

--- a/packages/presentation/ui/src/chat/__tests__/minimap-geometry.test.ts
+++ b/packages/presentation/ui/src/chat/__tests__/minimap-geometry.test.ts
@@ -1,10 +1,12 @@
+import { createFixedArray } from 'foxts/create-fixed-array';
 import { describe, expect, it } from 'vitest';
 import {
   fisheyeFactor,
-  fisheyeSize,
+  fisheyeWidth,
   MINIMAP_FISHEYE_SPREAD,
   MINIMAP_ROW_HEIGHT,
-  MINIMAP_TURN_TICK,
+  MINIMAP_TICK_BASE_WIDTH,
+  MINIMAP_TICK_PEAK_WIDTH,
   railScrollTopFor,
 } from '../minimap-geometry';
 
@@ -20,7 +22,8 @@ describe('fisheyeFactor', () => {
   });
 
   it('decreases monotonically across the falloff', () => {
-    const samples = [0, 10, 20, 30, 40, 50, 54].map((d) => fisheyeFactor(d));
+    const step = MINIMAP_FISHEYE_SPREAD / 6;
+    const samples = createFixedArray(7).map((_, i) => fisheyeFactor(i * step));
     for (let i = 1; i < samples.length; i++) expect(samples[i]).toBeLessThan(samples[i - 1]);
   });
 
@@ -29,27 +32,29 @@ describe('fisheyeFactor', () => {
   });
 });
 
-describe('fisheyeSize', () => {
+describe('fisheyeWidth', () => {
   it('spans exactly base to peak', () => {
-    expect(fisheyeSize(MINIMAP_TURN_TICK, 0)).toEqual({ width: 12, height: 3 });
-    expect(fisheyeSize(MINIMAP_TURN_TICK, 1)).toEqual({ width: 39, height: 6 });
+    expect(fisheyeWidth(0)).toBe(MINIMAP_TICK_BASE_WIDTH);
+    expect(fisheyeWidth(1)).toBe(MINIMAP_TICK_PEAK_WIDTH);
   });
 
-  it('interpolates both axes together', () => {
-    expect(fisheyeSize(MINIMAP_TURN_TICK, 0.5)).toEqual({ width: 25.5, height: 4.5 });
+  it('interpolates linearly between them', () => {
+    expect(fisheyeWidth(0.5)).toBe((MINIMAP_TICK_BASE_WIDTH + MINIMAP_TICK_PEAK_WIDTH) / 2);
   });
 });
 
 describe('railScrollTopFor', () => {
-  const railHeight = 180; // 10 rows
+  const railHeight = MINIMAP_ROW_HEIGHT * 10;
 
   it('does not scroll while every turn fits', () => {
     expect(railScrollTopFor({ start: 0, end: 4 }, 8, railHeight)).toBe(0);
   });
 
   it('centers the visible range once the rail overflows', () => {
-    // Rows 20..29 → center at row 25 → 25 * 18 - 90.
-    expect(railScrollTopFor({ start: 20, end: 29 }, 100, railHeight)).toBe(360);
+    // Rows 20..29 → center at row 25 → 25 pitches, less half a rail.
+    expect(railScrollTopFor({ start: 20, end: 29 }, 100, railHeight)).toBe(
+      25 * MINIMAP_ROW_HEIGHT - railHeight / 2,
+    );
   });
 
   it('clamps at both ends instead of overscrolling', () => {

--- a/packages/presentation/ui/src/chat/__tests__/minimap-geometry.test.ts
+++ b/packages/presentation/ui/src/chat/__tests__/minimap-geometry.test.ts
@@ -2,6 +2,7 @@ import { createFixedArray } from 'foxts/create-fixed-array';
 import { describe, expect, it } from 'vitest';
 import {
   fisheyeFactor,
+  fisheyeScaleX,
   fisheyeWidth,
   MINIMAP_FISHEYE_SPREAD,
   MINIMAP_ROW_HEIGHT,
@@ -40,6 +41,16 @@ describe('fisheyeWidth', () => {
 
   it('interpolates linearly between them', () => {
     expect(fisheyeWidth(0.5)).toBe((MINIMAP_TICK_BASE_WIDTH + MINIMAP_TICK_PEAK_WIDTH) / 2);
+  });
+});
+
+describe('fisheyeScaleX', () => {
+  it('leaves a resting tick untransformed', () => {
+    expect(fisheyeScaleX(0)).toBe(1);
+  });
+
+  it('reaches the peak width without the box changing size', () => {
+    expect(fisheyeScaleX(1) * MINIMAP_TICK_BASE_WIDTH).toBe(MINIMAP_TICK_PEAK_WIDTH);
   });
 });
 

--- a/packages/presentation/ui/src/chat/conversation-minimap.tsx
+++ b/packages/presentation/ui/src/chat/conversation-minimap.tsx
@@ -7,13 +7,14 @@ import { clamp } from 'foxts/clamp';
 import { useCallback, useMemo, useRef, useState } from 'react';
 import { useTranslations } from 'use-intl';
 import type { VirtualizerHandle } from 'virtua';
+import { useInputModality } from '../input-modality';
 import { cn } from '../lib/cn';
 import { SidePreviewCardPopup } from '../preview-card-popup';
 import { useRenderPrefs } from '../render-prefs';
 import { Markdown } from './markdown';
 import {
   fisheyeFactor,
-  fisheyeWidth,
+  fisheyeScaleX,
   MINIMAP_ROW_HEIGHT,
   railScrollTopFor,
 } from './minimap-geometry';
@@ -46,6 +47,7 @@ export function useConversationMinimap(count: number): {
   const railRef = useRef<HTMLDivElement>(null);
   const [range, setRange] = useState<MinimapVisibleRange | null>(null);
   const { reduceMotion } = useRenderPrefs();
+  const modality = useInputModality();
 
   const onScroll = useCallback(
     (offset: number) => {
@@ -69,10 +71,13 @@ export function useConversationMinimap(count: number): {
       const from = virtualizer.findItemIndex(virtualizer.scrollOffset);
       virtualizer.scrollToIndex(index, {
         align: 'start',
-        smooth: !reduceMotion && Math.abs(index - from) <= SMOOTH_JUMP_ROWS,
+        // Enter and Space reach this through the same click, and a keyed jump repeats far too often
+        // to animate.
+        smooth:
+          modality === 'pointer' && !reduceMotion && Math.abs(index - from) <= SMOOTH_JUMP_ROWS,
       });
     },
-    [reduceMotion],
+    [modality, reduceMotion],
   );
 
   return {
@@ -145,12 +150,12 @@ export function ConversationMinimap({
     tickNodesRef.current.forEach((tick, index) => {
       if (!tick) return;
       if (pointerY === null) {
-        // Back to the resting width in the class, which the transition eases into.
-        tick.style.width = '';
+        // Back to the resting size in the class, which the transition eases into.
+        tick.style.transform = '';
         return;
       }
       const center = listTop + index * MINIMAP_ROW_HEIGHT + MINIMAP_ROW_HEIGHT / 2;
-      tick.style.width = `${fisheyeWidth(fisheyeFactor(center - pointerY)).toFixed(2)}px`;
+      tick.style.transform = `scaleX(${fisheyeScaleX(fisheyeFactor(center - pointerY)).toFixed(3)})`;
     });
   }, []);
 
@@ -178,9 +183,8 @@ export function ConversationMinimap({
       const delta = event.key === 'ArrowDown' ? 1 : event.key === 'ArrowUp' ? -1 : 0;
       if (delta === 0) return;
       event.preventDefault();
-      const next = clamp(focusIndex + delta, 0, count - 1);
-      setFocused(next);
-      buttonNodesRef.current[next]?.focus();
+      // `onFocus` carries the roving index, so a tick focused by a click stays the arrows' origin.
+      buttonNodesRef.current[clamp(focusIndex + delta, 0, count - 1)]?.focus();
     },
     [count, focusIndex],
   );
@@ -193,21 +197,23 @@ export function ConversationMinimap({
       <nav
         aria-label={t('label')}
         className={cn(
-          // The column is transparent, but it must be at least as wide as a tick at full stretch:
-          // `overflow-y-auto` below makes the x axis clip too, which would cut the magnified tick.
-          'absolute inset-y-0 left-2.5 hidden w-8 @min-[55rem]/conversation:block',
+          // `left` is the gutter itself: ticks sit flush against this column's left edge. The column
+          // is transparent but must outrun a tick at full stretch — `overflow-y-auto` below clips
+          // the x axis too, which would cut the magnified tick off.
+          'absolute inset-y-0 left-[22px] hidden w-8 @min-[55rem]/conversation:block',
           className,
         )}
       >
         <div
-          className="flex h-full flex-col overflow-y-auto [scrollbar-width:none]"
+          className="flex h-full flex-col items-start overflow-y-auto [scrollbar-width:none]"
           onPointerLeave={handlePointerLeave}
           onPointerMove={handlePointerMove}
           ref={railRef}
         >
           {/* Auto margins center a short stack and collapse once it outgrows the rail, which
-              `justify-center` would instead clip at the top. */}
-          <div className="m-auto flex flex-col" ref={listRef}>
+              `justify-center` would instead clip at the top. Vertical only: centering this
+              fit-content column horizontally would move it whenever a tick's box changed. */}
+          <div className="my-auto flex flex-col" ref={listRef}>
             {segments.map((segment, index) => (
               <PreviewCardTrigger
                 aria-label={t('turn', { index: index + 1 })}
@@ -217,6 +223,7 @@ export function ConversationMinimap({
                 handle={handle}
                 key={segment.turnId ?? 'lead-in'}
                 onClick={() => onSelect(index)}
+                onFocus={() => setFocused(index)}
                 onKeyDown={handleKeyDown}
                 payload={index}
                 ref={(element) => {
@@ -226,17 +233,12 @@ export function ConversationMinimap({
                 style={{ height: MINIMAP_ROW_HEIGHT }}
                 tabIndex={index === focusIndex ? 0 : -1}
               >
-                {/* Resting width lives in the class, not `style`, so a re-render mid-hover can't
-                    clobber the magnification written to the node. The transition covers both the
-                    return to rest and the per-frame retargeting, which damps the follow.
-                    Dimming is a colour, not container opacity, which would flatten the on-screen
-                    step along with everything else. */}
+                {/* Resting size lives in the class, never `style`: a re-render mid-hover would
+                    otherwise clobber the magnification written straight to the node. */}
                 <span
                   className={cn(
-                    'h-[2px] w-2 rounded-full transition-[width,background-color] duration-(--motion-fast) ease-(--motion-ease-out) group-focus-visible/tick:bg-foreground group-hover/tick:bg-foreground',
-                    // Off-screen turns rest at the hairline tone — texture, not content. The label
-                    // tiers all sit too high for that; they are built for text, this is a fill.
-                    // Hovering the rail does not lift them: the magnification already announces it.
+                    'h-[2px] w-2 origin-left rounded-full transition-[transform,background-color] duration-(--motion-fast) ease-(--motion-ease-out) group-focus-visible/tick:bg-foreground group-hover/tick:bg-foreground',
+                    // A fill this small needs a tone below every label tier, which are built for text.
                     index >= visible.start && index <= visible.end
                       ? 'bg-muted-foreground'
                       : 'bg-border',

--- a/packages/presentation/ui/src/chat/conversation-minimap.tsx
+++ b/packages/presentation/ui/src/chat/conversation-minimap.tsx
@@ -1,0 +1,269 @@
+import {
+  PreviewCard,
+  PreviewCardPrimitive,
+  PreviewCardTrigger,
+} from 'coss-ui/components/preview-card';
+import { clamp } from 'foxts/clamp';
+import { useCallback, useMemo, useRef, useState } from 'react';
+import { useTranslations } from 'use-intl';
+import type { VirtualizerHandle } from 'virtua';
+import { cn } from '../lib/cn';
+import { SidePreviewCardPopup } from '../preview-card-popup';
+import { useRenderPrefs } from '../render-prefs';
+import { Markdown } from './markdown';
+import {
+  fisheyeFactor,
+  fisheyeSize,
+  MINIMAP_ROW_HEIGHT,
+  MINIMAP_TURN_TICK,
+  railScrollTopFor,
+} from './minimap-geometry';
+import type { TurnSegment } from './turn-edits';
+
+/** Beyond this many rows a smooth jump pages the whole window through the viewport. */
+const SMOOTH_JUMP_ROWS = 10;
+
+/** Markdown excerpt fed to the preview card; the card masks off whatever overflows. */
+const PREVIEW_BODY_CHARS = 600;
+
+export interface MinimapVisibleRange {
+  start: number;
+  /** Inclusive. */
+  end: number;
+}
+
+/**
+ * Wires the rail to the virtualized column. One callback resolves the visible range *and* scrolls
+ * the rail, so nothing has to watch either with an effect.
+ */
+export function useConversationMinimap(count: number): {
+  virtualizerRef: React.RefObject<VirtualizerHandle | null>;
+  railRef: React.RefObject<HTMLDivElement | null>;
+  visible: MinimapVisibleRange;
+  onScroll: (offset: number) => void;
+  onSelect: (index: number) => void;
+} {
+  const virtualizerRef = useRef<VirtualizerHandle>(null);
+  const railRef = useRef<HTMLDivElement>(null);
+  const [range, setRange] = useState<MinimapVisibleRange | null>(null);
+  const { reduceMotion } = useRenderPrefs();
+
+  const onScroll = useCallback(
+    (offset: number) => {
+      const virtualizer = virtualizerRef.current;
+      if (!virtualizer) return;
+      const next = {
+        start: virtualizer.findItemIndex(offset),
+        end: virtualizer.findItemIndex(offset + virtualizer.viewportSize),
+      };
+      setRange((prev) => (prev?.start === next.start && prev.end === next.end ? prev : next));
+      const rail = railRef.current;
+      if (rail) rail.scrollTop = railScrollTopFor(next, count, rail.clientHeight);
+    },
+    [count],
+  );
+
+  const onSelect = useCallback(
+    (index: number) => {
+      const virtualizer = virtualizerRef.current;
+      if (!virtualizer) return;
+      const from = virtualizer.findItemIndex(virtualizer.scrollOffset);
+      virtualizer.scrollToIndex(index, {
+        align: 'start',
+        smooth: !reduceMotion && Math.abs(index - from) <= SMOOTH_JUMP_ROWS,
+      });
+    },
+    [reduceMotion],
+  );
+
+  return {
+    virtualizerRef,
+    railRef,
+    onScroll,
+    onSelect,
+    // Until the first scroll every turn is on screen: true for a thread short enough never to
+    // scroll, and corrected immediately by the initial jump to bottom on one that does.
+    visible: range ?? { start: 0, end: count - 1 },
+  };
+}
+
+function segmentText(segment: TurnSegment, role: 'user' | 'assistant'): string {
+  for (const item of segment.items) {
+    if (item.kind !== 'message' || item.role !== role) continue;
+    const text = item.blocks
+      .map((block) => (block.type === 'text' ? block.text : ''))
+      .join('')
+      .trim();
+    if (text) return text;
+  }
+  return '';
+}
+
+export interface ConversationMinimapProps {
+  segments: readonly TurnSegment[];
+  visible: MinimapVisibleRange;
+  railRef: React.RefObject<HTMLDivElement | null>;
+  onSelect: (index: number) => void;
+  className?: string;
+}
+
+/**
+ * Turn navigation rail in the reading column's left gutter — one evenly spaced tick per turn, not a
+ * proportional minimap: under virtualization an unmounted row's offset is an estimate that shifts
+ * as it measures, so mapping ticks to document height makes them drift.
+ */
+export function ConversationMinimap({
+  segments,
+  visible,
+  railRef,
+  onSelect,
+  className,
+}: ConversationMinimapProps): React.ReactNode {
+  const t = useTranslations('workbench.conversation.minimap');
+  const { reduceMotion } = useRenderPrefs();
+  // One card serving every tick, so only the open turn's excerpt is ever built. Not a ref: base-ui
+  // reads the handle while rendering both the triggers and the card.
+  const handle = useMemo(() => PreviewCardPrimitive.createHandle<number>(), []);
+  const listRef = useRef<HTMLDivElement>(null);
+  const tickNodesRef = useRef<Array<HTMLElement | null>>([]);
+  const buttonNodesRef = useRef<Array<HTMLElement | null>>([]);
+  const pointerYRef = useRef<number | null>(null);
+  const frameRef = useRef<number | null>(null);
+  const [focused, setFocused] = useState(0);
+
+  const count = segments.length;
+  const focusIndex = Math.min(focused, count - 1);
+
+  // Magnification is a continuous per-frame value across every tick; routing it through state
+  // would re-render the whole rail each frame, so the falloff is written straight to the nodes.
+  // Row pitch is fixed, so one rect read locates all of them.
+  const paint = useCallback(() => {
+    frameRef.current = null;
+    const list = listRef.current;
+    if (!list) return;
+    const pointerY = pointerYRef.current;
+    const listTop = list.getBoundingClientRect().top;
+    tickNodesRef.current.forEach((tick, index) => {
+      if (!tick) return;
+      if (pointerY === null) {
+        tick.style.width = '';
+        tick.style.height = '';
+        return;
+      }
+      const center = listTop + index * MINIMAP_ROW_HEIGHT + MINIMAP_ROW_HEIGHT / 2;
+      const { width, height } = fisheyeSize(MINIMAP_TURN_TICK, fisheyeFactor(center - pointerY));
+      tick.style.width = `${width.toFixed(2)}px`;
+      tick.style.height = `${height.toFixed(2)}px`;
+    });
+  }, []);
+
+  const schedulePaint = useCallback(
+    (pointerY: number | null) => {
+      pointerYRef.current = pointerY;
+      frameRef.current ??= requestAnimationFrame(paint);
+    },
+    [paint],
+  );
+
+  const handlePointerMove = useCallback(
+    (event: React.PointerEvent) => {
+      if (!reduceMotion) schedulePaint(event.clientY);
+    },
+    [reduceMotion, schedulePaint],
+  );
+
+  const handlePointerLeave = useCallback(() => {
+    schedulePaint(null);
+  }, [schedulePaint]);
+
+  const handleKeyDown = useCallback(
+    (event: React.KeyboardEvent) => {
+      const delta = event.key === 'ArrowDown' ? 1 : event.key === 'ArrowUp' ? -1 : 0;
+      if (delta === 0) return;
+      event.preventDefault();
+      const next = clamp(focusIndex + delta, 0, count - 1);
+      setFocused(next);
+      buttonNodesRef.current[next]?.focus();
+    },
+    [count, focusIndex],
+  );
+
+  if (count === 0) return null;
+
+  return (
+    <>
+      <nav
+        aria-label={t('label')}
+        className={cn(
+          'absolute inset-y-0 left-4 hidden w-10 opacity-40 transition-opacity duration-(--motion-fast) ease-(--motion-ease-out) focus-within:opacity-100 hover:opacity-100 @min-[55rem]/conversation:block',
+          className,
+        )}
+      >
+        <div
+          className="flex h-full flex-col overflow-y-auto [scrollbar-width:none]"
+          onPointerLeave={handlePointerLeave}
+          onPointerMove={handlePointerMove}
+          ref={railRef}
+        >
+          {/* Auto margins center a short stack and collapse once it outgrows the rail, which
+              `justify-center` would instead clip at the top. */}
+          <div className="m-auto flex flex-col" ref={listRef}>
+            {segments.map((segment, index) => (
+              <PreviewCardTrigger
+                aria-label={t('turn', { index: index + 1 })}
+                className="flex shrink-0 items-center rounded-sm outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                closeDelay={100}
+                delay={300}
+                handle={handle}
+                key={segment.turnId ?? 'lead-in'}
+                onClick={() => onSelect(index)}
+                onKeyDown={handleKeyDown}
+                payload={index}
+                ref={(element) => {
+                  buttonNodesRef.current[index] = element;
+                }}
+                render={<button type="button" />}
+                style={{ height: MINIMAP_ROW_HEIGHT }}
+                tabIndex={index === focusIndex ? 0 : -1}
+              >
+                {/* Resting size is `MINIMAP_TURN_TICK`'s base, in classes rather than `style` so a
+                    re-render mid-hover can't clobber the magnification written to the node. */}
+                <span
+                  className={cn(
+                    'h-[3px] w-3 rounded-full transition-[width,height,background-color] duration-(--motion-fast) ease-(--motion-ease-out)',
+                    index >= visible.start && index <= visible.end
+                      ? 'bg-label-tertiary'
+                      : 'bg-label-quaternary',
+                  )}
+                  ref={(element) => {
+                    tickNodesRef.current[index] = element;
+                  }}
+                />
+              </PreviewCardTrigger>
+            ))}
+          </div>
+        </div>
+      </nav>
+      <PreviewCard handle={handle}>
+        {({ payload }) => {
+          const segment = payload === undefined ? undefined : segments[payload];
+          if (!segment) return null;
+          const title = segmentText(segment, 'user');
+          const body = segmentText(segment, 'assistant').slice(0, PREVIEW_BODY_CHARS);
+          return (
+            <SidePreviewCardPopup className="w-96 flex-col gap-2">
+              <p className="line-clamp-1 font-medium text-foreground">
+                {title || t('turn', { index: (payload ?? 0) + 1 })}
+              </p>
+              {body ? (
+                <div className="max-h-40 overflow-hidden [mask-image:linear-gradient(to_bottom,black_calc(100%-2rem),transparent)]">
+                  <Markdown>{body}</Markdown>
+                </div>
+              ) : null}
+            </SidePreviewCardPopup>
+          );
+        }}
+      </PreviewCard>
+    </>
+  );
+}

--- a/packages/presentation/ui/src/chat/conversation-minimap.tsx
+++ b/packages/presentation/ui/src/chat/conversation-minimap.tsx
@@ -13,9 +13,8 @@ import { useRenderPrefs } from '../render-prefs';
 import { Markdown } from './markdown';
 import {
   fisheyeFactor,
-  fisheyeSize,
+  fisheyeWidth,
   MINIMAP_ROW_HEIGHT,
-  MINIMAP_TURN_TICK,
   railScrollTopFor,
 } from './minimap-geometry';
 import type { TurnSegment } from './turn-edits';
@@ -134,9 +133,9 @@ export function ConversationMinimap({
   const count = segments.length;
   const focusIndex = Math.min(focused, count - 1);
 
-  // Magnification is a continuous per-frame value across every tick; routing it through state
-  // would re-render the whole rail each frame, so the falloff is written straight to the nodes.
-  // Row pitch is fixed, so one rect read locates all of them.
+  // A continuous per-frame value across every tick: routing it through state would re-render the
+  // whole rail each frame, so the falloff is written straight to the nodes. The row pitch is fixed,
+  // so one rect read locates all of them.
   const paint = useCallback(() => {
     frameRef.current = null;
     const list = listRef.current;
@@ -146,14 +145,12 @@ export function ConversationMinimap({
     tickNodesRef.current.forEach((tick, index) => {
       if (!tick) return;
       if (pointerY === null) {
+        // Back to the resting width in the class, which the transition eases into.
         tick.style.width = '';
-        tick.style.height = '';
         return;
       }
       const center = listTop + index * MINIMAP_ROW_HEIGHT + MINIMAP_ROW_HEIGHT / 2;
-      const { width, height } = fisheyeSize(MINIMAP_TURN_TICK, fisheyeFactor(center - pointerY));
-      tick.style.width = `${width.toFixed(2)}px`;
-      tick.style.height = `${height.toFixed(2)}px`;
+      tick.style.width = `${fisheyeWidth(fisheyeFactor(center - pointerY)).toFixed(2)}px`;
     });
   }, []);
 
@@ -188,14 +185,17 @@ export function ConversationMinimap({
     [count, focusIndex],
   );
 
-  if (count === 0) return null;
+  // A single turn has nowhere to navigate to, so the rail would be decoration.
+  if (count <= 1) return null;
 
   return (
     <>
       <nav
         aria-label={t('label')}
         className={cn(
-          'absolute inset-y-0 left-4 hidden w-10 opacity-40 transition-opacity duration-(--motion-fast) ease-(--motion-ease-out) focus-within:opacity-100 hover:opacity-100 @min-[55rem]/conversation:block',
+          // The column is transparent, but it must be at least as wide as a tick at full stretch:
+          // `overflow-y-auto` below makes the x axis clip too, which would cut the magnified tick.
+          'absolute inset-y-0 left-2.5 hidden w-8 @min-[55rem]/conversation:block',
           className,
         )}
       >
@@ -211,7 +211,7 @@ export function ConversationMinimap({
             {segments.map((segment, index) => (
               <PreviewCardTrigger
                 aria-label={t('turn', { index: index + 1 })}
-                className="flex shrink-0 items-center rounded-sm outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                className="group/tick flex shrink-0 items-center rounded-sm outline-none focus-visible:ring-2 focus-visible:ring-ring"
                 closeDelay={100}
                 delay={300}
                 handle={handle}
@@ -226,14 +226,20 @@ export function ConversationMinimap({
                 style={{ height: MINIMAP_ROW_HEIGHT }}
                 tabIndex={index === focusIndex ? 0 : -1}
               >
-                {/* Resting size is `MINIMAP_TURN_TICK`'s base, in classes rather than `style` so a
-                    re-render mid-hover can't clobber the magnification written to the node. */}
+                {/* Resting width lives in the class, not `style`, so a re-render mid-hover can't
+                    clobber the magnification written to the node. The transition covers both the
+                    return to rest and the per-frame retargeting, which damps the follow.
+                    Dimming is a colour, not container opacity, which would flatten the on-screen
+                    step along with everything else. */}
                 <span
                   className={cn(
-                    'h-[3px] w-3 rounded-full transition-[width,height,background-color] duration-(--motion-fast) ease-(--motion-ease-out)',
+                    'h-[2px] w-2 rounded-full transition-[width,background-color] duration-(--motion-fast) ease-(--motion-ease-out) group-focus-visible/tick:bg-foreground group-hover/tick:bg-foreground',
+                    // Off-screen turns rest at the hairline tone — texture, not content. The label
+                    // tiers all sit too high for that; they are built for text, this is a fill.
+                    // Hovering the rail does not lift them: the magnification already announces it.
                     index >= visible.start && index <= visible.end
-                      ? 'bg-label-tertiary'
-                      : 'bg-label-quaternary',
+                      ? 'bg-muted-foreground'
+                      : 'bg-border',
                   )}
                   ref={(element) => {
                     tickNodesRef.current[index] = element;

--- a/packages/presentation/ui/src/chat/conversation-view.tsx
+++ b/packages/presentation/ui/src/chat/conversation-view.tsx
@@ -9,6 +9,7 @@ import {
   ConversationEmptyState,
   ConversationScrollButton,
 } from './conversation';
+import { ConversationMinimap, useConversationMinimap } from './conversation-minimap';
 import { SubagentViewer } from './subagent-viewer';
 import { partitionSubagentItems } from './subagents';
 import { TurnSegmentView } from './turn-segment-view';
@@ -53,6 +54,14 @@ export function ConversationView({
     awaitingAnswer,
     questionsByToolCall,
   } = useTimelineModel(conversation);
+  // Destructured, not held as a bag: React Compiler infers any object a ref is read off as a ref.
+  const {
+    virtualizerRef,
+    railRef,
+    visible: visibleTurns,
+    onScroll: onTimelineScroll,
+    onSelect: onSelectTurn,
+  } = useConversationMinimap(segments.length);
 
   if (items.length === 0) {
     return (
@@ -87,6 +96,8 @@ export function ConversationView({
     >
       <ConversationContent
         data={segments}
+        onScroll={onTimelineScroll}
+        virtualizerRef={virtualizerRef}
         trailing={
           isThinking && (
             <div className="flex items-center gap-2 pt-5 pb-1 text-muted-foreground text-sm">
@@ -116,6 +127,12 @@ export function ConversationView({
           />
         )}
       </ConversationContent>
+      <ConversationMinimap
+        onSelect={onSelectTurn}
+        railRef={railRef}
+        segments={segments}
+        visible={visibleTurns}
+      />
       <ConversationScrollButton />
       <SubagentViewer
         awaitingApproval={awaitingApproval}

--- a/packages/presentation/ui/src/chat/conversation.tsx
+++ b/packages/presentation/ui/src/chat/conversation.tsx
@@ -9,6 +9,7 @@ import {
 import { ArrowDownIcon } from 'lucide-react';
 import { useCallback } from 'react';
 import { StickToBottom, useStickToBottomContext } from 'use-stick-to-bottom';
+import type { VirtualizerHandle } from 'virtua';
 import { Virtualizer } from 'virtua';
 import { cn } from '../lib/cn';
 
@@ -17,7 +18,9 @@ export type ConversationProps = React.ComponentProps<typeof StickToBottom>;
 export function Conversation({ className, ...props }: ConversationProps): React.ReactNode {
   return (
     <StickToBottom
-      className={cn('relative h-full overflow-hidden', className)}
+      // Named container: viewport-pinned overlays (the minimap) size themselves against the pane,
+      // which is narrower than the window whenever the sidebar or a side panel is open.
+      className={cn('@container/conversation relative h-full overflow-hidden', className)}
       // Instant initial positioning: animating from the top would page the whole virtualized
       // history through the viewport.
       initial="instant"
@@ -37,6 +40,11 @@ export interface ConversationContentProps<T> {
   children: (item: T, index: number) => React.ReactElement;
   /** Rendered after the virtualized rows, inside the scrolled column (e.g. the thinking row). */
   trailing?: React.ReactNode;
+  /** Row offsets and imperative scrolling, for overlays that navigate the stream (the minimap). */
+  virtualizerRef?: React.Ref<VirtualizerHandle>;
+  /** Scroll offset of the virtualized column. This version of virtua has no range callback, so
+   * consumers resolve the visible range themselves via the handle. */
+  onScroll?: (offset: number) => void;
 }
 
 /**
@@ -49,6 +57,8 @@ export function ConversationContent<T>({
   data,
   children,
   trailing,
+  virtualizerRef,
+  onScroll,
 }: ConversationContentProps<T>): React.ReactNode {
   const { scrollRef } = useStickToBottomContext();
   return (
@@ -57,7 +67,7 @@ export function ConversationContent<T>({
       // The browser's own scroll anchoring fights both scroll owners.
       scrollClassName="[overflow-anchor:none]"
     >
-      <Virtualizer data={data} scrollRef={scrollRef}>
+      <Virtualizer data={data} onScroll={onScroll} ref={virtualizerRef} scrollRef={scrollRef}>
         {children}
       </Virtualizer>
       {trailing}

--- a/packages/presentation/ui/src/chat/minimap-geometry.ts
+++ b/packages/presentation/ui/src/chat/minimap-geometry.ts
@@ -1,42 +1,27 @@
 import { clamp } from 'foxts/clamp';
 
 /** Row pitch. One turn per row regardless of its length, so a tick's hit area never shrinks. */
-export const MINIMAP_ROW_HEIGHT = 18;
+export const MINIMAP_ROW_HEIGHT = 14;
 
-/** Pointer distance at which magnification reaches zero — three rows. */
-export const MINIMAP_FISHEYE_SPREAD = 54;
+/** Resting and fully magnified tick width. Height never changes — a 2px hairline swelling into a
+ * 5px lozenge reads as a blob, where width alone reads as the line extending. */
+export const MINIMAP_TICK_BASE_WIDTH = 8;
+export const MINIMAP_TICK_PEAK_WIDTH = 28;
 
-export interface MinimapTickDims {
-  baseWidth: number;
-  baseHeight: number;
-  peakWidth: number;
-  peakHeight: number;
-}
-
-export const MINIMAP_TURN_TICK: MinimapTickDims = {
-  baseWidth: 12,
-  baseHeight: 3,
-  peakWidth: 39,
-  peakHeight: 6,
-};
+/** Pointer distance at which magnification reaches zero — three rows either side. */
+export const MINIMAP_FISHEYE_SPREAD = 42;
 
 /**
- * Dock-style magnification: 1 under the pointer, 0 at `spread` and beyond, eased so the falloff
- * reads as a curve rather than a cone.
+ * Dock-style magnification: 1 under the pointer, 0 at `spread` and beyond, eased so neighbours fall
+ * away along a curve rather than a cone.
  */
 export function fisheyeFactor(distance: number, spread = MINIMAP_FISHEYE_SPREAD): number {
   const t = 1 - Math.abs(distance) / spread;
   return t <= 0 ? 0 : 1 - (1 - t) ** 3;
 }
 
-export function fisheyeSize(
-  dims: MinimapTickDims,
-  factor: number,
-): { width: number; height: number } {
-  return {
-    width: dims.baseWidth + (dims.peakWidth - dims.baseWidth) * factor,
-    height: dims.baseHeight + (dims.peakHeight - dims.baseHeight) * factor,
-  };
+export function fisheyeWidth(factor: number): number {
+  return MINIMAP_TICK_BASE_WIDTH + (MINIMAP_TICK_PEAK_WIDTH - MINIMAP_TICK_BASE_WIDTH) * factor;
 }
 
 /**

--- a/packages/presentation/ui/src/chat/minimap-geometry.ts
+++ b/packages/presentation/ui/src/chat/minimap-geometry.ts
@@ -1,0 +1,57 @@
+import { clamp } from 'foxts/clamp';
+
+/** Row pitch. One turn per row regardless of its length, so a tick's hit area never shrinks. */
+export const MINIMAP_ROW_HEIGHT = 18;
+
+/** Pointer distance at which magnification reaches zero — three rows. */
+export const MINIMAP_FISHEYE_SPREAD = 54;
+
+export interface MinimapTickDims {
+  baseWidth: number;
+  baseHeight: number;
+  peakWidth: number;
+  peakHeight: number;
+}
+
+export const MINIMAP_TURN_TICK: MinimapTickDims = {
+  baseWidth: 12,
+  baseHeight: 3,
+  peakWidth: 39,
+  peakHeight: 6,
+};
+
+/**
+ * Dock-style magnification: 1 under the pointer, 0 at `spread` and beyond, eased so the falloff
+ * reads as a curve rather than a cone.
+ */
+export function fisheyeFactor(distance: number, spread = MINIMAP_FISHEYE_SPREAD): number {
+  const t = 1 - Math.abs(distance) / spread;
+  return t <= 0 ? 0 : 1 - (1 - t) ** 3;
+}
+
+export function fisheyeSize(
+  dims: MinimapTickDims,
+  factor: number,
+): { width: number; height: number } {
+  return {
+    width: dims.baseWidth + (dims.peakWidth - dims.baseWidth) * factor,
+    height: dims.baseHeight + (dims.peakHeight - dims.baseHeight) * factor,
+  };
+}
+
+/**
+ * Where the rail scrolls itself so the conversation's visible turns sit centered in it. Ticks are
+ * evenly spaced, so a long thread outgrows the rail and the rail follows the viewport instead of
+ * compressing — `end` is inclusive.
+ */
+export function railScrollTopFor(
+  visible: { start: number; end: number },
+  count: number,
+  railHeight: number,
+  rowHeight = MINIMAP_ROW_HEIGHT,
+): number {
+  const overflow = count * rowHeight - railHeight;
+  if (overflow <= 0) return 0;
+  const center = ((visible.start + visible.end + 1) / 2) * rowHeight;
+  return clamp(center - railHeight / 2, 0, overflow);
+}

--- a/packages/presentation/ui/src/chat/minimap-geometry.ts
+++ b/packages/presentation/ui/src/chat/minimap-geometry.ts
@@ -25,6 +25,15 @@ export function fisheyeWidth(factor: number): number {
 }
 
 /**
+ * The same stretch as a horizontal scale on a resting tick. The rail animates `transform`, never
+ * `width`: a tick's box has to stay fixed, or the fit-content column it sits in widens under the
+ * pointer and drags every other tick sideways.
+ */
+export function fisheyeScaleX(factor: number): number {
+  return fisheyeWidth(factor) / MINIMAP_TICK_BASE_WIDTH;
+}
+
+/**
  * Where the rail scrolls itself so the conversation's visible turns sit centered in it. Ticks are
  * evenly spaced, so a long thread outgrows the rail and the rail follows the viewport instead of
  * compressing — `end` is inclusive.

--- a/packages/presentation/ui/src/preview-card-popup.tsx
+++ b/packages/presentation/ui/src/preview-card-popup.tsx
@@ -1,25 +1,34 @@
 import { PreviewCardPrimitive } from 'coss-ui/components/preview-card';
-import { cn } from '../../lib/cn';
+import { cn } from './lib/cn';
+
+export type SidePreviewCardPopupProps = PreviewCardPrimitive.Popup.Props & {
+  side?: PreviewCardPrimitive.Positioner.Props['side'];
+  align?: PreviewCardPrimitive.Positioner.Props['align'];
+  sideOffset?: PreviewCardPrimitive.Positioner.Props['sideOffset'];
+};
 
 /**
  * Minimal fork of coss-ui's `PreviewCardPopup` (same popup styling) that exposes the positioner's
- * `side`, which the vendored component hard-defaults to `bottom`. Sidebar cards open to the right
- * of their row — like the row dropdown menus — so they never cover the list they annotate.
- * Compose with `PreviewCard` + `PreviewCardTrigger` from coss-ui.
+ * `side`, which the vendored component hard-defaults to `bottom`. Cards annotating a list open
+ * beside it so they never cover the rows they describe. Compose with `PreviewCard` +
+ * `PreviewCardTrigger` from coss-ui.
  */
-export function SidebarPreviewCardPopup({
+export function SidePreviewCardPopup({
   className,
   children,
+  side = 'right',
+  align = 'start',
+  sideOffset = 8,
   ...props
-}: PreviewCardPrimitive.Popup.Props): React.ReactNode {
+}: SidePreviewCardPopupProps): React.ReactNode {
   return (
     <PreviewCardPrimitive.Portal>
       <PreviewCardPrimitive.Positioner
-        side="right"
-        align="start"
-        sideOffset={8}
+        align={align}
         className="z-50"
         data-slot="preview-card-positioner"
+        side={side}
+        sideOffset={sideOffset}
       >
         <PreviewCardPrimitive.Popup
           className={cn(

--- a/packages/presentation/ui/src/shell/sidebar/group-header.tsx
+++ b/packages/presentation/ui/src/shell/sidebar/group-header.tsx
@@ -35,8 +35,8 @@ import { useState } from 'react';
 import { useTranslations } from 'use-intl';
 import { cn } from '../../lib/cn';
 import { SPRING } from '../../motion';
+import { SidePreviewCardPopup } from '../../preview-card-popup';
 import type { BranchStatusComponentType } from './branch-status';
-import { SidebarPreviewCardPopup } from './preview-card';
 import { ROW_ACTION_CLASS, ROW_HOVER_PE_CLASS, RowActionsCluster } from './row-actions';
 
 export interface ThreadGroupHeaderProps {
@@ -192,7 +192,7 @@ export function ThreadGroupHeader({
             }
           />
           {workspace && (
-            <SidebarPreviewCardPopup>
+            <SidePreviewCardPopup>
               <div className="flex min-w-0 flex-1 flex-col gap-2">
                 <span>{title}</span>
                 <div className="flex flex-col gap-1.5 text-muted-foreground text-xs">
@@ -206,7 +206,7 @@ export function ThreadGroupHeader({
                   </span>
                 </div>
               </div>
-            </SidebarPreviewCardPopup>
+            </SidePreviewCardPopup>
           )}
         </PreviewCard>
       )}

--- a/packages/presentation/ui/src/shell/sidebar/thread-row.tsx
+++ b/packages/presentation/ui/src/shell/sidebar/thread-row.tsx
@@ -8,10 +8,10 @@ import { ClockIcon, EllipsisIcon, FolderIcon, GitBranchIcon, PinIcon, XIcon } fr
 import { useTranslations } from 'use-intl';
 import { AGENT_LABELS, AgentIcon } from '../../chat/agent-icon';
 import { cn } from '../../lib/cn';
+import { SidePreviewCardPopup } from '../../preview-card-popup';
 import { repositoryLabel } from '../../repository-label';
 import { useRelativeTimeLabel } from '../use-relative-time-label';
 import type { BranchStatusComponentType } from './branch-status';
-import { SidebarPreviewCardPopup } from './preview-card';
 import {
   ROW_ACTION_CLASS,
   ROW_HOVER_PE_CLASS,
@@ -99,7 +99,7 @@ export function ThreadRow({
             {title}
           </span>
         </PreviewCardTrigger>
-        <SidebarPreviewCardPopup>
+        <SidePreviewCardPopup>
           <div className="flex min-w-0 flex-1 flex-col gap-2">
             <span>{title}</span>
             <div className="flex flex-col gap-1.5 text-muted-foreground text-xs">
@@ -120,7 +120,7 @@ export function ThreadRow({
               </span>
             </div>
           </div>
-        </SidebarPreviewCardPopup>
+        </SidePreviewCardPopup>
       </PreviewCard>
       <RowActionsCluster>
         {ImMenuComponent && (


### PR DESCRIPTION
## Summary

Adds a turn-navigation rail — a conversation minimap — in the reading column's left gutter. One tick
per turn; hovering a tick magnifies it and its neighbours and opens a preview of that turn; clicking
jumps to it. Closes CODE-517.

It is **not** a scrollbar and does not replace one. The native scrollbar answers "where am I in the
pixel stream"; the rail answers "what turns is this thread made of, and which one do I want". Inside
a single long turn the rail is deliberately static — the scrollbar is the only thing that moves
there, which is why it stays.

**Ticks are evenly spaced, not proportional to document height.** Under virtualization an unmounted
row's offset is an estimate that shifts as it measures, so mapping ticks to document position makes
them drift while you scroll. Index spacing also keeps every hit area the same size regardless of how
long a turn is.

Two facts made this much smaller than expected:

- `ConversationView` already virtualizes over `TurnSegment[]`, so a tick index **is** a virtualizer
  index — there is no mapping layer.
- `use-stick-to-bottom` needs no coaxing: scrolling up sets `escapedFromLock`, so an upward jump
  unpins itself, and a downward jump only re-pins within 70px of the bottom — exactly the behaviour
  you want when clicking the last tick. Zero mitigation code.

No new dependencies. The preview card is base-ui's `PreviewCard` (already vendored in coss-ui), used
with `createHandle()` + detached triggers so one card serves every tick and only the open turn's
excerpt is ever built.

### Commits

| | |
| --- | --- |
| `refactor(ui)` | Move the sidebar's side-capable preview-card fork up to `preview-card-popup.tsx` as `SidePreviewCardPopup`, rather than copy its class list a third time. Behaviour unchanged for both sidebar call sites. |
| `feat(chat)` | `ConversationContent` exposes the virtualizer handle and a scroll callback; the conversation root becomes a named container so viewport-pinned overlays size against the pane, not the window. |
| `feat(chat)` | Pure geometry: the magnification falloff and the rail's own scroll position, kept testable without layout. |
| `feat(chat)` | The rail itself, plus i18n and wiring. |
| `feat(mock)` | A 48-turn thread in the dev mock host, so length-dependent behaviour is reachable without a real agent. |
| `fix(chat)` | Tuning pass after driving it in the desktop app. |

### Notes for review

- **Magnification is written straight to the DOM** from a rAF-throttled `pointermove`, not through
  state — a continuous per-frame value across every tick would otherwise re-render the whole rail
  each frame. Resting width lives in a class rather than `style` so a re-render mid-hover cannot
  clobber it; that collision caused a visible snap-back before it was fixed.
- **The visible range and the rail's own scroll are resolved in one callback**, so nothing watches
  either with an effect (`sukka/react-no-use-effect-watching`). Before the first scroll every turn is
  treated as on-screen — correct for a thread too short to scroll, and corrected immediately by the
  initial jump to bottom on one that isn't.
- **The handle is `useMemo`, not `useSingleton`.** `sukka/react-no-use-state-as-ref` pushes toward
  `useSingleton`, but base-ui reads the handle during render and `react-hooks/refs` rejects that. The
  two rules conflict here; `useMemo` satisfies both.
- **Auto margins, not `justify-center`.** A centered flex column clips its first item once the
  content outgrows the scroll container, which would make the top tick permanently unreachable.
- **The rail's column is wider than what it draws.** `overflow-y-auto` makes the x axis clip too, so
  a column narrower than a fully magnified tick would cut it off.
- Off-screen ticks rest at the hairline tone (`bg-border`). The `label-*` tiers are built for text
  and all sit too high for a fill this small; the front-end rules exempt fills from the
  no-ad-hoc-opacity rule, but a semantic token is still better than a raw opacity.
- Rail hides below an 880px pane (content column + 56px each side) and for a thread with one turn,
  where it would be pure decoration.

## Verification

`pnpm check:ci` and `pnpm test` (2243 passed) both green.

Driven in the desktop app against the new 48-turn mock thread — magnification feel, tick states,
preview content, click-to-jump, and the rail following the viewport were all judged there over
several tuning rounds, which is where the final shape came from.

Measured in the browser (mock webview, no daemon):

- Rail renders in the left gutter; accessible as `button "Turn N"` per tick.
- Preview card: `side=right`, 376px wide (the `w-96` override beats the vendored `w-64`), anchored
  against the rail's right edge, title from the turn's user text, body rendered through Streamdown.
- Container query hides the rail below the pane threshold.
- Overflow contract with 61 ticks: `scrollHeight 1098 > clientHeight 687`; at `scrollTop 0` the first
  tick's top equals the rail's top (**not** clipped — the `justify-center` trap above); the last tick
  is fully reachable at the end; the rail's own scrollbar is not rendered.
- Transition tokens resolve to `150ms cubic-bezier(0.23, 1, 0.32, 1)`.

Not covered by automated checks: the magnification is rAF-driven, and the headless browser pane
produces no animation frames, so its motion was only verifiable by hand in the desktop window. The
falloff curve itself is unit-tested.

## Checklist

- [x] `pnpm check:ci` and `pnpm test` both pass (plus `cargo fmt` / `clippy` / `test` for Rust changes)
- [x] I ran the affected surface and observed the change working
- [x] If a wire message changed: `WIRE_PROTOCOL_VERSION` is bumped — n/a, no wire change
- [x] New code and assets are my own work, or their origin and license compatibility are noted above
- [x] Docs and comments are updated where behavior changed
