### PR TITLE
fix(desktop): keep the sidebar translucent over the native backdrop

### DIFF
--- a/apps/desktop/src/renderer/src/shell/desktop-shell.tsx
+++ b/apps/desktop/src/renderer/src/shell/desktop-shell.tsx
@@ -739,7 +739,9 @@ export function DesktopShell({
         onToggleResources={toggleResources}
         onResourcesOpenChange={setResourcesOpen}
       >
-        <div className="grid h-full min-h-0 grid-cols-[minmax(0,1fr)_auto] overflow-hidden bg-background">
+        {/* Never paint this wrapper: it spans the sidebar column, whose translucent tint has to
+            reach the native backdrop. Only the floating rail needs its own opaque gutter. */}
+        <div className="grid h-full min-h-0 grid-cols-[minmax(0,1fr)_auto] overflow-hidden">
           <DesktopWorkspace
             main={main}
             right={workspaceRight}
@@ -812,7 +814,7 @@ export function DesktopShell({
           <aside
             aria-hidden={!resourcesFloatingOpen}
             inert={!resourcesFloatingOpen}
-            className="min-h-0 min-w-0 shrink-0 overflow-hidden transition-[width] duration-(--motion-normal) ease-[cubic-bezier(0.4,0,0.2,1)] motion-reduce:transition-none"
+            className="min-h-0 min-w-0 shrink-0 overflow-hidden bg-background transition-[width] duration-(--motion-normal) ease-[cubic-bezier(0.4,0,0.2,1)] motion-reduce:transition-none"
             style={{ width: resourcesFloatingOpen ? RESOURCES_FLOATING_COLUMN_WIDTH : 0 }}
           >
             <div


### PR DESCRIPTION
## Problem

The sidebar lost its translucency over the native backdrop between v0.12.0 and v0.13.0 (still present on master / 0.14.0).

On macOS and Windows the window is created `transparent` with `vibrancy: 'sidebar'` (`apps/desktop/src/main/appearance.ts`), and the sidebar paints only a 25% tint (`bg-sidebar/25`) so the native material shows through. That relies on an implicit invariant: **no ancestor between `[data-shell-pane="sidebar"]` and `<html>` may paint an opaque background.** The main pane carries `bg-background` on purpose; the sidebar cell is deliberately left bare — `index.css` calls it "naked vibrancy in the workspace slits".

The resources panel wrapped `DesktopWorkspace` in a new grid container (80c97ae6), and b389a670 then added `bg-background` to that wrapper to unify the floating rail's gutter with the main content. The wrapper spans the sidebar column too, so the sidebar's 25% tint now composites over opaque white instead of the blurred backdrop.

Nothing catches this: it type-checks, lints and tests clean — the only signal is visual.

## Fix

Move `bg-background` off the shared grid wrapper onto the floating rail `<aside>` alone. The rail keeps the unified gutter b389a670 wanted; the sidebar column goes back to reaching the native backdrop.

`apps/webview` has the same class on its equivalent wrapper, but its sidebar is opaque `bg-sidebar`, so it has no visual effect there and is left untouched.

## Verification

Screenshots can't settle this — Playwright composites only the web layer, so native vibrancy never appears in a capture. Verified instead by reading the computed paint stack over CDP against a running `dev:mock` shell, walking from the sidebar pane up to `<html>`:

| | opaque ancestors | offending layer |
| --- | --- | --- |
| with `bg-background` on the wrapper | 1 | `<div class="grid … bg-background"> → rgb(255, 255, 255)` |
| after this change | 0 | — |

The rail itself still resolves to `rgb(255, 255, 255)`, matching `[data-shell-pane="main"]`.

Also confirmed visually in the real window on macOS.

`pnpm check:ci` — 0 errors. `pnpm test` — 2234 passed, 5 skipped.
