### PR TITLE
feat(desktop): show update download progress

### DIFF
--- a/apps/desktop/src/main/__tests__/updater.test.ts
+++ b/apps/desktop/src/main/__tests__/updater.test.ts
@@ -46,10 +46,18 @@ describe('desktop updater', () => {
     const updater = await import('../updater');
 
     updater.checkForUpdates();
-    expect(updater.getUpdaterState()).toEqual({ status: 'checking', version: null });
+    expect(updater.getUpdaterState()).toEqual({
+      status: 'checking',
+      version: null,
+      progress: null,
+    });
 
     await mocks.autoUpdater.checkForUpdates.mock.results[0]?.value;
-    expect(updater.getUpdaterState()).toEqual({ status: 'not-available', version: null });
+    expect(updater.getUpdaterState()).toEqual({
+      status: 'not-available',
+      version: null,
+      progress: null,
+    });
   });
 
   it('polls every four hours and preserves a downloaded update until installation', async () => {
@@ -66,11 +74,24 @@ describe('desktop updater', () => {
 
     emit('update-available', { version: '0.13.0' });
     emit('download-progress', { percent: 50 });
+    expect(updater.getUpdaterState()).toEqual({
+      status: 'downloading',
+      version: '0.13.0',
+      progress: 50,
+    });
     emit('update-downloaded', { version: '0.13.0' });
 
-    expect(updater.getUpdaterState()).toEqual({ status: 'downloaded', version: '0.13.0' });
-    expect(states).toContainEqual({ status: 'available', version: '0.13.0' });
-    expect(states).toContainEqual({ status: 'downloading', version: '0.13.0' });
+    expect(updater.getUpdaterState()).toEqual({
+      status: 'downloaded',
+      version: '0.13.0',
+      progress: null,
+    });
+    expect(states).toContainEqual({ status: 'available', version: '0.13.0', progress: null });
+    expect(states).toContainEqual({
+      status: 'downloading',
+      version: '0.13.0',
+      progress: 50,
+    });
 
     await vi.advanceTimersByTimeAsync(4 * 60 * 60 * 1000);
     expect(mocks.autoUpdater.checkForUpdates).toHaveBeenCalledTimes(2);

--- a/apps/desktop/src/main/updater.ts
+++ b/apps/desktop/src/main/updater.ts
@@ -17,7 +17,7 @@ const updatesDisabled = (): boolean => CHANNEL === 'development';
 
 type UpdaterStateListener = (state: UpdaterState) => void;
 const stateListeners = new Set<UpdaterStateListener>();
-let updaterState: UpdaterState = { status: 'idle', version: null };
+let updaterState: UpdaterState = { status: 'idle', version: null, progress: null };
 
 /** Subscribe to auto-update lifecycle state; the IPC layer forwards these to the renderer. */
 export function onUpdaterState(listener: UpdaterStateListener): () => void {
@@ -29,8 +29,12 @@ export function getUpdaterState(): UpdaterState {
   return updaterState;
 }
 
-function emitState(status: UpdaterStatus, version = updaterState.version): void {
-  updaterState = { status, version };
+function emitState(
+  status: UpdaterStatus,
+  version = updaterState.version,
+  progress: number | null = null,
+): void {
+  updaterState = { status, version, progress };
   for (const listener of stateListeners) listener(updaterState);
 }
 
@@ -43,7 +47,9 @@ export function initAutoUpdates(): void {
   autoUpdater.on('checking-for-update', () => emitState('checking', null));
   autoUpdater.on('update-available', ({ version }) => emitState('available', version));
   autoUpdater.on('update-not-available', () => emitState('not-available', null));
-  autoUpdater.on('download-progress', () => emitState('downloading'));
+  autoUpdater.on('download-progress', ({ percent }) => {
+    emitState('downloading', updaterState.version, percent);
+  });
   autoUpdater.on('update-downloaded', ({ version }) => {
     emitState('downloaded', version);
   });

--- a/apps/desktop/src/renderer/src/settings/__tests__/about-tab.test.tsx
+++ b/apps/desktop/src/renderer/src/settings/__tests__/about-tab.test.tsx
@@ -1,0 +1,46 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { AboutTab } from '../about-tab';
+
+vi.mock('../../ipc', () => ({
+  systemBridge: {
+    app: {
+      checkForUpdates: vi.fn(),
+      version: vi.fn(() => Promise.resolve('0.15.0')),
+    },
+  },
+}));
+
+vi.mock('../../updater', () => ({
+  useUpdaterState: () => ({
+    status: 'downloading',
+    version: '0.16.0',
+    progress: 42.4,
+  }),
+}));
+
+vi.mock('use-intl', () => ({
+  useTranslations() {
+    const messages: Record<string, string> = {
+      version: 'Version',
+      checkForUpdates: 'Check for updates',
+      'status.downloading': 'Downloading update…',
+    };
+    return (key: string) => messages[key] ?? key;
+  },
+}));
+
+describe('AboutTab', () => {
+  afterEach(cleanup);
+
+  it('shows accessible update download progress', async () => {
+    render(<AboutTab />);
+
+    expect(await screen.findByText('v0.15.0')).toBeTruthy();
+    const progress = screen.getByRole('progressbar', { name: 'Downloading update…' });
+    expect(progress.getAttribute('aria-valuenow')).toBe('42');
+    expect(screen.getByText('42%')).toBeTruthy();
+  });
+});

--- a/apps/desktop/src/renderer/src/settings/about-tab.tsx
+++ b/apps/desktop/src/renderer/src/settings/about-tab.tsx
@@ -1,6 +1,7 @@
 import type { UpdaterStatus } from '@linkcode/ipc';
 import { Button } from 'coss-ui/components/button';
 import { Field, FieldLabel } from 'coss-ui/components/field';
+import { Progress, ProgressIndicator, ProgressTrack } from 'coss-ui/components/progress';
 import { useEffect } from 'foxact/use-abortable-effect';
 import { useState } from 'react';
 import { useTranslations } from 'use-intl';
@@ -19,7 +20,7 @@ const STATUS_KEYS = {
 export function AboutTab(): React.ReactNode {
   const t = useTranslations('settings.about');
   const [version, setVersion] = useState('');
-  const { status } = useUpdaterState();
+  const { progress, status } = useUpdaterState();
 
   useEffect((signal) => {
     void systemBridge.app.version().then((value) => {
@@ -28,6 +29,7 @@ export function AboutTab(): React.ReactNode {
   }, []);
 
   const statusKey = status === 'idle' ? null : STATUS_KEYS[status];
+  const progressPercent = progress === null ? null : Math.round(progress);
 
   return (
     <div className="flex flex-col gap-6">
@@ -37,17 +39,37 @@ export function AboutTab(): React.ReactNode {
           {version ? `v${version}` : '—'}
         </span>
       </Field>
-      <div className="flex items-center gap-3">
-        <Button
-          size="sm"
-          variant="outline"
-          onClick={() => {
-            void systemBridge.app.checkForUpdates();
-          }}
-        >
-          {t('checkForUpdates')}
-        </Button>
-        {statusKey ? <span className="text-muted-foreground text-xs">{t(statusKey)}</span> : null}
+      <div className="flex flex-col gap-2">
+        <div className="flex items-center gap-3">
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => {
+              void systemBridge.app.checkForUpdates();
+            }}
+          >
+            {t('checkForUpdates')}
+          </Button>
+          {statusKey && progressPercent === null ? (
+            <span className="text-muted-foreground text-xs">{t(statusKey)}</span>
+          ) : null}
+        </div>
+        {status === 'downloading' && progressPercent !== null ? (
+          <Progress
+            aria-label={t('status.downloading')}
+            className="max-w-sm gap-1.5"
+            max={100}
+            value={progressPercent}
+          >
+            <div className="flex items-center justify-between text-muted-foreground text-xs">
+              <span>{t('status.downloading')}</span>
+              <span className="tabular-nums">{progressPercent}%</span>
+            </div>
+            <ProgressTrack>
+              <ProgressIndicator className="transition-none" />
+            </ProgressTrack>
+          </Progress>
+        ) : null}
       </div>
     </div>
   );

--- a/apps/desktop/src/renderer/src/shell/__tests__/update-notice.test.tsx
+++ b/apps/desktop/src/renderer/src/shell/__tests__/update-notice.test.tsx
@@ -9,7 +9,7 @@ import { UpdateNotice } from '../update-notice';
 const mocks = vi.hoisted(() => ({
   stateListener: undefined as ((state: UpdaterState) => void) | undefined,
   updaterState: vi.fn(() =>
-    Promise.resolve({ status: 'idle', version: null } satisfies UpdaterState),
+    Promise.resolve({ status: 'idle', version: null, progress: null } satisfies UpdaterState),
   ),
   installUpdate: vi.fn(),
   unsubscribe: vi.fn(),
@@ -55,7 +55,7 @@ describe('UpdateNotice', () => {
     expect(screen.queryByText('Update ready')).toBeNull();
 
     act(() => {
-      mocks.stateListener?.({ status: 'downloaded', version: '0.13.0' });
+      mocks.stateListener?.({ status: 'downloaded', version: '0.13.0', progress: null });
     });
 
     expect(screen.getByText('v0.13.0')).toBeTruthy();

--- a/apps/desktop/src/renderer/src/updater.ts
+++ b/apps/desktop/src/renderer/src/updater.ts
@@ -2,7 +2,7 @@ import type { UpdaterState } from '@linkcode/ipc';
 import { useSyncExternalStore } from 'react';
 import { systemBridge } from './ipc';
 
-let snapshot: UpdaterState = { status: 'idle', version: null };
+let snapshot: UpdaterState = { status: 'idle', version: null, progress: null };
 const listeners = new Set<() => void>();
 let unsubscribe: (() => void) | undefined;
 
@@ -22,7 +22,9 @@ function subscribe(listener: () => void): () => void {
         if (snapshot === pendingSnapshot) publish(state);
       })
       .catch(() => {
-        if (snapshot === pendingSnapshot) publish({ status: 'error', version: null });
+        if (snapshot === pendingSnapshot) {
+          publish({ status: 'error', version: null, progress: null });
+        }
       });
   }
 

--- a/packages/system-plane/ipc/src/context.ts
+++ b/packages/system-plane/ipc/src/context.ts
@@ -135,6 +135,7 @@ export type UpdaterStatus = z.infer<typeof UpdaterStatusSchema>;
 export const UpdaterStateSchema = z.object({
   status: UpdaterStatusSchema,
   version: z.string().nullable(),
+  progress: z.number().min(0).max(100).nullable(),
 });
 export type UpdaterState = z.infer<typeof UpdaterStateSchema>;
 


### PR DESCRIPTION
## Summary

- Carry `electron-updater` download percentage through the existing desktop updater state and system IPC bridge.
- Show a determinate, accessible progress bar with the current percentage in Settings → About while an update downloads.
- Clear progress when the updater moves to another lifecycle state and preserve the existing downloaded-update notice.

Linear: [CODE-522](https://linear.app/arcbox/issue/CODE-522/featdesktop-show-update-download-progress-in-about)

## Verification

- `pnpm check:ci`
- `pnpm test` — 287 files passed, 2250 tests passed, 1 skipped
- `pnpm -F @linkcode/desktop run build`
- Launched an isolated built Electron app with Playwright, opened Settings → About, injected a 42% updater event through the real IPC channel, and observed the progress bar with `aria-valuenow="42"`.

## Checklist

- [x] `pnpm check:ci` and `pnpm test` both pass
- [x] I ran the affected surface and observed the change working
- [x] Wire protocol change — N/A, this changes desktop system IPC only