### PR TITLE
fix(ui): tolerate generic keydown events

### DIFF
--- a/packages/presentation/ui/src/keyboard/__tests__/registry.test.ts
+++ b/packages/presentation/ui/src/keyboard/__tests__/registry.test.ts
@@ -212,6 +212,19 @@ describe('keyboard shortcut registry', () => {
     expect(altGraph).not.toHaveBeenCalled();
   });
 
+  it('dispatches keydown events without getModifierState', () => {
+    const registry = createKeyboardShortcutRegistry(false);
+    registry.register(binding());
+    registry.setPlatform('non-mac');
+
+    expect(
+      registry.dispatch(
+        keydown({ code: 'KeyK', ctrlKey: true, getModifierState: undefined }),
+        true,
+      ),
+    ).toBe(true);
+  });
+
   it('checks owners after matching and suppresses only a claimed collision', () => {
     const registry = createKeyboardShortcutRegistry(true);
     let currentOwner: Element | null = null;

--- a/packages/presentation/ui/src/keyboard/registry.ts
+++ b/packages/presentation/ui/src/keyboard/registry.ts
@@ -236,7 +236,9 @@ export function createKeyboardShortcutRegistry(warnOnMultipleMatches = IS_DEVELO
       event.defaultPrevented ||
       event.isComposing ||
       event.key === 'Process' ||
-      (currentPlatform === 'non-mac' && event.getModifierState('AltGraph')) ||
+      (currentPlatform === 'non-mac' &&
+        typeof event.getModifierState === 'function' &&
+        event.getModifierState('AltGraph')) ||
       event.repeat
     ) {
       return false;


### PR DESCRIPTION
## Summary

- Feature-test `KeyboardEvent#getModifierState` before AltGraph filtering.
- Keep generic `keydown` events flowing through normal shortcut dispatch.
- Add regression coverage for the malformed production event shape.

## Root cause

The global shortcut registry receives DOM `keydown` events but treated every event as a full `KeyboardEvent`. A generic `Event('keydown')` has the normal cancellation methods but no `getModifierState`, so non-macOS shortcut dispatch threw before matching.

## User impact

Settings interactions that deliver a generic keydown event no longer crash the renderer. Real AltGraph input remains excluded from application shortcuts.

## Verification

- `pnpm check:ci`
- `pnpm test` — 284 files / 2246 tests passed

Linear: [CODE-435](https://linear.app/arcbox/issue/CODE-435/fixui-prevent-malformed-keydown-events-from-crashing-shortcut-dispatch)