### PR TITLE
fix(composer): require shell directive separator

### DIFF
--- a/packages/presentation/ui/src/shell/__tests__/composer-directive-chips.test.tsx
+++ b/packages/presentation/ui/src/shell/__tests__/composer-directive-chips.test.tsx
@@ -405,18 +405,18 @@ describe('Composer directive chips', () => {
     expect(composerText()).toBe('please /review ');
   });
 
-  it('sends a bare $ as prose instead of materializing an empty shell directive', async () => {
+  it('sends a leading dollar word as prose', async () => {
     const onRunShellCommand = vi.fn();
     const onSend = vi.fn();
     render(composer({ onRunShellCommand, onSend, shellSupported: true }));
 
-    typeInComposer('$');
+    typeInComposer('$HOME');
 
     expect(screen.queryByRole('button', { name: '$' })).toBeNull();
     expect(screen.getByRole<HTMLButtonElement>('button', { name: 'send' }).disabled).toBe(false);
     await pressInComposer('Enter');
     expect(onRunShellCommand).not.toHaveBeenCalled();
-    expect(onSend).toHaveBeenCalledExactlyOnceWith([{ type: 'text', text: '$' }]);
+    expect(onSend).toHaveBeenCalledExactlyOnceWith([{ type: 'text', text: '$HOME' }]);
   });
 
   it('explains an unavailable shell directive and blocks submit', async () => {

--- a/packages/presentation/ui/src/shell/__tests__/new-session-surface.test.tsx
+++ b/packages/presentation/ui/src/shell/__tests__/new-session-surface.test.tsx
@@ -247,6 +247,32 @@ describe('NewSessionSurface', () => {
     },
   );
 
+  it('submits a leading dollar word as a prompt', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    render(
+      <NewSessionSurface
+        chatWorkspace={CHAT_WORKSPACE}
+        draft={{ initialProvider: 'codex', initialWorkspaceId: CHAT_WORKSPACE.workspaceId }}
+        mentionItems={[]}
+        onMentionQueryChange={vi.fn()}
+        onRegisterWorkspace={vi.fn().mockResolvedValue(CHAT_WORKSPACE)}
+        onSubmit={onSubmit}
+        workspaces={[]}
+      />,
+    );
+
+    typeInComposer('$HOME');
+    await pressInComposer('Enter');
+
+    await waitFor(() =>
+      expect(onSubmit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          input: { type: 'prompt', content: [{ type: 'text', text: '$HOME' }] },
+        }),
+      ),
+    );
+  });
+
   it.each([
     {
       draft: '/compact ',

--- a/packages/presentation/ui/src/shell/composer-editor/__tests__/composer-editor.test.ts
+++ b/packages/presentation/ui/src/shell/composer-editor/__tests__/composer-editor.test.ts
@@ -139,20 +139,19 @@ describe('directive tokenizer', () => {
     expect(draftText(editor)).toBe('/usage');
   });
 
-  it('chips a leading $ only after it has a shell payload', () => {
+  it('chips a leading $ only with a horizontal separator and shell payload', () => {
     const editor = createEditor();
-    setDraft(editor, '$ls -la');
-    expect(draftShape(editor)).toEqual(['composer-shell', 'text']);
-    expect(draftText(editor)).toBe('$ls -la');
 
-    setDraft(editor, '$');
-    expect(draftShape(editor)).toEqual(['text']);
+    for (const draft of ['$ ls -la', '$   pnpm test', '$\techo']) {
+      setDraft(editor, draft);
+      expect(draftShape(editor)).toEqual(['composer-shell', 'text']);
+      expect(draftText(editor)).toBe(draft);
+    }
 
-    setDraft(editor, '$   ');
-    expect(draftShape(editor)).toEqual(['text']);
-
-    setDraft(editor, '$ ls');
-    expect(draftShape(editor)).toEqual(['composer-shell', 'text']);
+    for (const draft of ['$ls', '$HOME', '$100', '$', '$   ']) {
+      setDraft(editor, draft);
+      expect(draftShape(editor)).toEqual(['text']);
+    }
   });
 
   it('chips a command when a line break supplies its boundary', () => {
@@ -415,7 +414,7 @@ describe('$draftDirective', () => {
 
   it('classifies shell drafts by capability', () => {
     const editor = createEditor();
-    setDraft(editor, '$ls -la');
+    setDraft(editor, '$ ls -la');
     expect(editor.read(() => $draftDirective(directiveState()))).toEqual({
       command: 'ls -la',
       kind: 'shell',
@@ -721,13 +720,13 @@ describe('$replaceTriggerWith', () => {
 describe('shell chip round-trip', () => {
   it('keeps the $ literal for clipboard/serialization', () => {
     const editor = createEditor();
-    setDraft(editor, '$echo hi');
+    setDraft(editor, '$ echo hi');
     editor.read(() => {
       const paragraph = $getRoot().getFirstChild();
       if (!$isElementNode(paragraph)) throw new Error('expected paragraph');
       expect(paragraph.getFirstChildOrThrow().getTextContent()).toBe('$');
     });
-    expect(draftText(editor)).toBe('$echo hi');
+    expect(draftText(editor)).toBe('$ echo hi');
   });
 
   it('imports/exports chips through JSON round-trips', () => {

--- a/packages/presentation/ui/src/shell/composer-editor/__tests__/composer-editor.test.ts
+++ b/packages/presentation/ui/src/shell/composer-editor/__tests__/composer-editor.test.ts
@@ -154,6 +154,25 @@ describe('directive tokenizer', () => {
     }
   });
 
+  it('dematerializes a shell chip when its separator is removed', () => {
+    const editor = createEditor();
+    setDraft(editor, '$ ls');
+
+    editor.update(
+      () => {
+        const paragraph = $getRoot().getFirstChild();
+        if (!$isElementNode(paragraph)) throw new Error('expected paragraph');
+        const payload = paragraph.getLastChild();
+        if (!$isTextNode(payload)) throw new Error('expected shell payload');
+        payload.setTextContent('ls');
+      },
+      { discrete: true },
+    );
+
+    expect(draftShape(editor)).toEqual(['text']);
+    expect(draftText(editor)).toBe('$ls');
+  });
+
   it('chips a command when a line break supplies its boundary', () => {
     const editor = createEditor();
     setDraft(editor, '/usage');
@@ -423,6 +442,23 @@ describe('$draftDirective', () => {
     expect(
       editor.read(() => $draftDirective(directiveState({ shell: { state: 'unsupported' } }))),
     ).toMatchObject({ status: 'unsupported' });
+  });
+
+  it('serializes a malformed restored shell chip as text', () => {
+    const editor = createEditor();
+    editor.update(
+      () => {
+        const paragraph = $createParagraphNode();
+        paragraph.append($createShellNode(), $createTextNode('HOME'));
+        $getRoot().clear().append(paragraph);
+      },
+      { discrete: true, tag: HISTORIC_TAG },
+    );
+
+    expect(editor.read(() => $draftDirective(directiveState()))).toEqual({
+      kind: 'text',
+      text: '$HOME',
+    });
   });
 
   it('serializes mention chips into command arguments', () => {

--- a/packages/presentation/ui/src/shell/composer-editor/serialize.ts
+++ b/packages/presentation/ui/src/shell/composer-editor/serialize.ts
@@ -17,6 +17,7 @@ import type {
 } from './directive-state';
 import { commandStatus, shellStatus } from './directive-state';
 import { $isCommandNode, $isShellNode } from './nodes';
+import { isShellDirectiveText } from './tokenize';
 
 const WHITESPACE_RE = /\s/;
 const BLOCK_SEPARATOR_SIZE = 2;
@@ -353,7 +354,7 @@ export function $draftDirective(
       status: commandStatus(leading.name, state.directiveControls.slash),
     };
   }
-  if (leading?.kind === 'shell') {
+  if (leading?.kind === 'shell' && isShellDirectiveText(text)) {
     return {
       command: text.slice(1).trim(),
       kind: 'shell',

--- a/packages/presentation/ui/src/shell/composer-editor/tokenize.ts
+++ b/packages/presentation/ui/src/shell/composer-editor/tokenize.ts
@@ -1,6 +1,7 @@
 import { mergeRegister } from '@lexical/utils';
 import type { LexicalEditor } from 'lexical';
 import {
+  $createTextNode,
   $getRoot,
   $hasUpdateTag,
   $isElementNode,
@@ -15,6 +16,10 @@ import { $createCommandNode, $createShellNode, $isCommandNode, $isShellNode } fr
 
 const WHITESPACE_RE = /\s/;
 const SHELL_DIRECTIVE_BODY_RE = /^[\t ]+\S/;
+
+export function isShellDirectiveText(text: string): boolean {
+  return text[0] === '$' && SHELL_DIRECTIVE_BODY_RE.test(text.slice(1));
+}
 
 type TokenizerState = Pick<ComposerDirectiveState, 'suppressed'>;
 
@@ -48,7 +53,7 @@ function $findDirectiveCandidate(
   if (!$isDocumentStart(node, 0) || state.suppressed.has(node.getKey())) return null;
 
   if (content[0] === '$') {
-    return SHELL_DIRECTIVE_BODY_RE.test($getRoot().getTextContent().slice(1))
+    return isShellDirectiveText($getRoot().getTextContent())
       ? { end: 1, kind: 'shell', start: 0 }
       : null;
   }
@@ -64,6 +69,10 @@ function $hasLeadingDirective(): boolean {
   const firstBlock = $getRoot().getFirstChild();
   if (!$isElementNode(firstBlock)) return false;
   const first = firstBlock.getFirstChild();
+  if ($isShellNode(first) && !isShellDirectiveText($getRoot().getTextContent())) {
+    first.replace($createTextNode('$'));
+    return false;
+  }
   return $isCommandNode(first) || $isShellNode(first);
 }
 

--- a/packages/presentation/ui/src/shell/composer-editor/tokenize.ts
+++ b/packages/presentation/ui/src/shell/composer-editor/tokenize.ts
@@ -14,6 +14,7 @@ import type { ComposerDirectiveState } from './directive-state';
 import { $createCommandNode, $createShellNode, $isCommandNode, $isShellNode } from './nodes';
 
 const WHITESPACE_RE = /\s/;
+const SHELL_DIRECTIVE_BODY_RE = /^[\t ]+\S/;
 
 type TokenizerState = Pick<ComposerDirectiveState, 'suppressed'>;
 
@@ -47,9 +48,9 @@ function $findDirectiveCandidate(
   if (!$isDocumentStart(node, 0) || state.suppressed.has(node.getKey())) return null;
 
   if (content[0] === '$') {
-    // A bare marker is ordinary prose. Shell intent becomes unambiguous only after the user
-    // supplies a non-whitespace payload, including when that payload is in a following node.
-    return $getRoot().getTextContent().slice(1).trim() ? { end: 1, kind: 'shell', start: 0 } : null;
+    return SHELL_DIRECTIVE_BODY_RE.test($getRoot().getTextContent().slice(1))
+      ? { end: 1, kind: 'shell', start: 0 }
+      : null;
   }
   if (content[0] !== '/') return null;
   let end = 1;


### PR DESCRIPTION
## Summary

- define one explicit shell-directive grammar: `$` + horizontal whitespace + a non-whitespace command
- use the same predicate for text materialization and final submission serialization
- dematerialize a Shell chip when edits remove its required separator
- keep malformed restored Shell nodes as prompt text instead of dispatching them

## Root cause

Shell intent was inferred only while creating a chip, and any existing Shell node was later trusted unconditionally. That made ordinary dollar-prefixed text ambiguous and allowed edits or restored editor state to bypass the intended grammar.

The fix makes the grammar a shared invariant at both boundaries: the only text-to-directive conversion point and the final directive-to-input serialization point.

## Validation

- `pnpm check:ci`
- focused Vitest: 98 passed
- `pnpm test`: 2248 passed, 5 skipped

Linear: CODE-333