### PR TITLE
chore(ui): add Opus 5 to the claude-code model options

### DIFF
--- a/packages/presentation/ui/src/__tests__/agent-models.test.ts
+++ b/packages/presentation/ui/src/__tests__/agent-models.test.ts
@@ -7,7 +7,7 @@ const codex = AGENT_MODEL_OPTIONS.codex;
 
 describe('resolveModel', () => {
   it('resolves an exact catalog id', () => {
-    expect(resolveModel(claude, 'claude-opus-4-8')?.label).toBe('Opus 4.8');
+    expect(resolveModel(claude, 'claude-opus-5')?.label).toBe('Opus 5');
   });
 
   it('resolves a served snapshot id back to its alias by prefix', () => {

--- a/packages/presentation/ui/src/shell/__tests__/new-session-surface.test.tsx
+++ b/packages/presentation/ui/src/shell/__tests__/new-session-surface.test.tsx
@@ -709,12 +709,12 @@ describe('NewSessionSurface', () => {
 
     await user.click(screen.getByRole('button', { name: RE_SONNET_5 }));
     await user.click(await screen.findByRole('menuitem', { name: 'Sonnet 5' }));
-    fireEvent.click(await screen.findByRole('menuitemradio', { name: 'Opus 4.8' }));
+    fireEvent.click(await screen.findByRole('menuitemradio', { name: 'Opus 5' }));
     typeInComposer('hello');
     await pressInComposer('Enter');
 
     await waitFor(() =>
-      expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({ model: 'claude-opus-4-8' })),
+      expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({ model: 'claude-opus-5' })),
     );
   });
 

--- a/packages/presentation/ui/src/shell/agent-models.ts
+++ b/packages/presentation/ui/src/shell/agent-models.ts
@@ -68,10 +68,13 @@ const CODEX_BASE_EFFORTS = ['low', 'medium', 'high', 'xhigh'] satisfies EffortLe
  * Curated model choices, keyed by adapter — only adapters with a *verified* live model switch get
  * an entry, and every id was confirmed by reading the served model back off a live stream (source
  * reading is not enough: claude-code's first design silently ignored the override). Legacy models
- * are included deliberately — the choice belongs to the user.
- * claude-opus-4-1 is deliberately excluded: setModel() accepts it but claude-opus-4-8 is silently
+ * are included deliberately — the choice belongs to the user. Anthropic ids and lifecycle come from
+ * https://platform.claude.com/docs/en/about-claude/models/overview.
+ * claude-opus-4-1 is deliberately excluded: setModel() accepts it but claude-opus-5 is silently
  * served instead. Offering claude-fable-5 to everyone is safe: accounts without access get a hard
  * CLI error and the picker keeps the previous model (confirm-then-reflect).
+ * `[1m]` ids (`claude-opus-5[1m]`) are a claude-code-side context tier, not Anthropic model ids;
+ * none are listed, and resolveModel() cannot fold one back onto its base entry.
  * Keeping this table static is a deliberate CODE-104 decision (the dynamic reference
  * implementation lives in closed PR #52); refresh it by hand under the discipline above.
  * codex ids/labels are the app-server's `model/list` verbatim; switches apply from the next turn,
@@ -80,6 +83,7 @@ const CODEX_BASE_EFFORTS = ['low', 'medium', 'high', 'xhigh'] satisfies EffortLe
 export const AGENT_MODEL_OPTIONS: Partial<Record<AgentKind, ModelOption[]>> = {
   'claude-code': [
     { id: 'claude-fable-5', label: 'Fable 5' },
+    { id: 'claude-opus-5', label: 'Opus 5' },
     { id: 'claude-opus-4-8', label: 'Opus 4.8' },
     { id: 'claude-opus-4-7', label: 'Opus 4.7 (Legacy)' },
     { id: 'claude-opus-4-6', label: 'Opus 4.6 (Legacy)' },


### PR DESCRIPTION
Closes CODE-523.

`AGENT_MODEL_OPTIONS['claude-code']` went Fable 5 → Opus 4.8 → 4.7/4.6 (Legacy): Opus 5 was missing entirely, and `rg claude-opus-5` over the repo returned zero hits. A plain omission, not one of the table's recorded exclusions.

## Verified, not just read

The table's rule is that an id only lands after the *served* model is read back off a live stream — source reading is not enough. Against the installed CLI 2.1.220:

```
claude -p … --model claude-opus-5 --output-format json
→ modelUsage: ["claude-haiku-4-5-20251001", "claude-opus-5"]
```

A real switch, not a silent substitution.

The same probe also showed the neighbouring comment had gone stale: `claude-opus-4-1` now falls through to `claude-opus-5`, not `claude-opus-4-8`. Corrected in place — the exclusion itself still stands.

## Source of truth for ids

The comment now points at <https://platform.claude.com/docs/en/about-claude/models/overview>, which carries the API ids, aliases, and deprecation dates for both current and legacy models (`docs.claude.com` 301s here). Live readback stays the gate for *this* table — the page tells you what exists, the probe tells you the adapter actually switches to it — but it removes the guesswork about id spelling and lifecycle on future refreshes.

## 1M context: deliberately not here

Worth recording because it is not what it looks like. On the API, `claude-opus-5` **is** a 1M-context model — the docs table lists 1M tokens with no suffixed variant anywhere. The `[1m]` ids are a claude-code-side context tier layered on the same model: `claude-opus-5[1m]`, `claude-opus-4-8[1m]`, `claude-sonnet-5[1m]`, each a separate entry in the CLI's own picker, marked as drawing from usage credits. Verified the same way — `claude-opus-5[1m]` is accepted by `--model` and reflects back verbatim rather than normalising to the base id.

So the base id is the smaller tier *in this client*, and the suffixed id is the only way to ask for 1M. Still left out here: the catalog lists no `[1m]` variant for any model, so adding them is a picker-shape decision rather than a table refresh. Related, and the reason it wants its own change: `resolveModel()` prefix-matches on `` `${option.id}-` ``, so a `[1m]` id can never fold back onto its base entry and shows as unresolved in the composer. Pre-existing for every `[1m]` variant; not a regression from this change.

## Test plan

- `pnpm test` — 2250 passed, 1 skipped
- `pnpm check:ci` — clean
