### PR TITLE
fix(ui): align inline code position

### DIFF
--- a/packages/presentation/ui/src/chat/markdown.tsx
+++ b/packages/presentation/ui/src/chat/markdown.tsx
@@ -25,7 +25,9 @@ import { LinkTargetIcon } from './link-icon';
 import { filePathTarget, linkTargetFor } from './link-target';
 import { useSmoothText } from './smooth-text-controller';
 
-const INLINE_CODE_CLASS = 'rounded bg-muted px-1 py-0.5 font-mono text-[0.85em]';
+/* Plex Mono's 0.275em metric descent bottom-weights the padded box against the prose optical
+ * center; the 0.04em raise re-centers it (measured against Plex Sans + PingFang at text-sm). */
+const INLINE_CODE_CLASS = 'rounded bg-muted px-1 py-0.5 align-[0.04em] font-mono text-[0.85em]';
 const NON_WORD_RE = /\W/g;
 /** Streamdown's bundled rehype-sanitize clobbers every id with this prefix; hrefs are not
  * clobbered, so scopeFragmentIdentifiers bakes it into rewritten fragment hrefs up front. */


### PR DESCRIPTION
## Summary

Make inline code vertically align with the rest of the text.

## Verification

<!-- How did you prove it works? Commands run, surfaces launched, before/after screenshots for UI changes. -->

## Checklist

- [x] `pnpm check:ci` and `pnpm test` both pass (plus `cargo fmt` / `clippy` / `test` for Rust changes)
- [x] I ran the affected surface and observed the change working
- [ ] If a wire message changed: `WIRE_PROTOCOL_VERSION` is bumped
- [x] New code and assets are my own work, or their origin and license compatibility are noted above
- [ ] Docs and comments are updated where behavior changed
