### PR TITLE
feat(schema,agent-adapter,ui): carry each agent's own configured default model/effort in the start catalog

### DIFF
--- a/packages/foundation/schema/src/model/agent/input.ts
+++ b/packages/foundation/schema/src/model/agent/input.ts
@@ -110,6 +110,11 @@ export const AgentStartCatalogSchema = z.object({
   models: z.array(AgentModelOptionSchema),
   policies: z.array(ApprovalPolicySchema),
   defaultPolicyId: ApprovalPolicyIdSchema.optional(),
+  /** What the agent's OWN configuration would start on, read before any session exists — display
+   * only, on the same terms as `defaultPolicyId`: sending either back would read as an explicit
+   * pick and override the resolution the agent does for itself. Absent when unreadable. */
+  defaultModel: z.string().min(1).optional(),
+  defaultEffort: EffortLevelSchema.optional(),
 });
 export type AgentStartCatalog = z.infer<typeof AgentStartCatalogSchema>;
 

--- a/packages/foundation/schema/src/wire/message.ts
+++ b/packages/foundation/schema/src/wire/message.ts
@@ -9,7 +9,7 @@ import { WIRE_PAYLOAD_KINDS, WirePayloadSchema } from './payload';
  */
 
 /** Stamped on every frame this build sends; bump on any wire schema change. */
-export const WIRE_PROTOCOL_VERSION = 66 as const;
+export const WIRE_PROTOCOL_VERSION = 67 as const;
 
 /** The oldest `v` this build still accepts. Bump only for a breaking change — a variant or field
  * removed, renamed, or given a new meaning; additive changes leave it alone. */

--- a/packages/host/agent-adapter/src/__tests__/codex-config.test.ts
+++ b/packages/host/agent-adapter/src/__tests__/codex-config.test.ts
@@ -2,7 +2,7 @@ import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { codexConfiguredSandbox } from '../native/codex';
+import { codexConfiguredModel, codexConfiguredSandbox } from '../native/codex';
 
 /** Exercises the real config.toml read + parse + profile/top-level resolution through a throwaway
  * `CODEX_HOME` — mocking the parser would test nothing. */
@@ -56,5 +56,59 @@ describe('codexConfiguredSandbox', () => {
   it('returns undefined on malformed TOML instead of throwing', async () => {
     await writeConfig('sandbox_mode = "read-only\n[unclosed');
     expect(await readConfigured()).toBeUndefined();
+  });
+});
+
+describe('codexConfiguredModel', () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'codex-cfg-'));
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  const writeConfig = (toml: string): Promise<void> => writeFile(join(dir, 'config.toml'), toml);
+  const readConfigured = () => codexConfiguredModel({ CODEX_HOME: dir });
+
+  it('returns nothing when config.toml is absent', async () => {
+    expect(await readConfigured()).toEqual({});
+  });
+
+  it('reads the top-level model and reasoning effort', async () => {
+    await writeConfig('model = "gpt-5.6-sol"\nmodel_reasoning_effort = "high"\n');
+    expect(await readConfigured()).toEqual({ model: 'gpt-5.6-sol', effort: 'high' });
+  });
+
+  it('prefers the active profile over the top-level values', async () => {
+    await writeConfig(
+      'model = "gpt-5.4"\nmodel_reasoning_effort = "low"\nprofile = "deep"\n[profiles.deep]\nmodel = "gpt-5.6-sol"\nmodel_reasoning_effort = "xhigh"\n',
+    );
+    expect(await readConfigured()).toEqual({ model: 'gpt-5.6-sol', effort: 'xhigh' });
+  });
+
+  it('ignores a model from a profile that is not the active one', async () => {
+    await writeConfig(
+      'profile = "a"\n[profiles.a]\nmodel = "gpt-5.4"\n[profiles.b]\nmodel = "o3"\n',
+    );
+    expect(await readConfigured()).toEqual({ model: 'gpt-5.4' });
+  });
+
+  // `minimal` is a real codex level with no LinkCode equivalent; dropping it leaves the model set.
+  it('drops an effort outside LinkCode vocabulary but keeps the model', async () => {
+    await writeConfig('model = "gpt-5.4"\nmodel_reasoning_effort = "minimal"\n');
+    expect(await readConfigured()).toEqual({ model: 'gpt-5.4' });
+  });
+
+  it('does not mistake a model nested in another table for the top-level one', async () => {
+    await writeConfig('[projects."/x"]\nmodel = "o3"\n');
+    expect(await readConfigured()).toEqual({});
+  });
+
+  it('returns nothing on malformed TOML instead of throwing', async () => {
+    await writeConfig('model = "gpt-5.4\n[unclosed');
+    expect(await readConfigured()).toEqual({});
   });
 });

--- a/packages/host/agent-adapter/src/__tests__/codex-shell.test.ts
+++ b/packages/host/agent-adapter/src/__tests__/codex-shell.test.ts
@@ -221,6 +221,16 @@ describe('CodexAdapter shell-command passthrough', () => {
     });
   });
 
+  it('reads config.toml from the same environment the app-server got', async () => {
+    const adapter = new TestCodex();
+    // An account's extraEnv can move CODEX_HOME; reading the unmerged environment would report
+    // defaults from a different codex home than the one the session actually uses.
+    await adapter.startCatalog({ config: { extraEnv: { CODEX_HOME: '/accounts/codex' } } });
+
+    expect(adapter.configuredModelEnvironment?.CODEX_HOME).toBe('/accounts/codex');
+    expect(adapter.fakeServers[0].opts.env?.CODEX_HOME).toBe('/accounts/codex');
+  });
+
   it('falls back to the effort advertised for the model config.toml names', async () => {
     const adapter = new TestCodex();
     adapter.configuredModel = { model: 'gpt-5.6-luna' };

--- a/packages/host/agent-adapter/src/__tests__/codex-shell.test.ts
+++ b/packages/host/agent-adapter/src/__tests__/codex-shell.test.ts
@@ -1,4 +1,4 @@
-import type { AgentEvent, StartOptions } from '@linkcode/schema';
+import type { AgentEvent, EffortLevel, StartOptions } from '@linkcode/schema';
 import { textBlock } from '@linkcode/schema';
 import { describe, expect, it } from 'vitest';
 import { asHistoryId } from '../history-util';
@@ -105,6 +105,8 @@ class FakeCodexServer {
 class TestCodex extends CodexAdapter {
   fakeServers: FakeCodexServer[] = [];
   configuredSandboxEnvironment: NodeJS.ProcessEnv | undefined;
+  configuredModelEnvironment: NodeJS.ProcessEnv | undefined;
+  configuredModel: { model?: string; effort?: EffortLevel } = {};
   emptyModelList = false;
   rejectMethod: string | undefined;
   threadResponse: unknown;
@@ -121,6 +123,12 @@ class TestCodex extends CodexAdapter {
   protected override readConfiguredSandbox(environment: NodeJS.ProcessEnv) {
     this.configuredSandboxEnvironment = environment;
     return Promise.resolve(undefined);
+  }
+  // Stubbed for the same reason as the sandbox above: the real read would reach the developer's
+  // own ~/.codex/config.toml and make the catalog assertions machine-dependent.
+  protected override readConfiguredModel(environment: NodeJS.ProcessEnv) {
+    this.configuredModelEnvironment = environment;
+    return Promise.resolve(this.configuredModel);
   }
 }
 
@@ -195,8 +203,32 @@ describe('CodexAdapter shell-command passthrough', () => {
         },
       ],
       defaultPolicyId: 'acceptEdits',
+      // No config.toml value, so the served catalog's own default stands, with the effort that
+      // model advertises.
+      defaultModel: 'gpt-5.6-sol',
+      defaultEffort: 'low',
     });
     expect(adapter.fakeServers[0].closed).toBe(true);
+  });
+
+  it('lets config.toml outrank the served catalog default before session start', async () => {
+    const adapter = new TestCodex();
+    adapter.configuredModel = { model: 'gpt-5.6-luna', effort: 'xhigh' };
+
+    await expect(adapter.startCatalog()).resolves.toMatchObject({
+      defaultModel: 'gpt-5.6-luna',
+      defaultEffort: 'xhigh',
+    });
+  });
+
+  it('falls back to the effort advertised for the model config.toml names', async () => {
+    const adapter = new TestCodex();
+    adapter.configuredModel = { model: 'gpt-5.6-luna' };
+
+    await expect(adapter.startCatalog()).resolves.toMatchObject({
+      defaultModel: 'gpt-5.6-luna',
+      defaultEffort: 'medium',
+    });
   });
 
   it('loads the project environment and lets account variables override it', async () => {

--- a/packages/host/agent-adapter/src/native/claude-code.ts
+++ b/packages/host/agent-adapter/src/native/claude-code.ts
@@ -576,7 +576,31 @@ export class ClaudeCodeAdapter extends BaseAgentAdapter {
       policies: [...APPROVAL_POLICIES],
       defaultPolicyId:
         (opts.cwd === undefined ? undefined : await settingsDefaultMode(opts.cwd)) ?? 'default',
+      ...(await this.settingsDefaults(opts.cwd)),
     };
+  }
+
+  /** The model/effort a session would adopt from settings, via the same `resolveSettings` the
+   * start path uses — it applies the managed and remote policy tiers a raw settings.json walk
+   * would miss. A load failure leaves the axes absent rather than sinking the whole catalog: the
+   * approval tiers above are readable without the SDK. */
+  private async settingsDefaults(
+    cwd: string | undefined,
+  ): Promise<{ defaultModel?: string; defaultEffort?: EffortLevel }> {
+    try {
+      const sdk = await this.loadSdk(
+        '@anthropic-ai/claude-agent-sdk',
+        () => import('@anthropic-ai/claude-agent-sdk'),
+      );
+      const { effective } = await sdk.resolveSettings(cwd === undefined ? {} : { cwd });
+      const effort = effective.ultracode === true ? 'ultracode' : effective.effortLevel;
+      return {
+        ...(effective.model !== undefined && { defaultModel: effective.model }),
+        ...(effort !== undefined && { defaultEffort: effort }),
+      };
+    } catch {
+      return {};
+    }
   }
 
   override async resumeHistory(

--- a/packages/host/agent-adapter/src/native/codex/adapter.ts
+++ b/packages/host/agent-adapter/src/native/codex/adapter.ts
@@ -395,15 +395,20 @@ export class CodexAdapter extends BaseAgentAdapter {
   override async startCatalog(opts: AgentStartCatalogOptions = {}): Promise<AgentStartCatalog> {
     const processEnvironment = await resolveCodexEnvironment(opts.cwd);
     const credentialEnv = codexEnv(readAgentCredential(opts.config));
+    // One environment for both, like openThread: an account's `extraEnv` can carry CODEX_HOME, and
+    // reading config.toml from the unmerged env would report a different home than the server uses.
+    const serverEnvironment = credentialEnv
+      ? { ...processEnvironment, ...credentialEnv }
+      : processEnvironment;
     const server = await this.startAppServer({
-      env: credentialEnv ? { ...processEnvironment, ...credentialEnv } : processEnvironment,
+      env: serverEnvironment,
       onNotification: noop,
       onExit: noop,
     });
     try {
       const [catalog, configured] = await Promise.all([
         server.request('model/list', {}).then(codexModelCatalog),
-        this.readConfiguredModel(processEnvironment),
+        this.readConfiguredModel(serverEnvironment),
       ]);
       // config.toml outranks the served catalog default, mirroring codex's own resolution at
       // thread/start; the effort falls back to whichever model that leaves selected.

--- a/packages/host/agent-adapter/src/native/codex/adapter.ts
+++ b/packages/host/agent-adapter/src/native/codex/adapter.ts
@@ -47,7 +47,7 @@ import { resolveAgentShellEnvironment } from '../../shell-env';
 import type { CodexAppServerOptions } from './app-server';
 import { CodexAppServer, resolveCodexBinaryPath } from './app-server';
 import type { CodexSandboxMode } from './config';
-import { codexConfiguredSandbox } from './config';
+import { codexConfiguredModel, codexConfiguredSandbox } from './config';
 import {
   codexHome,
   codexIndexEntryToSession,
@@ -401,11 +401,22 @@ export class CodexAdapter extends BaseAgentAdapter {
       onExit: noop,
     });
     try {
-      const catalog = codexModelCatalog(await server.request('model/list', {}));
+      const [catalog, configured] = await Promise.all([
+        server.request('model/list', {}).then(codexModelCatalog),
+        this.readConfiguredModel(processEnvironment),
+      ]);
+      // config.toml outranks the served catalog default, mirroring codex's own resolution at
+      // thread/start; the effort falls back to whichever model that leaves selected.
+      const defaultModel = configured.model ?? catalog.defaultModel;
+      const defaultEffort =
+        configured.effort ??
+        catalog.models.find((model) => model.id === defaultModel)?.defaultEffort;
       return {
         models: catalog.models,
         policies: [...APPROVAL_POLICIES],
         defaultPolicyId: INITIAL_POLICY_ID,
+        ...(defaultModel !== undefined && { defaultModel }),
+        ...(defaultEffort !== undefined && { defaultEffort }),
       };
     } finally {
       server.close();
@@ -696,6 +707,13 @@ export class CodexAdapter extends BaseAgentAdapter {
     environment: NodeJS.ProcessEnv,
   ): Promise<CodexSandboxMode | undefined> {
     return codexConfiguredSandbox(environment);
+  }
+
+  /** Test seam — same config.toml, read for the pre-session catalog's declared defaults. */
+  protected readConfiguredModel(
+    environment: NodeJS.ProcessEnv,
+  ): Promise<{ model?: string; effort?: EffortLevel }> {
+    return codexConfiguredModel(environment);
   }
 
   private async openThread(): Promise<void> {

--- a/packages/host/agent-adapter/src/native/codex/config.ts
+++ b/packages/host/agent-adapter/src/native/codex/config.ts
@@ -1,6 +1,8 @@
 import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { env } from 'node:process';
+import type { EffortLevel } from '@linkcode/schema';
+import { EffortLevelSchema } from '@linkcode/schema';
 import { parse as parseToml } from 'smol-toml';
 import { isRecord } from '../../history-util';
 import { codexHome } from './history';
@@ -17,26 +19,61 @@ function asSandboxMode(value: unknown): CodexSandboxMode | undefined {
   return SANDBOX_MODES.find((mode) => mode === value);
 }
 
-/**
- * The sandbox configured in `$CODEX_HOME/config.toml` (`~/.codex` by default): the active profile's
- * `sandbox_mode` if set, else the top-level one; undefined when unset or the file is
- * absent/malformed. Read only to decide whether a sandbox override may be sent at all (codex
- * resolves the config itself when none is sent) — a stricter configured choice like read-only must
- * never be silently loosened.
- */
-export async function codexConfiguredSandbox(
-  environment: NodeJS.ProcessEnv = env,
-): Promise<CodexSandboxMode | undefined> {
+/** `$CODEX_HOME/config.toml` (`~/.codex` by default) with the active profile resolved, in the
+ * lookup order codex itself uses: the profile's key if set, else the top-level one. Undefined when
+ * the file is absent, unreadable, or invalid TOML — all treated alike as unconfigured. */
+async function codexConfigScopes(
+  environment: NodeJS.ProcessEnv,
+): Promise<
+  [profile: Record<string, unknown> | undefined, top: Record<string, unknown>] | undefined
+> {
   let config: unknown;
   try {
     config = parseToml(await readFile(join(codexHome(environment), 'config.toml'), 'utf8'));
   } catch {
-    return undefined; // No config, unreadable, or invalid TOML — treat as unconfigured.
+    return undefined;
   }
   if (!isRecord(config)) return undefined;
   const profileName = typeof config.profile === 'string' ? config.profile : undefined;
   const profiles = isRecord(config.profiles) ? config.profiles : undefined;
-  const profile =
-    profileName && isRecord(profiles?.[profileName]) ? profiles[profileName] : undefined;
-  return asSandboxMode(profile?.sandbox_mode) ?? asSandboxMode(config.sandbox_mode);
+  return [
+    profileName && isRecord(profiles?.[profileName]) ? profiles[profileName] : undefined,
+    config,
+  ];
+}
+
+/**
+ * The sandbox configured in config.toml. Read only to decide whether a sandbox override may be
+ * sent at all (codex resolves the config itself when none is sent) — a stricter configured choice
+ * like read-only must never be silently loosened.
+ */
+export async function codexConfiguredSandbox(
+  environment: NodeJS.ProcessEnv = env,
+): Promise<CodexSandboxMode | undefined> {
+  const scopes = await codexConfigScopes(environment);
+  if (!scopes) return undefined;
+  const [profile, top] = scopes;
+  return asSandboxMode(profile?.sandbox_mode) ?? asSandboxMode(top.sandbox_mode);
+}
+
+/** The model and reasoning effort configured in config.toml, for the pre-session catalog only —
+ * codex resolves these itself at `thread/start`, so they are never sent back as an override.
+ * `minimal` is outside LinkCode's effort vocabulary and drops out here, same as in the live
+ * catalog. */
+export async function codexConfiguredModel(
+  environment: NodeJS.ProcessEnv = env,
+): Promise<{ model?: string; effort?: EffortLevel }> {
+  const scopes = await codexConfigScopes(environment);
+  if (!scopes) return {};
+  const [profile, top] = scopes;
+  const model = profile?.model ?? top.model;
+  const parsedEffort = EffortLevelSchema.safeParse(
+    profile?.model_reasoning_effort ?? top.model_reasoning_effort,
+  );
+  const effort =
+    parsedEffort.success && parsedEffort.data !== 'ultracode' ? parsedEffort.data : undefined;
+  return {
+    ...(typeof model === 'string' && model.length > 0 && { model }),
+    ...(effort !== undefined && { effort }),
+  };
 }

--- a/packages/host/agent-adapter/src/native/codex/index.ts
+++ b/packages/host/agent-adapter/src/native/codex/index.ts
@@ -5,5 +5,5 @@ export {
   mapCodexItemStatus,
   mapCodexTokenUsage,
 } from './adapter';
-export { codexConfiguredSandbox } from './config';
+export { codexConfiguredModel, codexConfiguredSandbox } from './config';
 export { diffContentFromUnified } from './unified-diff';

--- a/packages/host/agent-adapter/src/native/opencode/adapter.ts
+++ b/packages/host/agent-adapter/src/native/opencode/adapter.ts
@@ -688,6 +688,8 @@ export class OpenCodeAdapter extends BaseAgentAdapter {
         client.app.agents(scope),
       ]);
       const catalog = agents.error === undefined ? opencodeAgentPolicies(agents.data) : null;
+      // No `defaultModel`: `provider.list` carries a per-provider default map, but which of them a
+      // fresh session actually adopts is unverified against a live server.
       return {
         models: providers.error === undefined ? opencodeModelOptions(providers.data, null) : [],
         policies: catalog?.policies ?? [],

--- a/packages/host/agent-adapter/src/native/pi/adapter.ts
+++ b/packages/host/agent-adapter/src/native/pi/adapter.ts
@@ -199,10 +199,13 @@ export class PiAdapter extends BaseAgentAdapter {
   override async startCatalog(opts: AgentStartCatalogOptions = {}): Promise<AgentStartCatalog> {
     const pi = await this.importSdk();
     const { modelRegistry } = createConfiguredRegistry(pi, opts);
+    const models = modelOptions(modelRegistry.getAvailable());
     return {
-      models: modelOptions(modelRegistry.getAvailable()),
+      models,
       policies: [...POLICIES],
       defaultPolicyId: 'default',
+      // The registry's first entry is exactly what an unpicked session falls back to (see onStart).
+      ...(models[0] && { defaultModel: models[0].id }),
     };
   }
   override async listHistory(opts?: AgentHistoryListOptions) {

--- a/packages/presentation/ui/src/shell/__tests__/new-session-surface.test.tsx
+++ b/packages/presentation/ui/src/shell/__tests__/new-session-surface.test.tsx
@@ -49,7 +49,9 @@ const RE_CUSTOM_CLAUDE_MODEL = /custom\/claude-model/;
 const RE_DYNAMIC_CLAUDE_MODEL = /anthropic\/claude-sonnet-4-6/;
 const RE_PI_SONNET = /Pi Sonnet/;
 const RE_PI_BASIC = /Pi Basic/;
+const RE_PI_WIDE = /Pi Wide/;
 const RE_HIGH_EFFORT = /High/;
+const RE_LOW_EFFORT = /Low/;
 const RE_GPT_56_SOL = /GPT-5.6-Sol/;
 const RE_APPROVAL_DEFAULT = /Default/;
 const RE_ACCEPT_EDITS = /Accept edits/;
@@ -61,6 +63,8 @@ const PI_CONFIGURED_CATALOG: AgentStartCatalog = {
   models: [
     { id: 'pi/sonnet', label: 'Pi Sonnet', effortLevels: ['low', 'high'] },
     { id: 'pi/basic', label: 'Pi Basic', effortLevels: [] },
+    // Shares `high` with the catalog default so a leaked effort would still look plausible.
+    { id: 'pi/wide', label: 'Pi Wide', effortLevels: ['low', 'high'], defaultEffort: 'low' },
   ],
   policies: [{ policyId: 'default', name: 'Default' }],
   defaultPolicyId: 'default',
@@ -873,6 +877,49 @@ describe('NewSessionSurface', () => {
 
     expect(screen.getByRole('button', { name: RE_PI_BASIC })).toBeTruthy();
     expect(screen.queryByRole('button', { name: RE_HIGH_EFFORT })).toBeNull();
+  });
+
+  it('does not lend the catalog effort to a model the catalog did not default to', () => {
+    render(
+      <NewSessionSurface
+        agentCatalogs={{ pi: PI_CONFIGURED_CATALOG }}
+        chatWorkspace={CHAT_WORKSPACE}
+        defaultModels={{ pi: 'pi/wide' }}
+        draft={{ initialProvider: 'pi', initialWorkspaceId: CHAT_WORKSPACE.workspaceId }}
+        mentionItems={[]}
+        onMentionQueryChange={vi.fn()}
+        onRegisterWorkspace={vi.fn().mockResolvedValue(CHAT_WORKSPACE)}
+        onSubmit={vi.fn()}
+        workspaces={[]}
+      />,
+    );
+
+    // `pi/wide` accepts `high`, so a leaked catalog effort would render — the session would still
+    // start on this model's own default, leaving the chip advertising an effort nobody selected.
+    expect(screen.getByRole('button', { name: RE_PI_WIDE })).toBeTruthy();
+    expect(screen.queryByRole('button', { name: RE_HIGH_EFFORT })).toBeNull();
+    expect(screen.getByRole('button', { name: RE_LOW_EFFORT })).toBeTruthy();
+  });
+
+  it('keeps a model-independent configured effort when the catalog names no model', () => {
+    const { defaultModel: _unset, ...modelless } = PI_CONFIGURED_CATALOG;
+    render(
+      <NewSessionSurface
+        agentCatalogs={{ pi: modelless }}
+        chatWorkspace={CHAT_WORKSPACE}
+        defaultModels={{ pi: 'pi/wide' }}
+        draft={{ initialProvider: 'pi', initialWorkspaceId: CHAT_WORKSPACE.workspaceId }}
+        mentionItems={[]}
+        onMentionQueryChange={vi.fn()}
+        onRegisterWorkspace={vi.fn().mockResolvedValue(CHAT_WORKSPACE)}
+        onSubmit={vi.fn()}
+        workspaces={[]}
+      />,
+    );
+
+    // This is claude-code's shape: settings declare an effort but no model, so the effort is not
+    // tied to whichever model ends up selected.
+    expect(screen.getByRole('button', { name: RE_HIGH_EFFORT })).toBeTruthy();
   });
 
   it("lets a LinkCode-configured default outrank the agent's own", () => {

--- a/packages/presentation/ui/src/shell/__tests__/new-session-surface.test.tsx
+++ b/packages/presentation/ui/src/shell/__tests__/new-session-surface.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
 
+import type { AgentStartCatalog } from '@linkcode/schema';
 import { WorkspaceIdSchema } from '@linkcode/schema';
 import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -47,10 +48,25 @@ const RE_MEDIUM_EFFORT = /Medium/;
 const RE_CUSTOM_CLAUDE_MODEL = /custom\/claude-model/;
 const RE_DYNAMIC_CLAUDE_MODEL = /anthropic\/claude-sonnet-4-6/;
 const RE_PI_SONNET = /Pi Sonnet/;
+const RE_PI_BASIC = /Pi Basic/;
+const RE_HIGH_EFFORT = /High/;
 const RE_GPT_56_SOL = /GPT-5.6-Sol/;
 const RE_APPROVAL_DEFAULT = /Default/;
 const RE_ACCEPT_EDITS = /Accept edits/;
 const RE_PROJECT_WORKSPACE = /app/;
+
+/** A catalog carrying what the agent's own configuration would start on. `pi/basic` has no effort
+ * axis, so it doubles as the case where a configured effort cannot apply. */
+const PI_CONFIGURED_CATALOG: AgentStartCatalog = {
+  models: [
+    { id: 'pi/sonnet', label: 'Pi Sonnet', effortLevels: ['low', 'high'] },
+    { id: 'pi/basic', label: 'Pi Basic', effortLevels: [] },
+  ],
+  policies: [{ policyId: 'default', name: 'Default' }],
+  defaultPolicyId: 'default',
+  defaultModel: 'pi/sonnet',
+  defaultEffort: 'high',
+};
 
 type StandaloneProps = Omit<NewSessionSurfaceProps, 'workspaceId' | 'onWorkspaceChange'> &
   Partial<Pick<NewSessionSurfaceProps, 'onWorkspaceChange'>>;
@@ -811,6 +827,95 @@ describe('NewSessionSurface', () => {
     // …but an untouched picker is not a choice: sending it would override the agent's own startup
     // resolution (claude's settings defaultMode, codex's configured sandbox).
     expect(onSubmit.mock.calls[0]?.[0]).not.toHaveProperty('approvalPolicyId');
+  });
+
+  it("shows the agent's own configured model and effort without submitting them", async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    render(
+      <NewSessionSurface
+        agentCatalogs={{ pi: PI_CONFIGURED_CATALOG }}
+        chatWorkspace={CHAT_WORKSPACE}
+        draft={{ initialProvider: 'pi', initialWorkspaceId: CHAT_WORKSPACE.workspaceId }}
+        mentionItems={[]}
+        onMentionQueryChange={vi.fn()}
+        onRegisterWorkspace={vi.fn().mockResolvedValue(CHAT_WORKSPACE)}
+        onSubmit={onSubmit}
+        workspaces={[]}
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: RE_PI_SONNET })).toBeTruthy();
+    expect(screen.getByRole('button', { name: RE_HIGH_EFFORT })).toBeTruthy();
+
+    typeInComposer('untouched pickers');
+    await pressInComposer('Enter');
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledOnce());
+    // Same rule as the approval tier above: the agent resolves these itself at start.
+    expect(onSubmit.mock.calls[0]?.[0]).toEqual(expect.objectContaining({ model: undefined }));
+    expect(onSubmit.mock.calls[0]?.[0]).not.toHaveProperty('effort');
+  });
+
+  it('drops a configured effort the displayed model cannot take', () => {
+    render(
+      <NewSessionSurface
+        agentCatalogs={{
+          pi: { ...PI_CONFIGURED_CATALOG, defaultModel: 'pi/basic' },
+        }}
+        chatWorkspace={CHAT_WORKSPACE}
+        draft={{ initialProvider: 'pi', initialWorkspaceId: CHAT_WORKSPACE.workspaceId }}
+        mentionItems={[]}
+        onMentionQueryChange={vi.fn()}
+        onRegisterWorkspace={vi.fn().mockResolvedValue(CHAT_WORKSPACE)}
+        onSubmit={vi.fn()}
+        workspaces={[]}
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: RE_PI_BASIC })).toBeTruthy();
+    expect(screen.queryByRole('button', { name: RE_HIGH_EFFORT })).toBeNull();
+  });
+
+  it("lets a LinkCode-configured default outrank the agent's own", () => {
+    render(
+      <NewSessionSurface
+        agentCatalogs={{ pi: PI_CONFIGURED_CATALOG }}
+        chatWorkspace={CHAT_WORKSPACE}
+        defaultModels={{ pi: 'pi/basic' }}
+        draft={{ initialProvider: 'pi', initialWorkspaceId: CHAT_WORKSPACE.workspaceId }}
+        mentionItems={[]}
+        onMentionQueryChange={vi.fn()}
+        onRegisterWorkspace={vi.fn().mockResolvedValue(CHAT_WORKSPACE)}
+        onSubmit={vi.fn()}
+        workspaces={[]}
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: RE_PI_BASIC })).toBeTruthy();
+  });
+
+  it("lets a remembered pick outrank the agent's own default", async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    render(
+      <NewSessionSurface
+        agentCatalogs={{ pi: PI_CONFIGURED_CATALOG }}
+        chatWorkspace={CHAT_WORKSPACE}
+        draft={{ initialProvider: 'pi', initialWorkspaceId: CHAT_WORKSPACE.workspaceId }}
+        mentionItems={[]}
+        onMentionQueryChange={vi.fn()}
+        onRegisterWorkspace={vi.fn().mockResolvedValue(CHAT_WORKSPACE)}
+        onSubmit={onSubmit}
+        preferredModels={{ pi: 'pi/basic' }}
+        workspaces={[]}
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: RE_PI_BASIC })).toBeTruthy();
+    typeInComposer('use my last model');
+    await pressInComposer('Enter');
+    // A remembered pick is an explicit choice, so unlike the catalog default it does travel.
+    await waitFor(() =>
+      expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({ model: 'pi/basic' })),
+    );
   });
 
   it('submits compatible Pi catalog choices and suppresses stale effort for models without it', async () => {

--- a/packages/presentation/ui/src/shell/agent-models.ts
+++ b/packages/presentation/ui/src/shell/agent-models.ts
@@ -8,6 +8,8 @@ export interface ModelOption {
   description?: string;
   /** Per-model effort capability from a dynamic adapter catalog. */
   effortLevels?: EffortLevel[];
+  /** The effort this model runs at unpicked, when the catalog advertises one. */
+  defaultEffort?: EffortLevel;
 }
 
 export interface ModelProviderGroups {

--- a/packages/presentation/ui/src/shell/new-session-surface.tsx
+++ b/packages/presentation/ui/src/shell/new-session-surface.tsx
@@ -182,25 +182,37 @@ export function NewSessionSurface({
   const selectedBranch = selected
     ? (selectedBranches[selected.workspaceId] ?? preferredBranches?.[selected.workspaceId])
     : undefined;
+  const catalog = agentCatalogs?.[provider];
   const localModel = selectedModels[provider];
   const selectedModel =
     localModel === undefined ? (preferredModels?.[provider] ?? null) : localModel;
+  // The catalog default is what the agent's own config would start on, so it outranks the built-in
+  // guess but yields to anything the user expressed through LinkCode.
   const displayedModel =
     selectedModel ??
     (defaultModels === null
       ? null
-      : (defaultModels?.[provider] ?? AGENT_DEFAULT_MODELS[provider] ?? null));
+      : (defaultModels?.[provider] ??
+        catalog?.defaultModel ??
+        AGENT_DEFAULT_MODELS[provider] ??
+        null));
   const localEffort = selectedEfforts[provider];
   const effort = localEffort === undefined ? (preferredEfforts?.[provider] ?? null) : localEffort;
-  const catalog = agentCatalogs?.[provider];
   const dynamicModels = catalog && catalog.models.length > 0 ? catalog.models : null;
   const modelOption = resolveModel(dynamicModels ?? AGENT_MODEL_OPTIONS[provider], displayedModel);
   const effortLevels = modelOption?.effortLevels;
   const constrainedEffort =
     effortLevels === undefined || effortLevels.includes(effort ?? 'low') ? effort : null;
-  // Only a real pick travels to the adapter. The catalog default is a display value: submitting it
-  // would read as an explicit choice and override the agent's own startup resolution — claude's
-  // `permissions.defaultMode`, codex's configured `config.toml` sandbox.
+  const catalogEffort = catalog?.defaultEffort;
+  const displayedEffort =
+    constrainedEffort ??
+    (catalogEffort !== undefined &&
+    (effortLevels === undefined || effortLevels.includes(catalogEffort))
+      ? catalogEffort
+      : null);
+  // Only a real pick travels to the adapter. Every catalog default — policy, model, effort — is a
+  // display value: submitting one would read as an explicit choice and override the agent's own
+  // startup resolution — claude's `permissions.defaultMode`, codex's configured `config.toml`.
   const pickedPolicyId = selectedPolicies[provider];
   const currentPolicyId =
     pickedPolicyId ?? catalog?.defaultPolicyId ?? catalog?.policies[0]?.policyId;
@@ -338,7 +350,7 @@ export function NewSessionSurface({
             sendBlocked={cue !== undefined}
             currentModeId={modeId}
             currentModel={displayedModel}
-            currentEffort={constrainedEffort}
+            currentEffort={displayedEffort}
             agentModels={dynamicModels}
             approvalPolicy={approvalPolicy}
             approvalPolicyPlaceholder={t('permissionMode')}

--- a/packages/presentation/ui/src/shell/new-session-surface.tsx
+++ b/packages/presentation/ui/src/shell/new-session-surface.tsx
@@ -203,7 +203,13 @@ export function NewSessionSurface({
   const effortLevels = modelOption?.effortLevels;
   const constrainedEffort =
     effortLevels === undefined || effortLevels.includes(effort ?? 'low') ? effort : null;
-  const catalogEffort = catalog?.defaultEffort;
+  // A catalog effort paired with a default model belongs to that model: once something else picks
+  // the model, that model's own advertised default is the honest value. A catalog that names no
+  // default model (claude-code, whose effort setting is model-independent) keeps applying.
+  const catalogEffort =
+    catalog?.defaultModel === undefined || catalog.defaultModel === displayedModel
+      ? catalog?.defaultEffort
+      : modelOption?.defaultEffort;
   const displayedEffort =
     constrainedEffort ??
     (catalogEffort !== undefined &&


### PR DESCRIPTION
Closes CODE-524.

The New Task page showed a model it had guessed rather than the one the session would actually run. With no LinkCode provider config and no remembered pick, `displayedModel` fell through to the hardcoded `AGENT_DEFAULT_MODELS` table while the session started on whatever the agent CLI's own configuration said. The effort chip had the same hole with no fallback at all, so a `~/.codex/config.toml` carrying `model_reasoning_effort` rendered as an empty chip.

The pre-session catalog is the natural carrier and already reaches the surface per-workspace via `useAgentStartCatalogs`, but `AgentStartCatalogSchema` had nowhere to put it. The approval-policy axis has done this correctly for a while — claude-code's `startCatalog` resolves the tier from the user's `settings.json`. This closes the same gap on the model/effort axis.

## Precedence

Only layer 4 is new. It sits below the remembered pick deliberately: a past explicit choice outranks a config file the user did not make through LinkCode.

1. Explicit pick on the page
2. `preferredModels` — the remembered last pick
3. `providers[kind].defaultModel` / `account.model` — LinkCode settings
4. **The agent CLI's own config** ← new
5. `AGENT_DEFAULT_MODELS` hardcoded fallback

## Changes

- **schema** — `AgentStartCatalogSchema` gains optional `defaultModel` / `defaultEffort`. `WIRE_PROTOCOL_VERSION` 66 → 67; `MIN_COMPATIBLE_WIRE_VERSION` unchanged, since the change is purely additive.
- **codex** — new `codexConfiguredModel()` reads `model` / `model_reasoning_effort` with the active profile resolved, sharing one config.toml read with `codexConfiguredSandbox`. `startCatalog` prefers it over the served `model/list` default and falls back to the named model's own `defaultReasoningEffort`.
- **claude-code** — `startCatalog` resolves both axes through the SDK's `resolveSettings({cwd})`, the same call the start path already uses, so the managed and remote policy tiers a raw settings.json walk would miss are applied. A load failure leaves the axes absent rather than sinking the approval tiers, which are readable without the SDK.
- **pi** — `defaultModel` is the registry's first entry, exactly what an unpicked session falls back to.
- **opencode** — deliberately absent. `provider.list` carries a per-provider default map, but which one a fresh session adopts is unverified and no local install was available to check against.
- **grok-build** — left alone; its only model is the static table's single entry, so filling it would just re-hardcode the guess.
- **ui** — the surface consumes both at layer 4. Effort needed the display-vs-submit split the model already had: `displayedEffort` shows the catalog value, dropped when the displayed model has no such level, while only a real pick still travels to the adapter.

## Verification

Observed running — dev desktop against the real HOME with a throwaway `LINKCODE_PROFILE`, so nothing remembered and no provider config could shadow the catalog:

| agent | its own config | composer chip |
| --- | --- | --- |
| claude-code | `effortLevel: "xhigh"`, no `model` | `Sonnet 5 · xHigh` |
| codex | `model = "gpt-5.6-sol"`, `model_reasoning_effort = "ultra"` | `GPT-5.6-Sol · Ultra` |

Both effort values are new; that chip was empty before. claude-code's model correctly stays on the built-in `Sonnet 5` because its settings declare none. The codex model is weak evidence alone — `gpt-5.6-sol` happens to equal the hardcoded fallback — but it travels the same struct, wire field, and UI line as the effort, and the config-outranks-served-default precedence is covered by unit tests.

Also: `codexConfiguredModel` against a real `~/.codex/config.toml`, 7 cases over a throwaway `CODEX_HOME`, 3 codex `startCatalog` precedence cases, and 4 surface cases (shown-not-submitted, effort dropped for an incompatible model, LinkCode config outranks, remembered pick outranks). Whole repo: `check:ci` clean, `pnpm test` 2266 passed.

One fix worth calling out: the existing codex catalog test was reading the developer's own `~/.codex` through an unstubbed seam, so its assertions were machine-dependent. `TestCodex` now stubs `readConfiguredModel` the way it already stubbed the sandbox.

## Out of scope

opencode's axis stays open — it needs a live server to determine which provider default a fresh session adopts. claude-code's path has no test of its own; `resolveSettings` is `@alpha` in SDK 0.3.206.
