### PR TITLE
fix(ui): preserve local font query receiver

### DIFF
--- a/packages/presentation/ui/src/shell/terminal/__tests__/fonts.test.ts
+++ b/packages/presentation/ui/src/shell/terminal/__tests__/fonts.test.ts
@@ -1,0 +1,37 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it, vi } from 'vitest';
+import { resolveTerminalFonts } from '../fonts';
+
+describe('resolveTerminalFonts', () => {
+  it('preserves the Window receiver while probing local fallbacks', async () => {
+    const queryLocalFonts = vi.fn(function (this: Window) {
+      expect(this).toBe(window);
+      return Promise.resolve([
+        {
+          family: 'Hiragino Sans GB',
+          fullName: 'Hiragino Sans GB W3',
+          postscriptName: 'HiraginoSansGB-W3',
+        },
+        {
+          family: 'Apple Color Emoji',
+          fullName: 'Apple Color Emoji',
+          postscriptName: 'AppleColorEmoji',
+        },
+      ]);
+    });
+    Object.defineProperty(window, 'queryLocalFonts', {
+      configurable: true,
+      value: queryLocalFonts,
+    });
+
+    const fonts = await resolveTerminalFonts('code-150-test');
+    const families = fonts.flatMap((font) =>
+      typeof font === 'object' && 'family' in font ? [font.family] : [],
+    );
+
+    expect(queryLocalFonts).toHaveBeenCalledOnce();
+    expect(families).toContain('Hiragino Sans GB');
+    expect(families).toContain('Apple Color Emoji');
+  });
+});

--- a/packages/presentation/ui/src/shell/terminal/fonts.ts
+++ b/packages/presentation/ui/src/shell/terminal/fonts.ts
@@ -69,7 +69,7 @@ async function queryLocalFontsSafe(): Promise<readonly LocalFontData[]> {
   const query = (window as { queryLocalFonts?: () => Promise<LocalFontData[]> }).queryLocalFonts;
   if (!query) return [];
   try {
-    return await query();
+    return await query.call(window);
   } catch {
     // Local Font Access denied or unavailable — bundled fonts still cover latin + mono emoji.
     return [];


### PR DESCRIPTION
## Summary
- invoke `queryLocalFonts` with the real `Window` receiver
- cover receiver-sensitive browser implementations with a regression test

## Verification
- focused font tests pass
- `pnpm check:ci` passes
- `pnpm test` passes
- real Electron font probe selected local CJK and emoji fonts

Linear: [CODE-150](https://linear.app/arcbox/issue/CODE-150)