### PR TITLE
fix(daemon): bound AI gateway startup

### DIFF
--- a/apps/daemon/src/__tests__/ai-gateway.test.ts
+++ b/apps/daemon/src/__tests__/ai-gateway.test.ts
@@ -1,11 +1,21 @@
+import { existsSync } from 'node:fs';
+import { dirname } from 'node:path';
 import type { TranslatorUpstream } from '@linkcode/engine';
+import { nullthrow } from 'foxts/guard';
 import { noop } from 'foxts/noop';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { SidecarChildProcess, SidecarSpawn } from '../ai-gateway';
 import { createAiGatewaySidecar, upstreamToToml } from '../ai-gateway';
 
 const EXIT_BEFORE_LISTENING_RE = /before listening/;
+const FAILED_TO_START_RE = /failed to start.*ENOENT/;
 const NO_BINARY_RE = /no aigateway binary/;
+const STARTUP_TIMEOUT_RE = /did not become ready/;
+const STOPPED_BEFORE_LISTENING_RE = /stopped before listening/;
+
+function configDir(path: string | undefined): string {
+  return dirname(nullthrow(path, 'spawn did not receive a config path'));
+}
 
 const upstream: TranslatorUpstream = {
   baseUrl: 'https://api.openai.com/v1',
@@ -16,21 +26,31 @@ const upstream: TranslatorUpstream = {
 
 class FakeChild implements SidecarChildProcess {
   private readonly dataListeners: Array<(chunk: unknown) => void> = [];
+  private readonly errorListeners: Array<(error: Error) => void> = [];
   private readonly exitListeners: Array<(code: number | null) => void> = [];
   readonly stdout = {
     on: (_event: 'data', listener: (chunk: unknown) => void) => this.dataListeners.push(listener),
   };
   readonly stderr = { on: noop };
   killed = false;
+  signal: NodeJS.Signals | undefined;
 
   on(event: 'exit' | 'error', listener: (arg: never) => void): void {
-    if (event === 'exit') this.exitListeners.push(listener as (code: number | null) => void);
+    if (event === 'exit') {
+      this.exitListeners.push(listener as (code: number | null) => void);
+    } else {
+      this.errorListeners.push(listener as (error: Error) => void);
+    }
   }
-  kill(): void {
+  kill(signal?: NodeJS.Signals): void {
     this.killed = true;
+    this.signal = signal;
   }
   emitStdout(text: string): void {
     for (const listener of this.dataListeners) listener(text);
+  }
+  emitError(error: Error): void {
+    for (const listener of this.errorListeners) listener(error);
   }
   emitExit(code: number | null): void {
     for (const listener of this.exitListeners) listener(code);
@@ -45,6 +65,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  vi.useRealTimers();
   if (savedBinary === undefined) delete process.env.LINKCODE_AIGATEWAY_PATH;
   else process.env.LINKCODE_AIGATEWAY_PATH = savedBinary;
 });
@@ -75,6 +96,7 @@ describe('createAiGatewaySidecar', () => {
     const sidecar = createAiGatewaySidecar({ spawn });
     expect(await sidecar.ensure(upstream)).toBe('http://127.0.0.1:5123');
     expect(spawn).toHaveBeenCalledTimes(1);
+    await sidecar.closeAll();
   });
 
   it('reuses a running sidecar for the same upstream', async () => {
@@ -87,6 +109,7 @@ describe('createAiGatewaySidecar', () => {
     await sidecar.ensure(upstream);
     await sidecar.ensure(upstream);
     expect(spawn).toHaveBeenCalledTimes(1);
+    await sidecar.closeAll();
   });
 
   it('rejects when the process exits before listening', async () => {
@@ -112,6 +135,7 @@ describe('createAiGatewaySidecar', () => {
     expect(await sidecar.ensure(upstream)).toBe('http://127.0.0.1:5123');
     expect(ensureBinary).toHaveBeenCalled();
     expect(spawn).toHaveBeenCalledWith('/managed/aigateway', expect.any(Array));
+    await sidecar.closeAll();
   });
 
   it('rejects with a clear error when no binary is available', async () => {
@@ -119,5 +143,58 @@ describe('createAiGatewaySidecar', () => {
     await expect(
       createAiGatewaySidecar({ spawn: () => new FakeChild() }).ensure(upstream),
     ).rejects.toThrow(NO_BINARY_RE);
+  });
+
+  it('cleans temporary credentials when spawn emits an error', async () => {
+    let configPath: string | undefined;
+    const spawn: SidecarSpawn = (_command, args) => {
+      configPath = args.at(-1);
+      const child = new FakeChild();
+      queueMicrotask(() => child.emitError(new Error('spawn aigateway ENOENT')));
+      return child;
+    };
+
+    await expect(createAiGatewaySidecar({ spawn }).ensure(upstream)).rejects.toThrow(
+      FAILED_TO_START_RE,
+    );
+    expect(existsSync(configDir(configPath))).toBe(false);
+  });
+
+  it('terminates and cleans a sidecar that misses the readiness deadline', async () => {
+    vi.useFakeTimers();
+    let configPath: string | undefined;
+    const child = new FakeChild();
+    const spawn: SidecarSpawn = (_command, args) => {
+      configPath = args.at(-1);
+      return child;
+    };
+    const pending = createAiGatewaySidecar({ spawn }).ensure(upstream);
+    const rejection = expect(pending).rejects.toThrow(STARTUP_TIMEOUT_RE);
+
+    await vi.advanceTimersByTimeAsync(10000);
+
+    expect(child.killed).toBe(true);
+    expect(child.signal).toBe('SIGTERM');
+    expect(existsSync(configDir(configPath))).toBe(false);
+    await rejection;
+  });
+
+  it('terminates and cleans a sidecar before waiting for startup during shutdown', async () => {
+    let configPath: string | undefined;
+    const child = new FakeChild();
+    const spawn: SidecarSpawn = (_command, args) => {
+      configPath = args.at(-1);
+      return child;
+    };
+    const sidecar = createAiGatewaySidecar({ spawn });
+    const pending = sidecar.ensure(upstream);
+
+    const rejection = expect(pending).rejects.toThrow(STOPPED_BEFORE_LISTENING_RE);
+    await sidecar.closeAll();
+
+    await rejection;
+    expect(child.killed).toBe(true);
+    expect(child.signal).toBe('SIGTERM');
+    expect(existsSync(configDir(configPath))).toBe(false);
   });
 });

--- a/apps/daemon/src/ai-gateway.ts
+++ b/apps/daemon/src/ai-gateway.ts
@@ -35,13 +35,14 @@ export interface AiGatewaySidecarOptions {
   ensureBinary?: () => Promise<string | undefined>;
 }
 
-interface Sidecar {
-  url: string;
-  child: SidecarChildProcess;
-  dir: string;
+interface SidecarEntry {
+  ready: Promise<string>;
+  start: () => void;
+  close: () => void;
 }
 
 const LISTENING_RE = /listening on (http:\/\/127\.0\.0\.1:\d+)/;
+const STARTUP_TIMEOUT_MS = 10000;
 
 /** Serialize an upstream to the aigateway config.toml (only the fields the sidecar reads). */
 export function upstreamToToml(upstream: TranslatorUpstream): string {
@@ -57,88 +58,122 @@ export function upstreamToToml(upstream: TranslatorUpstream): string {
 
 export function createAiGatewaySidecar(options: AiGatewaySidecarOptions = {}): TranslatorService {
   const { spawn = defaultSpawn, ensureBinary } = options;
-  const running = new Map<string, Promise<Sidecar>>();
+  const running = new Map<string, SidecarEntry>();
 
-  const start = async (upstream: TranslatorUpstream, key: string): Promise<Sidecar> => {
-    // Env override (dev / standalone) wins; otherwise install-on-demand from the managed-asset store.
-    const binary = process.env.LINKCODE_AIGATEWAY_PATH ?? (await ensureBinary?.());
-    if (!binary) {
-      throw new Error(
-        'translation sidecar unavailable: no aigateway binary (set LINKCODE_AIGATEWAY_PATH or install the managed asset)',
-      );
-    }
-    const dir = mkdtempSync(join(tmpdir(), 'linkcode-aigw-'));
-    const configPath = join(dir, 'config.toml');
-    writeFileSync(configPath, upstreamToToml(upstream), { mode: 0o600 });
+  const createEntry = (upstream: TranslatorUpstream, key: string): SidecarEntry => {
+    let child: SidecarChildProcess | undefined;
+    let dir: string | undefined;
+    let timer: NodeJS.Timeout | undefined;
+    let buffer = '';
+    let stderrTail = '';
+    let closed = false;
+    let readySettled = false;
+    let resolveReady!: (url: string) => void;
+    let rejectReady!: (error: Error) => void;
+    const ready = new Promise<string>((resolve, reject) => {
+      resolveReady = resolve;
+      rejectReady = reject;
+    });
 
-    const child = spawn(binary, [
-      'serve',
-      '--host',
-      '127.0.0.1',
-      '--port',
-      '0',
-      '--config',
-      configPath,
-    ]);
+    let entry: SidecarEntry;
+    const cleanup = (error?: Error, terminate = false): void => {
+      if (closed) return;
+      closed = true;
+      if (timer) clearTimeout(timer);
+      if (running.get(key) === entry) running.delete(key);
+      if (terminate) child?.kill('SIGTERM');
+      if (dir) rmSync(dir, { recursive: true, force: true });
+      if (!readySettled) {
+        readySettled = true;
+        rejectReady(error ?? new Error('aigateway stopped before listening'));
+      }
+    };
 
-    return new Promise<Sidecar>((resolve, reject) => {
-      let buffer = '';
-      let settled = false;
-      let stderrTail = '';
-      child.stdout?.on('data', (chunk) => {
-        if (settled) return;
-        buffer += String(chunk);
-        const match = LISTENING_RE.exec(buffer);
-        if (match) {
-          settled = true;
-          resolve({ url: match[1], child, dir });
-        }
-      });
-      child.stderr?.on('data', (chunk) => {
-        stderrTail = String(chunk);
-      });
-      child.on('exit', (code) => {
-        running.delete(key);
-        rmSync(dir, { recursive: true, force: true });
-        if (!settled) {
-          settled = true;
-          reject(
-            new Error(
-              `aigateway exited (code ${code ?? 'signal'}) before listening: ${stderrTail.trim()}`,
-            ),
+    const start = async (): Promise<void> => {
+      try {
+        // Env override (dev / standalone) wins; otherwise install-on-demand from the managed store.
+        const binary = process.env.LINKCODE_AIGATEWAY_PATH ?? (await ensureBinary?.());
+        if (closed) return;
+        if (!binary) {
+          throw new Error(
+            'translation sidecar unavailable: no aigateway binary (set LINKCODE_AIGATEWAY_PATH or install the managed asset)',
           );
         }
-      });
-      child.on('error', (err) => {
-        if (!settled) {
-          settled = true;
-          reject(
+        dir = mkdtempSync(join(tmpdir(), 'linkcode-aigw-'));
+        const configPath = join(dir, 'config.toml');
+        writeFileSync(configPath, upstreamToToml(upstream), { mode: 0o600 });
+        child = spawn(binary, [
+          'serve',
+          '--host',
+          '127.0.0.1',
+          '--port',
+          '0',
+          '--config',
+          configPath,
+        ]);
+        child.stdout?.on('data', (chunk) => {
+          if (readySettled || closed) return;
+          buffer += String(chunk);
+          const match = LISTENING_RE.exec(buffer);
+          if (match) {
+            readySettled = true;
+            if (timer) clearTimeout(timer);
+            resolveReady(match[1]);
+          }
+        });
+        child.stderr?.on('data', (chunk) => {
+          stderrTail = String(chunk);
+        });
+        child.on('exit', (code) => {
+          cleanup(
+            readySettled
+              ? undefined
+              : new Error(
+                  `aigateway exited (code ${code ?? 'signal'}) before listening: ${stderrTail.trim()}`,
+                ),
+          );
+        });
+        child.on('error', (err) => {
+          cleanup(
             new Error(`aigateway failed to start: ${extractErrorMessage(err) ?? 'spawn error'}`),
           );
-        }
-      });
-    });
+        });
+        timer = setTimeout(() => {
+          cleanup(new Error(`aigateway did not become ready within ${STARTUP_TIMEOUT_MS}ms`), true);
+        }, STARTUP_TIMEOUT_MS);
+        timer.unref();
+      } catch (err) {
+        cleanup(
+          new Error(`aigateway failed to start: ${extractErrorMessage(err) ?? 'unknown error'}`),
+        );
+      }
+    };
+
+    entry = {
+      ready,
+      start() {
+        void start();
+      },
+      close: () => cleanup(undefined, true),
+    };
+    return entry;
   };
 
   return {
     ensure(upstream) {
       const key = hashUpstream(upstream);
-      let pending = running.get(key);
-      if (!pending) {
-        pending = start(upstream, key);
-        running.set(key, pending);
-        // A failed start must not stick: drop it so the next session can respawn.
-        pending.catch(() => running.delete(key));
+      let entry = running.get(key);
+      if (!entry) {
+        entry = createEntry(upstream, key);
+        running.set(key, entry);
+        entry.start();
       }
-      return pending.then((sidecar) => sidecar.url);
+      return entry.ready;
     },
     async closeAll() {
-      const pending = [...running.values()];
-      running.clear();
-      const settled = await Promise.allSettled(pending);
-      for (const result of settled) {
-        if (result.status === 'fulfilled') result.value.child.kill('SIGTERM');
-      }
+      const entries = [...running.values()];
+      for (const entry of entries) entry.close();
+      await Promise.allSettled(entries.map((entry) => entry.ready));
     },
   };
 }


### PR DESCRIPTION
## Summary
- track gateway startup synchronously so shutdown can terminate pending children
- clean temporary credential files on spawn errors, exits, timeouts, and shutdown
- bound readiness to 10 seconds and make cleanup idempotent

## Verification
- focused gateway tests: 10/10 pass
- real ENOENT spawn harness leaves no temp directory
- daemon build passes
- `pnpm check:ci` and `pnpm test` pass

Linear: [CODE-151](https://linear.app/arcbox/issue/CODE-151)