### PR TITLE
fix(config): persist provider config atomically

### DIFF
--- a/apps/daemon/AGENTS.md
+++ b/apps/daemon/AGENTS.md
@@ -23,9 +23,10 @@ Runs via `tsx` in dev (`pnpm -F @linkcode/daemon dev`) and a `tsup` bundle in pr
 - **Paths are owned by `src/config.ts`** (`configPath` / `databasePath` / `runtimeFilePath`) — never
   scatter `homedir()` joins elsewhere. `os.homedir()` is read at call time, so a fake `$HOME` fully
   redirects config/db/runtime (this is what isolates an E2E daemon).
-- **`config.json`** (optional, `0600`): the daemon writes back only `providers` via `saveProviders`,
-  re-reading and preserving other fields. `loadConfig` validates providers **field-by-field** — one
-  bad entry is dropped and logged, never blanks the rest. It holds **no secrets** since CODE-371 —
+- **`config.json`** (optional, `0600`): provider and account updates persist together through one
+  fsynced same-directory temporary file and atomic rename, preserving other fields; malformed or
+  unreadable input fails closed. `loadConfig` validates entries **field-by-field** — one bad entry is
+  dropped and logged, never blanks the rest. It holds **no secrets** since CODE-371 —
   `providers[kind].apiKey` and each account's credential secret live in `secrets.json` below, and
   `withAccountSecret` merges them back *before* zod validation, so a secret that is gone fails
   `AccountSchema` and drops through that same per-entry path.

--- a/apps/daemon/AGENTS.md
+++ b/apps/daemon/AGENTS.md
@@ -24,9 +24,10 @@ Runs via `tsx` in dev (`pnpm -F @linkcode/daemon dev`) and a `tsup` bundle in pr
   scatter `homedir()` joins elsewhere. `os.homedir()` is read at call time, so a fake `$HOME` fully
   redirects config/db/runtime (this is what isolates an E2E daemon).
 - **`config.json`** (optional, `0600`): provider and account updates persist together through one
-  fsynced same-directory temporary file and atomic rename, preserving other fields; malformed or
-  unreadable input fails closed. `loadConfig` validates entries **field-by-field** — one bad entry is
-  dropped and logged, never blanks the rest. It holds **no secrets** since CODE-371 —
+  fsynced same-directory temporary file, atomic rename, and POSIX parent-directory fsync, preserving
+  other fields; malformed or unreadable input fails closed. `loadConfig` validates entries
+  **field-by-field** — one bad entry is dropped and logged, never blanks the rest. It holds **no
+  secrets** since CODE-371 —
   `providers[kind].apiKey` and each account's credential secret live in `secrets.json` below, and
   `withAccountSecret` merges them back *before* zod validation, so a secret that is gone fails
   `AccountSchema` and drops through that same per-entry path.

--- a/apps/daemon/src/__tests__/config-persistence.test.ts
+++ b/apps/daemon/src/__tests__/config-persistence.test.ts
@@ -15,14 +15,36 @@ import { createProviderConfigStore } from '../provider-store';
 import { createInMemoryVault } from './fixtures/in-memory-vault';
 
 const fsMocks = vi.hoisted(() => ({
+  openTargets: new Map<number, string>(),
   renameTarget: null as string | null,
   renameTargets: [] as string[],
+  syncTargets: [] as string[],
 }));
 
 vi.mock('node:fs', async (importOriginal) => {
   const actual = await importOriginal<typeof import('node:fs')>();
   return {
     ...actual,
+    closeSync(descriptor: number) {
+      try {
+        actual.closeSync(descriptor);
+      } finally {
+        fsMocks.openTargets.delete(descriptor);
+      }
+    },
+    fsyncSync(descriptor: number) {
+      fsMocks.syncTargets.push(fsMocks.openTargets.get(descriptor) ?? '');
+      actual.fsyncSync(descriptor);
+    },
+    openSync(
+      path: Parameters<typeof actual.openSync>[0],
+      flags: Parameters<typeof actual.openSync>[1],
+      mode?: Parameters<typeof actual.openSync>[2],
+    ) {
+      const descriptor = actual.openSync(path, flags, mode);
+      fsMocks.openTargets.set(descriptor, String(path));
+      return descriptor;
+    },
     renameSync(
       oldPath: Parameters<typeof actual.renameSync>[0],
       newPath: Parameters<typeof actual.renameSync>[1],
@@ -55,6 +77,8 @@ afterEach(() => {
   delete process.env.LINKCODE_CHANNEL;
   fsMocks.renameTarget = null;
   fsMocks.renameTargets = [];
+  fsMocks.openTargets.clear();
+  fsMocks.syncTargets = [];
   vi.restoreAllMocks();
 });
 
@@ -91,6 +115,9 @@ describe('provider config persistence', () => {
     expect(store.getAccounts()).toEqual([oauthAccount]);
     expect(statSync(config).mode & 0o777).toBe(0o600);
     expect(fsMocks.renameTargets).toEqual([config]);
+    expect(fsMocks.syncTargets[0]).toContain(join(dir, '.config.'));
+    expect(fsMocks.syncTargets[0]?.endsWith('.tmp')).toBe(true);
+    expect(fsMocks.syncTargets.slice(1)).toEqual(process.platform === 'win32' ? [] : [dir]);
   });
 
   it('rejects corrupt JSON without replacing the file or publishing memory', () => {

--- a/apps/daemon/src/__tests__/config-persistence.test.ts
+++ b/apps/daemon/src/__tests__/config-persistence.test.ts
@@ -1,0 +1,135 @@
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { Account } from '@linkcode/schema';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createProviderConfigStore } from '../provider-store';
+import { createInMemoryVault } from './fixtures/in-memory-vault';
+
+const fsMocks = vi.hoisted(() => ({
+  renameTarget: null as string | null,
+  renameTargets: [] as string[],
+}));
+
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>();
+  return {
+    ...actual,
+    renameSync(
+      oldPath: Parameters<typeof actual.renameSync>[0],
+      newPath: Parameters<typeof actual.renameSync>[1],
+    ) {
+      const target = String(newPath);
+      fsMocks.renameTargets.push(target);
+      if (target === fsMocks.renameTarget) throw new Error('simulated rename failure');
+      actual.renameSync(oldPath, newPath);
+    },
+  };
+});
+
+const oauthAccount: Account = {
+  id: 'acc_oauth',
+  label: 'Subscription',
+  credential: { type: 'oauth', agent: 'claude-code' },
+  createdAt: 0,
+};
+
+let savedHome: string | undefined;
+
+beforeEach(() => {
+  savedHome = process.env.HOME;
+  process.env.HOME = mkdtempSync(join(tmpdir(), 'linkcode-config-persistence-'));
+  process.env.LINKCODE_CHANNEL = 'release';
+});
+
+afterEach(() => {
+  process.env.HOME = savedHome;
+  delete process.env.LINKCODE_CHANNEL;
+  fsMocks.renameTarget = null;
+  fsMocks.renameTargets = [];
+  vi.restoreAllMocks();
+});
+
+function paths(): { dir: string; config: string } {
+  const dir = join(process.env.HOME ?? '', '.linkcode');
+  return { dir, config: join(dir, 'config.json') };
+}
+
+function readConfig(): Record<string, unknown> {
+  return JSON.parse(readFileSync(paths().config, 'utf8')) as Record<string, unknown>;
+}
+
+describe('provider config persistence', () => {
+  it('atomically replaces providers and accounts, preserves other fields, and tightens the mode', () => {
+    const { dir, config } = paths();
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(config, JSON.stringify({ hostname: '127.0.0.2' }));
+    chmodSync(config, 0o644);
+    const store = createProviderConfigStore(createInMemoryVault(), {}, []);
+
+    store.update({
+      providers: { codex: { enabled: true, activeAccountId: oauthAccount.id } },
+      accounts: [oauthAccount],
+    });
+
+    expect(readConfig()).toEqual({
+      hostname: '127.0.0.2',
+      providers: { codex: { enabled: true, activeAccountId: oauthAccount.id } },
+      accounts: [oauthAccount],
+    });
+    expect(store.get()).toEqual({
+      codex: { enabled: true, activeAccountId: oauthAccount.id },
+    });
+    expect(store.getAccounts()).toEqual([oauthAccount]);
+    expect(statSync(config).mode & 0o777).toBe(0o600);
+    expect(fsMocks.renameTargets).toEqual([config]);
+  });
+
+  it('rejects corrupt JSON without replacing the file or publishing memory', () => {
+    const { dir, config } = paths();
+    mkdirSync(dir, { recursive: true });
+    const corrupt = '{ definitely not JSON';
+    writeFileSync(config, corrupt);
+    const store = createProviderConfigStore(createInMemoryVault(), {}, []);
+
+    expect(() =>
+      store.update({
+        providers: { codex: { enabled: true } },
+        accounts: [oauthAccount],
+      }),
+    ).toThrow(`Invalid JSON in daemon config at ${config}`);
+
+    expect(readFileSync(config, 'utf8')).toBe(corrupt);
+    expect(store.get()).toEqual({});
+    expect(store.getAccounts()).toEqual([]);
+  });
+
+  it('leaves the previous file and memory unchanged when rename fails', () => {
+    const { dir, config } = paths();
+    mkdirSync(dir, { recursive: true });
+    const previous = `${JSON.stringify({ providers: {}, accounts: [] }, null, 2)}\n`;
+    writeFileSync(config, previous);
+    const store = createProviderConfigStore(createInMemoryVault(), {}, []);
+    fsMocks.renameTarget = config;
+
+    expect(() =>
+      store.update({
+        providers: { codex: { enabled: true } },
+        accounts: [oauthAccount],
+      }),
+    ).toThrow('simulated rename failure');
+
+    expect(readFileSync(config, 'utf8')).toBe(previous);
+    expect(store.get()).toEqual({});
+    expect(store.getAccounts()).toEqual([]);
+    expect(readdirSync(dir).filter((entry) => entry.endsWith('.tmp'))).toEqual([]);
+  });
+});

--- a/apps/daemon/src/__tests__/config.test.ts
+++ b/apps/daemon/src/__tests__/config.test.ts
@@ -12,7 +12,7 @@ import {
   databasePath,
   loadConfig,
   runtimeFilePath,
-  saveAccounts,
+  saveProviderConfiguration,
 } from '../config';
 import { logger } from '../logger';
 import { daemonChannel, telemetryConfigCachePath } from '../paths';
@@ -296,7 +296,7 @@ describe('credential storage', () => {
   });
 
   it('round-trips an account through the vault without ever writing the secret', () => {
-    saveAccounts(vault, [validAccount]);
+    saveProviderConfiguration(vault, {}, [validAccount]);
 
     const stored = readConfigFile().accounts as Array<Record<string, unknown>>;
     expect(stored[0].credential).toEqual({ type: 'api-key' });
@@ -305,8 +305,8 @@ describe('credential storage', () => {
   });
 
   it('drops the stored secret when its account is removed', () => {
-    saveAccounts(vault, [validAccount]);
-    saveAccounts(vault, []);
+    saveProviderConfiguration(vault, {}, [validAccount]);
+    saveProviderConfiguration(vault, {}, []);
 
     // Otherwise a deleted account leaves a live credential behind in the OS keyring forever.
     expect(vault.refs.get('account:acc_1')).toBeUndefined();
@@ -319,7 +319,7 @@ describe('credential storage', () => {
       credential: { type: 'oauth', agent: 'claude-code' },
       createdAt: 0,
     };
-    saveAccounts(vault, [oauth]);
+    saveProviderConfiguration(vault, {}, [oauth]);
 
     const stored = readConfigFile().accounts as Array<Record<string, unknown>>;
     expect(stored[0].credential).toEqual({ type: 'oauth', agent: 'claude-code' });

--- a/apps/daemon/src/config.ts
+++ b/apps/daemon/src/config.ts
@@ -1,4 +1,15 @@
-import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { randomUUID } from 'node:crypto';
+import {
+  chmodSync,
+  closeSync,
+  fsyncSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
 import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { daemonRuntimeFilePath } from '@linkcode/common/node';
@@ -12,6 +23,7 @@ import {
 } from '@linkcode/schema';
 import { workspacesDirName } from '@linkcode/schema/product';
 import type { TransportServerOptions } from '@linkcode/transport/server';
+import { extractErrorMessage, isErrorLikeObject } from 'foxts/extract-error-message';
 import { logger } from './logger';
 import { daemonChannel, daemonProfile, daemonStateDir } from './paths';
 import type { SecretStore, SecretVault } from './secrets';
@@ -110,12 +122,7 @@ const providerSecrets = (vault: SecretVault): SecretStore => vault.namespace('pr
 const accountSecrets = (vault: SecretVault): SecretStore => vault.namespace('account');
 
 export function loadConfig(vault: SecretVault): DaemonConfig {
-  let file: ConfigFile = {};
-  try {
-    file = JSON.parse(readFileSync(configPath(), 'utf8')) as ConfigFile;
-  } catch {
-    // No config file (or unreadable) — fall back to defaults.
-  }
+  const file = readConfigFile();
   const fallbackListener = createDefaultSocketIoListener(file);
   const configuredListeners = Array.isArray(file.listeners)
     ? file.listeners.flatMap((value) => {
@@ -135,8 +142,7 @@ export function loadConfig(vault: SecretVault): DaemonConfig {
       { operation: 'config.load' },
       'Moving credentials out of config.json into the secret vault',
     );
-    saveProviders(vault, parsedProviders.value);
-    saveAccounts(vault, parsedAccounts.value);
+    saveProviderConfiguration(vault, parsedProviders.value, parsedAccounts.value);
   }
 
   return {
@@ -172,12 +178,12 @@ function parseSimulatorConsent(raw: unknown): SimulatorConsentState {
 
 /** Persist simulator agent-consent to config.json, preserving its other fields; `0600`. */
 export function saveSimulatorConsent(state: SimulatorConsentState): void {
-  writeConfigField('simulatorConsent', state);
+  writeConfigFields(readConfigFile(), { simulatorConsent: state });
 }
 
 /**
  * Parse element by element: an invalid account is dropped and logged, never blanking the pool —
- * `saveAccounts` would persist that loss on the next write. Mirrors {@link parseProviders}.
+ * a later save would persist that loss. Mirrors {@link parseProviders}.
  */
 function parseAccounts(store: SecretStore, raw: unknown): Parsed<Accounts> {
   if (raw === undefined) return { value: [], migrated: false };
@@ -204,7 +210,7 @@ function parseAccounts(store: SecretStore, raw: unknown): Parsed<Accounts> {
 
 /**
  * Parse field by field: an invalid entry is dropped and logged, never blanking the other entries —
- * `saveProviders` would persist that loss on the next write.
+ * a later save would persist that loss.
  */
 function parseProviders(store: SecretStore, raw: unknown): Parsed<ProvidersConfig> {
   if (raw === undefined) return { value: {}, migrated: false };
@@ -235,32 +241,72 @@ function parseProviders(store: SecretStore, raw: unknown): Parsed<ProvidersConfi
   return { value: providers, migrated };
 }
 
-/** Persist providers to config.json, preserving its other fields; api keys go to the vault instead. */
-export function saveProviders(vault: SecretVault, providers: ProvidersConfig): void {
-  writeConfigField('providers', detachProviderSecrets(providerSecrets(vault), providers));
+/** Persist providers and accounts in one config.json replacement; their secrets go to the vault. */
+export function saveProviderConfiguration(
+  vault: SecretVault,
+  providers: ProvidersConfig,
+  accounts: Accounts,
+): void {
+  const file = readConfigFile();
+  writeConfigFields(file, {
+    providers: detachProviderSecrets(providerSecrets(vault), providers),
+    accounts: detachAccountSecrets(accountSecrets(vault), accounts),
+  });
 }
 
-/** Persist the account pool to config.json; credential secrets go to the vault instead. */
-export function saveAccounts(vault: SecretVault, accounts: Accounts): void {
-  writeConfigField('accounts', detachAccountSecrets(accountSecrets(vault), accounts));
+function readConfigFile(): ConfigFile & Record<string, unknown> {
+  const path = configPath();
+  let contents: string;
+  try {
+    contents = readFileSync(path, 'utf8');
+  } catch (err) {
+    if (isErrorLikeObject(err) && (err as NodeJS.ErrnoException).code === 'ENOENT') return {};
+    throw new Error(`Could not read daemon config at ${path}: ${extractErrorMessage(err)}`, {
+      cause: err,
+    });
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(contents);
+  } catch (err) {
+    throw new SyntaxError(`Invalid JSON in daemon config at ${path}: ${extractErrorMessage(err)}`, {
+      cause: err,
+    });
+  }
+
+  if (!isRecord(parsed)) {
+    throw new TypeError(`Invalid daemon config at ${path}: expected a JSON object`);
+  }
+  return parsed;
 }
 
-/** Read-modify-write a single top-level field of config.json, preserving the rest; `0600`. */
-function writeConfigField(
-  key: 'providers' | 'accounts' | 'simulatorConsent',
-  value: unknown,
+function writeConfigFields(
+  file: Record<string, unknown>,
+  fields: Partial<Record<keyof ConfigFile, unknown>>,
 ): void {
   const path = configPath();
-  let file: Record<string, unknown> = {};
+  Object.assign(file, fields);
+  const directory = dirname(path);
+  mkdirSync(directory, { recursive: true });
+  const temporaryPath = join(directory, `.config.${process.pid}.${randomUUID()}.tmp`);
   try {
-    const parsed: unknown = JSON.parse(readFileSync(path, 'utf8'));
-    if (isRecord(parsed)) file = parsed;
-  } catch {
-    // Start from an empty document if the file is missing or malformed.
+    writeFileSync(temporaryPath, `${JSON.stringify(file, null, 2)}\n`, {
+      encoding: 'utf8',
+      flag: 'wx',
+      mode: 0o600,
+    });
+    const descriptor = openSync(temporaryPath, 'r');
+    try {
+      fsyncSync(descriptor);
+    } finally {
+      closeSync(descriptor);
+    }
+    chmodSync(temporaryPath, 0o600);
+    renameSync(temporaryPath, path);
+  } finally {
+    rmSync(temporaryPath, { force: true });
   }
-  file[key] = value;
-  mkdirSync(dirname(path), { recursive: true });
-  writeFileSync(path, `${JSON.stringify(file, null, 2)}\n`, { mode: 0o600 });
 }
 
 function createDefaultSocketIoListener(file: ConfigFile): DaemonListenerConfig {

--- a/apps/daemon/src/config.ts
+++ b/apps/daemon/src/config.ts
@@ -281,6 +281,15 @@ function readConfigFile(): ConfigFile & Record<string, unknown> {
   return parsed;
 }
 
+function fsyncPath(path: string): void {
+  const descriptor = openSync(path, 'r');
+  try {
+    fsyncSync(descriptor);
+  } finally {
+    closeSync(descriptor);
+  }
+}
+
 function writeConfigFields(
   file: Record<string, unknown>,
   fields: Partial<Record<keyof ConfigFile, unknown>>,
@@ -296,14 +305,10 @@ function writeConfigFields(
       flag: 'wx',
       mode: 0o600,
     });
-    const descriptor = openSync(temporaryPath, 'r');
-    try {
-      fsyncSync(descriptor);
-    } finally {
-      closeSync(descriptor);
-    }
     chmodSync(temporaryPath, 0o600);
+    fsyncPath(temporaryPath);
     renameSync(temporaryPath, path);
+    if (process.platform !== 'win32') fsyncPath(directory);
   } finally {
     rmSync(temporaryPath, { force: true });
   }

--- a/apps/daemon/src/provider-store.ts
+++ b/apps/daemon/src/provider-store.ts
@@ -1,6 +1,6 @@
 import type { ProviderConfigStore } from '@linkcode/engine';
 import type { Accounts, ProvidersConfig } from '@linkcode/schema';
-import { saveAccounts, saveProviders } from './config';
+import { saveProviderConfiguration } from './config';
 import type { SecretVault } from './secrets';
 
 /**
@@ -17,14 +17,13 @@ export function createProviderConfigStore(
   let accounts = initialAccounts;
   return {
     get: () => providers,
-    set(next) {
-      providers = next;
-      saveProviders(vault, next);
-    },
     getAccounts: () => accounts,
-    setAccounts(next) {
-      accounts = next;
-      saveAccounts(vault, next);
+    update(next) {
+      const nextProviders = next.providers ?? providers;
+      const nextAccounts = next.accounts ?? accounts;
+      saveProviderConfiguration(vault, nextProviders, nextAccounts);
+      providers = nextProviders;
+      accounts = nextAccounts;
     },
   };
 }

--- a/packages/host/engine/src/__tests__/engine-agent-catalog.test.ts
+++ b/packages/host/engine/src/__tests__/engine-agent-catalog.test.ts
@@ -35,10 +35,12 @@ describe('engine agent catalog', () => {
       model: 'provider/model',
       createdAt: 0,
     };
-    providers.set({
-      'claude-code': { enabled: true, activeAccountId: account.id },
+    providers.update({
+      providers: {
+        'claude-code': { enabled: true, activeAccountId: account.id },
+      },
+      accounts: [account],
     });
-    providers.setAccounts([account]);
     const h = createSessionHarness(
       undefined,
       () => adapter,

--- a/packages/host/engine/src/agent/provider-config.ts
+++ b/packages/host/engine/src/agent/provider-config.ts
@@ -13,10 +13,9 @@ import type {
  */
 export interface ProviderConfigStore {
   get(): ProvidersConfig;
-  set(next: ProvidersConfig): void | Promise<void>;
   /** The global account pool bound by `providers[kind].activeAccountId`. */
   getAccounts(): Accounts;
-  setAccounts(next: Accounts): void | Promise<void>;
+  update(next: { providers?: ProvidersConfig; accounts?: Accounts }): void | Promise<void>;
 }
 
 export class InMemoryProviderConfigStore implements ProviderConfigStore {
@@ -27,16 +26,13 @@ export class InMemoryProviderConfigStore implements ProviderConfigStore {
     return this.providers;
   }
 
-  set(next: ProvidersConfig): void {
-    this.providers = next;
-  }
-
   getAccounts(): Accounts {
     return this.accounts;
   }
 
-  setAccounts(next: Accounts): void {
-    this.accounts = next;
+  update(next: { providers?: ProvidersConfig; accounts?: Accounts }): void {
+    if (next.providers !== undefined) this.providers = next.providers;
+    if (next.accounts !== undefined) this.accounts = next.accounts;
   }
 }
 

--- a/packages/host/engine/src/agent/request-handler.ts
+++ b/packages/host/engine/src/agent/request-handler.ts
@@ -109,15 +109,11 @@ export class AgentRequestHandler {
         const accounts = payload.accounts;
         return this.responder.reply(
           payload.clientReqId,
-          Effect.andThen(
-            providers === undefined
-              ? Effect.void
-              : updateProviderConfig('config.set-providers', () => this.providers.set(providers)),
-            accounts === undefined
-              ? Effect.void
-              : updateProviderConfig('config.set-accounts', () =>
-                  this.providers.setAccounts(accounts),
-                ),
+          updateProviderConfig('config.set', () =>
+            this.providers.update({
+              ...(providers !== undefined && { providers }),
+              ...(accounts !== undefined && { accounts }),
+            }),
           ).pipe(
             Effect.andThen(Effect.sync(() => this.responder.sendSuccess(payload.clientReqId))),
           ),


### PR DESCRIPTION
## Summary
- persist providers and accounts through one complete `config.json` replacement
- chmod to `0600`, fsync the replacement, rename it atomically, then fsync the parent directory on POSIX
- reject corrupt or unreadable input and publish memory only after persistence succeeds
- collapse `config.set` to one store update

## Verification
- regression tests fail on the previous implementation and pass after the fix
- focused tests: 31/31 pass; persistence review regression: 3/3 pass
- `pnpm check:ci` passes
- `pnpm test`: 2,271 passed, 5 skipped
- follow-up GitHub Actions run 30696757720: all jobs pass

Scope: this PR implements CODE-149's original single-`config.json` acceptance. Cross-file `secrets.json` / cloud / device crash transactions are intentionally not included without an explicit scope decision.

Linear: [CODE-149](https://linear.app/arcbox/issue/CODE-149)