### PR TITLE
fix(desktop): offer the install when an update is already downloaded

### DIFF
--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -78,6 +78,9 @@ extraResources:
 publish:
   provider: generic
   url: https://releases.linkcode.ai/desktop
+  # electron-updater's DifferentialDownloader wires its progress callback only on the sequential
+  # range path, so leaving this at its default true means a differential update reports no progress.
+  useMultipleRangeRequest: false
 
 # Per-arch artifacts on every platform (half the download of a universal binary). The explicit
 # ${arch} suffix is load-bearing: electron-updater picks the feed entry whose filename contains

--- a/apps/desktop/src/renderer/src/settings/__tests__/about-tab.test.tsx
+++ b/apps/desktop/src/renderer/src/settings/__tests__/about-tab.test.tsx
@@ -1,24 +1,28 @@
 // @vitest-environment jsdom
 
-import { cleanup, render, screen } from '@testing-library/react';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { UpdaterState } from '@linkcode/ipc';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { AboutTab } from '../about-tab';
+
+const mocks = vi.hoisted(() => ({
+  useUpdaterState: vi.fn(),
+  checkForUpdates: vi.fn(),
+  installUpdate: vi.fn(),
+}));
 
 vi.mock('../../ipc', () => ({
   systemBridge: {
     app: {
-      checkForUpdates: vi.fn(),
+      checkForUpdates: mocks.checkForUpdates,
+      installUpdate: mocks.installUpdate,
       version: vi.fn(() => Promise.resolve('0.15.0')),
     },
   },
 }));
 
 vi.mock('../../updater', () => ({
-  useUpdaterState: () => ({
-    status: 'downloading',
-    version: '0.16.0',
-    progress: 42.4,
-  }),
+  useUpdaterState: mocks.useUpdaterState,
 }));
 
 vi.mock('use-intl', () => ({
@@ -26,13 +30,24 @@ vi.mock('use-intl', () => ({
     const messages: Record<string, string> = {
       version: 'Version',
       checkForUpdates: 'Check for updates',
+      restartToInstall: 'Restart to update',
       'status.downloading': 'Downloading update…',
+      'status.downloaded': 'Update ready — restart to install.',
     };
     return (key: string) => messages[key] ?? key;
   },
 }));
 
 describe('AboutTab', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.useUpdaterState.mockReturnValue({
+      status: 'downloading',
+      version: '0.16.0',
+      progress: 42.4,
+    } satisfies UpdaterState);
+  });
+
   afterEach(cleanup);
 
   it('shows accessible update download progress', async () => {
@@ -42,5 +57,21 @@ describe('AboutTab', () => {
     const progress = screen.getByRole('progressbar', { name: 'Downloading update…' });
     expect(progress.getAttribute('aria-valuenow')).toBe('42');
     expect(screen.getByText('42%')).toBeTruthy();
+  });
+
+  // Main refuses a re-check while an update sits downloaded, so the check button must not be offered.
+  it('offers the install instead of a check once the update is downloaded', () => {
+    mocks.useUpdaterState.mockReturnValue({
+      status: 'downloaded',
+      version: '0.16.0',
+      progress: null,
+    } satisfies UpdaterState);
+    render(<AboutTab />);
+
+    expect(screen.queryByRole('button', { name: 'Check for updates' })).toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Restart to update' }));
+    expect(mocks.installUpdate).toHaveBeenCalledOnce();
+    expect(mocks.checkForUpdates).not.toHaveBeenCalled();
   });
 });

--- a/apps/desktop/src/renderer/src/settings/about-tab.tsx
+++ b/apps/desktop/src/renderer/src/settings/about-tab.tsx
@@ -41,15 +41,27 @@ export function AboutTab(): React.ReactNode {
       </Field>
       <div className="flex flex-col gap-2">
         <div className="flex items-center gap-3">
-          <Button
-            size="sm"
-            variant="outline"
-            onClick={() => {
-              void systemBridge.app.checkForUpdates();
-            }}
-          >
-            {t('checkForUpdates')}
-          </Button>
+          {/* Main refuses a re-check once an update is downloaded, so offer the install instead of a dead button. */}
+          {status === 'downloaded' ? (
+            <Button
+              size="sm"
+              onClick={() => {
+                void systemBridge.app.installUpdate();
+              }}
+            >
+              {t('restartToInstall')}
+            </Button>
+          ) : (
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => {
+                void systemBridge.app.checkForUpdates();
+              }}
+            >
+              {t('checkForUpdates')}
+            </Button>
+          )}
           {statusKey && progressPercent === null ? (
             <span className="text-muted-foreground text-xs">{t(statusKey)}</span>
           ) : null}

--- a/packages/presentation/i18n/src/locales/en.ts
+++ b/packages/presentation/i18n/src/locales/en.ts
@@ -921,6 +921,7 @@ export const en = {
     about: {
       version: 'Version',
       checkForUpdates: 'Check for updates',
+      restartToInstall: 'Restart to update',
       status: {
         checking: 'Checking for updates…',
         available: 'Update available — downloading…',

--- a/packages/presentation/i18n/src/locales/zh-cn.ts
+++ b/packages/presentation/i18n/src/locales/zh-cn.ts
@@ -899,6 +899,7 @@ export const zhCN = {
     about: {
       version: '版本',
       checkForUpdates: '检查更新',
+      restartToInstall: '重启更新',
       status: {
         checking: '正在检查更新…',
         available: '发现更新，正在下载…',


### PR DESCRIPTION
Closes CODE-529.

## Why

`checkForUpdates()` in `apps/desktop/src/main/updater.ts` returns early — silently — once `updaterState.status === 'downloaded'`. No state is emitted, nothing is logged, and the About tab keeps showing the same label, so the button reads as broken for the rest of the session.

Traced from a real report. The user's click produced no `Checking for update` line in `main.log`; every other branch of `checkForUpdates()` either calls `autoUpdater.checkForUpdates()` (which always logs) or `emitState()` (which always moves the UI), so the silent guard is the only path that can produce zero output. The rest of the chain is fine — click → IPC → main → feed → state push was driven end to end over CDP against the shipped 0.17.0 build.

The guard itself is right: re-checking would clobber the downloaded state and take the sidebar install prompt with it. What was missing is an affordance in About.

## What

- About tab renders a restart-to-install button (wired to the existing `installUpdate()`) instead of the check button while an update sits downloaded.
- `useMultipleRangeRequest: false` on the publish block. electron-updater's `DifferentialDownloader` installs its progress callback only on the sequential range path, so with the default `true` a differential update emits no `download-progress` at all and the progress bar added in #362 never appeared on a real update — status jumped straight from `available` to `downloaded`. Confirmed against the 0.15.0 → 0.17.0 update, which took the blockmap path.

## Verification

- `pnpm check:ci` and `pnpm test` pass.
- New DOM test covers the downloaded branch: the check button is gone and the install button calls `installUpdate()`.
- Drove the real dev shell over CDP: Settings → About renders, clicking check still moves the label to "You are up to date."
- The progress percentage itself needs a published release to observe end to end.