### PR TITLE
fix(webview): restore conversation virtualization

### DIFF
--- a/apps/webview/e2e/browser-smoke.e2e.mts
+++ b/apps/webview/e2e/browser-smoke.e2e.mts
@@ -16,6 +16,7 @@ const webviewDir = fileURLToPath(new URL('..', import.meta.url));
 const daemonDir = fileURLToPath(new URL('../../daemon', import.meta.url));
 const viteCli = fileURLToPath(new URL('../../bin/vite.js', import.meta.resolve('vite')));
 const mockThreadTitle = 'Wire the workbench to the daemon';
+const longThreadTitle = 'Long thread · navigation testbed';
 
 interface ViteServer {
   child: ChildProcess;
@@ -61,6 +62,34 @@ async function sendPrompt(page: Page, prompt: string, appErrors: string[]): Prom
   await page.getByRole('button', { name: 'Send' }).click();
   await page.getByText(`You said: ${prompt}`, { exact: false }).waitFor({ timeout: 15000 });
   assertNoApplicationErrors(appErrors);
+}
+
+async function verifyLongThreadVirtualization(page: Page): Promise<void> {
+  await page.locator('[data-thread-title]', { hasText: longThreadTitle }).click();
+  await page.locator('[data-conversation-title]', { hasText: longThreadTitle }).waitFor();
+  await page.waitForFunction(() => {
+    const scroll = document.querySelector('[role="log"]')?.firstElementChild;
+    const virtualizer = scroll?.firstElementChild?.firstElementChild;
+    return (
+      scroll instanceof HTMLElement &&
+      scroll.scrollHeight > scroll.clientHeight &&
+      (virtualizer?.childElementCount ?? Number.POSITIVE_INFINITY) < 10
+    );
+  });
+
+  const metrics = await page.getByRole('log').evaluate((root) => {
+    const scroll = root.firstElementChild as HTMLElement;
+    const virtualizer = scroll.firstElementChild?.firstElementChild;
+    return {
+      bottomDifference: scroll.scrollHeight - scroll.clientHeight - scroll.scrollTop,
+      mountedRows: virtualizer?.childElementCount,
+    };
+  });
+  assert.ok(
+    metrics.bottomDifference <= 2,
+    `Long thread opened ${metrics.bottomDifference}px above bottom`,
+  );
+  assert.ok((metrics.mountedRows ?? 0) < 10, `Long thread mounted ${metrics.mountedRows} rows`);
 }
 
 async function main(): Promise<void> {
@@ -159,6 +188,7 @@ async function verifyMockEntry(browser: Browser): Promise<void> {
     await selectMockThread(page);
     const recoveryPrompt = `${firstPrompt}-after-reload`;
     await sendPrompt(page, recoveryPrompt, appErrors);
+    await verifyLongThreadVirtualization(page);
     assertNoApplicationErrors(appErrors);
     await page.close();
 

--- a/apps/webview/src/shell/web-workbench-shell.tsx
+++ b/apps/webview/src/shell/web-workbench-shell.tsx
@@ -55,7 +55,7 @@ export function WebWorkbenchShell({
 
   return (
     <div className="grid h-full min-h-0 grid-cols-[minmax(0,1fr)_auto] overflow-hidden bg-background">
-      <div className="h-full min-w-0">
+      <div className="h-full min-h-0 min-w-0">
         <ShellFrame
           {...props}
           showPlanInPromptDock={!resourcesSurfaceOpen}

--- a/packages/presentation/ui/src/chat/conversation.tsx
+++ b/packages/presentation/ui/src/chat/conversation.tsx
@@ -67,7 +67,13 @@ export function ConversationContent<T>({
       // The browser's own scroll anchoring fights both scroll owners.
       scrollClassName="[overflow-anchor:none]"
     >
-      <Virtualizer data={data} onScroll={onScroll} ref={virtualizerRef} scrollRef={scrollRef}>
+      <Virtualizer
+        data={data}
+        itemSize={300}
+        onScroll={onScroll}
+        ref={virtualizerRef}
+        scrollRef={scrollRef}
+      >
         {children}
       </Virtualizer>
       {trailing}


### PR DESCRIPTION
## Summary

- constrain the Web workbench grid child so the conversation keeps a real scroll viewport
- give `virtua` a 300px initial turn-size hint to avoid an expensive first measurement
- add a bundled browser regression check for a scrollable, bottom-pinned, virtualized long thread

## Root cause

The direct grid child in `WebWorkbenchShell` lacked `min-h-0`. Its automatic minimum size expanded to the transcript's min-content height, so `virtua` saw the entire 48-turn thread as visible and mounted every row during a thread switch. The earlier scroll-to-bottom change was not the cause.

With the constrained height chain restored, the 48-turn mock mounts 4 rows instead of 48. The initial virtualizer layout callback dropped from roughly 150–170ms to 37ms; five short/long round trips painted in 11–16ms with no long tasks.

## Validation

- `pnpm -F @linkcode/webview e2e:browser`
- `pnpm check:ci`
- `pnpm test` — 302 files and 2435 tests passed

Linear: CODE-259