### PR TITLE
feat(mobile): add remote push notifications

### DIFF
--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -10,6 +10,7 @@ import {
   AppKeyboardProvider,
   AppThemeProvider,
 } from '@mobile/components/shell/app-providers';
+import { NotificationObserver } from '@mobile/components/shell/notification-observer';
 import { MobileProductAnalyticsProvider } from '@mobile/components/shell/product-analytics-provider';
 import { RootNavigator } from '@mobile/components/shell/root-navigator';
 import { ThemeController } from '@mobile/components/shell/theme-controller';
@@ -84,6 +85,7 @@ function RootLayout() {
         ]}
       >
         <ThemeController />
+        <NotificationObserver />
         <RootNavigator />
       </ComposeContextProvider>
     </GestureHandlerRootView>

--- a/apps/mobile/src/app/account.tsx
+++ b/apps/mobile/src/app/account.tsx
@@ -3,6 +3,7 @@ import { DevicesSection } from '@mobile/components/account/devices-section';
 import { ProfileRow } from '@mobile/components/account/profile-row';
 import { signOutOfCloud, useCloudAccount } from '@mobile/runtime/cloud/account';
 import { Redirect, Stack } from 'expo-router';
+import { Alert } from 'react-native';
 import { useTranslations } from 'use-intl';
 
 /** Account screen: profile, the account's device registry, and sign-out. */
@@ -30,9 +31,7 @@ export default function AccountScreen(): React.ReactNode {
                 <Button
                   role="destructive"
                   label={t('signOut')}
-                  onPress={() => {
-                    void signOutOfCloud();
-                  }}
+                  onPress={() => signOutOfCloud().catch(() => Alert.alert(t('signOutError')))}
                 />
               </Section>
             </>

--- a/apps/mobile/src/components/account/devices-section.tsx
+++ b/apps/mobile/src/components/account/devices-section.tsx
@@ -12,12 +12,7 @@ import { badge, buttonStyle, disabled, foregroundStyle } from '@expo/ui/swift-ui
 import { FOOTNOTE, SECONDARY } from '@mobile/components/form/styles';
 import { signOutOfCloud } from '@mobile/runtime/cloud/account';
 import type { CloudDevice } from '@mobile/runtime/cloud/devices';
-import {
-  clearDeviceEnrollment,
-  fetchDevices,
-  getEnrolledDeviceId,
-  revokeDevice,
-} from '@mobile/runtime/cloud/devices';
+import { fetchDevices, getEnrolledDeviceId, revokeDevice } from '@mobile/runtime/cloud/devices';
 import { formatRelativeShort } from '@mobile/utils/relative-time';
 import { noop } from 'foxact/noop';
 import { useCallback, useEffect, useState } from 'react';
@@ -58,10 +53,8 @@ export function DevicesSection(): React.ReactNode {
     try {
       await revokeDevice(device.id);
       if (device.id === enrolledId) {
-        // The cloud already killed this phone's sessions along with the device; the
-        // sign-out is local cookie/enrollment cleanup against a dead session.
-        await clearDeviceEnrollment().catch(noop);
-        await signOutOfCloud().catch(noop);
+        // The device revoke already removed its push token and killed this phone's sessions.
+        await signOutOfCloud({ revokePushToken: false }).catch(noop);
         return;
       }
       refresh();

--- a/apps/mobile/src/components/settings/settings-screen.tsx
+++ b/apps/mobile/src/components/settings/settings-screen.tsx
@@ -1,15 +1,19 @@
 import { Form, Host, Link, Picker, Section, Text, Toggle, VStack } from '@expo/ui/swift-ui';
-import { font, foregroundStyle, pickerStyle, tag } from '@expo/ui/swift-ui/modifiers';
+import { disabled, font, foregroundStyle, pickerStyle, tag } from '@expo/ui/swift-ui/modifiers';
 import { AgentKindSchema, WIRE_PROTOCOL_VERSION } from '@linkcode/schema';
 import { NavigationRow } from '@mobile/components/form/navigation-row';
 import { useHostMenuItems } from '@mobile/components/host/use-host-menu-items';
 import { useCloudAccount } from '@mobile/runtime/cloud/account';
+import {
+  disableDeviceNotifications,
+  enableDeviceNotifications,
+} from '@mobile/runtime/notifications';
 import { setMobileProductAnalyticsEnabled } from '@mobile/runtime/product-analytics';
 import { useAnalyticsPreferenceStore } from '@mobile/stores/analytics-store';
 import type { ThemePreference } from '@mobile/stores/settings-store';
 import { useSettingsStore } from '@mobile/stores/settings-store';
 import { Stack, useRouter } from 'expo-router';
-import { View } from 'react-native';
+import { Alert, Linking, View } from 'react-native';
 import { useTranslations } from 'use-intl';
 
 const THEME_PREFERENCES: readonly ThemePreference[] = ['system', 'light', 'dark'];
@@ -37,9 +41,32 @@ export function SettingsScreen(): React.ReactNode {
   const hostMenuItems = useHostMenuItems();
   const productAnalyticsEnabled = useAnalyticsPreferenceStore((state) => state.enabled);
   const themePreference = useSettingsStore((state) => state.themePreference);
+  const notificationsEnabled = useSettingsStore((state) => state.notificationsEnabled);
   const setThemePreference = useSettingsStore((state) => state.setThemePreference);
   const keepHostsConnected = useSettingsStore((state) => state.keepHostsConnected);
   const setKeepHostsConnected = useSettingsStore((state) => state.setKeepHostsConnected);
+
+  const updateNotifications = async (enabled: boolean) => {
+    if (account.status !== 'signed-in') return;
+    try {
+      if (!enabled) {
+        await disableDeviceNotifications();
+        return;
+      }
+      if (await enableDeviceNotifications(account.user.id)) return;
+      Alert.alert(t('notificationsDeniedTitle'), t('notificationsDenied'), [
+        { text: t('cancel'), style: 'cancel' },
+        {
+          text: t('openSettings'),
+          onPress() {
+            void Linking.openSettings();
+          },
+        },
+      ]);
+    } catch {
+      Alert.alert(t('notificationsErrorTitle'), t('notificationsError'));
+    }
+  };
 
   // The flex container is load-bearing: a SwiftUI host left as the screen's direct child is
   // proposed the whole window and paints straight over the large title.
@@ -100,6 +127,24 @@ export function SettingsScreen(): React.ReactNode {
               isOn={productAnalyticsEnabled}
               onIsOnChange={setMobileProductAnalyticsEnabled}
               label={t('analytics')}
+            />
+          </Section>
+
+          <Section
+            title={t('notifications')}
+            footer={
+              <Text>
+                {account.status === 'signed-in'
+                  ? t('notificationsHint')
+                  : t('notificationsRequiresCloud')}
+              </Text>
+            }
+          >
+            <Toggle
+              isOn={notificationsEnabled}
+              onIsOnChange={updateNotifications}
+              label={t('notifications')}
+              modifiers={[disabled(account.status !== 'signed-in')]}
             />
           </Section>
 

--- a/apps/mobile/src/components/settings/settings-screen.tsx
+++ b/apps/mobile/src/components/settings/settings-screen.tsx
@@ -13,6 +13,7 @@ import { useAnalyticsPreferenceStore } from '@mobile/stores/analytics-store';
 import type { ThemePreference } from '@mobile/stores/settings-store';
 import { useSettingsStore } from '@mobile/stores/settings-store';
 import { Stack, useRouter } from 'expo-router';
+import { useRef, useState } from 'react';
 import { Alert, Linking, View } from 'react-native';
 import { useTranslations } from 'use-intl';
 
@@ -45,9 +46,13 @@ export function SettingsScreen(): React.ReactNode {
   const setThemePreference = useSettingsStore((state) => state.setThemePreference);
   const keepHostsConnected = useSettingsStore((state) => state.keepHostsConnected);
   const setKeepHostsConnected = useSettingsStore((state) => state.setKeepHostsConnected);
+  const [notificationUpdatePending, setNotificationUpdatePending] = useState(false);
+  const notificationUpdatePendingRef = useRef(false);
 
   const updateNotifications = async (enabled: boolean) => {
-    if (account.status !== 'signed-in') return;
+    if (account.status !== 'signed-in' || notificationUpdatePendingRef.current) return;
+    notificationUpdatePendingRef.current = true;
+    setNotificationUpdatePending(true);
     try {
       if (!enabled) {
         await disableDeviceNotifications();
@@ -65,6 +70,9 @@ export function SettingsScreen(): React.ReactNode {
       ]);
     } catch {
       Alert.alert(t('notificationsErrorTitle'), t('notificationsError'));
+    } finally {
+      notificationUpdatePendingRef.current = false;
+      setNotificationUpdatePending(false);
     }
   };
 
@@ -144,7 +152,7 @@ export function SettingsScreen(): React.ReactNode {
               isOn={notificationsEnabled}
               onIsOnChange={updateNotifications}
               label={t('notifications')}
-              modifiers={[disabled(account.status !== 'signed-in')]}
+              modifiers={[disabled(account.status !== 'signed-in' || notificationUpdatePending)]}
             />
           </Section>
 

--- a/apps/mobile/src/components/shell/notification-observer.ts
+++ b/apps/mobile/src/components/shell/notification-observer.ts
@@ -1,0 +1,70 @@
+import { useCloudAccount } from '@mobile/runtime/cloud/account';
+import { resolveNotificationRoute } from '@mobile/runtime/notification-route';
+import { activateNotificationSync, syncDevicePushToken } from '@mobile/runtime/notifications';
+import { useHostRegistryHydrated, useHostRegistryStore } from '@mobile/stores/host-store';
+import { useSettingsStore } from '@mobile/stores/settings-store';
+import * as Sentry from '@sentry/react-native';
+import * as Notifications from 'expo-notifications';
+import { useRouter } from 'expo-router';
+import { useEffect, useEffectEvent } from 'react';
+import { AppState } from 'react-native';
+
+export function NotificationObserver(): null {
+  const router = useRouter();
+  const account = useCloudAccount();
+  const hydrated = useHostRegistryHydrated();
+  const hosts = useHostRegistryStore((state) => state.hosts);
+  const setLastActiveHostId = useHostRegistryStore((state) => state.setLastActiveHostId);
+  const enabled = useSettingsStore((state) => state.notificationsEnabled);
+  const userId = account.status === 'signed-in' ? account.user.id : null;
+
+  const openNotification = useEffectEvent((response: Notifications.NotificationResponse) => {
+    try {
+      const target = resolveNotificationRoute(response.notification.request.content.data, hosts);
+      if (target?.type === 'session') {
+        setLastActiveHostId(target.hostId);
+        router.push({
+          pathname: '/session/[sessionId]',
+          params: { sessionId: target.sessionId },
+        });
+      } else if (target?.type === 'connect') {
+        router.push('/connect');
+      }
+    } finally {
+      Notifications.clearLastNotificationResponse();
+    }
+  });
+
+  useEffect(() => {
+    if (!hydrated) return;
+
+    const initial = Notifications.getLastNotificationResponse();
+    if (initial) openNotification(initial);
+    const subscription = Notifications.addNotificationResponseReceivedListener(openNotification);
+    return () => subscription.remove();
+  }, [hydrated]);
+
+  useEffect(() => {
+    if (!enabled || !userId) return;
+
+    const deactivate = activateNotificationSync(userId);
+    const sync = (devicePushToken?: Notifications.DevicePushToken) => {
+      syncDevicePushToken(userId, devicePushToken).catch((error: unknown) =>
+        Sentry.captureException(error),
+      );
+    };
+
+    sync();
+    const tokenSubscription = Notifications.addPushTokenListener(sync);
+    const appStateSubscription = AppState.addEventListener('change', (state) => {
+      if (state === 'active') sync();
+    });
+    return () => {
+      deactivate();
+      tokenSubscription.remove();
+      appStateSubscription.remove();
+    };
+  }, [enabled, userId]);
+
+  return null;
+}

--- a/apps/mobile/src/runtime/__tests__/notification-route.test.ts
+++ b/apps/mobile/src/runtime/__tests__/notification-route.test.ts
@@ -5,17 +5,15 @@ describe('resolveNotificationRoute', () => {
   const hosts = [{ id: 'local host', tunnelHostId: 'tunnel-1' }];
 
   it('routes known tunnel hosts, falls back for unknown hosts, and rejects invalid data', () => {
-    expect(resolveNotificationRoute({ hostId: 'tunnel-1', sessionId: 'session/1' }, hosts)).toEqual(
-      { type: 'session', hostId: 'local host', sessionId: 'session/1' },
-    );
-    expect(resolveNotificationRoute({ hostId: 'tunnel-2', sessionId: 'session-2' }, hosts)).toEqual(
-      {
-        type: 'connect',
-      },
-    );
-    expect(resolveNotificationRoute({ hostId: 'tunnel-1' }, hosts)).toBeNull();
     expect(
       resolveNotificationRoute({ tunnelHostId: 'tunnel-1', sessionId: 'session-1' }, hosts),
+    ).toEqual({ type: 'session', hostId: 'local host', sessionId: 'session-1' });
+    expect(
+      resolveNotificationRoute({ tunnelHostId: 'tunnel-2', sessionId: 'session-2' }, hosts),
+    ).toEqual({ type: 'connect' });
+    expect(resolveNotificationRoute({ tunnelHostId: 'tunnel-1' }, hosts)).toBeNull();
+    expect(
+      resolveNotificationRoute({ hostId: 'tunnel-1', sessionId: 'session-1' }, hosts),
     ).toBeNull();
   });
 });

--- a/apps/mobile/src/runtime/__tests__/notification-route.test.ts
+++ b/apps/mobile/src/runtime/__tests__/notification-route.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { resolveNotificationRoute } from '../notification-route';
+
+describe('resolveNotificationRoute', () => {
+  const hosts = [{ id: 'local host', tunnelHostId: 'tunnel-1' }];
+
+  it('routes known tunnel hosts, falls back for unknown hosts, and rejects invalid data', () => {
+    expect(resolveNotificationRoute({ hostId: 'tunnel-1', sessionId: 'session/1' }, hosts)).toEqual(
+      { type: 'session', hostId: 'local host', sessionId: 'session/1' },
+    );
+    expect(resolveNotificationRoute({ hostId: 'tunnel-2', sessionId: 'session-2' }, hosts)).toEqual(
+      {
+        type: 'connect',
+      },
+    );
+    expect(resolveNotificationRoute({ hostId: 'tunnel-1' }, hosts)).toBeNull();
+    expect(
+      resolveNotificationRoute({ tunnelHostId: 'tunnel-1', sessionId: 'session-1' }, hosts),
+    ).toBeNull();
+  });
+});

--- a/apps/mobile/src/runtime/__tests__/notification-token-coordinator.test.ts
+++ b/apps/mobile/src/runtime/__tests__/notification-token-coordinator.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+import { createNotificationTokenCoordinator } from '../notification-token-coordinator';
+
+describe('notification token coordination', () => {
+  it('drops a token acquired after notifications are disabled', async () => {
+    const coordinator = createNotificationTokenCoordinator();
+    const events: string[] = [];
+    let releaseToken!: () => void;
+    let markAcquiring!: () => void;
+    const tokenGate = new Promise<void>((resolve) => {
+      releaseToken = resolve;
+    });
+    const acquiring = new Promise<void>((resolve) => {
+      markAcquiring = resolve;
+    });
+
+    coordinator.selectUser('user-1');
+    const sync = coordinator.sync(
+      'user-1',
+      async () => {
+        events.push('acquire');
+        markAcquiring();
+        await tokenGate;
+        return 'token';
+      },
+      () => {
+        events.push('register');
+      },
+    );
+    await acquiring;
+    coordinator.selectUser(null);
+    const revoke = coordinator.revoke(() => {
+      events.push('revoke');
+    });
+    releaseToken();
+
+    await Promise.all([sync, revoke]);
+    expect(events).toEqual(['acquire', 'revoke']);
+  });
+
+  it('runs revocation after an in-flight registration', async () => {
+    const coordinator = createNotificationTokenCoordinator();
+    const events: string[] = [];
+    let releaseRegistration!: () => void;
+    let markRegistering!: () => void;
+    const registrationGate = new Promise<void>((resolve) => {
+      releaseRegistration = resolve;
+    });
+    const registering = new Promise<void>((resolve) => {
+      markRegistering = resolve;
+    });
+
+    coordinator.selectUser('user-1');
+    const sync = coordinator.sync(
+      'user-1',
+      () => 'token',
+      async () => {
+        events.push('register:start');
+        markRegistering();
+        await registrationGate;
+        events.push('register:end');
+      },
+    );
+    await registering;
+    coordinator.selectUser(null);
+    const revoke = coordinator.revoke(() => {
+      events.push('revoke');
+    });
+    releaseRegistration();
+
+    await Promise.all([sync, revoke]);
+    expect(events).toEqual(['register:start', 'register:end', 'revoke']);
+  });
+});

--- a/apps/mobile/src/runtime/__tests__/notification-token-coordinator.test.ts
+++ b/apps/mobile/src/runtime/__tests__/notification-token-coordinator.test.ts
@@ -1,3 +1,4 @@
+import { noop } from 'foxts/noop';
 import { describe, expect, it } from 'vitest';
 import { createNotificationTokenCoordinator } from '../notification-token-coordinator';
 
@@ -29,13 +30,18 @@ describe('notification token coordination', () => {
     );
     await acquiring;
     coordinator.selectUser(null);
-    const revoke = coordinator.revoke(() => {
-      events.push('revoke');
-    });
+    const revoke = coordinator.revoke(
+      () => {
+        events.push('revoke');
+      },
+      () => {
+        events.push('unregister');
+      },
+    );
     releaseToken();
 
     await Promise.all([sync, revoke]);
-    expect(events).toEqual(['acquire', 'revoke']);
+    expect(events).toEqual(['acquire', 'revoke', 'unregister']);
   });
 
   it('runs revocation after an in-flight registration', async () => {
@@ -63,12 +69,32 @@ describe('notification token coordination', () => {
     );
     await registering;
     coordinator.selectUser(null);
-    const revoke = coordinator.revoke(() => {
-      events.push('revoke');
-    });
+    const revoke = coordinator.revoke(
+      () => {
+        events.push('revoke');
+      },
+      () => {
+        events.push('unregister');
+      },
+    );
     releaseRegistration();
 
     await Promise.all([sync, revoke]);
-    expect(events).toEqual(['register:start', 'register:end', 'revoke']);
+    expect(events).toEqual(['register:start', 'register:end', 'revoke', 'unregister']);
+  });
+
+  it('fails revocation only when both the server and native token removal fail', async () => {
+    const coordinator = createNotificationTokenCoordinator();
+    coordinator.selectUser(null);
+
+    await expect(
+      coordinator.revoke(() => Promise.reject(new Error('server failed')), noop),
+    ).resolves.toBeUndefined();
+    await expect(
+      coordinator.revoke(
+        () => Promise.reject(new Error('server failed')),
+        () => Promise.reject(new Error('native failed')),
+      ),
+    ).rejects.toThrow('server failed');
   });
 });

--- a/apps/mobile/src/runtime/cloud/account.ts
+++ b/apps/mobile/src/runtime/cloud/account.ts
@@ -1,5 +1,5 @@
 import { disableDeviceNotifications } from '@mobile/runtime/notifications';
-import { noop } from 'foxact/noop';
+import { falseFn, noop, trueFn } from 'foxts/noop';
 import { cloudAuthClient } from './client';
 import { clearDeviceEnrollment } from './devices';
 
@@ -40,15 +40,18 @@ export async function signInToCloud(): Promise<void> {
 }
 
 export async function signOutOfCloud(options: { revokePushToken?: boolean } = {}): Promise<void> {
+  let pushDeliveryDisabled = false;
   try {
-    await disableDeviceNotifications({
+    pushDeliveryDisabled = await disableDeviceNotifications({
       revokeToken: options.revokePushToken,
       rollbackOnFailure: false,
-    }).catch(noop);
+    })
+      .then(trueFn)
+      .catch(falseFn);
     const { error } = await cloudAuthClient.signOut();
     if (error) throw new Error(`sign-out failed (${error.status})`);
   } finally {
-    // A different account must enroll this phone under a fresh device row.
-    await clearDeviceEnrollment().catch(noop);
+    // Keep the enrollment if both revocation paths fail so the stale binding remains identifiable.
+    if (pushDeliveryDisabled) await clearDeviceEnrollment().catch(noop);
   }
 }

--- a/apps/mobile/src/runtime/cloud/account.ts
+++ b/apps/mobile/src/runtime/cloud/account.ts
@@ -41,6 +41,7 @@ export async function signInToCloud(): Promise<void> {
 
 export async function signOutOfCloud(options: { revokePushToken?: boolean } = {}): Promise<void> {
   let pushDeliveryDisabled = false;
+  let signedOut = false;
   try {
     pushDeliveryDisabled = await disableDeviceNotifications({
       revokeToken: options.revokePushToken,
@@ -50,8 +51,12 @@ export async function signOutOfCloud(options: { revokePushToken?: boolean } = {}
       .catch(falseFn);
     const { error } = await cloudAuthClient.signOut();
     if (error) throw new Error(`sign-out failed (${error.status})`);
+    signedOut = true;
   } finally {
-    // Keep the enrollment if both revocation paths fail so the stale binding remains identifiable.
-    if (pushDeliveryDisabled) await clearDeviceEnrollment().catch(noop);
+    // Retain enrollment whenever a still-live device binding may need recovery after sign-out.
+    const deviceAlreadyRevoked = options.revokePushToken === false;
+    if (pushDeliveryDisabled && (signedOut || deviceAlreadyRevoked)) {
+      await clearDeviceEnrollment().catch(noop);
+    }
   }
 }

--- a/apps/mobile/src/runtime/cloud/account.ts
+++ b/apps/mobile/src/runtime/cloud/account.ts
@@ -40,8 +40,11 @@ export async function signInToCloud(): Promise<void> {
 }
 
 export async function signOutOfCloud(options: { revokePushToken?: boolean } = {}): Promise<void> {
-  await disableDeviceNotifications({ revokeToken: options.revokePushToken });
   try {
+    await disableDeviceNotifications({
+      revokeToken: options.revokePushToken,
+      rollbackOnFailure: false,
+    }).catch(noop);
     const { error } = await cloudAuthClient.signOut();
     if (error) throw new Error(`sign-out failed (${error.status})`);
   } finally {

--- a/apps/mobile/src/runtime/cloud/account.ts
+++ b/apps/mobile/src/runtime/cloud/account.ts
@@ -1,3 +1,4 @@
+import { disableDeviceNotifications } from '@mobile/runtime/notifications';
 import { noop } from 'foxact/noop';
 import { cloudAuthClient } from './client';
 import { clearDeviceEnrollment } from './devices';
@@ -38,9 +39,13 @@ export async function signInToCloud(): Promise<void> {
   if (error) throw new Error(`sign-in failed (${error.status})`);
 }
 
-export async function signOutOfCloud(): Promise<void> {
-  await cloudAuthClient.signOut();
-  // Forget the enrollment so a different account signing in on this phone
-  // registers the device under itself instead of silently skipping.
-  await clearDeviceEnrollment().catch(noop);
+export async function signOutOfCloud(options: { revokePushToken?: boolean } = {}): Promise<void> {
+  await disableDeviceNotifications({ revokeToken: options.revokePushToken });
+  try {
+    const { error } = await cloudAuthClient.signOut();
+    if (error) throw new Error(`sign-out failed (${error.status})`);
+  } finally {
+    // A different account must enroll this phone under a fresh device row.
+    await clearDeviceEnrollment().catch(noop);
+  }
 }

--- a/apps/mobile/src/runtime/cloud/devices.ts
+++ b/apps/mobile/src/runtime/cloud/devices.ts
@@ -61,6 +61,21 @@ export async function clearDeviceEnrollment(): Promise<void> {
   await SecureStore.deleteItemAsync(ENROLLMENT_KEY);
 }
 
+export async function registerDevicePushToken(expoPushToken: string): Promise<void> {
+  const { error } = await cloudAuthClient.$fetch<unknown>(`${CLOUD_URL}/devices/push-token`, {
+    method: 'PUT',
+    body: { expoPushToken },
+  });
+  if (error) throw new Error(`push token registration failed (${error.status})`);
+}
+
+export async function revokeDevicePushToken(): Promise<void> {
+  const { error } = await cloudAuthClient.$fetch<unknown>(`${CLOUD_URL}/devices/push-token`, {
+    method: 'DELETE',
+  });
+  if (error) throw new Error(`push token revocation failed (${error.status})`);
+}
+
 /** Client view of cloud device rows; timestamps arrive as ISO strings over JSON. */
 export const CloudDeviceSchema = z.object({
   id: z.string().min(1),

--- a/apps/mobile/src/runtime/notification-route.ts
+++ b/apps/mobile/src/runtime/notification-route.ts
@@ -1,0 +1,27 @@
+import { SessionIdSchema } from '@linkcode/schema';
+import { z } from 'zod';
+
+const NotificationDataSchema = z.object({
+  hostId: z.string().min(1),
+  sessionId: SessionIdSchema,
+});
+
+interface NotificationHost {
+  id: string;
+  tunnelHostId?: string;
+}
+
+export type NotificationTarget =
+  | { type: 'connect' }
+  | { type: 'session'; hostId: string; sessionId: z.infer<typeof SessionIdSchema> };
+
+export function resolveNotificationRoute(
+  data: unknown,
+  hosts: readonly NotificationHost[],
+): NotificationTarget | null {
+  const parsed = NotificationDataSchema.safeParse(data);
+  if (!parsed.success) return null;
+  const host = hosts.find((candidate) => candidate.tunnelHostId === parsed.data.hostId);
+  if (!host) return { type: 'connect' };
+  return { type: 'session', hostId: host.id, sessionId: parsed.data.sessionId };
+}

--- a/apps/mobile/src/runtime/notification-route.ts
+++ b/apps/mobile/src/runtime/notification-route.ts
@@ -2,7 +2,7 @@ import { SessionIdSchema } from '@linkcode/schema';
 import { z } from 'zod';
 
 const NotificationDataSchema = z.object({
-  hostId: z.string().min(1),
+  tunnelHostId: z.string().min(1),
   sessionId: SessionIdSchema,
 });
 
@@ -21,7 +21,7 @@ export function resolveNotificationRoute(
 ): NotificationTarget | null {
   const parsed = NotificationDataSchema.safeParse(data);
   if (!parsed.success) return null;
-  const host = hosts.find((candidate) => candidate.tunnelHostId === parsed.data.hostId);
+  const host = hosts.find((candidate) => candidate.tunnelHostId === parsed.data.tunnelHostId);
   if (!host) return { type: 'connect' };
   return { type: 'session', hostId: host.id, sessionId: parsed.data.sessionId };
 }

--- a/apps/mobile/src/runtime/notification-token-coordinator.ts
+++ b/apps/mobile/src/runtime/notification-token-coordinator.ts
@@ -2,6 +2,19 @@ export interface NotificationTokenIntent {
   readonly userId: string | null;
 }
 
+async function revokeTokenEverywhere(
+  revokeRegisteredToken: () => void | PromiseLike<void>,
+  unregisterDeviceToken: () => void | PromiseLike<void>,
+): Promise<void> {
+  const [registeredResult, deviceResult] = await Promise.allSettled([
+    Promise.resolve().then(revokeRegisteredToken),
+    Promise.resolve().then(unregisterDeviceToken),
+  ]);
+  if (registeredResult.status === 'rejected' && deviceResult.status === 'rejected') {
+    throw registeredResult.reason;
+  }
+}
+
 export function createNotificationTokenCoordinator() {
   let intent: NotificationTokenIntent = { userId: null };
   let tail: Promise<unknown> = Promise.resolve();
@@ -34,6 +47,10 @@ export function createNotificationTokenCoordinator() {
         if (intent.userId !== userId) return;
         await registerToken(token);
       }),
-    revoke: (revokeToken: () => void | PromiseLike<void>): Promise<void> => enqueue(revokeToken),
+    revoke: (
+      revokeRegisteredToken: () => void | PromiseLike<void>,
+      unregisterDeviceToken: () => void | PromiseLike<void>,
+    ): Promise<void> =>
+      enqueue(() => revokeTokenEverywhere(revokeRegisteredToken, unregisterDeviceToken)),
   };
 }

--- a/apps/mobile/src/runtime/notification-token-coordinator.ts
+++ b/apps/mobile/src/runtime/notification-token-coordinator.ts
@@ -1,0 +1,39 @@
+export interface NotificationTokenIntent {
+  readonly userId: string | null;
+}
+
+export function createNotificationTokenCoordinator() {
+  let intent: NotificationTokenIntent = { userId: null };
+  let tail: Promise<unknown> = Promise.resolve();
+
+  const selectUser = (userId: string | null): NotificationTokenIntent => {
+    if (intent.userId === userId) return intent;
+    intent = { userId };
+    return intent;
+  };
+
+  const enqueue = <T>(operation: () => T | PromiseLike<T>): Promise<T> => {
+    const result = tail.catch(() => null).then(operation);
+    // Keep the queue live after the caller observes the original rejection.
+    tail = result.catch(() => null);
+    return result;
+  };
+
+  return {
+    selectUser,
+    getSelectedUser: () => intent.userId,
+    isCurrent: (candidate: NotificationTokenIntent) => candidate === intent,
+    sync: (
+      userId: string,
+      acquireToken: () => string | PromiseLike<string>,
+      registerToken: (token: string) => void | PromiseLike<void>,
+    ): Promise<void> =>
+      enqueue(async () => {
+        if (intent.userId !== userId) return;
+        const token = await acquireToken();
+        if (intent.userId !== userId) return;
+        await registerToken(token);
+      }),
+    revoke: (revokeToken: () => void | PromiseLike<void>): Promise<void> => enqueue(revokeToken),
+  };
+}

--- a/apps/mobile/src/runtime/notifications.ts
+++ b/apps/mobile/src/runtime/notifications.ts
@@ -1,0 +1,120 @@
+import {
+  ensureDeviceRegistered,
+  registerDevicePushToken,
+  revokeDevicePushToken as revokeRegisteredDevicePushToken,
+} from '@mobile/runtime/cloud/devices';
+import { createNotificationTokenCoordinator } from '@mobile/runtime/notification-token-coordinator';
+import { useSettingsStore } from '@mobile/stores/settings-store';
+import Constants from 'expo-constants';
+import * as Device from 'expo-device';
+import type { DevicePushToken } from 'expo-notifications';
+import * as Notifications from 'expo-notifications';
+
+export const NOTIFICATION_CHANNEL_ID = 'session-events';
+
+const tokenCoordinator = createNotificationTokenCoordinator();
+
+Notifications.setNotificationHandler({
+  handleNotification: () =>
+    Promise.resolve({
+      shouldPlaySound: true,
+      shouldSetBadge: false,
+      shouldShowBanner: true,
+      shouldShowList: true,
+    }),
+});
+
+function permissionGranted(settings: Notifications.NotificationPermissionsStatus): boolean {
+  return (
+    settings.granted || settings.ios?.status === Notifications.IosAuthorizationStatus.PROVISIONAL
+  );
+}
+
+async function ensureNotificationChannel(): Promise<void> {
+  if (process.env.EXPO_OS === 'android') {
+    await Notifications.setNotificationChannelAsync(NOTIFICATION_CHANNEL_ID, {
+      name: 'Session events',
+      importance: Notifications.AndroidImportance.HIGH,
+      sound: 'default',
+    });
+  }
+}
+
+async function requestNotificationPermission(): Promise<boolean> {
+  await ensureNotificationChannel();
+  const current = await Notifications.getPermissionsAsync();
+  if (permissionGranted(current)) return true;
+  if (!current.canAskAgain) return false;
+  return permissionGranted(await Notifications.requestPermissionsAsync());
+}
+
+export async function syncDevicePushToken(
+  userId: string,
+  devicePushToken?: DevicePushToken,
+): Promise<void> {
+  await tokenCoordinator.sync(
+    userId,
+    async () => {
+      if (!Device.isDevice) throw new Error('push notifications require a physical device');
+      const projectId =
+        Constants.easConfig?.projectId ?? Constants.expoConfig?.extra?.eas?.projectId;
+      if (typeof projectId !== 'string' || !projectId) {
+        throw new Error('Expo project ID is missing');
+      }
+      await ensureNotificationChannel();
+      await ensureDeviceRegistered(userId);
+      const expoPushToken = await Notifications.getExpoPushTokenAsync({
+        projectId,
+        devicePushToken,
+      });
+      return expoPushToken.data;
+    },
+    registerDevicePushToken,
+  );
+}
+
+export function activateNotificationSync(userId: string): () => void {
+  const intent = tokenCoordinator.selectUser(userId);
+  return () => {
+    if (tokenCoordinator.isCurrent(intent)) tokenCoordinator.selectUser(null);
+  };
+}
+
+export async function enableDeviceNotifications(userId: string): Promise<boolean> {
+  if (!(await requestNotificationPermission())) return false;
+
+  const intent = tokenCoordinator.selectUser(userId);
+  const settings = useSettingsStore.getState();
+  settings.setNotificationsEnabled(true);
+  try {
+    await syncDevicePushToken(userId);
+    return true;
+  } catch (error) {
+    if (tokenCoordinator.isCurrent(intent)) {
+      tokenCoordinator.selectUser(null);
+      settings.setNotificationsEnabled(false);
+    }
+    throw error;
+  }
+}
+
+export async function disableDeviceNotifications(
+  options: { revokeToken?: boolean } = {},
+): Promise<void> {
+  const settings = useSettingsStore.getState();
+  const wasEnabled = settings.notificationsEnabled;
+  const previousUserId = tokenCoordinator.getSelectedUser();
+  const intent = tokenCoordinator.selectUser(null);
+  settings.setNotificationsEnabled(false);
+  if (!wasEnabled || options.revokeToken === false) return;
+
+  try {
+    await tokenCoordinator.revoke(revokeRegisteredDevicePushToken);
+  } catch (error) {
+    if (tokenCoordinator.isCurrent(intent)) {
+      tokenCoordinator.selectUser(previousUserId);
+      settings.setNotificationsEnabled(true);
+    }
+    throw error;
+  }
+}

--- a/apps/mobile/src/runtime/notifications.ts
+++ b/apps/mobile/src/runtime/notifications.ts
@@ -109,7 +109,10 @@ export async function disableDeviceNotifications(
   if (!wasEnabled || options.revokeToken === false) return;
 
   try {
-    await tokenCoordinator.revoke(revokeRegisteredDevicePushToken);
+    await tokenCoordinator.revoke(
+      revokeRegisteredDevicePushToken,
+      Notifications.unregisterForNotificationsAsync,
+    );
   } catch (error) {
     if (options.rollbackOnFailure !== false && tokenCoordinator.isCurrent(intent)) {
       tokenCoordinator.selectUser(previousUserId);

--- a/apps/mobile/src/runtime/notifications.ts
+++ b/apps/mobile/src/runtime/notifications.ts
@@ -9,6 +9,7 @@ import Constants from 'expo-constants';
 import * as Device from 'expo-device';
 import type { DevicePushToken } from 'expo-notifications';
 import * as Notifications from 'expo-notifications';
+import { Platform } from 'react-native';
 
 export const NOTIFICATION_CHANNEL_ID = 'session-events';
 
@@ -31,7 +32,7 @@ function permissionGranted(settings: Notifications.NotificationPermissionsStatus
 }
 
 async function ensureNotificationChannel(): Promise<void> {
-  if (process.env.EXPO_OS === 'android') {
+  if (Platform.OS === 'android') {
     await Notifications.setNotificationChannelAsync(NOTIFICATION_CHANNEL_ID, {
       name: 'Thread events',
       importance: Notifications.AndroidImportance.HIGH,

--- a/apps/mobile/src/runtime/notifications.ts
+++ b/apps/mobile/src/runtime/notifications.ts
@@ -33,7 +33,7 @@ function permissionGranted(settings: Notifications.NotificationPermissionsStatus
 async function ensureNotificationChannel(): Promise<void> {
   if (process.env.EXPO_OS === 'android') {
     await Notifications.setNotificationChannelAsync(NOTIFICATION_CHANNEL_ID, {
-      name: 'Session events',
+      name: 'Thread events',
       importance: Notifications.AndroidImportance.HIGH,
       sound: 'default',
     });
@@ -99,7 +99,7 @@ export async function enableDeviceNotifications(userId: string): Promise<boolean
 }
 
 export async function disableDeviceNotifications(
-  options: { revokeToken?: boolean } = {},
+  options: { revokeToken?: boolean; rollbackOnFailure?: boolean } = {},
 ): Promise<void> {
   const settings = useSettingsStore.getState();
   const wasEnabled = settings.notificationsEnabled;
@@ -111,7 +111,7 @@ export async function disableDeviceNotifications(
   try {
     await tokenCoordinator.revoke(revokeRegisteredDevicePushToken);
   } catch (error) {
-    if (tokenCoordinator.isCurrent(intent)) {
+    if (options.rollbackOnFailure !== false && tokenCoordinator.isCurrent(intent)) {
       tokenCoordinator.selectUser(previousUserId);
       settings.setNotificationsEnabled(true);
     }

--- a/apps/mobile/src/stores/settings-store.ts
+++ b/apps/mobile/src/stores/settings-store.ts
@@ -9,7 +9,11 @@ export type ThemePreference = z.infer<typeof ThemePreferenceSchema>;
 
 /** Persisted subset — every field optional so partial/stale storage merges over the defaults. */
 const PersistedSettingsSchema = z
-  .object({ themePreference: ThemePreferenceSchema, keepHostsConnected: z.boolean() })
+  .object({
+    themePreference: ThemePreferenceSchema,
+    keepHostsConnected: z.boolean(),
+    notificationsEnabled: z.boolean(),
+  })
   .partial();
 type PersistedSettings = z.infer<typeof PersistedSettingsSchema>;
 
@@ -18,8 +22,10 @@ export interface SettingsState {
   /** Hold every saved host's connection open, not just the selected one. Off by default: a phone
    * pays for each socket in bytes and battery, and only one host is on screen at a time. */
   keepHostsConnected: boolean;
+  notificationsEnabled: boolean;
   setThemePreference: (preference: ThemePreference) => void;
   setKeepHostsConnected: (keep: boolean) => void;
+  setNotificationsEnabled: (enabled: boolean) => void;
 }
 
 export const useSettingsStore = create<SettingsState>()(
@@ -27,8 +33,10 @@ export const useSettingsStore = create<SettingsState>()(
     (set) => ({
       themePreference: 'system',
       keepHostsConnected: false,
+      notificationsEnabled: false,
       setThemePreference: (preference) => set({ themePreference: preference }),
       setKeepHostsConnected: (keep) => set({ keepHostsConnected: keep }),
+      setNotificationsEnabled: (enabled) => set({ notificationsEnabled: enabled }),
     }),
     {
       name: 'linkcode.mobile.settings:v2',
@@ -37,6 +45,7 @@ export const useSettingsStore = create<SettingsState>()(
       partialize: (state) => ({
         themePreference: state.themePreference,
         keepHostsConnected: state.keepHostsConnected,
+        notificationsEnabled: state.notificationsEnabled,
       }),
     },
   ),

--- a/packages/presentation/i18n/src/locales/en.ts
+++ b/packages/presentation/i18n/src/locales/en.ts
@@ -1273,6 +1273,7 @@ export const en = {
     account: {
       title: 'Account',
       signOut: 'Sign out',
+      signOutError: 'Could not sign out. Check your connection and try again.',
       devices: 'Devices',
       refresh: 'Refresh',
       devicesEmpty: 'No devices registered on this account yet.',
@@ -1404,6 +1405,15 @@ export const en = {
       keepHostsConnected: 'Keep every host connected',
       keepHostsConnectedHint:
         'Holds a connection to every saved host so switching is instant, at the cost of battery and data. Off keeps only the selected host dialed.',
+      notifications: 'Notifications',
+      notificationsHint: 'Notify you when a Thread finishes a turn or needs approval.',
+      notificationsRequiresCloud: 'Sign in to LinkCode Cloud to enable remote notifications.',
+      notificationsDeniedTitle: 'Notifications are off',
+      notificationsDenied: 'Allow notifications in system settings to enable this feature.',
+      notificationsErrorTitle: 'Could not update notifications',
+      notificationsError: 'Try again after checking your network and system settings.',
+      openSettings: 'Open Settings',
+      cancel: 'Cancel',
       legalAndSupport: 'Legal & Support',
       privacyPolicy: 'Privacy Policy',
       termsOfService: 'Terms of Service',

--- a/packages/presentation/i18n/src/locales/zh-cn.ts
+++ b/packages/presentation/i18n/src/locales/zh-cn.ts
@@ -1237,6 +1237,7 @@ export const zhCN = {
     account: {
       title: '账号',
       signOut: '退出登录',
+      signOutError: '无法退出登录，请检查网络后重试。',
       devices: '设备',
       refresh: '刷新',
       devicesEmpty: '该账号还没有注册设备。',
@@ -1365,6 +1366,15 @@ export const zhCN = {
       keepHostsConnected: '保持所有主机连接',
       keepHostsConnectedHint:
         '开启后每台已保存的主机都持续连接，切换是瞬时的，代价是更费电和流量。关闭时只连当前主机，切回去要重新握手。',
+      notifications: '通知',
+      notificationsHint: 'Thread 完成一轮或需要授权时通知你。',
+      notificationsRequiresCloud: '登录 LinkCode Cloud 后可启用远程通知。',
+      notificationsDeniedTitle: '通知已关闭',
+      notificationsDenied: '请在系统设置中允许通知后再启用此功能。',
+      notificationsErrorTitle: '无法更新通知',
+      notificationsError: '请检查网络和系统设置后重试。',
+      openSettings: '打开设置',
+      cancel: '取消',
       legalAndSupport: '法律与支持',
       privacyPolicy: '隐私政策',
       termsOfService: '服务条款',


### PR DESCRIPTION
## Summary

- add an explicit, persisted Mobile notification opt-in that requests native permission only after user action
- create the Android `session-events` channel before requesting permission or acquiring a token
- register, refresh, rotate, and revoke Expo push tokens through the CODE-531 device API contract
- install foreground and notification-response handlers at the app root
- validate `{ tunnelHostId, sessionId }` notification data, resolve the persisted local tunnel host, and open the matching Thread or `/connect`
- add English and Simplified Chinese settings/error copy plus an RN-free routing test

## Why

A phone client needs to notify users when a remote agent completes a turn or requests approval while the app is backgrounded or terminated. The flow is opt-in and Cloud-only so Direct/LAN hosts do not promise delivery they cannot provide.

Linear: [CODE-187](https://linear.app/arcbox/issue/CODE-187/featmobile-remote-push-notifications-turn-complete-approval-needed)

## Validation

- `pnpm check:ci`
- `pnpm test` — 303 test files / 2436 tests passed
- `pnpm -F @linkcode/mobile smoke:export` — Android and iOS production Router exports
- `devenv shell -- mobile` — iOS dev build succeeded and launched on an iPhone 17 Pro simulator
- visually verified the signed-out disabled Notifications control and Cloud requirement copy in Settings
- verified generated iOS entitlements include `aps-environment`

## Remaining before ready for review

- deploy the backend delivery and `/devices/push-token` API from [CODE-531](https://linear.app/arcbox/issue/CODE-531/feathq-deliver-mobile-push-notifications-for-session-events)
- verify token issuance, remote delivery, foreground presentation, terminated-app tap routing, and revocation on an EAS-credentialed physical device