### PR TITLE
fix(mobile): align Live Activity target name for EAS signing

### DIFF
--- a/apps/mobile/targets/agent-activity/expo-target.config.json
+++ b/apps/mobile/targets/agent-activity/expo-target.config.json
@@ -1,6 +1,7 @@
 {
   "type": "widget",
-  "name": "LinkCode Agent Activity",
+  "name": "LinkCodeAgentActivity",
+  "displayName": "LinkCode Agent Activity",
   "frameworks": ["SwiftUI", "WidgetKit", "ActivityKit"],
   "deploymentTarget": "16.2"
 }


### PR DESCRIPTION
## Summary

- make the Live Activity Xcode target name match the EAS signing target exactly
- preserve the user-facing `LinkCode Agent Activity` display name
- keep the Live Activity target and signing configuration intact

## Root cause

`@bacons/apple-targets` sanitized `LinkCode Agent Activity` to the EAS target name `LinkCodeAgentActivity`, while Expo provisioning looked up `PBXNativeTarget.name` by exact equality. The generated Xcode target retained spaces, so the production iOS build failed during `Configure Xcode project`.

## Impact

Production EAS builds can assign the existing widget provisioning profile to the generated Live Activity target.

## Validation

- clean iOS Expo prebuild
- Expo config introspection confirms EAS `targetName: LinkCodeAgentActivity`
- Expo's exact `findNativeTargetByName` lookup succeeds against the generated project
- `pnpm check:ci`
- `pnpm test` — 2,439 passed, 1 skipped
- `pnpm -F @linkcode/mobile smoke:export` — Android and iOS passed

Linear: [CODE-534](https://linear.app/arcbox/issue/CODE-534/fixmobile-align-live-activity-target-name-for-eas-signing)