### PR TITLE
fix(mobile): raise Gradle Metaspace limit

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -73,6 +73,7 @@
       }
     },
     "plugins": [
+      "./plugins/with-gradle-jvm-memory.cjs",
       "expo-router",
       [
         "@sentry/react-native/expo",

--- a/apps/mobile/plugins/with-gradle-jvm-memory.cjs
+++ b/apps/mobile/plugins/with-gradle-jvm-memory.cjs
@@ -1,0 +1,13 @@
+const { AndroidConfig, withGradleProperties } = require('expo/config-plugins');
+
+const GRADLE_JVM_ARGS = '-Xmx2048m -XX:MaxMetaspaceSize=1024m';
+
+module.exports = (config) =>
+  withGradleProperties(config, (config) => {
+    config.modResults = AndroidConfig.BuildProperties.updateAndroidBuildProperty(
+      config.modResults,
+      'org.gradle.jvmargs',
+      GRADLE_JVM_ARGS,
+    );
+    return config;
+  });


### PR DESCRIPTION
## Summary

- persist a 1 GiB Gradle Metaspace limit through Expo clean prebuilds
- keep the existing 2 GiB heap and Android release lint enabled
- apply the fix to local, GitHub Actions, and EAS-generated Android projects

## Root cause

[Build Mobile #1](https://github.com/arcboxlabs/linkcode/actions/runs/30715102363) exhausted the Expo template's 512 MiB Gradle Metaspace during `lintVitalAnalyzeRelease`. Gradle emitted `FAILED`, while the EAS local-build wrapper remained alive until the job timeout.

## Validation

- clean Android Expo prebuild generated `org.gradle.jvmargs=-Xmx2048m -XX:MaxMetaspaceSize=1024m`
- `pnpm check:ci`
- `pnpm test` — 2,439 passed, 1 skipped
- `pnpm -F @linkcode/mobile smoke:export` — Android and iOS passed

Linear: [CODE-535](https://linear.app/arcbox/issue/CODE-535/fixmobile-raise-gradle-metaspace-for-android-release-builds)