### PR TITLE
test(config): verify signed client vector (CODE-537)

### DIFF
--- a/apps/desktop/e2e/unpackaged-smoke.e2e.mts
+++ b/apps/desktop/e2e/unpackaged-smoke.e2e.mts
@@ -39,6 +39,14 @@ async function main(): Promise<void> {
     assert.match(boundary.version, VERSION_RE);
     assert.equal(boundary.managed, false);
     assert.equal(typeof boundary.maximized, 'boolean');
+    await page.waitForFunction(() => window.configSigningPoc !== undefined);
+    const signingPoc = await page.evaluate(() => window.configSigningPoc);
+    assert.deepEqual(signingPoc?.noble, signingPoc?.webCrypto);
+    assert.equal(
+      signingPoc?.webCrypto.snapshotSha256,
+      '513910f70984fbd2290d4538d8e668a8b9d853b466921e6839695b2d98b10e97',
+    );
+    console.log('PASS Electron WebCrypto and Noble config signing vector');
     console.log('PASS unpackaged built main, sandbox preload bridge, and renderer window');
   } finally {
     await app?.close().catch(noop);

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -14,7 +14,7 @@
     "stage:host-runtime": "pnpm -F @linkcode/daemon build && node scripts/stage-sidecar.mts",
     "package": "pnpm run stage:host-runtime && node scripts/build.mts && node scripts/package-app.mts",
     "package:devshell": "pnpm run stage:host-runtime && node scripts/build.mts --mode devshell && node scripts/package-app.mts --devshell",
-    "e2e:unpackaged": "pnpm -F @linkcode/daemon build && pnpm run build && node e2e/unpackaged-smoke.e2e.mts",
+    "e2e:unpackaged": "pnpm -F @linkcode/daemon build && RENDERER_VITE_CONFIG_SIGNING_POC=1 pnpm run build && node e2e/unpackaged-smoke.e2e.mts",
     "e2e:packaged:smoke": "pnpm --dir ../.. exec tsx apps/desktop/e2e/packaged-smoke.e2e.mts",
     "e2e:packaged": "pnpm run package:devshell && pnpm run e2e:packaged:smoke",
     "e2e:notifications": "node e2e/notifications.e2e.mts",

--- a/apps/desktop/src/renderer/src/main.tsx
+++ b/apps/desktop/src/renderer/src/main.tsx
@@ -25,6 +25,15 @@ import { openDesktopSettings } from './settings/store';
 import { installAdaptiveTheme } from './theme';
 import './index.css';
 
+if (import.meta.env.RENDERER_VITE_CONFIG_SIGNING_POC === '1') {
+  window.configSigningPoc = import('@linkcode/common/config-signing-poc').then(
+    async ({ runNobleConfigSigningPoc, runWebCryptoConfigSigningPoc }) => ({
+      noble: runNobleConfigSigningPoc(),
+      webCrypto: await runWebCryptoConfigSigningPoc(crypto.subtle),
+    }),
+  );
+}
+
 setKeyboardShortcutPlatform(systemBridge.app.platform === 'darwin' ? 'mac' : 'non-mac');
 
 initializeProductAnalytics({

--- a/apps/desktop/src/renderer/src/vite-env.d.ts
+++ b/apps/desktop/src/renderer/src/vite-env.d.ts
@@ -1,4 +1,19 @@
 /// <reference types="vite/client" />
 
+interface ConfigSigningPocResult {
+  canonicalPayloadSha256: string;
+  emergencySignatureValid: boolean;
+  pointerSignatureValid: boolean;
+  rfc8032SignatureValid: boolean;
+  snapshotSha256: string;
+}
+
 /** Inlined by vite.renderer.config.ts from the main-process Sentry configuration. */
 declare const __LINKCODE_SENTRY_ENABLED__: boolean;
+
+interface Window {
+  configSigningPoc?: Promise<{
+    noble: ConfigSigningPocResult;
+    webCrypto: ConfigSigningPocResult;
+  }>;
+}

--- a/apps/mobile/scripts/smoke-native-entry-export.cjs
+++ b/apps/mobile/scripts/smoke-native-entry-export.cjs
@@ -13,6 +13,7 @@ const requiredRouteModules = [
   '/apps/mobile/src/app/index.tsx',
   '/apps/mobile/src/app/(tabs)/threads/index.tsx',
   '/apps/mobile/src/app/(tabs)/terminals/index.tsx',
+  '/packages/foundation/common/src/config-signing-poc/index.ts',
 ];
 
 async function runExpoExport(platform, outputDirectory) {
@@ -36,6 +37,7 @@ async function runExpoExport(platform, outputDirectory) {
         env: {
           ...process.env,
           CI: '1',
+          EXPO_PUBLIC_CONFIG_SIGNING_POC: '1',
           EXPO_NO_TELEMETRY: '1',
           NODE_ENV: 'production',
         },

--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -23,6 +23,12 @@ import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import '@mobile/global.css';
 
+if (process.env.EXPO_PUBLIC_CONFIG_SIGNING_POC === '1') {
+  void import('@linkcode/common/config-signing-poc')
+    .then(({ runNobleConfigSigningPoc }) => runNobleConfigSigningPoc())
+    .then((result) => console.info('config signing POC passed', result));
+}
+
 // The DSN is a publishable identifier (not a secret); Expo inlines EXPO_PUBLIC_* env vars at build time.
 // With no DSN the SDK no-ops, so local dev reports nothing unless EXPO_PUBLIC_SENTRY_DSN is set.
 const navigationIntegration = Sentry.reactNavigationIntegration({

--- a/apps/mobile/src/env.d.ts
+++ b/apps/mobile/src/env.d.ts
@@ -10,6 +10,7 @@ declare namespace NodeJS {
     /** Public PostHog project configuration; both values are required or analytics no-ops. */
     EXPO_PUBLIC_POSTHOG_PROJECT_TOKEN?: string;
     EXPO_PUBLIC_POSTHOG_HOST?: string;
+    EXPO_PUBLIC_CONFIG_SIGNING_POC?: string;
   }
 }
 

--- a/packages/foundation/common/package.json
+++ b/packages/foundation/common/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "type": "module",
   "exports": {
+    "./config-signing-poc": "./src/config-signing-poc/index.ts",
     "./node": "./src/node/index.ts",
     "./sentry": "./src/sentry/index.ts",
     "./telemetry-config": "./src/telemetry-config/index.ts",
@@ -14,6 +15,9 @@
   },
   "dependencies": {
     "@linkcode/schema": "workspace:*",
+    "@noble/ed25519": "3.0.0",
+    "@noble/hashes": "2.2.0",
+    "canonicalize": "3.0.0",
     "zod": "catalog:",
     "zustand": "catalog:"
   },

--- a/packages/foundation/common/src/config-signing-poc/__fixtures__/config-signing-vector.json
+++ b/packages/foundation/common/src/config-signing-poc/__fixtures__/config-signing-vector.json
@@ -1,0 +1,59 @@
+{
+  "schemaVersion": 1,
+  "rfc8785": {
+    "source": "RFC 8785 sections 3.2.2-3.2.3",
+    "input": {
+      "numbers": [333333333.3333333, 1e30, 4.5, 0.002, 1e-27],
+      "string": "€$\u000f\nA'B\"\\\\\"/",
+      "literals": [null, true, false]
+    },
+    "canonical": "{\"literals\":[null,true,false],\"numbers\":[333333333.3333333,1e+30,4.5,0.002,1e-27],\"string\":\"€$\\u000f\\nA'B\\\"\\\\\\\\\\\"/\"}"
+  },
+  "rfc8032": {
+    "source": "RFC 8032 section 7.1 test 2",
+    "publicKeyBase64Url": "PUAXw-hDiVqStwqnTRt-vJyYLM8uxJaMwM1V8Sr0Zgw",
+    "messageBase64Url": "cg",
+    "signatureBase64Url": "kqAJqfDUyrhyDoILX2QlQKKye1QWUD-Ps3YiI-vbadoIWsHkPhWZbkWPNhPQ8R2MOHsurrQwKu6wDSkWErsMAA"
+  },
+  "snapshot": {
+    "payload": {
+      "brand": "acme",
+      "channel": "canary",
+      "configVersion": "code-537-poc-1",
+      "platform": "desktop",
+      "schemaVersion": 1,
+      "values": {
+        "content.poc": "签名配置",
+        "feature.poc": true
+      }
+    },
+    "canonicalPayload": "{\"brand\":\"acme\",\"channel\":\"canary\",\"configVersion\":\"code-537-poc-1\",\"platform\":\"desktop\",\"schemaVersion\":1,\"values\":{\"content.poc\":\"签名配置\",\"feature.poc\":true}}",
+    "canonicalPayloadBase64Url": "eyJicmFuZCI6ImFjbWUiLCJjaGFubmVsIjoiY2FuYXJ5IiwiY29uZmlnVmVyc2lvbiI6ImNvZGUtNTM3LXBvYy0xIiwicGxhdGZvcm0iOiJkZXNrdG9wIiwic2NoZW1hVmVyc2lvbiI6MSwidmFsdWVzIjp7ImNvbnRlbnQucG9jIjoi562-5ZCN6YWN572uIiwiZmVhdHVyZS5wb2MiOnRydWV9fQ",
+    "sha256": "513910f70984fbd2290d4538d8e668a8b9d853b466921e6839695b2d98b10e97",
+    "sizeBytes": 166
+  },
+  "configPointer": {
+    "payload": {
+      "activationVersion": "1",
+      "createdAt": "2026-08-03T09:14:00Z",
+      "keyId": "rfc8032-test-2",
+      "sha256": "513910f70984fbd2290d4538d8e668a8b9d853b466921e6839695b2d98b10e97",
+      "sizeBytes": 166
+    },
+    "canonicalPayload": "{\"activationVersion\":\"1\",\"createdAt\":\"2026-08-03T09:14:00Z\",\"keyId\":\"rfc8032-test-2\",\"sha256\":\"513910f70984fbd2290d4538d8e668a8b9d853b466921e6839695b2d98b10e97\",\"sizeBytes\":166}",
+    "canonicalPayloadBase64Url": "eyJhY3RpdmF0aW9uVmVyc2lvbiI6IjEiLCJjcmVhdGVkQXQiOiIyMDI2LTA4LTAzVDA5OjE0OjAwWiIsImtleUlkIjoicmZjODAzMi10ZXN0LTIiLCJzaGEyNTYiOiI1MTM5MTBmNzA5ODRmYmQyMjkwZDQ1MzhkOGU2NjhhOGI5ZDg1M2I0NjY5MjFlNjgzOTY5NWIyZDk4YjEwZTk3Iiwic2l6ZUJ5dGVzIjoxNjZ9",
+    "publicKeyBase64Url": "PUAXw-hDiVqStwqnTRt-vJyYLM8uxJaMwM1V8Sr0Zgw",
+    "signatureBase64Url": "hmu_EFSVNODmzhIROkIySXGqYvDTWRIvKZys7E7SGsnB5SXTBg-WWx2oZJvznKFCfEGOM5Rf_V2TN_WJt4aPDQ"
+  },
+  "emergency": {
+    "payload": {
+      "disabledFeatures": ["feature.poc"],
+      "forceMinVersion": null,
+      "keyId": "rfc8032-test-1",
+      "version": 1
+    },
+    "canonicalPayload": "{\"disabledFeatures\":[\"feature.poc\"],\"forceMinVersion\":null,\"keyId\":\"rfc8032-test-1\",\"version\":1}",
+    "publicKeyBase64Url": "11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo",
+    "signatureBase64Url": "gS8pQHrYZWqix17Xcdcgj5GoEl_3XhcHT1gJTc9XRfTi6ICnENIrK7j-lw5rhftmneKRpQe7mu6n8s0XjpCiDA"
+  }
+}

--- a/packages/foundation/common/src/config-signing-poc/__tests__/index.test.ts
+++ b/packages/foundation/common/src/config-signing-poc/__tests__/index.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { decodeBase64Url, runNobleConfigSigningPoc, runWebCryptoConfigSigningPoc } from '..';
+
+describe('client config signing vector', () => {
+  it('verifies JCS, Base64URL, SHA-256, and Ed25519 with the portable Noble path', () => {
+    expect(runNobleConfigSigningPoc()).toEqual({
+      canonicalPayloadSha256: 'd3fcd06bb81156590026099066bf54f896cf69a1f63073292001a702ef77411f',
+      emergencySignatureValid: true,
+      pointerSignatureValid: true,
+      rfc8032SignatureValid: true,
+      snapshotSha256: '513910f70984fbd2290d4538d8e668a8b9d853b466921e6839695b2d98b10e97',
+    });
+  });
+
+  it('verifies the same bytes with WebCrypto', async () => {
+    await expect(runWebCryptoConfigSigningPoc(crypto.subtle)).resolves.toEqual({
+      canonicalPayloadSha256: 'd3fcd06bb81156590026099066bf54f896cf69a1f63073292001a702ef77411f',
+      emergencySignatureValid: true,
+      pointerSignatureValid: true,
+      rfc8032SignatureValid: true,
+      snapshotSha256: '513910f70984fbd2290d4538d8e668a8b9d853b466921e6839695b2d98b10e97',
+    });
+  });
+
+  it('rejects malformed Base64URL', () => {
+    expect(() => decodeBase64Url('a')).toThrow('Invalid Base64URL value');
+    expect(() => decodeBase64Url('ch')).toThrow('Invalid Base64URL value');
+    expect(() => decodeBase64Url('cg==')).toThrow('Invalid Base64URL value');
+    expect(decodeBase64Url('cg')).toEqual(new Uint8Array([114]));
+  });
+});

--- a/packages/foundation/common/src/config-signing-poc/index.ts
+++ b/packages/foundation/common/src/config-signing-poc/index.ts
@@ -1,0 +1,241 @@
+import { hashes, verify } from '@noble/ed25519';
+import { sha256, sha512 } from '@noble/hashes/sha2.js';
+import canonicalize from 'canonicalize';
+import vector from './__fixtures__/config-signing-vector.json';
+
+export interface ConfigSigningPocResult {
+  canonicalPayloadSha256: string;
+  emergencySignatureValid: boolean;
+  pointerSignatureValid: boolean;
+  rfc8032SignatureValid: boolean;
+  snapshotSha256: string;
+}
+
+const encoder = new TextEncoder();
+const BASE64URL_PATTERN = /^[\w-]*$/;
+hashes.sha512 = sha512;
+
+export function runNobleConfigSigningPoc(): ConfigSigningPocResult {
+  const canonicalRfc8785 = canonicalize(vector.rfc8785.input);
+  assertEqual(canonicalRfc8785, vector.rfc8785.canonical, 'RFC 8785 canonical JSON');
+
+  const canonicalPayload = canonicalize(vector.configPointer.payload);
+  assertEqual(
+    canonicalPayload,
+    vector.configPointer.canonicalPayload,
+    'config pointer canonical JSON',
+  );
+  const canonicalPayloadBytes = encoder.encode(canonicalPayload);
+  assertBytesEqual(
+    decodeBase64Url(vector.configPointer.canonicalPayloadBase64Url),
+    canonicalPayloadBytes,
+    'config pointer canonical UTF-8 bytes',
+  );
+
+  const canonicalSnapshot = canonicalize(vector.snapshot.payload);
+  assertEqual(canonicalSnapshot, vector.snapshot.canonicalPayload, 'snapshot canonical JSON');
+  const snapshotBytes = encoder.encode(canonicalSnapshot);
+  assertBytesEqual(
+    decodeBase64Url(vector.snapshot.canonicalPayloadBase64Url),
+    snapshotBytes,
+    'snapshot canonical UTF-8 bytes',
+  );
+  assertTrue(snapshotBytes.length === vector.snapshot.sizeBytes, 'snapshot UTF-8 byte length');
+  const snapshotSha256 = toHex(sha256(snapshotBytes));
+  assertEqual(snapshotSha256, vector.snapshot.sha256, 'snapshot SHA-256 digest');
+  assertEqual(
+    snapshotSha256,
+    vector.configPointer.payload.sha256,
+    'config pointer snapshot SHA-256 digest',
+  );
+  const canonicalEmergency = canonicalize(vector.emergency.payload);
+  assertEqual(canonicalEmergency, vector.emergency.canonicalPayload, 'emergency canonical JSON');
+  const emergencyBytes = encoder.encode(canonicalEmergency);
+
+  const rfc8032SignatureValid = verifyVector(
+    vector.rfc8032.signatureBase64Url,
+    decodeBase64Url(vector.rfc8032.messageBase64Url),
+    vector.rfc8032.publicKeyBase64Url,
+  );
+  const pointerSignatureValid = verifyVector(
+    vector.configPointer.signatureBase64Url,
+    canonicalPayloadBytes,
+    vector.configPointer.publicKeyBase64Url,
+  );
+  const emergencySignatureValid = verifyVector(
+    vector.emergency.signatureBase64Url,
+    emergencyBytes,
+    vector.emergency.publicKeyBase64Url,
+  );
+
+  assertTrue(rfc8032SignatureValid, 'RFC 8032 signature');
+  assertTrue(pointerSignatureValid, 'config pointer signature');
+  assertTrue(emergencySignatureValid, 'emergency signature');
+
+  const mutatedSignature = decodeBase64Url(vector.configPointer.signatureBase64Url);
+  mutatedSignature[0] ^= 1;
+  assertTrue(
+    !verify(
+      mutatedSignature,
+      canonicalPayloadBytes,
+      decodeBase64Url(vector.configPointer.publicKeyBase64Url),
+      { zip215: false },
+    ),
+    'mutated config pointer signature rejection',
+  );
+
+  return {
+    canonicalPayloadSha256: toHex(sha256(canonicalPayloadBytes)),
+    emergencySignatureValid,
+    pointerSignatureValid,
+    rfc8032SignatureValid,
+    snapshotSha256,
+  };
+}
+
+export async function runWebCryptoConfigSigningPoc(
+  subtle: SubtleCrypto,
+): Promise<ConfigSigningPocResult> {
+  const nobleResult = runNobleConfigSigningPoc();
+  const canonicalPayloadBytes = encoder.encode(vector.configPointer.canonicalPayload);
+  const nativeDigest = new Uint8Array(
+    await subtle.digest('SHA-256', toArrayBuffer(canonicalPayloadBytes)),
+  );
+  assertEqual(toHex(nativeDigest), nobleResult.canonicalPayloadSha256, 'WebCrypto SHA-256 digest');
+  const nativeSnapshotDigest = new Uint8Array(
+    await subtle.digest('SHA-256', toArrayBuffer(encoder.encode(vector.snapshot.canonicalPayload))),
+  );
+  assertEqual(
+    toHex(nativeSnapshotDigest),
+    vector.snapshot.sha256,
+    'WebCrypto snapshot SHA-256 digest',
+  );
+  const canonicalEmergency = canonicalize(vector.emergency.payload);
+  assertEqual(canonicalEmergency, vector.emergency.canonicalPayload, 'emergency canonical JSON');
+
+  const [rfc8032SignatureValid, pointerSignatureValid, emergencySignatureValid] = await Promise.all(
+    [
+      verifyWebCryptoVector(
+        subtle,
+        vector.rfc8032.signatureBase64Url,
+        decodeBase64Url(vector.rfc8032.messageBase64Url),
+        vector.rfc8032.publicKeyBase64Url,
+      ),
+      verifyWebCryptoVector(
+        subtle,
+        vector.configPointer.signatureBase64Url,
+        canonicalPayloadBytes,
+        vector.configPointer.publicKeyBase64Url,
+      ),
+      verifyWebCryptoVector(
+        subtle,
+        vector.emergency.signatureBase64Url,
+        encoder.encode(canonicalEmergency),
+        vector.emergency.publicKeyBase64Url,
+      ),
+    ],
+  );
+
+  assertTrue(rfc8032SignatureValid, 'WebCrypto RFC 8032 signature');
+  assertTrue(pointerSignatureValid, 'WebCrypto config pointer signature');
+  assertTrue(emergencySignatureValid, 'WebCrypto emergency signature');
+
+  const mutatedSignature = decodeBase64Url(vector.configPointer.signatureBase64Url);
+  mutatedSignature[0] ^= 1;
+  assertTrue(
+    !(await verifyWebCryptoBytes(
+      subtle,
+      mutatedSignature,
+      canonicalPayloadBytes,
+      vector.configPointer.publicKeyBase64Url,
+    )),
+    'WebCrypto mutated config pointer signature rejection',
+  );
+
+  return {
+    canonicalPayloadSha256: toHex(nativeDigest),
+    emergencySignatureValid,
+    pointerSignatureValid,
+    rfc8032SignatureValid,
+    snapshotSha256: toHex(nativeSnapshotDigest),
+  };
+}
+
+export function decodeBase64Url(value: string): Uint8Array {
+  if (!BASE64URL_PATTERN.test(value) || value.length % 4 === 1) {
+    throw new TypeError('Invalid Base64URL value');
+  }
+
+  const alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_';
+  const bytes = new Uint8Array(Math.floor((value.length * 6) / 8));
+  let accumulator = 0;
+  let bits = 0;
+  let offset = 0;
+
+  for (const character of value) {
+    accumulator = accumulator * 64 + alphabet.indexOf(character);
+    bits += 6;
+    if (bits < 8) continue;
+    bits -= 8;
+    bytes[offset] = Math.floor(accumulator / 2 ** bits) % 256;
+    accumulator %= 2 ** bits;
+    offset += 1;
+  }
+  if (accumulator !== 0) throw new TypeError('Invalid Base64URL value');
+
+  return bytes;
+}
+
+function verifyVector(signature: string, message: Uint8Array, publicKey: string): boolean {
+  return verify(decodeBase64Url(signature), message, decodeBase64Url(publicKey), {
+    zip215: false,
+  });
+}
+
+async function verifyWebCryptoVector(
+  subtle: SubtleCrypto,
+  signature: string,
+  message: Uint8Array,
+  publicKey: string,
+): Promise<boolean> {
+  return verifyWebCryptoBytes(subtle, decodeBase64Url(signature), message, publicKey);
+}
+
+async function verifyWebCryptoBytes(
+  subtle: SubtleCrypto,
+  signature: Uint8Array,
+  message: Uint8Array,
+  publicKey: string,
+): Promise<boolean> {
+  const key = await subtle.importKey(
+    'raw',
+    toArrayBuffer(decodeBase64Url(publicKey)),
+    { name: 'Ed25519' },
+    false,
+    ['verify'],
+  );
+  return subtle.verify({ name: 'Ed25519' }, key, toArrayBuffer(signature), toArrayBuffer(message));
+}
+
+function assertBytesEqual(actual: Uint8Array, expected: Uint8Array, name: string): void {
+  assertTrue(
+    actual.length === expected.length && actual.every((byte, index) => byte === expected[index]),
+    name,
+  );
+}
+
+function assertEqual(actual: string | undefined, expected: string, name: string): asserts actual {
+  if (actual !== expected) throw new Error(`${name} does not match the CODE-537 fixture`);
+}
+
+function assertTrue(value: boolean, name: string): asserts value {
+  if (!value) throw new Error(`${name} does not match the CODE-537 fixture`);
+}
+
+function toHex(bytes: Uint8Array): string {
+  return Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0')).join('');
+}
+
+function toArrayBuffer(bytes: Uint8Array): ArrayBuffer {
+  return bytes.slice().buffer;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -874,6 +874,15 @@ importers:
       '@linkcode/schema':
         specifier: workspace:*
         version: link:../schema
+      '@noble/ed25519':
+        specifier: 3.0.0
+        version: 3.0.0
+      '@noble/hashes':
+        specifier: 2.2.0
+        version: 2.2.0
+      canonicalize:
+        specifier: 3.0.0
+        version: 3.0.0
       zod:
         specifier: 'catalog:'
         version: 4.4.3
@@ -3591,6 +3600,9 @@ packages:
     resolution: {integrity: sha512-Z6pjIZ/8IJcCGzb2S/0Px5J81yij85xASuk1teLNeg75bfT07MV3a/O2Mtn1I2se43k3lkVEcFaR10N4cgQcZA==}
     engines: {node: '>= 20.19.0'}
 
+  '@noble/ed25519@3.0.0':
+    resolution: {integrity: sha512-QyteqMNm0GLqfa5SoYbSC3+Pvykwpn95Zgth4MFVSMKBB75ELl9tX1LAVsN4c3HXOrakHsF2gL4zWDAYCcsnzg==}
+
   '@noble/hashes@1.4.0':
     resolution: {integrity: sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==}
     engines: {node: '>= 16'}
@@ -6122,6 +6134,11 @@ packages:
 
   caniuse-lite@1.0.30001800:
     resolution: {integrity: sha512-MMHtuAz9Ys840zAY5F4k6fV5GaivZ9sPk+nz0mY+GYVzRBnYkN0mpqkSR92oWRQ19yQWo4HvBV/FnC16AJX8MA==}
+
+  canonicalize@3.0.0:
+    resolution: {integrity: sha512-yYLfHyDMIXRyRqsKBRLX023riFLpXY2YOfdtqKXZRZy9qsfOJ9U+4F9YZL7MEzL5+ziN2x2nlBvY/Voi3EBljA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
@@ -13978,6 +13995,8 @@ snapshots:
 
   '@noble/ciphers@2.2.0': {}
 
+  '@noble/ed25519@3.0.0': {}
+
   '@noble/hashes@1.4.0': {}
 
   '@noble/hashes@2.2.0': {}
@@ -16454,6 +16473,8 @@ snapshots:
   camelcase@6.3.0: {}
 
   caniuse-lite@1.0.30001800: {}
+
+  canonicalize@3.0.0: {}
 
   ccount@2.0.1: {}
 


### PR DESCRIPTION
## Summary

- add the cloud-owned deterministic config-signing fixture to `@linkcode/common`
- verify RFC 8785/JCS canonical bytes, Base64URL decoding, SHA-256, RFC 8032/config-pointer/emergency Ed25519 signatures, and mutated-signature rejection
- exercise Chromium WebCrypto and Noble in the actual unpackaged Electron renderer
- compile the Noble verification path into Android and iOS Hermes bundles without adding a native module or WebCrypto polyfill

## Runtime evidence

- **Electron:** actual renderer runtime passed with `PASS Electron WebCrypto and Noble config signing vector` and the existing unpackaged main/preload/renderer smoke test.
- **Expo/Hermes:** Android and iOS production exports passed and include the POC in Hermes bytecode. This is bundle/compile proof only; no simulator or physical-device runtime was executed. Hermes does not provide the required WebCrypto Ed25519 path, so the POC uses pure-JS `@noble/ed25519` and `@noble/hashes`.

## Validation

- `pnpm test packages/foundation/common/src/config-signing-poc` — 3/3 passed
- `xvfb-run -a pnpm -F @linkcode/desktop e2e:unpackaged` — Electron renderer runtime passed
- `pnpm -F @linkcode/mobile smoke:export` — Android and iOS Hermes exports passed
- `pnpm typecheck`
- `pnpm format:check`
- `pnpm lint:ci` — full lint with concurrency disabled passed
- `pnpm test` — 305 files passed, 1 skipped; 2,442 tests passed, 1 skipped

Linear: [CODE-537](https://linear.app/arcbox/issue/CODE-537/white-label-multi-platform-config-client-runtime-poc)