### PR TITLE
feat(schema): define LinkCode plugin package contracts

### DIFF
--- a/packages/foundation/schema/src/model/__tests__/plugin.test.ts
+++ b/packages/foundation/schema/src/model/__tests__/plugin.test.ts
@@ -1,5 +1,27 @@
 import { describe, expect, it } from 'vitest';
+import {
+  InstalledLinkCodePluginSchema,
+  LinkCodePluginManifestSchema,
+  LinkCodePluginReleaseSchema,
+} from '../linkcode-plugin';
 import { PluginSchema } from '../plugin';
+
+const latexManifest = {
+  manifestVersion: 1,
+  id: 'arcbox/latex',
+  version: '1.2.0',
+  displayName: 'LaTeX',
+  description: 'Compile LaTeX documents with a portable Agent Skill.',
+  keywords: ['latex', 'pdf'],
+  components: [
+    {
+      kind: 'skill',
+      name: 'latex',
+      entry: 'skills/latex/SKILL.md',
+    },
+  ],
+  assets: [{ id: { kind: 'tool', name: 'tectonic' }, versionRange: '>=0.16.0 <0.17.0' }],
+} as const;
 
 describe('PluginSchema', () => {
   it('keeps Claude Code installation scope separate from enablement', () => {
@@ -163,5 +185,163 @@ describe('PluginSchema', () => {
         },
       }).success,
     ).toBe(false);
+  });
+});
+
+describe('LinkCode plugin package contracts', () => {
+  it('represents one agent-independent plugin with trusted tool requirements', () => {
+    expect(LinkCodePluginManifestSchema.parse(latexManifest)).toMatchObject({
+      id: 'arcbox/latex',
+      components: [{ kind: 'skill', entry: 'skills/latex/SKILL.md' }],
+      assets: [{ id: { kind: 'tool', name: 'tectonic' } }],
+    });
+  });
+
+  it('keeps provider identity and mutable installation state out of the manifest', () => {
+    expect(
+      LinkCodePluginManifestSchema.safeParse({
+        ...latexManifest,
+        provider: 'claude-code',
+      }).success,
+    ).toBe(false);
+    expect(
+      LinkCodePluginManifestSchema.safeParse({
+        ...latexManifest,
+        enabled: true,
+      }).success,
+    ).toBe(false);
+  });
+
+  it.each([
+    '../SKILL.md',
+    '/skills/latex/SKILL.md',
+    String.raw`skills\latex\SKILL.md`,
+    'C:/SKILL.md',
+    'skills/latex./SKILL.md',
+    `skills/latex${String.fromCodePoint(0)}/SKILL.md`,
+  ])('rejects unsafe package entry %s', (entry) => {
+    expect(
+      LinkCodePluginManifestSchema.safeParse({
+        ...latexManifest,
+        components: [{ ...latexManifest.components[0], entry }],
+      }).success,
+    ).toBe(false);
+  });
+
+  it.each([
+    'arcbox./latex',
+    'arcbox/a..b',
+    'nul/latex',
+    'arcbox/con',
+    'arcbox/con.txt',
+    'ArcBox/latex',
+    `${'a'.repeat(65)}/latex`,
+  ])('rejects unsafe plugin id %s', (id) => {
+    expect(LinkCodePluginManifestSchema.safeParse({ ...latexManifest, id }).success).toBe(false);
+  });
+
+  it('rejects a non-canonical semver release identity', () => {
+    expect(
+      LinkCodePluginManifestSchema.safeParse({ ...latexManifest, version: '1.2.0-01' }).success,
+    ).toBe(false);
+  });
+
+  it('accepts hyphens and numeric identifiers in semver build metadata', () => {
+    expect(
+      LinkCodePluginManifestSchema.safeParse({
+        ...latexManifest,
+        version: '1.2.0+build-01',
+      }).success,
+    ).toBe(true);
+  });
+
+  it('rejects duplicate component identities', () => {
+    expect(
+      LinkCodePluginManifestSchema.safeParse({
+        ...latexManifest,
+        components: [latexManifest.components[0], latexManifest.components[0]],
+      }).success,
+    ).toBe(false);
+  });
+
+  it('continues to reject agent runtimes as plugin assets', () => {
+    expect(
+      LinkCodePluginManifestSchema.safeParse({
+        ...latexManifest,
+        assets: [{ id: { kind: 'agent', name: 'codex' } }],
+      }).success,
+    ).toBe(false);
+  });
+
+  it('pins immutable marketplace package bytes with SRI integrity', () => {
+    expect(
+      LinkCodePluginReleaseSchema.parse({
+        manifest: {
+          ...latexManifest,
+          components: [
+            {
+              ...latexManifest.components[0],
+              futureComponentMetadata: 'ignored by older readers',
+            },
+          ],
+          futureManifestMetadata: 'ignored by older readers',
+        },
+        artifact: {
+          urls: ['releases/arcbox-latex-1.2.0.tgz'],
+          integrity: 'sha256-7bZ8YaunaCifbaRByeb1I8+v9PiypXCFI+8pxUP46I4=',
+          size: 4096,
+          format: 'tgz',
+        },
+        publishedAt: '2026-08-03T00:00:00.000Z',
+        deprecated: false,
+      }),
+    ).toMatchObject({ manifest: { id: 'arcbox/latex', version: '1.2.0' } });
+  });
+
+  it('rejects marketplace releases without parseable integrity', () => {
+    expect(
+      LinkCodePluginReleaseSchema.safeParse({
+        manifest: latexManifest,
+        artifact: {
+          urls: ['https://plugins.linkcode.ai/arcbox/latex/1.2.0.tgz'],
+          integrity: '7bZ8YaunaCifbaRByeb1I8+v9PiypXCFI+8pxUP46I4=',
+          format: 'tgz',
+        },
+      }).success,
+    ).toBe(false);
+  });
+
+  it('rejects non-HTTPS absolute artifact URLs', () => {
+    expect(
+      LinkCodePluginReleaseSchema.safeParse({
+        manifest: latexManifest,
+        artifact: {
+          urls: ['http://plugins.linkcode.ai/arcbox/latex/1.2.0.tgz'],
+          integrity: 'sha256-7bZ8YaunaCifbaRByeb1I8+v9PiypXCFI+8pxUP46I4=',
+          format: 'tgz',
+        },
+      }).success,
+    ).toBe(false);
+  });
+
+  it('stores mutable local state separately with marketplace provenance', () => {
+    expect(
+      InstalledLinkCodePluginSchema.parse({
+        id: 'arcbox/latex',
+        version: '1.2.0',
+        marketplaceId: 'linkcode-official',
+        integrity: 'sha256-7bZ8YaunaCifbaRByeb1I8+v9PiypXCFI+8pxUP46I4=',
+        enabled: true,
+        path: '/home/user/.linkcode/plugins/arcbox/latex/1.2.0',
+        futureStoreMetadata: 'ignored by older readers',
+      }),
+    ).toEqual({
+      id: 'arcbox/latex',
+      version: '1.2.0',
+      marketplaceId: 'linkcode-official',
+      integrity: 'sha256-7bZ8YaunaCifbaRByeb1I8+v9PiypXCFI+8pxUP46I4=',
+      enabled: true,
+      path: '/home/user/.linkcode/plugins/arcbox/latex/1.2.0',
+    });
   });
 });

--- a/packages/foundation/schema/src/model/__tests__/plugin.test.ts
+++ b/packages/foundation/schema/src/model/__tests__/plugin.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   InstalledLinkCodePluginSchema,
+  LinkCodePluginIntegritySchema,
   LinkCodePluginManifestSchema,
   LinkCodePluginReleaseSchema,
 } from '../linkcode-plugin';
@@ -219,7 +220,9 @@ describe('LinkCode plugin package contracts', () => {
     'C:/SKILL.md',
     'skills/latex./SKILL.md',
     `skills/latex${String.fromCodePoint(0)}/SKILL.md`,
-  ])('rejects unsafe package entry %s', (entry) => {
+    'skills/latex/readme.md',
+    'skills/latex/skill.md',
+  ])('rejects invalid skill package entry %s', (entry) => {
     expect(
       LinkCodePluginManifestSchema.safeParse({
         ...latexManifest,
@@ -309,6 +312,29 @@ describe('LinkCode plugin package contracts', () => {
         },
       }).success,
     ).toBe(false);
+  });
+
+  it.each([
+    'sha256-A',
+    'sha256-Zg==',
+    `sha256-${'A'.repeat(43)}`,
+    `sha256-${'A'.repeat(42)}B=`,
+    `sha384-${'A'.repeat(44)}`,
+    `sha512-${'A'.repeat(64)}`,
+  ])('rejects non-canonical or incorrectly sized SRI digest %s', (integrity) => {
+    expect(LinkCodePluginIntegritySchema.safeParse(integrity).success).toBe(false);
+  });
+
+  it('accepts canonical digests with the size required by each SRI algorithm', () => {
+    expect(
+      LinkCodePluginIntegritySchema.safeParse(
+        [
+          `sha256-${'A'.repeat(43)}=`,
+          `sha384-${'A'.repeat(64)}`,
+          `sha512-${'A'.repeat(86)}==`,
+        ].join(' '),
+      ).success,
+    ).toBe(true);
   });
 
   it('rejects non-HTTPS absolute artifact URLs', () => {

--- a/packages/foundation/schema/src/model/index.ts
+++ b/packages/foundation/schema/src/model/index.ts
@@ -10,6 +10,7 @@ export * from './file';
 export * from './git';
 export * from './history';
 export * from './im';
+export * from './linkcode-plugin';
 export * from './loop';
 export * from './managed-asset';
 export * from './permission';

--- a/packages/foundation/schema/src/model/linkcode-plugin.ts
+++ b/packages/foundation/schema/src/model/linkcode-plugin.ts
@@ -1,0 +1,175 @@
+import { z } from 'zod';
+import { PluginAssetRequirementSchema, PluginAuthorSchema, PluginLinksSchema } from './plugin';
+
+const ID_SEGMENT_RE = /^[a-z0-9]+(?:[._-][a-z0-9]+)*$/;
+const PACKAGE_PATH_SEGMENT_RE = /^[0-9A-Z][\w.-]*$/i;
+const WINDOWS_RESERVED_SEGMENT_RE = /^(?:aux|con|nul|prn|com[1-9]|lpt[1-9])(?:\.|$)/i;
+const NUMERIC_IDENTIFIER_RE = /^\d+$/;
+const MAX_ID_SEGMENT_LENGTH = 64;
+const SEMVER_RE =
+  /^(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-[0-9A-Z-]+(?:\.[0-9A-Z-]+)*)?(?:\+[0-9A-Z-]+(?:\.[0-9A-Z-]+)*)?$/i;
+const SRI_RE =
+  /^(?:sha256|sha384|sha512)-[A-Za-z0-9+/]+={0,2}(?:\s+(?:sha256|sha384|sha512)-[A-Za-z0-9+/]+={0,2})*$/;
+
+function isSafeIdSegment(value: string): boolean {
+  return (
+    value.length <= MAX_ID_SEGMENT_LENGTH &&
+    ID_SEGMENT_RE.test(value) &&
+    !WINDOWS_RESERVED_SEGMENT_RE.test(value)
+  );
+}
+
+function isSemver(value: string): boolean {
+  if (!SEMVER_RE.test(value)) return false;
+  const buildStart = value.indexOf('+');
+  const versionWithoutBuild = buildStart === -1 ? value : value.slice(0, buildStart);
+  const prereleaseStart = versionWithoutBuild.indexOf('-');
+  if (prereleaseStart === -1) return true;
+  const prerelease = versionWithoutBuild.slice(prereleaseStart + 1);
+  return prerelease
+    .split('.')
+    .every(
+      (identifier) =>
+        !NUMERIC_IDENTIFIER_RE.test(identifier) || identifier === '0' || identifier[0] !== '0',
+    );
+}
+
+/** Stable LinkCode marketplace identity, independent of every agent provider. */
+export const LinkCodePluginIdSchema = z.string().refine((id) => {
+  const segments = id.split('/');
+  return segments.length === 2 && segments.every((segment) => isSafeIdSegment(segment));
+}, 'Expected a safe lowercase publisher/name plugin id');
+export type LinkCodePluginId = z.infer<typeof LinkCodePluginIdSchema>;
+
+/** Stable configured-marketplace identity persisted in local installation records. */
+export const LinkCodeMarketplaceIdSchema = z
+  .string()
+  .refine(isSafeIdSegment, 'Expected a safe lowercase marketplace id');
+export type LinkCodeMarketplaceId = z.infer<typeof LinkCodeMarketplaceIdSchema>;
+
+/** Exact package version. Compatibility ranges belong on requirements, never release identity. */
+export const LinkCodePluginVersionSchema = z.string().refine(isSemver, 'Expected a semver version');
+export type LinkCodePluginVersion = z.infer<typeof LinkCodePluginVersionSchema>;
+
+/** Forward-slash path inside a verified plugin archive. */
+export const LinkCodePluginPackagePathSchema = z
+  .string()
+  .min(1)
+  .refine(
+    (path) => {
+      if (path[0] === '/' || path.includes('\\')) return false;
+      return path
+        .split('/')
+        .every(
+          (segment) =>
+            PACKAGE_PATH_SEGMENT_RE.test(segment) &&
+            !segment.endsWith('.') &&
+            !WINDOWS_RESERVED_SEGMENT_RE.test(segment),
+        );
+    },
+    { error: 'Expected a normalized relative package path' },
+  );
+export type LinkCodePluginPackagePath = z.infer<typeof LinkCodePluginPackagePathSchema>;
+
+const linkCodePluginSkillFields = {
+  kind: z.literal('skill'),
+  name: z.string().refine(isSafeIdSegment, 'Expected a safe lowercase skill name'),
+  description: z.string().optional(),
+  /** Package-relative SKILL.md entry point. */
+  entry: LinkCodePluginPackagePathSchema,
+} as const;
+
+/** First portable LinkCode component: an Agent Skill package that adapters can materialize. */
+export const LinkCodePluginSkillSchema = z.strictObject(linkCodePluginSkillFields);
+export type LinkCodePluginSkill = z.infer<typeof LinkCodePluginSkillSchema>;
+
+const linkCodePluginManifestFields = {
+  manifestVersion: z.literal(1),
+  id: LinkCodePluginIdSchema,
+  version: LinkCodePluginVersionSchema,
+  displayName: z.string().min(1).optional(),
+  description: z.string().optional(),
+  author: PluginAuthorSchema.optional(),
+  category: z.string().min(1).optional(),
+  keywords: z.array(z.string().min(1)),
+  links: PluginLinksSchema.optional(),
+  components: z.array(z.object(linkCodePluginSkillFields)).min(1),
+  /** Trusted managed-tool requirements; URLs and exact asset versions remain host-owned. */
+  assets: z.array(PluginAssetRequirementSchema),
+} as const;
+
+function rejectDuplicateComponents(
+  manifest: { components: LinkCodePluginSkill[] },
+  ctx: z.RefinementCtx,
+): void {
+  const names = new Set<string>();
+  for (const component of manifest.components) {
+    const key = `${component.kind}:${component.name}`;
+    if (names.has(key)) {
+      ctx.addIssue({
+        code: 'custom',
+        message: `Duplicate plugin component: ${key}`,
+        path: ['components'],
+      });
+    }
+    names.add(key);
+  }
+}
+
+/**
+ * Agent-independent package manifest. Provider-specific discovery remains on `PluginSchema`; this
+ * contract is the source format LinkCode installs once and projects into supported agents.
+ */
+export const LinkCodePluginManifestSchema = z
+  .strictObject({
+    ...linkCodePluginManifestFields,
+    components: z.array(LinkCodePluginSkillSchema).min(1),
+  })
+  .superRefine(rejectDuplicateComponents);
+export type LinkCodePluginManifest = z.infer<typeof LinkCodePluginManifestSchema>;
+
+/** Forward-compatible marketplace reader for additive fields within manifest version 1. */
+const LinkCodePluginManifestReaderSchema = z
+  .object(linkCodePluginManifestFields)
+  .superRefine(rejectDuplicateComponents);
+
+export const LinkCodePluginArchiveFormatSchema = z.enum(['tgz', 'zip']);
+export type LinkCodePluginArchiveFormat = z.infer<typeof LinkCodePluginArchiveFormatSchema>;
+
+/** SRI digest of immutable package bytes; retained after install for audit and re-verification. */
+export const LinkCodePluginIntegritySchema = z
+  .string()
+  .regex(SRI_RE, 'Expected sha256, sha384, or sha512 SRI integrity');
+export type LinkCodePluginIntegrity = z.infer<typeof LinkCodePluginIntegritySchema>;
+
+/** Immutable package bytes advertised by a marketplace release. */
+export const LinkCodePluginArtifactSchema = z.object({
+  /** Ordered HTTPS or marketplace-relative mirrors of the same integrity-pinned bytes. */
+  urls: z.array(z.union([z.url({ protocol: /^https$/ }), LinkCodePluginPackagePathSchema])).min(1),
+  integrity: LinkCodePluginIntegritySchema,
+  size: z.number().int().positive().optional(),
+  format: LinkCodePluginArchiveFormatSchema,
+});
+export type LinkCodePluginArtifact = z.infer<typeof LinkCodePluginArtifactSchema>;
+
+/** One immutable marketplace release: catalog metadata plus its verified package artifact. */
+export const LinkCodePluginReleaseSchema = z.object({
+  manifest: LinkCodePluginManifestReaderSchema,
+  artifact: LinkCodePluginArtifactSchema,
+  publishedAt: z.iso.datetime().optional(),
+});
+export type LinkCodePluginRelease = z.infer<typeof LinkCodePluginReleaseSchema>;
+
+/** Mutable local Store state, deliberately separate from manifest and marketplace release data. */
+export const InstalledLinkCodePluginSchema = z.object({
+  id: LinkCodePluginIdSchema,
+  version: LinkCodePluginVersionSchema,
+  /** Stable id of the configured marketplace that supplied this release. */
+  marketplaceId: LinkCodeMarketplaceIdSchema,
+  /** Artifact digest actually verified before this package was published into the Store. */
+  integrity: LinkCodePluginIntegritySchema,
+  enabled: z.boolean(),
+  /** Absolute package root in the daemon's local plugin Store. */
+  path: z.string().min(1),
+});
+export type InstalledLinkCodePlugin = z.infer<typeof InstalledLinkCodePluginSchema>;

--- a/packages/foundation/schema/src/model/linkcode-plugin.ts
+++ b/packages/foundation/schema/src/model/linkcode-plugin.ts
@@ -5,11 +5,16 @@ const ID_SEGMENT_RE = /^[a-z0-9]+(?:[._-][a-z0-9]+)*$/;
 const PACKAGE_PATH_SEGMENT_RE = /^[0-9A-Z][\w.-]*$/i;
 const WINDOWS_RESERVED_SEGMENT_RE = /^(?:aux|con|nul|prn|com[1-9]|lpt[1-9])(?:\.|$)/i;
 const NUMERIC_IDENTIFIER_RE = /^\d+$/;
+const WHITESPACE_RE = /\s+/;
 const MAX_ID_SEGMENT_LENGTH = 64;
 const SEMVER_RE =
   /^(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-[0-9A-Z-]+(?:\.[0-9A-Z-]+)*)?(?:\+[0-9A-Z-]+(?:\.[0-9A-Z-]+)*)?$/i;
-const SRI_RE =
-  /^(?:sha256|sha384|sha512)-[A-Za-z0-9+/]+={0,2}(?:\s+(?:sha256|sha384|sha512)-[A-Za-z0-9+/]+={0,2})*$/;
+const SRI_TOKEN_RE = /^(sha256|sha384|sha512)-([A-Za-z0-9+/]+={0,2})$/;
+const SRI_DIGEST_LENGTHS: Readonly<Record<string, number>> = {
+  sha256: 32,
+  sha384: 48,
+  sha512: 64,
+};
 
 function isSafeIdSegment(value: string): boolean {
   return (
@@ -32,6 +37,21 @@ function isSemver(value: string): boolean {
       (identifier) =>
         !NUMERIC_IDENTIFIER_RE.test(identifier) || identifier === '0' || identifier[0] !== '0',
     );
+}
+
+function isSri(value: string): boolean {
+  if (value.length === 0 || value.trim() !== value) return false;
+  return value.split(WHITESPACE_RE).every((token) => {
+    const match = SRI_TOKEN_RE.exec(token);
+    if (!match) return false;
+    const [, algorithm, encoded] = match;
+    try {
+      const decoded = atob(encoded);
+      return decoded.length === SRI_DIGEST_LENGTHS[algorithm] && btoa(decoded) === encoded;
+    } catch {
+      return false;
+    }
+  });
 }
 
 /** Stable LinkCode marketplace identity, independent of every agent provider. */
@@ -76,7 +96,10 @@ const linkCodePluginSkillFields = {
   name: z.string().refine(isSafeIdSegment, 'Expected a safe lowercase skill name'),
   description: z.string().optional(),
   /** Package-relative SKILL.md entry point. */
-  entry: LinkCodePluginPackagePathSchema,
+  entry: LinkCodePluginPackagePathSchema.refine(
+    (path) => path.split('/').at(-1) === 'SKILL.md',
+    'Expected a package path ending in SKILL.md',
+  ),
 } as const;
 
 /** First portable LinkCode component: an Agent Skill package that adapters can materialize. */
@@ -139,7 +162,7 @@ export type LinkCodePluginArchiveFormat = z.infer<typeof LinkCodePluginArchiveFo
 /** SRI digest of immutable package bytes; retained after install for audit and re-verification. */
 export const LinkCodePluginIntegritySchema = z
   .string()
-  .regex(SRI_RE, 'Expected sha256, sha384, or sha512 SRI integrity');
+  .refine(isSri, 'Expected canonical sha256, sha384, or sha512 SRI integrity');
 export type LinkCodePluginIntegrity = z.infer<typeof LinkCodePluginIntegritySchema>;
 
 /** Immutable package bytes advertised by a marketplace release. */


### PR DESCRIPTION
## Summary

- define provider-independent LinkCode plugin manifest, immutable release artifact, and mutable installation contracts
- model portable Skill components and trusted managed-tool requirements such as `tectonic`
- pin marketplace package bytes with HTTPS/package-relative sources and SRI integrity
- keep existing Claude Code/Codex native plugin schemas and the wire protocol unchanged
- establish the base layer for subsequent stacked marketplace index, Store, asset-install, and agent-projection PRs

Linear: [CODE-563](https://linear.app/arcbox/issue/CODE-563/featplugins-define-linkcode-plugin-package-contracts)

## Verification

- `devenv shell -- pnpm test` — 304 files passed, 2462 tests passed
- `devenv shell -- pnpm exec vitest run packages/foundation/schema/src/model/__tests__/plugin.test.ts` — 29 tests passed
- `devenv shell -- pnpm exec tsc --build --noEmit packages/foundation/schema`
- Biome and ESLint pass on all three changed files
- `pnpm check:ci` is currently blocked by 11 pre-existing Biome formatting failures on `master`; none are files changed by this PR

## Checklist

- [ ] `pnpm check:ci` and `pnpm test` both pass (plus `cargo fmt` / `clippy` / `test` for Rust changes) — tests pass; `check:ci` has the unrelated baseline failure documented above
- [x] I ran the affected schema parse surface and observed the change working
- [x] If a wire message changed: `WIRE_PROTOCOL_VERSION` is bumped — no wire message changed
- [x] New code and assets are my own work, or their origin and license compatibility are noted above
- [x] Docs and comments are updated where behavior changed