### PR TITLE
test(workbench): guard new chat session isolation

### DIFF
--- a/apps/webview/e2e/browser-smoke.e2e.mts
+++ b/apps/webview/e2e/browser-smoke.e2e.mts
@@ -16,6 +16,7 @@ const webviewDir = fileURLToPath(new URL('..', import.meta.url));
 const daemonDir = fileURLToPath(new URL('../../daemon', import.meta.url));
 const viteCli = fileURLToPath(new URL('../../bin/vite.js', import.meta.resolve('vite')));
 const mockThreadTitle = 'Wire the workbench to the daemon';
+const mockChatThreadTitle = 'Prototype without git';
 const longThreadTitle = 'Long thread · navigation testbed';
 const longThreadTurns = 48;
 const maxMountedRows = 10;
@@ -64,6 +65,57 @@ async function sendPrompt(page: Page, prompt: string, appErrors: string[]): Prom
   await editor.fill(prompt);
   await page.getByRole('button', { name: 'Send' }).click();
   await page.getByText(`You said: ${prompt}`, { exact: false }).waitFor({ timeout: 15000 });
+  assertNoApplicationErrors(appErrors);
+}
+
+async function verifyNewChatIsolation(page: Page, appErrors: string[]): Promise<void> {
+  await page.evaluate(() => {
+    localStorage.setItem(
+      'linkcode.workbench.new-session-defaults:v5',
+      JSON.stringify({ state: { lastProvider: 'pi' }, version: 0 }),
+    );
+  });
+  await page.reload({ waitUntil: 'domcontentloaded' });
+  await page.locator('[data-thread-title]', { hasText: mockChatThreadTitle }).waitFor();
+  await page.locator('[data-thread-title]', { hasText: mockChatThreadTitle }).click();
+  await page.locator('[data-conversation-title]', { hasText: mockChatThreadTitle }).waitFor();
+  await page.getByRole('button', { name: 'New chat' }).click();
+
+  const prompt = `new-chat-isolation-${Date.now().toString(36)}`;
+  const editor = page.locator('[data-slot="composer-editor"][contenteditable="true"]');
+  await editor.waitFor({ state: 'visible' });
+  await editor.fill(prompt);
+  await page.evaluate(() => {
+    const main = document.querySelector('main');
+    if (!main) throw new Error('Missing workbench main');
+    const titles = new Set<string | null>();
+    const collect = (): void => {
+      titles.add(document.querySelector('[data-conversation-title]')?.textContent ?? null);
+    };
+    const observer = new MutationObserver(collect);
+    observer.observe(main, { childList: true, characterData: true, subtree: true });
+    Reflect.set(window, '__newChatIsolationProbe', () => {
+      collect();
+      observer.disconnect();
+      return [...titles];
+    });
+  });
+
+  await page.getByRole('button', { name: 'Send' }).click();
+  await page.getByText(`You said: ${prompt}`, { exact: false }).waitFor({ timeout: 15000 });
+  const titles = await page.evaluate(() => {
+    const finish = Reflect.get(window, '__newChatIsolationProbe') as
+      | undefined
+      | (() => Array<string | null>);
+    if (!finish) throw new Error('Missing new-chat isolation probe');
+    Reflect.deleteProperty(window, '__newChatIsolationProbe');
+    return finish();
+  });
+  assert.equal(
+    titles.some((title) => title?.includes(mockChatThreadTitle)),
+    false,
+    `New chat rendered the previous conversation after submission: ${JSON.stringify(titles)}`,
+  );
   assertNoApplicationErrors(appErrors);
 }
 
@@ -312,6 +364,7 @@ async function verifyMockEntry(browser: Browser): Promise<void> {
     await selectMockThread(page);
     const recoveryPrompt = `${firstPrompt}-after-reload`;
     await sendPrompt(page, recoveryPrompt, appErrors);
+    await verifyNewChatIsolation(page, appErrors);
     await verifyLongThreadVirtualization(page);
     assertNoApplicationErrors(appErrors);
     await page.close();

--- a/packages/client/workbench/src/mock/data/sessions.ts
+++ b/packages/client/workbench/src/mock/data/sessions.ts
@@ -1,4 +1,4 @@
-import type { AgentKind, SessionResource, SessionStatus } from '@linkcode/schema';
+import type { AgentKind, SessionResource, SessionStatus, WorkspaceKind } from '@linkcode/schema';
 
 export const SHOWCASE_TITLE = 'Mocked streaming showcase';
 export const SHOWCASE_TERMINAL_ID = 'mock-terminal-showcase';
@@ -14,6 +14,7 @@ export interface SeedSession {
   title: string;
   status: SessionStatus;
   ageMs: number;
+  workspaceKind?: WorkspaceKind;
   showcase?: boolean;
   /** Seeds a long settled transcript instead of the scripted showcase (see `long-thread.ts`). */
   longThread?: boolean;
@@ -123,5 +124,6 @@ export const SEED_SESSIONS: SeedSession[] = [
     title: 'Prototype without git',
     status: 'idle',
     ageMs: 72 * 3_600_000,
+    workspaceKind: 'chat',
   },
 ];

--- a/packages/client/workbench/src/mock/dev-mock-host.ts
+++ b/packages/client/workbench/src/mock/dev-mock-host.ts
@@ -300,11 +300,12 @@ export class DevMockHost {
       void this.handle(msg);
     });
     const now = Date.now();
-    for (const { ageMs, resources, ...seed } of SEED_SESSIONS) {
+    for (const { ageMs, resources, workspaceKind, ...seed } of SEED_SESSIONS) {
       const createdAt = now - ageMs;
       const session = this.addSession({ ...seed, createdAt, updatedAt: createdAt });
       this.seedResources(session.sessionId, now, resources ?? []);
-      this.touchWorkspace(seed.cwd, createdAt);
+      const workspace = this.touchWorkspace(seed.cwd, createdAt);
+      if (workspaceKind) workspace.kind = workspaceKind;
     }
     this.history = SEED_HISTORY.map(({ ageMs, ...entry }) => ({
       ...entry,


### PR DESCRIPTION
## What changed

- provision a real `chat` workspace in the wire-compatible workbench mock
- extend the browser smoke flow to create a chat from an existing chat and submit its first prompt
- record every rendered conversation title during submission and reject any frame that returns to the previous session

## Root cause

The retired View Transition path left `useDeferredValue(selectedId)` in the shared workbench session resolver. When a new-chat draft exited, the draft cleared immediately while the deferred selection still named the previous session, so React committed one frame of the previous conversation before rendering the new session.

The live-selection fix is already present on `master`; this PR adds the missing chat-creation regression boundary. Restoring the deferred selection makes the new assertion fail with `New chat rendered the previous conversation after submission`.

## Impact

Desktop and webview share the guarded workbench session path. A future change can no longer reintroduce the stale-session frame without failing the browser smoke gate.

## Verification

- `pnpm check:ci`
- `pnpm test` — 302 files passed, 3 skipped; 2,435 tests passed, 5 skipped
- `pnpm -F @linkcode/webview e2e:browser`
- mutation check: restoring `useDeferredValue(selectedId)` fails the new-chat isolation assertion

Tracks CODE-103.