### PR TITLE
fix(workbench): isolate identity-scoped cache data

### DIFF
--- a/packages/client/workbench/src/runtime/__tests__/provider-cache-policy.test.tsx
+++ b/packages/client/workbench/src/runtime/__tests__/provider-cache-policy.test.tsx
@@ -1,0 +1,44 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import { asyncNoop, noop } from 'foxts/noop';
+import useSWR from 'swr';
+import { afterEach, expect, it } from 'vitest';
+import { DebugProvider } from '../debug';
+import { WorkbenchRuntimeProvider } from '../provider';
+import { TestTransport } from './connection-controller-test-helpers';
+
+const connectionSource = {
+  resolve: () => ({
+    endpoint: 'http://daemon',
+    transport: new TestTransport(asyncNoop),
+  }),
+};
+
+function Transcript({ historyId }: { historyId: string }): React.ReactNode {
+  const { data } = useSWR(historyId, () =>
+    historyId === 'old' ? Promise.resolve('old transcript') : new Promise<string>(noop),
+  );
+  return <output data-testid="transcript">{data ?? 'empty'}</output>;
+}
+
+function Runtime({ historyId }: { historyId: string }): React.ReactNode {
+  return (
+    <DebugProvider>
+      <WorkbenchRuntimeProvider connectionSource={connectionSource}>
+        <Transcript historyId={historyId} />
+      </WorkbenchRuntimeProvider>
+    </DebugProvider>
+  );
+}
+
+afterEach(cleanup);
+
+it('does not carry identity-scoped data to a new pending key', async () => {
+  const view = render(<Runtime historyId="old" />);
+  await waitFor(() => expect(screen.getByTestId('transcript').textContent).toBe('old transcript'));
+
+  view.rerender(<Runtime historyId="new" />);
+
+  expect(screen.getByTestId('transcript').textContent).toBe('empty');
+});

--- a/packages/client/workbench/src/runtime/provider.tsx
+++ b/packages/client/workbench/src/runtime/provider.tsx
@@ -164,6 +164,8 @@ function WorkbenchRuntimeGeneration({
       contexts={[
         <WorkbenchSdkClientContext.Provider key="sdk-client" value={contextGeneration.client} />,
         <TayoriProvider key="tayori" initClient={() => contextGeneration.client} />,
+        // Tayori enables this by default; identity-scoped data must not survive a key change.
+        <SWRConfig key="swr-policy" value={{ keepPreviousData: false }} />,
         <LinkCodeProvider key="linkcode" client={contextGeneration.client.raw} />,
       ]}
     >
@@ -217,11 +219,6 @@ function WorkbenchSWRConfig({ children }: React.PropsWithChildren): React.ReactN
   const { current: cache } = useSingleton<Cache>(() => new Map());
   const { current: provider } = useSingleton(() => createCacheProvider(cache));
   return (
-    // `keepPreviousData` stays at SWR's own default (off) on purpose. Turning it on here made the
-    // risky option the default: every identity-scoped request — keyed by session, workspace, loop —
-    // would answer with the *previous* identity's data while the new key loads, and forever if that
-    // request fails. A surface that genuinely wants the stale-while-loading behavior asks for it at
-    // its own call site, where the intent is visible.
     <SWRConfig
       value={{
         onError: handleFetchError,


### PR DESCRIPTION
## What changed

- override Tayori's `keepPreviousData: true` default inside the shared workbench runtime
- add a provider-composition regression test that switches from a resolved identity to a pending identity

## Root cause

`tayori@0.3.8` nests its own `SWRConfig` and enables `keepPreviousData` by default. That inner configuration overrode the workbench's intended SWR default. After the explicit conversation-level opt-out was removed on July 30, a newly created session without a `historyId` temporarily received the previous session's transcript seed. The first live prompt therefore rendered after the previous transcript until the new history binding arrived and replaced the seed.

The earlier View Transition fix removed a separate stale-selection frame, but PR #401's browser probe only observed conversation titles and the mock sessions had no history seeds, so it could not detect this data leak.

## Impact

Desktop and webview share this runtime boundary. Identity-scoped requests now clear data on key changes by default; call sites that intentionally want stale-while-loading behavior still opt in with `keepPreviousData: true`.

## Verification

- mutation check: before the fix, the new regression test rendered `old transcript` for the pending new key
- `pnpm check:ci`
- `pnpm test` — 303 files passed, 3 skipped; 2,473 tests passed, 5 skipped
- `pnpm -F @linkcode/webview e2e:browser`

Tracks CODE-103.