### PR TITLE
test(config): harden client recovery paths

### DIFF
--- a/apps/desktop/e2e/config-canary.e2e.mts
+++ b/apps/desktop/e2e/config-canary.e2e.mts
@@ -8,10 +8,15 @@ import { join } from 'node:path';
 import { noop } from 'foxts/noop';
 import { wait } from 'foxts/wait';
 import type { ElectronApplication } from 'playwright-core';
-import type { DistServer, ServerMode } from './config-canary/dist-server.mts';
-import { startDistServer, waitForRequest } from './config-canary/dist-server.mts';
+import type { DistServer, EmergencyServerMode, ServerMode } from './config-canary/dist-server.mts';
+import {
+  startDistServer,
+  startEmergencyServer,
+  waitForRequest,
+} from './config-canary/dist-server.mts';
 import {
   buildDesktopWithBootstrap,
+  EMERGENCY_PORT,
   generateTlsMaterial,
   launchApp,
   PORT,
@@ -21,6 +26,7 @@ import { baseline, canary, rollback, rollForward } from './config-canary/fixture
 import type { ConfigStateFile } from './config-canary/state-file.mts';
 import {
   readConfigState,
+  readEmergencyState,
   waitForConfigState,
   writeCorruptConfigState,
 } from './config-canary/state-file.mts';
@@ -28,11 +34,13 @@ import {
 const REJECTION_SETTLE_MS = 1000;
 
 let mode: ServerMode = 'offline';
+let emergencyMode: EmergencyServerMode = 'offline';
 
 interface Harness {
   app: ElectronApplication | null;
   readonly caCert: string;
   readonly dist: DistServer;
+  readonly emergency: DistServer;
   readonly home: string;
   readonly userData: string;
 }
@@ -199,6 +207,106 @@ async function driveScenarios(harness: Harness): Promise<void> {
     assertAccepted(state, baseline);
     console.log('PASS baseline republication recovers after corrupt-state reset');
   });
+
+  emergencyMode = 'kill-switch';
+  harness.emergency.requests.length = 0;
+  await withLaunch(harness, 'offline', async () => {
+    const app = assertApp(harness);
+    const boundary = await refreshBoundary(app);
+    assert.equal(boundary.report.normal, 'error');
+    assert.equal(boundary.report.emergency, 'updated');
+    const emergency = boundary.info.emergency;
+    assert(emergency);
+    assert.deepEqual(emergency.disabledFeatures, ['feature.aiAssist']);
+    assert.equal(emergency.emergencyVersion, '1');
+    await waitForRequest(
+      harness.dist,
+      (request) => request.path === baseline.pointerPath && request.status === 'disconnected',
+    );
+    await waitForRequest(
+      harness.emergency,
+      (request) => request.mode === 'kill-switch' && request.status === 200,
+    );
+    console.log('PASS emergency origin activates kill switch during main-channel outage');
+  });
+
+  emergencyMode = 'forced-minimum';
+  harness.emergency.requests.length = 0;
+  await withLaunch(harness, 'offline', async () => {
+    const boundary = await refreshBoundary(assertApp(harness));
+    assert.equal(boundary.report.emergency, 'updated');
+    const emergency = boundary.info.emergency;
+    assert(emergency);
+    assert.equal(emergency.emergencyVersion, '2');
+    assert.equal(emergency.forceMinVersion, '2.4.0');
+    console.log('PASS newer emergency state replaces the persisted kill switch');
+  });
+
+  emergencyMode = 'offline';
+  harness.emergency.requests.length = 0;
+  await withLaunch(harness, 'offline', async () => {
+    const boundary = await refreshBoundary(assertApp(harness));
+    assert.equal(boundary.report.emergency, 'error');
+    const emergency = boundary.info.emergency;
+    assert(emergency);
+    assert.equal(emergency.emergencyVersion, '2');
+    assert.equal(emergency.forceMinVersion, '2.4.0');
+    console.log('PASS forced minimum survives reconstructed runtime and emergency outage');
+  });
+
+  emergencyMode = 'release';
+  harness.emergency.requests.length = 0;
+  let releaseRaw = '';
+  await withLaunch(harness, 'offline', async () => {
+    const boundary = await refreshBoundary(assertApp(harness));
+    assert.equal(boundary.report.emergency, 'updated');
+    const emergency = boundary.info.emergency;
+    assert(emergency);
+    assert.deepEqual(emergency.disabledFeatures, []);
+    assert.equal(emergency.emergencyVersion, '3');
+    releaseRaw = (await readEmergencyState(harness.home))?.raw ?? '';
+    assert(releaseRaw);
+    console.log('PASS explicit newer release clears emergency restrictions');
+  });
+
+  emergencyMode = 'equivocation';
+  harness.emergency.requests.length = 0;
+  await withLaunch(harness, 'offline', async () => {
+    const boundary = await refreshBoundary(assertApp(harness));
+    assert.equal(boundary.report.emergency, 'error');
+    const emergency = boundary.info.emergency;
+    assert(emergency);
+    assert.deepEqual(emergency.disabledFeatures, []);
+    assert.equal(emergency.emergencyVersion, '3');
+    assert.equal((await readEmergencyState(harness.home))?.raw, releaseRaw);
+    console.log('PASS equal-version emergency equivocation cannot replace explicit release');
+  });
+
+  emergencyMode = 'offline';
+  harness.emergency.requests.length = 0;
+  await withLaunch(harness, 'offline', async () => {
+    const boundary = await refreshBoundary(assertApp(harness));
+    assert.equal(boundary.report.emergency, 'error');
+    const emergency = boundary.info.emergency;
+    assert(emergency);
+    assert.deepEqual(emergency.disabledFeatures, []);
+    assert.equal(emergency.emergencyVersion, '3');
+    assert.equal((await readEmergencyState(harness.home))?.raw, releaseRaw);
+    console.log('PASS explicit release remains sticky across reconstructed runtime and outage');
+  });
+}
+
+function assertApp(harness: Harness): ElectronApplication {
+  assert(harness.app);
+  return harness.app;
+}
+
+async function refreshBoundary(app: ElectronApplication) {
+  const page = await app.firstWindow();
+  return page.evaluate(async () => {
+    const report = await window.linkcodeConfig.refresh();
+    return { info: window.linkcodeConfig.snapshotInfo(), report };
+  });
 }
 
 async function main(): Promise<void> {
@@ -210,7 +318,8 @@ async function main(): Promise<void> {
     const tls = generateTlsMaterial(scratch);
     buildDesktopWithBootstrap();
     const dist = await startDistServer(tls, PORT, () => mode);
-    harness = { app: null, caCert: tls.cert, dist, home, userData };
+    const emergency = await startEmergencyServer(tls, EMERGENCY_PORT, () => emergencyMode);
+    harness = { app: null, caCert: tls.cert, dist, emergency, home, userData };
     await driveScenarios(harness);
 
     console.log(
@@ -219,6 +328,7 @@ async function main(): Promise<void> {
   } finally {
     await harness?.app?.close().catch(noop);
     harness?.dist.server.close();
+    harness?.emergency.server.close();
     rmSync(scratch, { recursive: true, force: true });
   }
 }

--- a/apps/desktop/e2e/config-canary.e2e.mts
+++ b/apps/desktop/e2e/config-canary.e2e.mts
@@ -49,9 +49,12 @@ async function withLaunch(
   harness: Harness,
   nextMode: ServerMode,
   assertion: () => Promise<void>,
+  nextEmergencyMode: EmergencyServerMode = 'offline',
 ): Promise<void> {
   mode = nextMode;
+  emergencyMode = nextEmergencyMode;
   harness.dist.requests.length = 0;
+  harness.emergency.requests.length = 0;
   harness.app = await launchApp(harness.userData, harness.home, harness.caCert);
   try {
     await assertion();
@@ -208,42 +211,50 @@ async function driveScenarios(harness: Harness): Promise<void> {
     console.log('PASS baseline republication recovers after corrupt-state reset');
   });
 
-  emergencyMode = 'kill-switch';
-  harness.emergency.requests.length = 0;
-  await withLaunch(harness, 'offline', async () => {
-    const app = assertApp(harness);
-    const boundary = await refreshBoundary(app);
-    assert.equal(boundary.report.normal, 'error');
-    assert.equal(boundary.report.emergency, 'updated');
-    const emergency = boundary.info.emergency;
-    assert(emergency);
-    assert.deepEqual(emergency.disabledFeatures, ['feature.aiAssist']);
-    assert.equal(emergency.emergencyVersion, '1');
-    await waitForRequest(
-      harness.dist,
-      (request) => request.path === baseline.pointerPath && request.status === 'disconnected',
-    );
-    await waitForRequest(
-      harness.emergency,
-      (request) => request.mode === 'kill-switch' && request.status === 200,
-    );
-    console.log('PASS emergency origin activates kill switch during main-channel outage');
-  });
+  await withLaunch(
+    harness,
+    'offline',
+    async () => {
+      const app = assertApp(harness);
+      const boundary = await refreshBoundary(app);
+      assert.equal(boundary.report.normal, 'error');
+      assert(
+        boundary.report.emergency === 'updated' || boundary.report.emergency === 'not-modified',
+      );
+      const emergency = boundary.info.emergency;
+      assert(emergency);
+      assert.deepEqual(emergency.disabledFeatures, ['feature.aiAssist']);
+      assert.equal(emergency.emergencyVersion, '1');
+      await waitForRequest(
+        harness.dist,
+        (request) => request.path === baseline.pointerPath && request.status === 'disconnected',
+      );
+      await waitForRequest(
+        harness.emergency,
+        (request) => request.mode === 'kill-switch' && request.status === 200,
+      );
+      console.log('PASS emergency origin activates kill switch during main-channel outage');
+    },
+    'kill-switch',
+  );
 
-  emergencyMode = 'forced-minimum';
-  harness.emergency.requests.length = 0;
-  await withLaunch(harness, 'offline', async () => {
-    const boundary = await refreshBoundary(assertApp(harness));
-    assert.equal(boundary.report.emergency, 'updated');
-    const emergency = boundary.info.emergency;
-    assert(emergency);
-    assert.equal(emergency.emergencyVersion, '2');
-    assert.equal(emergency.forceMinVersion, '2.4.0');
-    console.log('PASS newer emergency state replaces the persisted kill switch');
-  });
+  await withLaunch(
+    harness,
+    'offline',
+    async () => {
+      const boundary = await refreshBoundary(assertApp(harness));
+      assert(
+        boundary.report.emergency === 'updated' || boundary.report.emergency === 'not-modified',
+      );
+      const emergency = boundary.info.emergency;
+      assert(emergency);
+      assert.equal(emergency.emergencyVersion, '2');
+      assert.equal(emergency.forceMinVersion, '2.4.0');
+      console.log('PASS newer emergency state replaces the persisted kill switch');
+    },
+    'forced-minimum',
+  );
 
-  emergencyMode = 'offline';
-  harness.emergency.requests.length = 0;
   await withLaunch(harness, 'offline', async () => {
     const boundary = await refreshBoundary(assertApp(harness));
     assert.equal(boundary.report.emergency, 'error');
@@ -254,36 +265,46 @@ async function driveScenarios(harness: Harness): Promise<void> {
     console.log('PASS forced minimum survives reconstructed runtime and emergency outage');
   });
 
-  emergencyMode = 'release';
-  harness.emergency.requests.length = 0;
   let releaseRaw = '';
-  await withLaunch(harness, 'offline', async () => {
-    const boundary = await refreshBoundary(assertApp(harness));
-    assert.equal(boundary.report.emergency, 'updated');
-    const emergency = boundary.info.emergency;
-    assert(emergency);
-    assert.deepEqual(emergency.disabledFeatures, []);
-    assert.equal(emergency.emergencyVersion, '3');
-    releaseRaw = (await readEmergencyState(harness.home))?.raw ?? '';
-    assert(releaseRaw);
-    console.log('PASS explicit newer release clears emergency restrictions');
-  });
+  await withLaunch(
+    harness,
+    'offline',
+    async () => {
+      const boundary = await refreshBoundary(assertApp(harness));
+      assert(
+        boundary.report.emergency === 'updated' || boundary.report.emergency === 'not-modified',
+      );
+      const emergency = boundary.info.emergency;
+      assert(emergency);
+      assert.deepEqual(emergency.disabledFeatures, []);
+      assert.equal(emergency.emergencyVersion, '3');
+      releaseRaw = (await readEmergencyState(harness.home))?.raw ?? '';
+      assert(releaseRaw);
+      console.log('PASS explicit newer release clears emergency restrictions');
+    },
+    'release',
+  );
 
-  emergencyMode = 'equivocation';
-  harness.emergency.requests.length = 0;
-  await withLaunch(harness, 'offline', async () => {
-    const boundary = await refreshBoundary(assertApp(harness));
-    assert.equal(boundary.report.emergency, 'error');
-    const emergency = boundary.info.emergency;
-    assert(emergency);
-    assert.deepEqual(emergency.disabledFeatures, []);
-    assert.equal(emergency.emergencyVersion, '3');
-    assert.equal((await readEmergencyState(harness.home))?.raw, releaseRaw);
-    console.log('PASS equal-version emergency equivocation cannot replace explicit release');
-  });
+  await withLaunch(
+    harness,
+    'offline',
+    async () => {
+      const boundary = await refreshBoundary(assertApp(harness));
+      assert.equal(boundary.report.emergency, 'error');
+      await waitForRequest(
+        harness.emergency,
+        (request) => request.mode === 'equivocation' && request.status === 200,
+      );
+      const emergency = boundary.info.emergency;
+      assert(emergency);
+      assert.deepEqual(emergency.disabledFeatures, []);
+      assert.equal(emergency.emergencyVersion, '3');
+      assert.equal((await readEmergencyState(harness.home))?.raw, releaseRaw);
+      console.log('PASS equal-version emergency equivocation cannot replace explicit release');
+    },
+    'equivocation',
+  );
 
-  emergencyMode = 'offline';
-  harness.emergency.requests.length = 0;
   await withLaunch(harness, 'offline', async () => {
     const boundary = await refreshBoundary(assertApp(harness));
     assert.equal(boundary.report.emergency, 'error');

--- a/apps/desktop/e2e/config-canary/dist-server.mts
+++ b/apps/desktop/e2e/config-canary/dist-server.mts
@@ -86,6 +86,7 @@ for (const step of fixture.steps) {
   assert(!existing || existing.equals(bytes), `conflicting fixture path ${step.snapshotPath}`);
   snapshotArtifacts.set(step.snapshotPath, bytes);
 }
+const emergencyPath = `/v1/${fixture.target.brandId}/desktop/emergency.json`;
 
 function pointerResponse(mode: ServerMode, path: string): PointerArtifact | null {
   if (mode === 'offline') return null;
@@ -174,7 +175,7 @@ export function startEmergencyServer(
         request.socket.destroy();
         return;
       }
-      if (path !== '/v1/acme/desktop/emergency.json') {
+      if (path !== emergencyPath) {
         requests.push({ ifNoneMatch, mode, path, status: 404 });
         response.writeHead(404).end();
         return;

--- a/apps/desktop/e2e/config-canary/dist-server.mts
+++ b/apps/desktop/e2e/config-canary/dist-server.mts
@@ -8,6 +8,7 @@ import type { PilotFixtureStep } from './fixture.mts';
 import {
   baseline,
   canary,
+  emergencyBytes,
   fixture,
   pointerBytes,
   rollback,
@@ -27,9 +28,16 @@ export type ServerMode =
   | 'tampered-pointer'
   | 'tampered-snapshot';
 
+export type EmergencyServerMode =
+  | 'equivocation'
+  | 'forced-minimum'
+  | 'kill-switch'
+  | 'offline'
+  | 'release';
+
 export interface DistRequest {
   readonly ifNoneMatch: string | null;
-  readonly mode: ServerMode;
+  readonly mode: EmergencyServerMode | ServerMode;
   readonly path: string;
   readonly status: 200 | 304 | 404 | 'disconnected';
 }
@@ -140,6 +148,55 @@ export function startDistServer(
       }
       requests.push({ ifNoneMatch, mode, path, status: 404 });
       response.writeHead(404).end();
+    },
+  );
+  return new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(port, '127.0.0.1', () => resolve({ requests, server }));
+  });
+}
+
+export function startEmergencyServer(
+  tls: { cert: string; key: string },
+  port: number,
+  getMode: () => EmergencyServerMode,
+): Promise<DistServer> {
+  const requests: DistRequest[] = [];
+  const server = createServer(
+    { cert: readFileSync(tls.cert), key: readFileSync(tls.key) },
+    (request, response) => {
+      const mode = getMode();
+      const path = new URL(request.url ?? '/', `https://127.0.0.1:${port}`).pathname;
+      const header = request.headers['if-none-match'];
+      const ifNoneMatch = typeof header === 'string' ? header : null;
+      if (mode === 'offline') {
+        requests.push({ ifNoneMatch, mode, path, status: 'disconnected' });
+        request.socket.destroy();
+        return;
+      }
+      if (path !== '/v1/acme/desktop/emergency.json') {
+        requests.push({ ifNoneMatch, mode, path, status: 404 });
+        response.writeHead(404).end();
+        return;
+      }
+      const name =
+        mode === 'kill-switch' ? 'killSwitch' : mode === 'forced-minimum' ? 'forcedMinimum' : mode;
+      const bytes = emergencyBytes(name);
+      const etag = `"emergency-${mode}"`;
+      if (ifNoneMatch === etag) {
+        requests.push({ ifNoneMatch, mode, path, status: 304 });
+        response.writeHead(304, { etag }).end();
+        return;
+      }
+      requests.push({ ifNoneMatch, mode, path, status: 200 });
+      response
+        .writeHead(200, {
+          'cache-control': 'public, max-age=60, must-revalidate',
+          'content-length': bytes.byteLength,
+          'content-type': 'application/json',
+          etag,
+        })
+        .end(bytes);
     },
   );
   return new Promise((resolve, reject) => {

--- a/apps/desktop/e2e/config-canary/electron-app.mts
+++ b/apps/desktop/e2e/config-canary/electron-app.mts
@@ -5,13 +5,14 @@ import { join, resolve as resolvePath } from 'node:path';
 import type { ElectronApplication } from 'playwright-core';
 import { _electron } from 'playwright-core';
 
-import { fixture } from './fixture.mts';
+import { emergencyFixture, fixture } from './fixture.mts';
 
 const require = createRequire(import.meta.url);
 const desktopDir = resolvePath(import.meta.dirname, '../..');
 const electronBinary = require('electron') as unknown as string;
 
 export const PORT = 44100 + (process.pid % 1000);
+export const EMERGENCY_PORT = PORT + 1000;
 
 export function generateTlsMaterial(directory: string): { cert: string; key: string } {
   const key = join(directory, 'key.pem');
@@ -49,8 +50,8 @@ export function buildDesktopWithBootstrap(): void {
     brandId: fixture.target.brandId,
     channel: fixture.target.channel,
     defaults: fixture.bootstrapDefaults,
-    emergencyEndpoint: null,
-    emergencyPublicKeys: {},
+    emergencyEndpoint: `https://127.0.0.1:${EMERGENCY_PORT}`,
+    emergencyPublicKeys: emergencyFixture.keys.emergency,
     endpoint: `https://127.0.0.1:${PORT}`,
     maximumSchemaVersion: fixture.maximumSchemaVersion,
     publicKeys: fixture.keys,

--- a/apps/desktop/e2e/config-canary/fixture.mts
+++ b/apps/desktop/e2e/config-canary/fixture.mts
@@ -24,9 +24,28 @@ interface PilotFixture {
   readonly target: { brandId: string; channel: string; platform: string };
 }
 
+interface EmergencyFixture {
+  readonly documents: Readonly<
+    Record<
+      'equivocation' | 'forcedMinimum' | 'killSwitch' | 'release',
+      { readonly document: Readonly<Record<string, unknown>> }
+    >
+  >;
+  readonly keys: { readonly emergency: Readonly<Record<string, string>> };
+}
+
 export const fixture = JSON.parse(
   readFileSync(join(import.meta.dirname, '../fixtures/pilot-e2e-v1.json'), 'utf8'),
 ) as PilotFixture;
+export const emergencyFixture = JSON.parse(
+  readFileSync(
+    join(
+      import.meta.dirname,
+      '../../../../packages/foundation/common/src/config/__fixtures__/emergency-handoff-v1.json',
+    ),
+    'utf8',
+  ),
+) as EmergencyFixture;
 
 function fixtureStep(name: PilotFixtureStep['name']): PilotFixtureStep {
   const found = fixture.steps.find((step) => step.name === name);
@@ -44,6 +63,9 @@ export function pointerBytes(step: PilotFixtureStep): Buffer {
 }
 export function snapshotBytes(step: PilotFixtureStep): Buffer {
   return Buffer.from(step.snapshotBase64Url, 'base64url');
+}
+export function emergencyBytes(name: keyof EmergencyFixture['documents']): Buffer {
+  return Buffer.from(JSON.stringify(emergencyFixture.documents[name].document), 'utf8');
 }
 
 // Same byte length keeps the JSON canonical while invalidating the Ed25519 signature.

--- a/apps/desktop/e2e/config-canary/state-file.mts
+++ b/apps/desktop/e2e/config-canary/state-file.mts
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 import { asyncRetry } from 'foxts/async-retry';
 
 const STORAGE_KEY = 'linkcode-config:v1:normal:acme:desktop:canary';
+const EMERGENCY_STORAGE_KEY = 'linkcode-config:v1:emergency:acme:desktop';
 
 export interface ConfigState {
   readonly highWater?: { readonly payloadSha256: string; readonly version: string };
@@ -17,19 +18,29 @@ export interface ConfigStateFile {
   readonly value: ConfigState;
 }
 
-function statePath(home: string): string {
+function statePath(home: string, storageKey: string): string {
   return join(
     home,
     '.config',
     'LinkCode Development',
     'config',
-    `${Buffer.from(STORAGE_KEY).toString('base64url')}.json`,
+    `${Buffer.from(storageKey).toString('base64url')}.json`,
   );
 }
 
 export async function readConfigState(home: string): Promise<ConfigStateFile | null> {
   try {
-    const raw = await readFile(statePath(home), 'utf8');
+    const raw = await readFile(statePath(home, STORAGE_KEY), 'utf8');
+    return { raw, value: JSON.parse(raw) as ConfigState };
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return null;
+    throw error;
+  }
+}
+
+export async function readEmergencyState(home: string): Promise<ConfigStateFile | null> {
+  try {
+    const raw = await readFile(statePath(home, EMERGENCY_STORAGE_KEY), 'utf8');
     return { raw, value: JSON.parse(raw) as ConfigState };
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === 'ENOENT') return null;
@@ -58,5 +69,5 @@ export function waitForConfigState(
 }
 
 export function writeCorruptConfigState(home: string): Promise<void> {
-  return writeFile(statePath(home), '{"lkg":"corrupted', 'utf8');
+  return writeFile(statePath(home, STORAGE_KEY), '{"lkg":"corrupted', 'utf8');
 }

--- a/apps/mobile/src/runtime/config/__tests__/adapters.test.ts
+++ b/apps/mobile/src/runtime/config/__tests__/adapters.test.ts
@@ -89,48 +89,45 @@ describe('mobile configuration adapters', () => {
     },
   );
 
-  it.each(['ios', 'android'] as const)(
-    'keeps emergency state available through main-channel outage, restart, and release on %s',
-    async (os) => {
-      const storage = new MemoryAtomicStorage();
-      const firstEmergencyFetch = emergencyFixtureFetch('killSwitch', 'forcedMinimum');
-      const first = createEmergencyFixtureCore(os, storage, firstEmergencyFetch);
+  it('keeps emergency state available through main-channel outage, restart, and release', async () => {
+    const storage = new MemoryAtomicStorage();
+    const firstEmergencyFetch = emergencyFixtureFetch('killSwitch', 'forcedMinimum');
+    const first = createEmergencyFixtureCore(storage, firstEmergencyFetch);
 
-      await first.initialize();
-      await expect(first.refresh()).resolves.toMatchObject({ status: 'error' });
-      await expect(first.refreshEmergency()).resolves.toEqual({ status: 'updated' });
-      await expect(first.refreshEmergency()).resolves.toEqual({ status: 'updated' });
-      expect(first.get('feature.aiAssist')).toBe(false);
-      expect(first.getState().emergency).toMatchObject({
-        emergencyVersion: '2',
-        forceMinVersion: '2.4.0',
-      });
-      expect(firstEmergencyFetch.mock.calls[0]?.[0]).toBe(
-        'https://emergency.example.test/v1/acme/desktop/emergency.json',
-      );
+    await first.initialize();
+    await expect(first.refresh()).resolves.toMatchObject({ status: 'error' });
+    await expect(first.refreshEmergency()).resolves.toEqual({ status: 'updated' });
+    await expect(first.refreshEmergency()).resolves.toEqual({ status: 'updated' });
+    expect(first.get('feature.aiAssist')).toBe(false);
+    expect(first.getState().emergency).toMatchObject({
+      emergencyVersion: '2',
+      forceMinVersion: '2.4.0',
+    });
+    expect(firstEmergencyFetch.mock.calls[0]?.[0]).toBe(
+      'https://emergency.example.test/v1/acme/desktop/emergency.json',
+    );
 
-      const releaseFetch = emergencyFixtureFetch('release');
-      const restarted = createEmergencyFixtureCore(os, storage, releaseFetch);
-      await expect(restarted.initialize()).resolves.toMatchObject({
-        emergency: { emergencyVersion: '2', forceMinVersion: '2.4.0' },
-      });
-      expect(restarted.get('feature.aiAssist')).toBe(false);
-      await expect(restarted.refresh()).resolves.toMatchObject({ status: 'error' });
-      await expect(restarted.refreshEmergency()).resolves.toEqual({ status: 'updated' });
-      expect(restarted.get('feature.aiAssist')).toBe(true);
-      expect(restarted.getState().emergency).toMatchObject({
-        disabledFeatures: [],
-        emergencyVersion: '3',
-        forceMinVersion: null,
-      });
+    const releaseFetch = emergencyFixtureFetch('release');
+    const restarted = createEmergencyFixtureCore(storage, releaseFetch);
+    await expect(restarted.initialize()).resolves.toMatchObject({
+      emergency: { emergencyVersion: '2', forceMinVersion: '2.4.0' },
+    });
+    expect(restarted.get('feature.aiAssist')).toBe(false);
+    await expect(restarted.refresh()).resolves.toMatchObject({ status: 'error' });
+    await expect(restarted.refreshEmergency()).resolves.toEqual({ status: 'updated' });
+    expect(restarted.get('feature.aiAssist')).toBe(true);
+    expect(restarted.getState().emergency).toMatchObject({
+      disabledFeatures: [],
+      emergencyVersion: '3',
+      forceMinVersion: null,
+    });
 
-      const offline = createEmergencyFixtureCore(os, storage, rejectingFetch);
-      await expect(offline.initialize()).resolves.toMatchObject({
-        emergency: { disabledFeatures: [], emergencyVersion: '3', forceMinVersion: null },
-      });
-      expect(offline.get('feature.aiAssist')).toBe(true);
-    },
-  );
+    const offline = createEmergencyFixtureCore(storage, rejectingFetch);
+    await expect(offline.initialize()).resolves.toMatchObject({
+      emergency: { disabledFeatures: [], emergencyVersion: '3', forceMinVersion: null },
+    });
+    expect(offline.get('feature.aiAssist')).toBe(true);
+  });
 
   it('forwards ETags and preserves exact response bytes', async () => {
     const body = new Uint8Array([0, 127, 128, 255]);
@@ -207,13 +204,9 @@ function createFixtureCore(
   });
 }
 
-function createEmergencyFixtureCore(
-  os: 'android' | 'ios',
-  storage: AtomicKeyValueStorage,
-  emergencyFetch: ConfigFetch,
-) {
+function createEmergencyFixtureCore(storage: AtomicKeyValueStorage, emergencyFetch: ConfigFetch) {
   return new ConfigCore({
-    context: { appVersion: '2.5.0', locale: 'ZH_cn', os },
+    context: { appVersion: '2.5.0', locale: 'ZH_cn', os: 'ios' },
     crypto: createNobleConfigCrypto(() => DEVICE_ID),
     definitions,
     emergencyKeyring: handoffFixture.keys.emergency,

--- a/apps/mobile/src/runtime/config/__tests__/adapters.test.ts
+++ b/apps/mobile/src/runtime/config/__tests__/adapters.test.ts
@@ -3,6 +3,8 @@ import { ConfigCore, createNobleConfigCrypto, decodeBase64Url } from '@linkcode/
 import { describe, expect, it, vi } from 'vitest';
 // eslint-disable-next-line import-x/no-relative-packages -- Keep immutable conformance data out of production exports.
 import fixture from '../../../../../../packages/foundation/common/src/config/__fixtures__/contract-v1.json';
+// eslint-disable-next-line import-x/no-relative-packages -- Keep immutable conformance data out of production exports.
+import handoffFixture from '../../../../../../packages/foundation/common/src/config/__fixtures__/emergency-handoff-v1.json';
 import type { AtomicKeyValueStorage, ConfigFetch } from '../adapters';
 import { createConfigNetwork, createConfigStorage, resolveMobileConfigPlatform } from '../adapters';
 
@@ -87,6 +89,49 @@ describe('mobile configuration adapters', () => {
     },
   );
 
+  it.each(['ios', 'android'] as const)(
+    'keeps emergency state available through main-channel outage, restart, and release on %s',
+    async (os) => {
+      const storage = new MemoryAtomicStorage();
+      const firstEmergencyFetch = emergencyFixtureFetch('killSwitch', 'forcedMinimum');
+      const first = createEmergencyFixtureCore(os, storage, firstEmergencyFetch);
+
+      await first.initialize();
+      await expect(first.refresh()).resolves.toMatchObject({ status: 'error' });
+      await expect(first.refreshEmergency()).resolves.toEqual({ status: 'updated' });
+      await expect(first.refreshEmergency()).resolves.toEqual({ status: 'updated' });
+      expect(first.get('feature.aiAssist')).toBe(false);
+      expect(first.getState().emergency).toMatchObject({
+        emergencyVersion: '2',
+        forceMinVersion: '2.4.0',
+      });
+      expect(firstEmergencyFetch.mock.calls[0]?.[0]).toBe(
+        'https://emergency.example.test/v1/acme/desktop/emergency.json',
+      );
+
+      const releaseFetch = emergencyFixtureFetch('release');
+      const restarted = createEmergencyFixtureCore(os, storage, releaseFetch);
+      await expect(restarted.initialize()).resolves.toMatchObject({
+        emergency: { emergencyVersion: '2', forceMinVersion: '2.4.0' },
+      });
+      expect(restarted.get('feature.aiAssist')).toBe(false);
+      await expect(restarted.refresh()).resolves.toMatchObject({ status: 'error' });
+      await expect(restarted.refreshEmergency()).resolves.toEqual({ status: 'updated' });
+      expect(restarted.get('feature.aiAssist')).toBe(true);
+      expect(restarted.getState().emergency).toMatchObject({
+        disabledFeatures: [],
+        emergencyVersion: '3',
+        forceMinVersion: null,
+      });
+
+      const offline = createEmergencyFixtureCore(os, storage, rejectingFetch);
+      await expect(offline.initialize()).resolves.toMatchObject({
+        emergency: { disabledFeatures: [], emergencyVersion: '3', forceMinVersion: null },
+      });
+      expect(offline.get('feature.aiAssist')).toBe(true);
+    },
+  );
+
   it('forwards ETags and preserves exact response bytes', async () => {
     const body = new Uint8Array([0, 127, 128, 255]);
     const fetch: ConfigFetch = vi.fn(() => Promise.resolve(response(body, 200, '"next"')));
@@ -162,6 +207,25 @@ function createFixtureCore(
   });
 }
 
+function createEmergencyFixtureCore(
+  os: 'android' | 'ios',
+  storage: AtomicKeyValueStorage,
+  emergencyFetch: ConfigFetch,
+) {
+  return new ConfigCore({
+    context: { appVersion: '2.5.0', locale: 'ZH_cn', os },
+    crypto: createNobleConfigCrypto(() => DEVICE_ID),
+    definitions,
+    emergencyKeyring: handoffFixture.keys.emergency,
+    emergencyNetwork: createConfigNetwork('https://emergency.example.test', emergencyFetch),
+    maximumSchemaVersion: 1,
+    network: createConfigNetwork('https://normal.example.test', rejectingFetch),
+    normalKeyring: fixture.keys.normal,
+    storage: createConfigStorage(storage),
+    target: { brandId: 'acme', channel: 'canary', platform: 'desktop' },
+  });
+}
+
 function fixtureFetch(): ReturnType<typeof vi.fn<ConfigFetch>> {
   return vi.fn<ConfigFetch>((url) => {
     if (url.endsWith('/latest.json')) {
@@ -173,6 +237,23 @@ function fixtureFetch(): ReturnType<typeof vi.fn<ConfigFetch>> {
       );
     }
     return Promise.resolve(response(new Uint8Array(), 404));
+  });
+}
+
+function emergencyFixtureFetch(
+  ...names: Array<keyof typeof handoffFixture.documents>
+): ReturnType<typeof vi.fn<ConfigFetch>> {
+  let index = 0;
+  return vi.fn<ConfigFetch>(() => {
+    const name = names.at(index++);
+    if (!name) return Promise.reject(new Error('offline'));
+    return Promise.resolve(
+      response(
+        jsonBytes(handoffFixture.documents[name].document),
+        200,
+        `"emergency-${handoffFixture.documents[name].document.emergencyVersion}"`,
+      ),
+    );
   });
 }
 

--- a/packages/foundation/common/src/config/__tests__/core.test.ts
+++ b/packages/foundation/common/src/config/__tests__/core.test.ts
@@ -177,6 +177,58 @@ describe('ConfigCore normal state machine', () => {
     expect(setup.normal.requests).toHaveLength(5);
   });
 
+  it.each([
+    ['404', { status: 404 }],
+    ['missing body', { status: 200 }],
+  ] as const)(
+    'retains trusted high-water when the snapshot response is %s',
+    async (_name, fault) => {
+      const setup = makeSetup({
+        normalResponses: [ok(pointerBytes('normal'), '"p100"'), fault],
+      });
+      await setup.core.initialize();
+
+      await expectError(setup.core.refresh(), 'fetch');
+      expect(setup.core.getState()).toMatchObject({ configVersion: null, source: 'defaults' });
+      expect(setup.normal.requests).toHaveLength(2);
+      const stored = JSON.parse(
+        setup.storage.values.get('linkcode-config:v1:normal:acme:desktop:canary') ?? '{}',
+      ) as { highWater?: { version?: string }; lkg?: unknown; trusted?: unknown };
+      expect(stored.highWater?.version).toBe('100');
+      expect(stored.trusted).toBeDefined();
+      expect(stored.lkg).toBeUndefined();
+    },
+  );
+
+  it('rejects a stale intermediary 200 and preserves accepted state through a stale 304', async () => {
+    const setup = makeSetup({
+      normalResponses: [
+        ok(pointerBytes('rollback'), '"fresh"'),
+        ok(snapshotBytes('previous')),
+        ok(pointerBytes('normal'), '"stale"'),
+        { status: 304 },
+      ],
+    });
+    await setup.core.initialize();
+    await expect(setup.core.refresh()).resolves.toEqual({ status: 'updated' });
+    const acceptedState = setup.core.getState();
+    const acceptedRaw = setup.storage.values.get('linkcode-config:v1:normal:acme:desktop:canary');
+
+    await expectError(setup.core.refresh(), 'replay');
+    expect(setup.normal.requests).toHaveLength(3);
+    expect(setup.core.getState()).toEqual(acceptedState);
+    expect(setup.storage.values.get('linkcode-config:v1:normal:acme:desktop:canary')).toBe(
+      acceptedRaw,
+    );
+
+    await expect(setup.core.refresh()).resolves.toEqual({ status: 'not-modified' });
+    expect(setup.normal.requests[3]?.request).toEqual({ etag: '"fresh"' });
+    expect(setup.core.getState()).toEqual(acceptedState);
+    expect(setup.storage.values.get('linkcode-config:v1:normal:acme:desktop:canary')).toBe(
+      acceptedRaw,
+    );
+  });
+
   it('rejects a pointer 304 when no trusted pointer exists', async () => {
     const setup = makeSetup({ normalResponses: [{ status: 304 }] });
     await setup.core.initialize();


### PR DESCRIPTION
## Summary

- cover snapshot fetch faults and stale intermediary recovery without activating bad configuration
- exercise mobile adapter composition across normal-channel outage, persisted emergency state, and explicit release
- extend the real Electron pilot harness with independent normal/emergency HTTPS origins, reconstructed-runtime persistence, equal-version equivocation rejection, and sticky release

## Verification

- `pnpm check:ci`
- `pnpm test` — 2,732 passed, 1 skipped
- `pnpm test packages/foundation/common/src/config/__tests__/core.test.ts apps/mobile/src/runtime/config/__tests__/adapters.test.ts` — 40 passed
- `xvfb-run -a pnpm -F @linkcode/desktop e2e:config-canary`
- `pnpm -F @linkcode/mobile smoke:export` — Android and iOS Hermes bytecode, source maps, routes, and bundled config sentinel validated
- pilot fixture: 10,238 bytes, SHA-256 `54ce1fc855e12295a8dd1490463c9afac8e84a526f1e16340bcefe4f0fec8e39`
- emergency fixture: 14,540 bytes, SHA-256 `2fa79670900ed6e80c159cd2a569814f6e5c0302059b7c5ffeb2c0a5707af3b4`

## Boundaries

Electron restart coverage uses separate real app launches over shared atomic files, not abrupt OS process-kill injection. Mobile restart coverage reconstructs the core over the adapter seam with the frozen desktop-target fixture; the Hermes export is an app-entry bundle gate, not device/provider/native-module execution.

HQ counterpart: https://github.com/arcboxlabs/linkcodehq/pull/40
