### PR TITLE
refactor(ui): reference theme variables directly in shimmer

### DIFF
--- a/packages/presentation/ui/src/chat/shimmer.tsx
+++ b/packages/presentation/ui/src/chat/shimmer.tsx
@@ -27,7 +27,9 @@ export function Shimmer({
       style={
         {
           backgroundImage:
-            'linear-gradient(90deg, transparent 35%, var(--color-background), transparent 65%), linear-gradient(var(--color-muted-foreground), var(--color-muted-foreground))',
+            // coss-ui's semantic --color-* aliases are @theme inline and Tailwind never scans a JS
+            // style string, so they are not emitted to :root — read the underlying vars directly.
+            'linear-gradient(90deg, transparent 35%, var(--background), transparent 65%), linear-gradient(var(--muted-foreground), var(--muted-foreground))',
           backgroundRepeat: 'no-repeat',
         } satisfies React.CSSProperties
       }

--- a/packages/presentation/ui/src/chat/shimmer.tsx
+++ b/packages/presentation/ui/src/chat/shimmer.tsx
@@ -27,8 +27,6 @@ export function Shimmer({
       style={
         {
           backgroundImage:
-            // coss-ui's semantic --color-* aliases are @theme inline and Tailwind never scans a JS
-            // style string, so they are not emitted to :root — read the underlying vars directly.
             'linear-gradient(90deg, transparent 35%, var(--background), transparent 65%), linear-gradient(var(--muted-foreground), var(--muted-foreground))',
           backgroundRepeat: 'no-repeat',
         } satisfies React.CSSProperties


### PR DESCRIPTION
## Summary

- Reference `--background` and `--muted-foreground` directly in the shimmer gradient.
- Avoid depending on Tailwind-generated `--color-*` aliases from the inline style.
- Remove the inaccurate source-scanning comment.

## Correction

The earlier description attributed the reported shimmer failure to Tailwind not detecting custom-property references in an inline TSX style. That claim was incorrect.

With Tailwind, the Vite integration, and Oxide pinned to 4.3.3, the renderer's `@source "./"` registration includes `shimmer.tsx`. A clean pre-change build emits both `--color-background` and `--color-muted-foreground`, and Chromium computes the same gradient before and after this change in light and dark themes.

Pairing pre-change JavaScript with CSS generated after those aliases lose their final references produces `background-image: none`, but that hybrid state is not a clean build.

This PR is therefore a dependency-reduction refactor with no intended behavior change, rather than a verified bug fix.

Closes CODE-575

## Verification

- `pnpm check:ci`
- `env TMPDIR=/private/var/folders/p9/6ggjwjj97ll8gtlfbmqftbl00000gn/T/ pnpm test` — 337 files passed, 3 skipped; 2,914 tests passed, 5 skipped.
- Exact Tailwind 4.3.3 compiler/Oxide reproduction for both renderers.
- Chromium computed-style comparison in light and dark themes.

The canonical `TMPDIR` path avoids the existing macOS `/var` → `/private/var` alias mismatch in release-artifact containment tests; it does not change product behavior.

## Checklist

- [x] `pnpm check:ci` and `pnpm test` both pass
- [x] The affected renderer output was reproduced and compared
- [x] No wire message changed
- [x] No new assets
- [x] Source comments and PR rationale are accurate
