### PR TITLE
fix(ui): tighten grouped activity spacing

### DIFF
--- a/apps/webview/e2e/browser-smoke.e2e.mts
+++ b/apps/webview/e2e/browser-smoke.e2e.mts
@@ -18,6 +18,7 @@ const viteCli = fileURLToPath(new URL('../../bin/vite.js', import.meta.resolve('
 const newSessionDefaultsKey = 'linkcode.workbench.new-session-defaults:v7';
 const mockThreadTitle = 'Wire the workbench to the daemon';
 const mockChatThreadTitle = 'Prototype without git';
+const showcaseThreadTitle = 'Mocked streaming showcase';
 const longThreadTitle = 'Long thread · navigation testbed';
 const longThreadTurns = 48;
 const maxMountedRows = 10;
@@ -124,6 +125,49 @@ async function verifyNewChatIsolation(page: Page, appErrors: string[]): Promise<
     `New chat rendered the previous conversation after submission: ${JSON.stringify(titles)}`,
   );
   assertNoApplicationErrors(appErrors);
+}
+
+async function verifyActivityRunHierarchy(page: Page): Promise<void> {
+  await page.locator('[data-thread-title]', { hasText: showcaseThreadTitle }).click();
+  await page.locator('[data-conversation-title]', { hasText: showcaseThreadTitle }).waitFor();
+
+  const runHeader = page.getByRole('button', {
+    name: 'Activity details: An action failed · Ran a command · Made a file change · Explored 2 times',
+  });
+  await runHeader.waitFor({ timeout: 15000 });
+  await runHeader.click();
+
+  const metrics = await runHeader.evaluate((header) => {
+    const group = header.closest('[data-slot="collapsible"]');
+    const body = group?.querySelector(
+      ':scope > [data-slot="collapsible-panel"] [data-slot="scroll-area-content"] > div',
+    );
+    if (!(body instanceof HTMLElement)) throw new Error('Missing expanded activity body');
+
+    const children = [...body.children].map((row) => {
+      const child = row.firstElementChild;
+      if (!(child instanceof HTMLElement)) throw new Error('Missing activity child header');
+      return {
+        paddingBlockStart: Number.parseFloat(getComputedStyle(child).paddingBlockStart),
+        slot: child.dataset.slot,
+        tagName: child.tagName,
+      };
+    });
+    return {
+      children,
+      paddingBlockStart: Number.parseFloat(getComputedStyle(header).paddingBlockStart),
+    };
+  });
+
+  assert.ok(metrics.children.length >= 5, 'Mixed activity run did not render every child');
+  assert.ok(metrics.children.some((child) => child.slot === 'tooltip-trigger'));
+  assert.ok(metrics.children.some((child) => child.tagName === 'DIV'));
+  assert.ok(
+    metrics.children.every(
+      (child) => child.paddingBlockStart > 0 && child.paddingBlockStart < metrics.paddingBlockStart,
+    ),
+    `Activity children were not denser than the group: ${JSON.stringify(metrics)}`,
+  );
 }
 
 async function verifyLongThreadVirtualization(page: Page): Promise<void> {
@@ -372,6 +416,7 @@ async function verifyMockEntry(browser: Browser): Promise<void> {
     const recoveryPrompt = `${firstPrompt}-after-reload`;
     await sendPrompt(page, recoveryPrompt, appErrors);
     await verifyNewChatIsolation(page, appErrors);
+    await verifyActivityRunHierarchy(page);
     await verifyLongThreadVirtualization(page);
     assertNoApplicationErrors(appErrors);
     await page.close();

--- a/apps/webview/e2e/browser-smoke.e2e.mts
+++ b/apps/webview/e2e/browser-smoke.e2e.mts
@@ -22,6 +22,8 @@ const showcaseThreadTitle = 'Mocked streaming showcase';
 const longThreadTitle = 'Long thread · navigation testbed';
 const longThreadTurns = 48;
 const maxMountedRows = 10;
+const RE_ACTIVITY_RUN_DETAILS =
+  /^Activity details: .*failed.*ran .*command.*made .*file change.*explored.*$/iu;
 const RE_LONG_THREAD_TURN = /Turn (\d+) —/g;
 
 interface ViteServer {
@@ -132,7 +134,7 @@ async function verifyActivityRunHierarchy(page: Page): Promise<void> {
   await page.locator('[data-conversation-title]', { hasText: showcaseThreadTitle }).waitFor();
 
   const runHeader = page.getByRole('button', {
-    name: 'Activity details: An action failed · Ran a command · Made a file change · Explored 2 times',
+    name: RE_ACTIVITY_RUN_DETAILS,
   });
   await runHeader.waitFor({ timeout: 15000 });
   await runHeader.click();
@@ -160,8 +162,14 @@ async function verifyActivityRunHierarchy(page: Page): Promise<void> {
   });
 
   assert.ok(metrics.children.length >= 5, 'Mixed activity run did not render every child');
-  assert.ok(metrics.children.some((child) => child.slot === 'tooltip-trigger'));
-  assert.ok(metrics.children.some((child) => child.tagName === 'DIV'));
+  assert.ok(
+    metrics.children.some((child) => child.slot === 'tooltip-trigger'),
+    `No tooltip-backed activity row rendered: ${JSON.stringify(metrics.children)}`,
+  );
+  assert.ok(
+    metrics.children.some((child) => child.tagName === 'DIV'),
+    `No bodyless activity row rendered: ${JSON.stringify(metrics.children)}`,
+  );
   assert.ok(
     metrics.children.every(
       (child) => child.paddingBlockStart > 0 && child.paddingBlockStart < metrics.paddingBlockStart,

--- a/packages/client/workbench/src/mock/data/showcase.ts
+++ b/packages/client/workbench/src/mock/data/showcase.ts
@@ -701,6 +701,13 @@ export function createShowcaseToolBursts(terminalId = SHOWCASE_TERMINAL_ID): Sho
           rawInput: { path: 'packages/presentation/ui/src/chat/activity-groups.ts' },
         },
         {
+          toolCallId: 'mock-activity-read-bodyless',
+          title: 'Inspect activity boundaries',
+          kind: 'read',
+          status: 'completed',
+          content: [],
+        },
+        {
           toolCallId: 'mock-activity-execute-failed',
           title: 'Run compact activity check',
           kind: 'execute',

--- a/packages/presentation/ui/src/chat/activity-run.tsx
+++ b/packages/presentation/ui/src/chat/activity-run.tsx
@@ -154,7 +154,7 @@ export function ActivityRun({
         ) : null}
         <ChatDisclosureChevron />
       </CollapsibleTrigger>
-      <ChatDisclosureContent bodyClassName="space-y-0.5">
+      <ChatDisclosureContent bodyClassName="space-y-0.5 [&>[data-slot=collapsible]>*:first-child]:py-0.5">
         {run.items.map((item) => {
           if (item.kind === 'reasoning') {
             return (


### PR DESCRIPTION
## Summary
- tighten spacing only for activities nested inside expanded activity groups
- preserve normal spacing for group headers and top-level activities
- cover standard, tooltip-backed, and bodyless activity rows in the bundled browser smoke

## Why
Grouped activity rows used the same block padding as top-level rows, which weakened the visual hierarchy. The group now scopes denser padding to each direct child header.

## Validation
- `pnpm check:ci`
- `pnpm test --maxWorkers=2 --maxConcurrency=2`
- `pnpm -F @linkcode/webview run e2e:browser`

Linear: CODE-376