### PR TITLE
feat(providers): allow ordering accounts and selecting default models

### DIFF
--- a/packages/client/workbench/src/settings/providers/__tests__/model-selection.test.tsx
+++ b/packages/client/workbench/src/settings/providers/__tests__/model-selection.test.tsx
@@ -7,8 +7,9 @@ import { useState } from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { ModelSelection } from '../model-selection';
 
-function translateKey(key: string): string {
-  return key;
+function translateKey(key: string, values?: Record<string, unknown>): string {
+  const interpolation = values ? Object.values(values).join(',') : '';
+  return interpolation ? `${key}:${interpolation}` : key;
 }
 
 vi.mock('use-intl', () => ({
@@ -96,16 +97,36 @@ describe('ModelSelection', () => {
       />,
     );
 
-    expect(screen.getByRole('button', { name: 'models.defaultModel' })).toHaveProperty(
+    expect(screen.getByRole('button', { name: 'models.defaultModel:Model A' })).toHaveProperty(
       'disabled',
       true,
     );
-    fireEvent.click(screen.getByRole('button', { name: 'models.makeDefault' }));
+    fireEvent.click(screen.getByRole('button', { name: 'models.makeDefault:Model B' }));
 
     expect(onChange).toHaveBeenCalledWith([
       { id: 'model-b', label: 'Model B' },
       { id: 'model-a', label: 'Model A' },
     ]);
+  });
+
+  it('keeps only the disabled default marker fully opaque while the form is busy', () => {
+    render(
+      <ModelSelection
+        selected={[
+          { id: 'model-a', label: 'Model A' },
+          { id: 'model-b', label: 'Model B' },
+        ]}
+        onChange={vi.fn()}
+        disabled
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: 'models.defaultModel:Model A' }).className).toContain(
+      'disabled:opacity-100',
+    );
+    expect(
+      screen.getByRole('button', { name: 'models.makeDefault:Model B' }).className,
+    ).not.toContain('disabled:opacity-100');
   });
 
   it("surfaces the fetch failure's own reason instead of swallowing it", async () => {

--- a/packages/client/workbench/src/settings/providers/__tests__/model-selection.test.tsx
+++ b/packages/client/workbench/src/settings/providers/__tests__/model-selection.test.tsx
@@ -84,6 +84,30 @@ describe('ModelSelection', () => {
     expect(screen.getAllByText('already')).toHaveLength(1);
   });
 
+  it('moves a picked model to the head when it becomes the default', () => {
+    const onChange = vi.fn();
+    render(
+      <ModelSelection
+        selected={[
+          { id: 'model-a', label: 'Model A' },
+          { id: 'model-b', label: 'Model B' },
+        ]}
+        onChange={onChange}
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: 'models.defaultModel' })).toHaveProperty(
+      'disabled',
+      true,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'models.makeDefault' }));
+
+    expect(onChange).toHaveBeenCalledWith([
+      { id: 'model-b', label: 'Model B' },
+      { id: 'model-a', label: 'Model A' },
+    ]);
+  });
+
   it("surfaces the fetch failure's own reason instead of swallowing it", async () => {
     const onFetch = vi.fn().mockRejectedValue(new Error('401 Unauthorized — invalid api key'));
     render(<Harness onFetch={onFetch} />);

--- a/packages/client/workbench/src/settings/providers/__tests__/providers-settings.test.tsx
+++ b/packages/client/workbench/src/settings/providers/__tests__/providers-settings.test.tsx
@@ -1,0 +1,178 @@
+// @vitest-environment jsdom
+
+import type { Accounts } from '@linkcode/schema';
+import { getAccounts, getProviderConfig, setAccounts, setProviderConfig } from '@linkcode/sdk';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ProvidersSettingsPanel } from '../providers-settings';
+
+const mocks = vi.hoisted(() => ({
+  mutateAccounts: vi.fn(),
+  mutateProviders: vi.fn(),
+  saveAccounts: vi.fn(),
+  saveProviders: vi.fn(),
+  toastAdd: vi.fn(),
+  translate: vi.fn((key: string) => key),
+  useData: vi.fn(),
+  useMutation: vi.fn(),
+}));
+
+vi.mock('../../../runtime/tayori', () => ({
+  useData: mocks.useData,
+  useMutation: mocks.useMutation,
+}));
+
+vi.mock('../../../agent-runtime/hooks', () => ({
+  useAgentRuntimes: () => ({ data: undefined }),
+}));
+
+vi.mock('../../../agent-runtime/onboarding', () => ({
+  useAgentRuntimeOnboarding: () => ({ cancelLogin: vi.fn() }),
+}));
+
+vi.mock('../add-flow', () => ({
+  AddAccountForm: () => null,
+  EditAccountForm: () => null,
+  ServiceCatalogView: () => null,
+}));
+
+vi.mock('../model-selection', () => ({
+  useModelSources: () => ({}),
+}));
+
+vi.mock('@linkcode/ui', () => ({
+  AccountDetail: () => null,
+  AccountList({
+    accounts,
+    onReorder,
+  }: {
+    accounts: Array<{ id: string; label: string }>;
+    onReorder?: (orderedIds: string[]) => void;
+  }) {
+    return (
+      <>
+        <output data-testid="account-order">{accounts.map(({ label }) => label).join(',')}</output>
+        <button
+          type="button"
+          onClick={() => onReorder?.([...accounts].reverse().map(({ id }) => id))}
+        >
+          reorder
+        </button>
+      </>
+    );
+  },
+}));
+
+vi.mock('coss-ui/components/toast', () => ({
+  toastManager: { add: mocks.toastAdd },
+}));
+
+vi.mock('use-intl', () => ({
+  useTranslations() {
+    return mocks.translate;
+  },
+}));
+
+const INITIAL_ACCOUNTS = [
+  {
+    id: 'account-a',
+    label: 'Account A',
+    service: 'anthropic-api',
+    credential: { type: 'api-key', key: 'anthropic-key' },
+    models: [{ id: 'claude-opus-5' }],
+    createdAt: 1,
+  },
+  {
+    id: 'account-b',
+    label: 'Account B',
+    service: 'deepseek',
+    credential: { type: 'api-key', key: 'deepseek-key' },
+    models: [{ id: 'deepseek-v4-pro' }],
+    createdAt: 2,
+  },
+] satisfies Accounts;
+
+let accountData: Accounts;
+let daemonAccounts: Accounts;
+
+beforeEach(() => {
+  accountData = [...INITIAL_ACCOUNTS];
+  daemonAccounts = [...INITIAL_ACCOUNTS];
+
+  mocks.mutateAccounts.mockImplementation((next?: Accounts) => {
+    accountData = next ?? daemonAccounts;
+    return Promise.resolve(accountData);
+  });
+  mocks.saveAccounts.mockImplementation(({ accounts }: { accounts: Accounts }) => {
+    daemonAccounts = accounts;
+    return Promise.resolve();
+  });
+  mocks.useData.mockImplementation((operation: unknown) => {
+    if (operation === getAccounts) {
+      return { data: accountData, isLoading: false, mutate: mocks.mutateAccounts };
+    }
+    if (operation === getProviderConfig) {
+      return { data: {}, mutate: mocks.mutateProviders };
+    }
+    throw new Error('Unexpected data operation');
+  });
+  mocks.useMutation.mockImplementation((operation: unknown) => {
+    if (operation === setAccounts) {
+      return { trigger: mocks.saveAccounts, isMutating: false };
+    }
+    if (operation === setProviderConfig) {
+      return { trigger: mocks.saveProviders, isMutating: false };
+    }
+    throw new Error('Unexpected mutation operation');
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe('provider account ordering', () => {
+  it('persists the emitted order and reconciles it from daemon state', async () => {
+    const { rerender } = render(<ProvidersSettingsPanel />);
+    expect(screen.getByTestId('account-order').textContent).toBe('Account A,Account B');
+
+    fireEvent.click(screen.getByRole('button', { name: 'reorder' }));
+
+    await waitFor(() => expect(mocks.saveAccounts).toHaveBeenCalledTimes(1));
+    expect(
+      mocks.saveAccounts.mock.calls[0]?.[0].accounts.map(({ id }: Accounts[number]) => id),
+    ).toEqual(['account-b', 'account-a']);
+    await waitFor(() => expect(mocks.mutateAccounts).toHaveBeenCalledTimes(2));
+    expect(mocks.mutateAccounts.mock.calls[0]?.[0].map(({ id }: Accounts[number]) => id)).toEqual([
+      'account-b',
+      'account-a',
+    ]);
+    expect(mocks.mutateAccounts.mock.calls[1]).toEqual([]);
+
+    rerender(<ProvidersSettingsPanel />);
+    expect(screen.getByTestId('account-order').textContent).toBe('Account B,Account A');
+  });
+
+  it('restores the previous order and reports a rejected save', async () => {
+    mocks.saveAccounts.mockRejectedValueOnce(new Error('disk full'));
+    const { rerender } = render(<ProvidersSettingsPanel />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'reorder' }));
+
+    await waitFor(() => expect(mocks.toastAdd).toHaveBeenCalledTimes(1));
+    expect(mocks.mutateAccounts).toHaveBeenCalledTimes(2);
+    expect(mocks.mutateAccounts.mock.calls[1]?.[0].map(({ id }: Accounts[number]) => id)).toEqual([
+      'account-a',
+      'account-b',
+    ]);
+    expect(mocks.toastAdd).toHaveBeenCalledWith({
+      type: 'error',
+      title: 'reorderFailed',
+      description: 'disk full',
+    });
+
+    rerender(<ProvidersSettingsPanel />);
+    expect(screen.getByTestId('account-order').textContent).toBe('Account A,Account B');
+  });
+});

--- a/packages/client/workbench/src/settings/providers/model-selection.tsx
+++ b/packages/client/workbench/src/settings/providers/model-selection.tsx
@@ -5,7 +5,7 @@ import { Button } from 'coss-ui/components/button';
 import { Checkbox } from 'coss-ui/components/checkbox';
 import { Input } from 'coss-ui/components/input';
 import { extractErrorMessage } from 'foxts/extract-error-message';
-import { PlusIcon, RefreshCwIcon } from 'lucide-react';
+import { PlusIcon, RefreshCwIcon, StarIcon } from 'lucide-react';
 import { useState } from 'react';
 import { useTranslations } from 'use-intl';
 import { useMutation } from '../../runtime/tayori';
@@ -109,6 +109,10 @@ export function ModelSelection({
     setDraft('');
   };
 
+  const makeDefault = (model: AccountModel): void => {
+    onChange([model, ...selected.filter((candidate) => candidate.id !== model.id)]);
+  };
+
   return (
     <div className="flex flex-col gap-2">
       <div className="flex items-center justify-between gap-2">
@@ -131,25 +135,46 @@ export function ModelSelection({
       <p className="text-muted-foreground text-xs">
         {onFetch ? t('models.hint') : t('models.hintUnlistable')}
       </p>
-      {error !== undefined ? <p className="text-destructive text-xs">{error}</p> : null}
+      {error === undefined ? null : <p className="text-destructive text-xs">{error}</p>}
       {listed.length > 0 ? (
         <div className="flex max-h-56 flex-col gap-1 overflow-y-auto rounded-lg border border-border p-2">
-          {listed.map((model) => (
-            <label
-              className="flex min-w-0 items-center gap-2 rounded-md px-1.5 py-(--density-row-py) hover:bg-muted/50"
-              key={model.id}
-            >
-              <Checkbox
-                checked={picked.has(model.id)}
-                disabled={disabled}
-                onCheckedChange={(next) => toggle(model, next)}
-              />
-              <span className="min-w-0 flex-1 truncate font-mono text-xs">{model.id}</span>
-              {model.label !== undefined ? (
-                <span className="shrink-0 text-label-tertiary text-xs">{model.label}</span>
-              ) : null}
-            </label>
-          ))}
+          {listed.map((model) => {
+            const isPicked = picked.has(model.id);
+            const isDefault = selected[0]?.id === model.id;
+            return (
+              <div
+                className="flex min-w-0 items-center rounded-md hover:bg-muted/50"
+                key={model.id}
+              >
+                <label className="flex min-w-0 flex-1 items-center gap-2 px-1.5 py-(--density-row-py)">
+                  <Checkbox
+                    checked={isPicked}
+                    disabled={disabled}
+                    onCheckedChange={(next) => toggle(model, next)}
+                  />
+                  <span className="min-w-0 flex-1 truncate font-mono text-xs">{model.id}</span>
+                  {model.label === undefined ? null : (
+                    <span className="shrink-0 text-label-tertiary text-xs">{model.label}</span>
+                  )}
+                </label>
+                {isPicked ? (
+                  <Button
+                    type="button"
+                    size="icon"
+                    variant="ghost"
+                    disabled={disabled || isDefault}
+                    aria-label={t(isDefault ? 'models.defaultModel' : 'models.makeDefault', {
+                      model: model.label ?? model.id,
+                    })}
+                    className="me-0.5 size-7 shrink-0 text-label-tertiary disabled:opacity-100"
+                    onClick={() => makeDefault(model)}
+                  >
+                    <StarIcon className={isDefault ? 'size-3.5 fill-current' : 'size-3.5'} />
+                  </Button>
+                ) : null}
+              </div>
+            );
+          })}
         </div>
       ) : null}
       <div className="flex gap-2">

--- a/packages/client/workbench/src/settings/providers/model-selection.tsx
+++ b/packages/client/workbench/src/settings/providers/model-selection.tsx
@@ -1,6 +1,7 @@
 import { CURATED_AGENT_MODELS } from '@linkcode/providers';
 import type { AccountModel, AccountSecret, AgentKind } from '@linkcode/schema';
 import { getAgentCatalog, probeAccountModels } from '@linkcode/sdk';
+import { cn } from '@linkcode/ui';
 import { Button } from 'coss-ui/components/button';
 import { Checkbox } from 'coss-ui/components/checkbox';
 import { Input } from 'coss-ui/components/input';
@@ -166,7 +167,10 @@ export function ModelSelection({
                     aria-label={t(isDefault ? 'models.defaultModel' : 'models.makeDefault', {
                       model: model.label ?? model.id,
                     })}
-                    className="me-0.5 size-7 shrink-0 text-label-tertiary disabled:opacity-100"
+                    className={cn(
+                      'me-0.5 size-7 shrink-0 text-label-tertiary',
+                      isDefault && 'disabled:opacity-100',
+                    )}
                     onClick={() => makeDefault(model)}
                   >
                     <StarIcon className={isDefault ? 'size-3.5 fill-current' : 'size-3.5'} />

--- a/packages/client/workbench/src/settings/providers/providers-settings.tsx
+++ b/packages/client/workbench/src/settings/providers/providers-settings.tsx
@@ -78,6 +78,21 @@ export function ProvidersSettingsPanel({
     void applyProviders(withAccountEnabled(providers ?? {}, kind, selected.id, enabled, pool));
   };
 
+  const handleReorder = async (orderedIds: string[]): Promise<void> => {
+    const reordered = orderedIds.flatMap((id) => {
+      const account = accountsById.get(id);
+      return account ? [account] : [];
+    });
+    if (reordered.length !== pool.length) return;
+
+    await mutateAccounts(reordered, { revalidate: false });
+    try {
+      await saveAccounts.trigger({ accounts: reordered });
+    } catch {
+      await mutateAccounts(pool, { revalidate: false });
+    }
+  };
+
   // Every account joins the pool the same way. A subscription used to bind itself to its agent on
   // the way in; with no default to claim, adding one is adding one.
   const handleAdd = async (account: Account): Promise<void> => {
@@ -123,7 +138,11 @@ export function ProvidersSettingsPanel({
       <AccountList
         {...accountList}
         loading={accountsLoading}
+        reorderDisabled={busy}
         onSelect={select}
+        onReorder={(orderedIds) => {
+          void handleReorder(orderedIds);
+        }}
         onAdd={startAdd}
         onUseLinkCodeGateway={
           linkCodeGateway ? () => pickService(LINKCODE_GATEWAY_SERVICE_ID) : undefined

--- a/packages/client/workbench/src/settings/providers/providers-settings.tsx
+++ b/packages/client/workbench/src/settings/providers/providers-settings.tsx
@@ -10,6 +10,8 @@ import {
   DialogTitle,
 } from 'coss-ui/components/dialog';
 import { Skeleton } from 'coss-ui/components/skeleton';
+import { toastManager } from 'coss-ui/components/toast';
+import { extractErrorMessage } from 'foxts/extract-error-message';
 import { useTranslations } from 'use-intl';
 import { useAgentRuntimes } from '../../agent-runtime/hooks';
 import { useAgentRuntimeOnboarding } from '../../agent-runtime/onboarding';
@@ -88,9 +90,16 @@ export function ProvidersSettingsPanel({
     await mutateAccounts(reordered, { revalidate: false });
     try {
       await saveAccounts.trigger({ accounts: reordered });
-    } catch {
+    } catch (error) {
       await mutateAccounts(pool, { revalidate: false });
+      toastManager.add({
+        type: 'error',
+        title: t('reorderFailed'),
+        description: extractErrorMessage(error, false),
+      });
+      return;
     }
+    await mutateAccounts();
   };
 
   // Every account joins the pool the same way. A subscription used to bind itself to its agent on

--- a/packages/presentation/i18n/src/locales/en.ts
+++ b/packages/presentation/i18n/src/locales/en.ts
@@ -1083,6 +1083,8 @@ export const en = {
         refresh: 'Fetch list',
         fetchFailed: 'Could not read the model list',
         secretFirst: 'Enter the key first, then fetch the model list',
+        defaultModel: '{model} is the default model',
+        makeDefault: 'Make {model} the default model',
         add: 'Add',
         addPlaceholder: 'Add a model id by hand',
       },

--- a/packages/presentation/i18n/src/locales/en.ts
+++ b/packages/presentation/i18n/src/locales/en.ts
@@ -1050,6 +1050,7 @@ export const en = {
       orderHint:
         'Drag accounts to set their priority. New tasks use the first model from the first compatible account.',
       reorderAccount: 'Reorder {label}',
+      reorderFailed: 'Could not save account order',
       customService: 'Custom endpoint',
       noMatches: 'No matching accounts.',
       emptyTitle: 'No accounts yet',

--- a/packages/presentation/i18n/src/locales/en.ts
+++ b/packages/presentation/i18n/src/locales/en.ts
@@ -1047,6 +1047,9 @@ export const en = {
       hint: 'Connect subscriptions, AI gateways, or custom endpoints to your agents; one account can back several agents, and each agent uses one account at a time.',
       searchPlaceholder: 'Search accounts…',
       addAccount: 'Add account',
+      orderHint:
+        'Drag accounts to set their priority. New tasks use the first model from the first compatible account.',
+      reorderAccount: 'Reorder {label}',
       customService: 'Custom endpoint',
       noMatches: 'No matching accounts.',
       emptyTitle: 'No accounts yet',

--- a/packages/presentation/i18n/src/locales/zh-cn.ts
+++ b/packages/presentation/i18n/src/locales/zh-cn.ts
@@ -1023,6 +1023,7 @@ export const zhCN = {
       addAccount: '添加账号',
       orderHint: '拖动账号调整优先级；新建任务默认使用首个兼容账号的首个模型。',
       reorderAccount: '调整{label}的顺序',
+      reorderFailed: '保存账号顺序失败',
       customService: '自定义端点',
       noMatches: '没有匹配的账号。',
       emptyTitle: '尚未添加账号',

--- a/packages/presentation/i18n/src/locales/zh-cn.ts
+++ b/packages/presentation/i18n/src/locales/zh-cn.ts
@@ -1055,6 +1055,8 @@ export const zhCN = {
         refresh: '获取列表',
         fetchFailed: '获取模型列表失败',
         secretFirst: '请先填写密钥，再获取模型列表',
+        defaultModel: '{model}是默认模型',
+        makeDefault: '将{model}设为默认模型',
         add: '添加',
         addPlaceholder: '手动添加模型 ID',
       },

--- a/packages/presentation/i18n/src/locales/zh-cn.ts
+++ b/packages/presentation/i18n/src/locales/zh-cn.ts
@@ -1021,6 +1021,8 @@ export const zhCN = {
       hint: '把订阅、AI 网关或自定义端点接入你的智能体;一个账号可接入多个智能体,每个智能体同一时刻使用一个账号。',
       searchPlaceholder: '搜索账号…',
       addAccount: '添加账号',
+      orderHint: '拖动账号调整优先级；新建任务默认使用首个兼容账号的首个模型。',
+      reorderAccount: '调整{label}的顺序',
       customService: '自定义端点',
       noMatches: '没有匹配的账号。',
       emptyTitle: '尚未添加账号',

--- a/packages/presentation/ui/src/shell/__tests__/account-master-list.test.tsx
+++ b/packages/presentation/ui/src/shell/__tests__/account-master-list.test.tsx
@@ -1,0 +1,108 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { ProviderAccountListItem } from '../providers/account-master-list';
+import { AccountList } from '../providers/account-master-list';
+
+function reversed(items: string[]): string[] {
+  return [...items].reverse();
+}
+
+function passthrough(key: string): string {
+  return key;
+}
+
+function translations(): typeof passthrough {
+  return passthrough;
+}
+
+const dnd = vi.hoisted(() => ({
+  onDragEnd: undefined as undefined | ((event: { canceled: boolean }) => void),
+  move: vi.fn(reversed),
+}));
+
+vi.mock('@dnd-kit/helpers', () => ({ move: dnd.move }));
+vi.mock('@dnd-kit/react', () => ({
+  DragDropProvider({
+    children,
+    onDragEnd,
+  }: {
+    children: React.ReactNode;
+    onDragEnd: (event: { canceled: boolean }) => void;
+  }) {
+    dnd.onDragEnd = onDragEnd;
+    return children;
+  },
+}));
+vi.mock('@dnd-kit/react/sortable', () => ({
+  useSortable: () => ({
+    ref: vi.fn(),
+    handleRef: vi.fn(),
+    isDragging: false,
+  }),
+}));
+vi.mock('use-intl', () => ({ useTranslations: translations }));
+
+afterEach(() => {
+  cleanup();
+  dnd.move.mockClear();
+  dnd.onDragEnd = undefined;
+});
+
+const ACCOUNTS: ProviderAccountListItem[] = [
+  {
+    id: 'account-a',
+    label: 'Account A',
+    credentialType: 'api-key',
+    boundAgents: [],
+  },
+  {
+    id: 'account-b',
+    label: 'Account B',
+    credentialType: 'api-key',
+    boundAgents: [],
+  },
+];
+
+describe('AccountList', () => {
+  it('emits the full reordered account id list when a drag ends', () => {
+    const onReorder = vi.fn();
+    render(
+      <AccountList
+        accounts={ACCOUNTS}
+        loading={false}
+        onAdd={vi.fn()}
+        onReorder={onReorder}
+        onSelect={vi.fn()}
+      />,
+    );
+
+    expect(screen.getAllByRole('button', { name: 'reorderAccount' })).toHaveLength(2);
+    act(() => dnd.onDragEnd?.({ canceled: false }));
+
+    expect(dnd.move).toHaveBeenCalledWith(['account-a', 'account-b'], { canceled: false });
+    expect(onReorder).toHaveBeenCalledWith(['account-b', 'account-a']);
+  });
+
+  it('disables reordering while the account list is filtered', () => {
+    const onReorder = vi.fn();
+    render(
+      <AccountList
+        accounts={ACCOUNTS}
+        loading={false}
+        onAdd={vi.fn()}
+        onReorder={onReorder}
+        onSelect={vi.fn()}
+      />,
+    );
+
+    fireEvent.change(screen.getByPlaceholderText('searchPlaceholder'), {
+      target: { value: 'Account A' },
+    });
+    expect(screen.getByRole('button', { name: 'reorderAccount' })).toHaveProperty('disabled', true);
+    act(() => dnd.onDragEnd?.({ canceled: false }));
+
+    expect(onReorder).not.toHaveBeenCalled();
+  });
+});

--- a/packages/presentation/ui/src/shell/__tests__/account-master-list.test.tsx
+++ b/packages/presentation/ui/src/shell/__tests__/account-master-list.test.tsx
@@ -9,8 +9,9 @@ function reversed(items: string[]): string[] {
   return [...items].reverse();
 }
 
-function passthrough(key: string): string {
-  return key;
+function passthrough(key: string, values?: Record<string, unknown>): string {
+  const interpolation = values ? Object.values(values).join(',') : '';
+  return interpolation ? `${key}:${interpolation}` : key;
 }
 
 function translations(): typeof passthrough {
@@ -78,7 +79,8 @@ describe('AccountList', () => {
       />,
     );
 
-    expect(screen.getAllByRole('button', { name: 'reorderAccount' })).toHaveLength(2);
+    expect(screen.getByRole('button', { name: 'reorderAccount:Account A' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'reorderAccount:Account B' })).toBeTruthy();
     act(() => dnd.onDragEnd?.({ canceled: false }));
 
     expect(dnd.move).toHaveBeenCalledWith(['account-a', 'account-b'], { canceled: false });
@@ -97,10 +99,15 @@ describe('AccountList', () => {
       />,
     );
 
+    expect(screen.getByText('orderHint')).toBeTruthy();
     fireEvent.change(screen.getByPlaceholderText('searchPlaceholder'), {
       target: { value: 'Account A' },
     });
-    expect(screen.getByRole('button', { name: 'reorderAccount' })).toHaveProperty('disabled', true);
+    expect(screen.queryByText('orderHint')).toBeNull();
+    expect(screen.getByRole('button', { name: 'reorderAccount:Account A' })).toHaveProperty(
+      'disabled',
+      true,
+    );
     act(() => dnd.onDragEnd?.({ canceled: false }));
 
     expect(onReorder).not.toHaveBeenCalled();

--- a/packages/presentation/ui/src/shell/providers/account-master-list.tsx
+++ b/packages/presentation/ui/src/shell/providers/account-master-list.tsx
@@ -1,13 +1,18 @@
+import { move } from '@dnd-kit/helpers';
+import type { DragEndEvent } from '@dnd-kit/react';
+import { DragDropProvider } from '@dnd-kit/react';
+import { useSortable } from '@dnd-kit/react/sortable';
 import type { AgentKind } from '@linkcode/schema';
 import { Badge } from 'coss-ui/components/badge';
 import { Button } from 'coss-ui/components/button';
 import { Card } from 'coss-ui/components/card';
 import { Input } from 'coss-ui/components/input';
 import { Skeleton } from 'coss-ui/components/skeleton';
-import { ChevronRightIcon, PlusIcon } from 'lucide-react';
+import { ChevronRightIcon, GripVerticalIcon, PlusIcon } from 'lucide-react';
 import { useState } from 'react';
 import { useTranslations } from 'use-intl';
 import { ServiceIcon } from '../service-icon';
+import { SIDEBAR_SORTABLE_SENSORS } from '../sidebar';
 import type { ProviderAccountRouting } from './routing';
 
 export interface ProviderAccountListItem {
@@ -29,18 +34,21 @@ export interface ProviderAccountListViewModel {
 export function AccountList({
   accounts,
   loading,
+  reorderDisabled = false,
   onSelect,
+  onReorder,
   onAdd,
   onUseLinkCodeGateway,
 }: ProviderAccountListViewModel & {
   loading: boolean;
+  reorderDisabled?: boolean;
   onSelect: (id: string) => void;
+  onReorder?: (orderedIds: string[]) => void;
   onAdd: () => void;
   /** Explicit first-party path shown only when no third-party account or login is available. */
   onUseLinkCodeGateway?: () => void;
 }): React.ReactNode {
   const t = useTranslations('settings.providers');
-  const tAgent = useTranslations('workbench.agentKind');
   const [query, setQuery] = useState('');
 
   const credentialLabel = (account: ProviderAccountListItem): string => {
@@ -74,6 +82,14 @@ export function AccountList({
           .includes(needle),
       )
     : accounts;
+  const canReorder = onReorder !== undefined && !reorderDisabled && needle === '';
+
+  function handleDragEnd(event: DragEndEvent): void {
+    if (!canReorder || event.canceled) return;
+    const current = accounts.map(({ id }) => id);
+    const reordered = move(current, event);
+    if (reordered.some((id, index) => id !== current[index])) onReorder(reordered);
+  }
 
   return (
     <div className="flex min-w-0 flex-col gap-3">
@@ -92,75 +108,122 @@ export function AccountList({
           </Button>
         </div>
       </div>
+      {accounts.length > 1 ? (
+        <p className="text-muted-foreground text-xs">{t('orderHint')}</p>
+      ) : null}
       <Card className="overflow-hidden">
-        <ul className="divide-y divide-border">
-          {loading && accounts.length === 0 ? (
-            <>
-              <li className="p-4">
-                <Skeleton className="h-14 w-full rounded-lg" />
+        <DragDropProvider sensors={SIDEBAR_SORTABLE_SENSORS} onDragEnd={handleDragEnd}>
+          <ul className="divide-y divide-border">
+            {loading && accounts.length === 0 ? (
+              <>
+                <li className="p-4">
+                  <Skeleton className="h-14 w-full rounded-lg" />
+                </li>
+                <li className="p-4">
+                  <Skeleton className="h-14 w-full rounded-lg" />
+                </li>
+              </>
+            ) : null}
+            {rows.map((account, index) => (
+              <AccountRow
+                key={account.id}
+                account={account}
+                detailLine={accountDetailLine(account)}
+                credentialLabel={credentialLabel(account)}
+                index={index}
+                reorderEnabled={canReorder}
+                onSelect={onSelect}
+              />
+            ))}
+            {!loading && needle && rows.length === 0 ? (
+              <li className="px-4 py-12 text-center text-muted-foreground text-sm">
+                {t('noMatches')}
               </li>
-              <li className="p-4">
-                <Skeleton className="h-14 w-full rounded-lg" />
+            ) : null}
+            {!loading && needle === '' && accounts.length === 0 ? (
+              <li className="flex flex-col items-center gap-2 px-6 py-12 text-center">
+                <span className="font-medium text-sm">{t('emptyTitle')}</span>
+                <span className="max-w-sm text-muted-foreground text-xs">{t('emptyHint')}</span>
+                {onUseLinkCodeGateway ? (
+                  <Button type="button" size="sm" className="mt-2" onClick={onUseLinkCodeGateway}>
+                    {t('linkCodeUseGateway')}
+                  </Button>
+                ) : null}
               </li>
-            </>
-          ) : null}
-          {rows.map((account) => {
-            const detailLine = accountDetailLine(account);
-            return (
-              <li key={account.id}>
-                <button
-                  type="button"
-                  className="flex w-full items-center gap-3 px-4 py-3.5 text-left transition-colors hover:bg-muted/50"
-                  onClick={() => onSelect(account.id)}
-                >
-                  <ServiceIcon
-                    service={account.service}
-                    label={account.label}
-                    className="size-10"
-                  />
-                  <span className="min-w-0 flex-1">
-                    <span className="block truncate font-medium text-sm">{account.label}</span>
-                    <span className="block truncate text-muted-foreground text-xs">
-                      {account.serviceLabel ?? t('customService')} · {credentialLabel(account)}
-                    </span>
-                    {detailLine ? (
-                      <span className="block truncate text-muted-foreground text-xs">
-                        {detailLine}
-                      </span>
-                    ) : null}
-                  </span>
-                  {/* Naming no agent is not a defect — the account's models still reach every
-                      picker it is enabled for — so the row says nothing rather than "not connected". */}
-                  <span className="hidden max-w-60 flex-wrap justify-end gap-1 sm:flex">
-                    {account.boundAgents.map((kind) => (
-                      <Badge key={kind} variant="outline" size="sm" className="rounded-full">
-                        {tAgent(kind)}
-                      </Badge>
-                    ))}
-                  </span>
-                  <ChevronRightIcon className="size-4 shrink-0 text-muted-foreground" />
-                </button>
-              </li>
-            );
-          })}
-          {!loading && needle && rows.length === 0 ? (
-            <li className="px-4 py-12 text-center text-muted-foreground text-sm">
-              {t('noMatches')}
-            </li>
-          ) : null}
-          {!loading && needle === '' && accounts.length === 0 ? (
-            <li className="flex flex-col items-center gap-2 px-6 py-12 text-center">
-              <span className="font-medium text-sm">{t('emptyTitle')}</span>
-              <span className="max-w-sm text-muted-foreground text-xs">{t('emptyHint')}</span>
-              {onUseLinkCodeGateway ? (
-                <Button type="button" size="sm" className="mt-2" onClick={onUseLinkCodeGateway}>
-                  {t('linkCodeUseGateway')}
-                </Button>
-              ) : null}
-            </li>
-          ) : null}
-        </ul>
+            ) : null}
+          </ul>
+        </DragDropProvider>
       </Card>
     </div>
+  );
+}
+
+function AccountRow({
+  account,
+  detailLine,
+  credentialLabel,
+  index,
+  reorderEnabled,
+  onSelect,
+}: {
+  account: ProviderAccountListItem;
+  detailLine: string | undefined;
+  credentialLabel: string;
+  index: number;
+  reorderEnabled: boolean;
+  onSelect: (id: string) => void;
+}): React.ReactNode {
+  const t = useTranslations('settings.providers');
+  const tAgent = useTranslations('workbench.agentKind');
+  const { ref, handleRef, isDragging } = useSortable({
+    id: account.id,
+    index,
+    type: 'provider-account',
+    accept: 'provider-account',
+    disabled: !reorderEnabled,
+  });
+
+  return (
+    <li ref={ref} className={isDragging ? 'relative z-10 bg-background shadow-lg' : undefined}>
+      <div className="flex items-stretch">
+        <Button
+          ref={handleRef}
+          type="button"
+          variant="ghost"
+          size="icon"
+          disabled={!reorderEnabled}
+          aria-label={t('reorderAccount', { label: account.label })}
+          className="ms-1 my-auto shrink-0 cursor-grab touch-none text-label-tertiary active:cursor-grabbing"
+        >
+          <GripVerticalIcon className="size-4" />
+        </Button>
+        <button
+          type="button"
+          className="flex min-w-0 flex-1 items-center gap-3 px-3 py-3.5 text-left transition-colors hover:bg-muted/50 active:bg-muted/50"
+          onClick={() => onSelect(account.id)}
+        >
+          <ServiceIcon service={account.service} label={account.label} className="size-10" />
+          <span className="min-w-0 flex-1">
+            <span className="block truncate font-medium text-sm">{account.label}</span>
+            <span className="block truncate text-muted-foreground text-xs">
+              {account.serviceLabel ?? t('customService')} · {credentialLabel}
+            </span>
+            {detailLine ? (
+              <span className="block truncate text-muted-foreground text-xs">{detailLine}</span>
+            ) : null}
+          </span>
+          {/* Naming no agent is not a defect — the account's models still reach every picker it is
+              enabled for — so the row says nothing rather than "not connected". */}
+          <span className="hidden max-w-60 flex-wrap justify-end gap-1 sm:flex">
+            {account.boundAgents.map((kind) => (
+              <Badge key={kind} variant="outline" size="sm" className="rounded-full">
+                {tAgent(kind)}
+              </Badge>
+            ))}
+          </span>
+          <ChevronRightIcon className="size-4 shrink-0 text-muted-foreground" />
+        </button>
+      </div>
+    </li>
   );
 }

--- a/packages/presentation/ui/src/shell/providers/account-master-list.tsx
+++ b/packages/presentation/ui/src/shell/providers/account-master-list.tsx
@@ -12,7 +12,7 @@ import { ChevronRightIcon, GripVerticalIcon, PlusIcon } from 'lucide-react';
 import { useState } from 'react';
 import { useTranslations } from 'use-intl';
 import { ServiceIcon } from '../service-icon';
-import { SIDEBAR_SORTABLE_SENSORS } from '../sidebar';
+import { SORTABLE_SENSORS } from '../sortable-sensors';
 import type { ProviderAccountRouting } from './routing';
 
 export interface ProviderAccountListItem {
@@ -108,11 +108,11 @@ export function AccountList({
           </Button>
         </div>
       </div>
-      {accounts.length > 1 ? (
+      {canReorder && accounts.length > 1 ? (
         <p className="text-muted-foreground text-xs">{t('orderHint')}</p>
       ) : null}
       <Card className="overflow-hidden">
-        <DragDropProvider sensors={SIDEBAR_SORTABLE_SENSORS} onDragEnd={handleDragEnd}>
+        <DragDropProvider sensors={SORTABLE_SENSORS} onDragEnd={handleDragEnd}>
           <ul className="divide-y divide-border">
             {loading && accounts.length === 0 ? (
               <>

--- a/packages/presentation/ui/src/shell/sidebar/index.ts
+++ b/packages/presentation/ui/src/shell/sidebar/index.ts
@@ -11,7 +11,6 @@ export { PinnedSection } from './pinned-section';
 export { SectionAccordionTrigger } from './section-header';
 export type { ShowMoreToggleProps } from './show-more-toggle';
 export { ShowMoreToggle } from './show-more-toggle';
-export { SIDEBAR_SORTABLE_SENSORS } from './sortable-sensors';
 export type {
   SidebarSectionKey,
   ThreadGroupActions,

--- a/packages/presentation/ui/src/shell/sortable-sensors.ts
+++ b/packages/presentation/ui/src/shell/sortable-sensors.ts
@@ -9,14 +9,8 @@ function isTextInputTarget(target: EventTarget | null): boolean {
   );
 }
 
-/**
- * Overrides two PointerSensor defaults that assume non-interactive drag handles: default
- * `preventActivation` would make the button-built rows/headers undraggable, so only text inputs
- * stay protected (drag-to-select in the rename field must not start a group drag); and instant
- * in-handle activation would swallow plain clicks, so a 5px distance threshold keeps clicks as
- * clicks while touch keeps a hold delay so scrolling over rows doesn't start drags.
- */
-export const SIDEBAR_SORTABLE_SENSORS: Sensors = [
+/** Preserve text editing and plain clicks while requiring deliberate pointer or touch drags. */
+export const SORTABLE_SENSORS: Sensors = [
   PointerSensor.configure({
     activationConstraints: (event) =>
       event.pointerType === 'touch'

--- a/packages/presentation/ui/src/shell/threads-view.tsx
+++ b/packages/presentation/ui/src/shell/threads-view.tsx
@@ -17,10 +17,10 @@ import {
   PinnedSection,
   SectionAccordionTrigger,
   ShowMoreToggle,
-  SIDEBAR_SORTABLE_SENSORS,
   ThreadGroupHeader,
   ThreadRow,
 } from './sidebar';
+import { SORTABLE_SENSORS } from './sortable-sensors';
 
 const SIDEBAR_SECTIONS = [
   'pinned',
@@ -154,7 +154,7 @@ export function ThreadsView({
 
   return (
     <DragDropProvider
-      sensors={SIDEBAR_SORTABLE_SENSORS}
+      sensors={SORTABLE_SENSORS}
       onDragOver={handleDragOver}
       onDragEnd={handleDragEnd}
     >


### PR DESCRIPTION
## Summary

- add drag-and-drop priority ordering for provider accounts and persist the complete account order
- update New Task defaults from the first compatible account's first model
- allow users to promote a selected account model to the default position
- add English/Chinese copy and focused tests

Linear: [CODE-590](https://linear.app/arcbox/issue/CODE-590/featproviders-allow-ordering-accounts-and-selecting-default-models)

## Verification

- `pnpm check:ci`
- `pnpm test` — 2966 passed, 1 skipped
- exercised the mock Webview end-to-end and verified that dragging DeepSeek above Anthropic changes the New Task default from Claude Opus 5 to DeepSeek V4 Pro

## Checklist

- [x] `pnpm check:ci` and `pnpm test` both pass
- [x] I ran the affected surface and observed the change working
- [x] No wire message changed
- [x] New code and assets are my own work
- [x] Docs and comments are updated where behavior changed