### PR TITLE
fix(assets): update aigateway to 0.6.0

### DIFF
--- a/packages/host/assets/src/catalog.ts
+++ b/packages/host/assets/src/catalog.ts
@@ -120,7 +120,7 @@ function tectonicArtifact(
   };
 }
 
-const AIGATEWAY_VERSION = '0.5.0-rc2';
+const AIGATEWAY_VERSION = '0.6.0';
 const AIGATEWAY_RELEASE = `https://github.com/arcboxlabs/aigateway/releases/download/v${AIGATEWAY_VERSION}`;
 
 function aigatewayArtifact(
@@ -247,32 +247,32 @@ export const CATALOG: readonly AssetDescriptor[] = [
       'darwin-arm64': aigatewayArtifact(
         'aarch64-apple-darwin',
         'tgz',
-        'sha256-7dF2X2fZOEDlzow1+Vodu9T+XGfyEmOtW/5M+/xQYq4=',
-        3_404_002,
+        'sha256-Ju/7oNC/3GPGFT6SPOnEJLYSvI2BU8tI/bFVAnmrUeA=',
+        3_370_411,
       ),
       'darwin-x64': aigatewayArtifact(
         'x86_64-apple-darwin',
         'tgz',
-        'sha256-QUG0Ayw9U0Xr8LoBNP3JJtBHq8ohFGScEUoA0jTcebA=',
-        3_612_759,
+        'sha256-HQep7p0f3OcdmcMNVa7WMuye4HB9vxXkOStkZ8UukuM=',
+        3_555_667,
       ),
       'linux-arm64': aigatewayArtifact(
         'aarch64-unknown-linux-musl',
         'tgz',
-        'sha256-FeW0CEd1hwoBu91y/1Uc/ZoK+crcXGoq3zDsPa/5xYQ=',
-        3_479_607,
+        'sha256-/xie7myRP3Gi+Ga5f7bDP0cNvOS1yGNgQ7jqSfZZmv8=',
+        3_455_536,
       ),
       'linux-x64': aigatewayArtifact(
         'x86_64-unknown-linux-musl',
         'tgz',
-        'sha256-fAJd9IRBFOqLf5uhNkoPGMdO2KTuycNh0niZ7ian4Fk=',
-        3_769_337,
+        'sha256-fEknw27bmD1L7LUgW3/bAUyZRyP0fNisbJ3eI3Uw7y0=',
+        3_731_765,
       ),
       'win32-x64': aigatewayArtifact(
         'x86_64-pc-windows-msvc',
         'zip',
-        'sha256-440fIMPnL+5+kp142ffRzTq+XKsOeTU5RljnOnG0ubQ=',
-        3_759_629,
+        'sha256-QOd7+UHmoKCvo0nb6xGgQgQMprLRIQluKTScy227EkA=',
+        3_721_793,
       ),
     },
   },


### PR DESCRIPTION
## Summary
- update the managed aigateway sidecar from v0.5.0-rc2 to [v0.6.0](https://github.com/arcboxlabs/aigateway/releases/tag/v0.6.0)
- pin the exact compressed sizes and SHA-256 SRI values for all five supported release artifacts

## Why
v0.6.0 accepts inline Anthropic system messages, fixing local requests that failed with HTTP 400 `unknown variant system`.

## Checks
- `pnpm check:ci`
- `pnpm test`
- downloaded all five release artifacts and verified them against the published `SHA256SUMS`
- ran the Linux x64 binary and observed `aigateway 0.6.0`
