### PR TITLE
fix(attachments): preserve original image filenames

### DIFF
--- a/packages/foundation/schema/src/model/content.ts
+++ b/packages/foundation/schema/src/model/content.ts
@@ -28,6 +28,7 @@ export const ContentBlockSchema = z.discriminatedUnion('type', [
     type: z.literal('image'),
     data: z.string(), // base64
     mimeType: z.string(),
+    name: z.string().optional(),
     uri: z.string().optional(),
     annotations: AnnotationsSchema.optional(),
   }),

--- a/packages/foundation/schema/src/wire/message.ts
+++ b/packages/foundation/schema/src/wire/message.ts
@@ -9,7 +9,7 @@ import { WIRE_PAYLOAD_KINDS, WirePayloadSchema } from './payload';
  */
 
 /** Stamped on every frame this build sends; bump on any wire schema change. */
-export const WIRE_PROTOCOL_VERSION = 77 as const;
+export const WIRE_PROTOCOL_VERSION = 78 as const;
 
 /** The oldest `v` this build still accepts. Bump only for a breaking change — a variant or field
  * removed, renamed, or given a new meaning; additive changes leave it alone. */

--- a/packages/foundation/schema/tests/contract/wire/agent.test.ts
+++ b/packages/foundation/schema/tests/contract/wire/agent.test.ts
@@ -98,6 +98,31 @@ describe('agent wire variants', () => {
     ).toBe(false);
   });
 
+  it('preserves image attachment names through the wire schema', () => {
+    const parsed = WireMessageSchema.parse({
+      v: WIRE_PROTOCOL_VERSION,
+      id: 'message-1',
+      ts: 0,
+      payload: {
+        kind: 'agent.input',
+        clientReqId: 'request-1',
+        sessionId: 'session-1',
+        input: {
+          type: 'prompt',
+          content: [
+            { type: 'image', data: 'cG5n', mimeType: 'image/png', name: 'architecture.png' },
+          ],
+        },
+      },
+    });
+
+    expect(parsed).toMatchObject({
+      payload: {
+        input: { content: [{ name: 'architecture.png' }] },
+      },
+    });
+  });
+
   it('requires identity on user messages', () => {
     expect(
       WireMessageSchema.safeParse({

--- a/packages/host/agent-adapter/src/__tests__/opencode.test.ts
+++ b/packages/host/agent-adapter/src/__tests__/opencode.test.ts
@@ -710,6 +710,32 @@ describe('OpenCodeAdapter prompt dispatch', () => {
       parts: [{ type: 'text', text: 'hi' }],
     });
   });
+
+  it('forwards image attachment names as file part filenames', async () => {
+    const { adapter } = await makeAdapter();
+
+    await adapter.send({
+      type: 'prompt',
+      content: [
+        { type: 'text', text: 'review this' },
+        { type: 'image', data: 'cG5n', mimeType: 'image/png', name: 'architecture.png' },
+      ],
+    });
+
+    expect(client.session.promptAsync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        parts: [
+          { type: 'text', text: 'review this' },
+          {
+            type: 'file',
+            mime: 'image/png',
+            filename: 'architecture.png',
+            url: 'data:image/png;base64,cG5n',
+          },
+        ],
+      }),
+    );
+  });
 });
 
 describe('OpenCodeAdapter permission round-trip', () => {

--- a/packages/host/agent-adapter/src/native/opencode/adapter.ts
+++ b/packages/host/agent-adapter/src/native/opencode/adapter.ts
@@ -492,6 +492,7 @@ export class OpenCodeAdapter extends BaseAgentAdapter {
         (image): FilePartInput => ({
           type: 'file',
           mime: image.mimeType,
+          filename: image.name,
           url: `data:${image.mimeType};base64,${image.data}`,
         }),
       ),

--- a/packages/host/agent-adapter/src/util.ts
+++ b/packages/host/agent-adapter/src/util.ts
@@ -23,11 +23,10 @@ export function contentToText(content: ContentBlock[]): string {
  * from — the target shape differs per vendor, so only this extraction step is shared. */
 export function imageBlocksFrom(
   content: ContentBlock[],
-): Array<{ data: string; mimeType: string }> {
-  return content.reduce<Array<{ data: string; mimeType: string }>>((images, c) => {
-    if (c.type === 'image') images.push({ data: c.data, mimeType: c.mimeType });
-    return images;
-  }, []);
+): Array<Extract<ContentBlock, { type: 'image' }>> {
+  return content.filter(
+    (block): block is Extract<ContentBlock, { type: 'image' }> => block.type === 'image',
+  );
 }
 
 const PATH_INPUT_KEYS = ['file_path', 'path', 'notebook_path', 'filePath'] as const;

--- a/packages/presentation/ui/src/chat/__tests__/content-block-view.test.tsx
+++ b/packages/presentation/ui/src/chat/__tests__/content-block-view.test.tsx
@@ -14,6 +14,23 @@ function resourceLink(uri: string): ContentBlock {
   return { type: 'resource_link', uri, name: 'ARCHITECTURE.md' };
 }
 
+it('uses the preserved attachment name for an image preview', () => {
+  const { getByRole } = render(
+    <ContentBlockView
+      block={{
+        type: 'image',
+        data: 'cG5n',
+        mimeType: 'image/png',
+        name: 'architecture.png',
+      }}
+    />,
+  );
+
+  const image = getByRole('img', { name: 'architecture.png' });
+  expect(image.getAttribute('title')).toBe('architecture.png');
+  expect(image.getAttribute('src')).toBe('data:image/png;base64,cG5n');
+});
+
 // The pre-chip renderer emitted a target=_blank anchor whose file:// href was blocked from
 // http(s) origins — a dead click. File uris must route the artifact host actions instead.
 it('opens file resource links through the artifact host actions', () => {

--- a/packages/presentation/ui/src/chat/content-block-view.tsx
+++ b/packages/presentation/ui/src/chat/content-block-view.tsx
@@ -36,9 +36,10 @@ export function ContentBlockView({
     case 'image':
       return (
         <img
-          alt=""
+          alt={block.name ?? ''}
           className="my-2 max-h-80 max-w-full rounded-xl border border-border"
           src={block.uri ?? `data:${block.mimeType};base64,${block.data}`}
+          title={block.name}
         />
       );
     case 'audio':

--- a/packages/presentation/ui/src/shell/__tests__/composer-attachments.test.ts
+++ b/packages/presentation/ui/src/shell/__tests__/composer-attachments.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  attachmentFromReadFile,
   failedComposerAttachmentFromPath,
   pendingComposerAttachment,
 } from '../composer-attachments';
@@ -24,5 +25,25 @@ describe('composer attachment presentation kinds', () => {
 
   it('uses the file extension when a failed native read has no MIME type', () => {
     expect(failedComposerAttachmentFromPath('/tmp/guide.pdf', 'Failed').kind).toBe('pdf');
+  });
+
+  it('keeps the basename on image blocks created from native file reads', () => {
+    const attachment = attachmentFromReadFile(
+      {
+        path: String.raw`C:\screenshots\architecture.png`,
+        content: 'cG5n',
+        encoding: 'base64',
+        mimeType: 'image/png',
+        size: 3,
+      },
+      { unsupportedType: 'Unsupported', tooLarge: 'Too large' },
+    );
+
+    expect(attachment.block).toEqual({
+      type: 'image',
+      data: 'cG5n',
+      mimeType: 'image/png',
+      name: 'architecture.png',
+    });
   });
 });

--- a/packages/presentation/ui/src/shell/__tests__/composer-command-menu.test.tsx
+++ b/packages/presentation/ui/src/shell/__tests__/composer-command-menu.test.tsx
@@ -391,7 +391,12 @@ describe('Composer command menu', () => {
 
     expect(onSend).toHaveBeenCalledExactlyOnceWith([
       { type: 'text', text: 'ship it' },
-      { type: 'image', data: expect.any(String) as string, mimeType: 'image/png' },
+      {
+        type: 'image',
+        data: expect.any(String) as string,
+        mimeType: 'image/png',
+        name: 'probe.png',
+      },
     ]);
     expect(screen.queryByRole('img', { name: 'probe.png' })).toBeNull();
   });

--- a/packages/presentation/ui/src/shell/composer-attachments.ts
+++ b/packages/presentation/ui/src/shell/composer-attachments.ts
@@ -87,7 +87,12 @@ export async function readImageFileAsComposerAttachment(
     ...pending,
     status: 'ready',
     url: dataUrl,
-    block: { type: 'image', data: dataUrl.slice(dataUrl.indexOf(',') + 1), mimeType: file.type },
+    block: {
+      type: 'image',
+      data: dataUrl.slice(dataUrl.indexOf(',') + 1),
+      mimeType: file.type,
+      name: file.name,
+    },
   };
 }
 
@@ -155,7 +160,7 @@ export function attachmentFromReadFile(
     sizeBytes: file.size,
     status: 'ready',
     url: `data:${mimeType};base64,${file.content}`,
-    block: { type: 'image', data: file.content, mimeType },
+    block: { type: 'image', data: file.content, mimeType, name },
   };
 }
 


### PR DESCRIPTION
## Summary

- Preserve each image attachment's original filename from browser/native selection through the additive wire schema.
- Forward the filename to OpenCode file parts and expose it on rendered image previews while keeping historical unnamed image blocks compatible.
- Bump `WIRE_PROTOCOL_VERSION` to 78 while leaving the compatibility floor at 76.

Linear: [CODE-599](https://linear.app/arcbox/issue/CODE-599/fixattachments-preserve-original-image-filenames)

## Verification

- `pnpm check:ci`
- `pnpm test` — 346 files passed, 2977 tests passed, 1 skipped
- Browser mock acceptance: uploaded `icon-dock.png` and `icon.png`, observed distinct filename tooltips, sent both through the OpenCode transport, and verified the sent images retained their names with no page errors
- [Acceptance recording](https://ampcode.com/threads/T-01a01f9e-9850-71ff-b8e0-d99b07ba3696)

## Checklist

- [x] `pnpm check:ci` and `pnpm test` both pass (plus `cargo fmt` / `clippy` / `test` for Rust changes)
- [x] I ran the affected surface and observed the change working
- [x] If a wire message changed: `WIRE_PROTOCOL_VERSION` is bumped
- [x] New code and assets are my own work, or their origin and license compatibility are noted above
- [x] Docs and comments are updated where behavior changed (no documentation change required)
