### PR TITLE
fix(agent-adapter): support fish when loading the project shell environment

### DIFF
--- a/packages/host/agent-adapter/src/__tests__/shell-env.test.ts
+++ b/packages/host/agent-adapter/src/__tests__/shell-env.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { parseShellEnvironment } from '../shell-env';
+import { parseShellEnvironment, shellProbeCommand } from '../shell-env';
 
 describe('project shell environment', () => {
   it('ignores shell output and parses the marked JSON environment', () => {
@@ -20,5 +20,17 @@ describe('project shell environment', () => {
     expect(() => parseShellEnvironment('startup output', 'missing', '/repo')).toThrow(
       'Project shell did not return an environment for /repo',
     );
+  });
+});
+
+describe('shell probe command', () => {
+  it('emits fish syntax for fish and POSIX syntax otherwise', () => {
+    expect(shellProbeCommand('/opt/homebrew/bin/fish', 'PRINT_ENV')).toBe(
+      'if command -v direnv >/dev/null 2>&1; exec direnv exec "$PWD" PRINT_ENV; else; exec PRINT_ENV; end',
+    );
+    expect(shellProbeCommand('/bin/zsh', 'PRINT_ENV')).toBe(
+      'if command -v direnv >/dev/null 2>&1; then exec direnv exec "$PWD" PRINT_ENV; else exec PRINT_ENV; fi',
+    );
+    expect(shellProbeCommand('/bin/bash', 'PRINT_ENV')).toContain('then exec');
   });
 });

--- a/packages/host/agent-adapter/src/shell-env.ts
+++ b/packages/host/agent-adapter/src/shell-env.ts
@@ -11,6 +11,8 @@ const CAPTURE_ENV = {
   ELECTRON_NO_ATTACH_CONSOLE: '1',
   LINKCODE_RESOLVING_ENVIRONMENT: '1',
 };
+const FISH_SHELL_PATTERN = /(?:^|\/)fish$/;
+
 const ShellEnvironmentSchema = z
   .record(z.string(), z.string())
   .refine((value) => Boolean(value.PATH), 'PATH is required');
@@ -28,7 +30,7 @@ export async function resolveShellEnvironment(
   const marker = randomUUID().replaceAll('-', '');
   const expression = `"${marker}" + JSON.stringify(process.env) + "${marker}"`;
   const printEnv = `${quoteShellArg(process.execPath)} -p ${quoteShellArg(expression)}`;
-  const command = `if command -v direnv >/dev/null 2>&1; then exec direnv exec "$PWD" ${printEnv}; else exec ${printEnv}; fi`;
+  const command = shellProbeCommand(shell, printEnv);
   let stdout: string;
   try {
     ({ stdout } = await execFileAsync(shell, ['-i', '-l', '-c', command], {
@@ -52,6 +54,14 @@ export async function resolveShellEnvironment(
     resolved.LINKCODE_RESOLVING_ENVIRONMENT = baseEnv.LINKCODE_RESOLVING_ENVIRONMENT;
   }
   return resolved;
+}
+
+/** fish rejects POSIX if/then/else — it alone gets its own syntax; every other login shell is POSIX. */
+export function shellProbeCommand(shell: string, printEnv: string): string {
+  if (FISH_SHELL_PATTERN.test(shell)) {
+    return `if command -v direnv >/dev/null 2>&1; exec direnv exec "$PWD" ${printEnv}; else; exec ${printEnv}; end`;
+  }
+  return `if command -v direnv >/dev/null 2>&1; then exec direnv exec "$PWD" ${printEnv}; else exec ${printEnv}; fi`;
 }
 
 export function parseShellEnvironment(


### PR DESCRIPTION
Linear: CODE-643

## 问题（Problem）

macOS 上用 fish 做登录 shell 时，启动 Codex 会话失败，UI 只显示：

> 操作失败 — Error: Agent failed to start

daemon 日志（`~/Library/Logs/LinkCode/main.log`）里有真实 cause：

```text
Failed to load the project shell environment for /Users/adminliu
cause: Command failed: /opt/homebrew/bin/fish -i -l -c if command -v direnv …; fi
fish: Missing end to balance this if statement
```

## 根因（Root cause）

CODE-473 的 agent 子进程环境解析（`resolveShellEnvironment`，`packages/host/agent-adapter/src/shell-env.ts`）会通过用户的**登录 shell**（`$SHELL`）执行一段写死的 POSIX 命令来加载项目环境，并按需套一层 `direnv exec`：

```sh
if command -v direnv >/dev/null 2>&1; then …; else …; fi
```

fish 不认 `if/then/else/fi`（它要求 `if …; …; else; …; end`），命令在解析阶段就挂了。该解析按设计**大声失败、不回退**（不回退到 launchd 的 PATH），于是 `adapter.start()` 抛错，被 orchestrator 包装成笼统的 `Agent failed to start`。

- 这段逻辑 Codex 和 Claude **共用**，两个 agent 都受影响；
- zsh / bash 等 POSIX 系 shell 不受影响，bug 仅 fish（macOS 上唯一语法不兼容 POSIX 的主流登录 shell）；
- 该探测仅 macOS 启用（`shell-env.ts` 的 darwin guard）；Windows / Linux 直接复用 daemon 自身环境，不 spawn shell，PowerShell 不在此路径；
- daemon 日志本身带完整 cause（fish 报错 + stack），只是 UI 文案笼统。

## 修复（Fix）

把命令构造抽成 `shellProbeCommand(shell, printEnv)`：

- **fish** → fish 语法（`if …; …; else; …; end`）；
- 其余 shell → 原 POSIX 命令，行为不变。

大声失败契约保留，未引入静默回退。

```diff
- const command = `if command -v direnv >/dev/null 2>&1; then exec direnv exec "$PWD" ${printEnv}; else exec ${printEnv}; fi`;
+ const command = shellProbeCommand(shell, printEnv);
```

+2 文件，+24/-2。

## 验证（Verification）

- `tsc --build --noEmit packages/host/agent-adapter` 干净；
- `vitest run shell-env.test.ts` — 3/3（新增 fish / POSIX 语法断言）；
- 改动文件 ESLint + Biome 干净；
- 本机（登录 shell = fish）实测：新命令两个分支在真实 `fish -i -l -c` 下都能执行（`exec` / `"$PWD"` / `direnv exec` 均正常），并完整模拟 daemon 的调用方式成功解析出环境（PATH / HOME）；zsh 实测走 POSIX 分支通过；
- 真实 Codex 会话在 fish 下启动正常（本机实测通过）；
- `pnpm check:ci` 干净（0 error）；
- `pnpm test` 有 4 个既存失败，在 `packages/foundation/common/src/node/__tests__/release-artifact.test.ts`（`artifact path escapes its isolated root`，macOS `/tmp`→`/private/tmp` 符号链接问题），在 clean `master` 上同样复现，与本次改动无关（#466 也有同样说明）。

## Checklist

- [x] `pnpm check:ci` 与 `pnpm test` 均通过（4 个 `release-artifact` 既存失败与本次无关，见验证）
- [x] 跑过受影响面并观察到改动生效
- [x] 若改了 wire 消息：`WIRE_PROTOCOL_VERSION` 已 bump（不适用）
- [x] 新代码与资源为本人原创，或来源与许可证兼容性已在上方说明
- [x] 行为变更处文档与注释已更新
