### PR TITLE
feat(ui): refine thread hover feedback

### DIFF
--- a/packages/presentation/ui/src/shell/sidebar/row-actions.tsx
+++ b/packages/presentation/ui/src/shell/sidebar/row-actions.tsx
@@ -16,6 +16,15 @@ export const ROW_HOVER_PE_WIDE_CLASS =
 export const ROW_ACTION_CLASS =
   'opacity-0 transition-opacity hover:bg-transparent data-pressed:bg-transparent group-hover/menu-item:opacity-100 group-has-[:focus-visible]/menu-item:opacity-100 group-has-data-popup-open/menu-item:opacity-100';
 
+export const THREAD_ROW_HOVER_PE_CLASS =
+  'group-hover/menu-item:pe-15 group-has-[:focus-visible]/menu-item:pe-15 sm:group-hover/menu-item:pe-13 sm:group-has-[:focus-visible]/menu-item:pe-13';
+
+export const THREAD_ROW_HOVER_PE_WIDE_CLASS =
+  'group-hover/menu-item:pe-21 group-has-[:focus-visible]/menu-item:pe-21 sm:group-hover/menu-item:pe-19 sm:group-has-[:focus-visible]/menu-item:pe-19';
+
+export const THREAD_ROW_ACTION_CLASS =
+  'opacity-0 hover:bg-transparent data-pressed:bg-transparent group-hover/menu-item:opacity-100 group-has-[:focus-visible]/menu-item:opacity-100';
+
 /** Anchors a row's action buttons over the space `ROW_HOVER_PE_CLASS` frees up on hover. */
 export function RowActionsCluster({
   children,

--- a/packages/presentation/ui/src/shell/sidebar/thread-row.tsx
+++ b/packages/presentation/ui/src/shell/sidebar/thread-row.tsx
@@ -4,7 +4,9 @@ import { Button } from 'coss-ui/components/button';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuTrigger } from 'coss-ui/components/menu';
 import { PreviewCard, PreviewCardTrigger } from 'coss-ui/components/preview-card';
 import { SidebarMenuButton, SidebarMenuItem } from 'coss-ui/components/sidebar';
+import { noop } from 'foxts/noop';
 import { ClockIcon, EllipsisIcon, FolderIcon, GitBranchIcon, PinIcon, XIcon } from 'lucide-react';
+import { useCallback, useRef, useState, useSyncExternalStore } from 'react';
 import { useTranslations } from 'use-intl';
 import { AGENT_LABELS, AgentIcon } from '../../chat/agent-icon';
 import { cn } from '../../lib/cn';
@@ -13,10 +15,10 @@ import { repositoryLabel } from '../../repository-label';
 import { useRelativeTimeLabel } from '../use-relative-time-label';
 import type { BranchStatusComponentType } from './branch-status';
 import {
-  ROW_ACTION_CLASS,
-  ROW_HOVER_PE_CLASS,
-  ROW_HOVER_PE_WIDE_CLASS,
   RowActionsCluster,
+  THREAD_ROW_ACTION_CLASS,
+  THREAD_ROW_HOVER_PE_CLASS,
+  THREAD_ROW_HOVER_PE_WIDE_CLASS,
 } from './row-actions';
 import type { ThreadImMenuComponentType } from './thread-im-menu';
 import { SESSION_STATUS_DOT_CLASS } from './thread-status';
@@ -57,6 +59,7 @@ export function ThreadRow({
   const agent = AGENT_LABELS[session.kind];
   const title = session.title ?? `${agent} in ${repositoryLabel(session.cwd)}`;
   const createdAtLabel = useRelativeTimeLabel(session.createdAt);
+  const [imMenuOpen, setImMenuOpen] = useState(false);
   const { ref: sortableRef } = useSortable({
     id: session.sessionId,
     index: sortIndex,
@@ -71,6 +74,8 @@ export function ThreadRow({
     <SidebarMenuItem ref={sortableRef}>
       <PreviewCard>
         <PreviewCardTrigger
+          closeDelay={0}
+          delay={0}
           render={
             <SidebarMenuButton
               isActive={active}
@@ -78,8 +83,9 @@ export function ThreadRow({
               className={cn(
                 // No font-medium when active: IBM Plex Sans lacks CJK, so 500 falls back to
                 // PingFang Medium and mixed-script titles read artificially bold.
-                'h-(--density-thread-row-h) data-[active=true]:font-normal hover:bg-transparent data-[active=true]:hover:bg-sidebar-accent',
-                ImMenuComponent ? ROW_HOVER_PE_WIDE_CLASS : ROW_HOVER_PE_CLASS,
+                'h-(--density-thread-row-h) transition-none data-[active=true]:font-normal hover:bg-sidebar-accent data-[active=true]:hover:bg-sidebar-accent',
+                ImMenuComponent ? THREAD_ROW_HOVER_PE_WIDE_CLASS : THREAD_ROW_HOVER_PE_CLASS,
+                imMenuOpen && 'pe-21 sm:pe-19',
               )}
             />
           }
@@ -94,12 +100,9 @@ export function ThreadRow({
               )}
             />
           </span>
-          {/* data-thread-title is the browser-smoke E2E's row selector, not product styling. */}
-          <span className="min-w-0 flex-1 truncate" data-thread-title={session.sessionId}>
-            {title}
-          </span>
+          <OverflowingThreadTitle sessionId={session.sessionId} title={title} />
         </PreviewCardTrigger>
-        <SidePreviewCardPopup>
+        <SidePreviewCardPopup className="transition-none data-ending-style:scale-100 data-starting-style:scale-100 data-ending-style:opacity-100 data-starting-style:opacity-100">
           <div className="flex min-w-0 flex-1 flex-col gap-2">
             <span>{title}</span>
             <div className="flex flex-col gap-1.5 text-muted-foreground text-xs">
@@ -124,11 +127,17 @@ export function ThreadRow({
       </PreviewCard>
       <RowActionsCluster>
         {ImMenuComponent && (
-          <DropdownMenu>
+          <DropdownMenu onOpenChange={setImMenuOpen} open={imMenuOpen}>
             <DropdownMenuTrigger
               aria-label={t('threadActions')}
               title={t('threadActions')}
-              render={<Button className={ROW_ACTION_CLASS} size="icon-xs" variant="ghost" />}
+              render={
+                <Button
+                  className={cn(THREAD_ROW_ACTION_CLASS, imMenuOpen && 'opacity-100')}
+                  size="icon-xs"
+                  variant="ghost"
+                />
+              }
             >
               <EllipsisIcon />
             </DropdownMenuTrigger>
@@ -141,7 +150,7 @@ export function ThreadRow({
           aria-label={pinned ? t('unpinThread') : t('pinThread')}
           title={pinned ? t('unpinThread') : t('pinThread')}
           onClick={onTogglePin}
-          className={ROW_ACTION_CLASS}
+          className={cn(THREAD_ROW_ACTION_CLASS, imMenuOpen && 'opacity-100')}
           size="icon-xs"
           variant="ghost"
         >
@@ -151,7 +160,7 @@ export function ThreadRow({
           aria-label={t('closeThread')}
           title={t('closeThread')}
           onClick={onClose}
-          className={ROW_ACTION_CLASS}
+          className={cn(THREAD_ROW_ACTION_CLASS, imMenuOpen && 'opacity-100')}
           size="icon-xs"
           variant="ghost"
         >
@@ -159,5 +168,58 @@ export function ThreadRow({
         </Button>
       </RowActionsCluster>
     </SidebarMenuItem>
+  );
+}
+
+function OverflowingThreadTitle({
+  sessionId,
+  title,
+}: {
+  sessionId: string;
+  title: string;
+}): React.ReactNode {
+  const containerRef = useRef<HTMLSpanElement>(null);
+  const textRef = useRef<HTMLSpanElement>(null);
+  const subscribeToSize = useCallback((onChange: () => void): (() => void) => {
+    const container = containerRef.current;
+    const text = textRef.current;
+    if (!container || !text || typeof ResizeObserver === 'undefined') return noop;
+
+    const observer = new ResizeObserver(onChange);
+    observer.observe(container);
+    observer.observe(text);
+    return () => observer.disconnect();
+  }, []);
+  const readOverflow = useCallback((): number => {
+    const container = containerRef.current;
+    const text = textRef.current;
+    return container && text ? Math.max(0, text.scrollWidth - container.clientWidth) : 0;
+  }, []);
+  const overflow = useSyncExternalStore(subscribeToSize, readOverflow, () => 0);
+
+  return (
+    <span
+      className="min-w-0 flex-1 overflow-hidden text-ellipsis whitespace-nowrap group-hover/menu-item:text-clip"
+      data-thread-title={sessionId}
+      ref={containerRef}
+    >
+      <span
+        className={cn(
+          'inline-block',
+          overflow > 0 &&
+            'motion-safe:group-hover/menu-item:translate-x-[var(--thread-title-overflow)] motion-safe:group-hover/menu-item:transition-transform motion-safe:group-hover/menu-item:[transition-duration:var(--thread-title-scroll-duration)] motion-safe:group-hover/menu-item:ease-linear',
+        )}
+        ref={textRef}
+        style={
+          {
+            '--thread-title-overflow': `-${overflow}px`,
+            // Scale with hidden width so long titles move at a consistent, readable speed.
+            '--thread-title-scroll-duration': `${Math.max(1800, overflow * 30)}ms`,
+          } as React.CSSProperties
+        }
+      >
+        {title}
+      </span>
+    </span>
   );
 }


### PR DESCRIPTION
## Summary
- make thread hover background, row actions, and the detail preview respond immediately
- scroll overflowing titles while hovered and reset them immediately on exit
- hide row actions while the pointer is over the preview card without destabilizing the IM menu

## Verification
- `pnpm check:ci`
- `pnpm test` — 3040 passed, 1 skipped
- browser mock interaction verified at 1280×800

[CODE-650](https://linear.app/arcbox/issue/CODE-650/featui-refine-sidebar-thread-hover-feedback)