### PR TITLE
feat(providers): resolve LinkCode Gateway as a claude-code-native endpoint

### DIFF
--- a/packages/foundation/providers/src/__tests__/enabled-models.test.ts
+++ b/packages/foundation/providers/src/__tests__/enabled-models.test.ts
@@ -72,7 +72,7 @@ describe('enabledAccountModels', () => {
       credential: { type: 'auth-token', token: 'lc-test' },
       models: [
         { id: 'openai/gpt-5.6', protocols: ['openai-chat', 'openai-responses'] },
-        { id: 'anthropic/claude-sonnet-5', protocols: ['openai-chat'] },
+        { id: 'anthropic/claude-sonnet-5', protocols: ['openai-chat', 'anthropic'] },
         // Probed before `protocols` existed, or never probed — absence must still offer it.
         { id: 'openai/gpt-4.1' },
       ],
@@ -83,9 +83,13 @@ describe('enabledAccountModels', () => {
       'openai/gpt-5.6',
       'openai/gpt-4.1',
     ]);
-    // opencode/pi accept any wire this account offers, so nothing here is narrowed.
+    // claude-code and opencode both fall through to the account's own native anthropic wire (no
+    // knownProvider pins opencode elsewhere), so only the model actually tagged for it, plus the
+    // untagged one, survive.
+    expect(enabledAccountModels([gateway], {}, 'claude-code').map(({ model }) => model.id)).toEqual(
+      ['anthropic/claude-sonnet-5', 'openai/gpt-4.1'],
+    );
     expect(enabledAccountModels([gateway], {}, 'opencode').map(({ model }) => model.id)).toEqual([
-      'openai/gpt-5.6',
       'anthropic/claude-sonnet-5',
       'openai/gpt-4.1',
     ]);

--- a/packages/foundation/providers/src/__tests__/enabled-models.test.ts
+++ b/packages/foundation/providers/src/__tests__/enabled-models.test.ts
@@ -83,12 +83,8 @@ describe('enabledAccountModels', () => {
       'openai/gpt-5.6',
       'openai/gpt-4.1',
     ]);
-    // claude-code and opencode both fall through to the account's own native anthropic wire (no
-    // knownProvider pins opencode elsewhere), so only the model actually tagged for it, plus the
-    // untagged one, survive.
-    expect(enabledAccountModels([gateway], {}, 'claude-code').map(({ model }) => model.id)).toEqual(
-      ['anthropic/claude-sonnet-5', 'openai/gpt-4.1'],
-    );
+    // opencode falls through to the account's own native anthropic wire (no knownProvider pins it
+    // elsewhere), so only the model actually tagged for it, plus the untagged one, survive.
     expect(enabledAccountModels([gateway], {}, 'opencode').map(({ model }) => model.id)).toEqual([
       'anthropic/claude-sonnet-5',
       'openai/gpt-4.1',

--- a/packages/foundation/providers/src/__tests__/resolve.test.ts
+++ b/packages/foundation/providers/src/__tests__/resolve.test.ts
@@ -1,12 +1,7 @@
 import type { Account, AgentKind, AgentRuntimes } from '@linkcode/schema';
 import { nullthrow } from 'foxts/guard';
 import { describe, expect, it } from 'vitest';
-import {
-  endpointServiceById,
-  modelListSource,
-  modelListSourceForProtocol,
-  serviceById,
-} from '../catalog';
+import { endpointServiceById, modelListSource, serviceById } from '../catalog';
 import { detectedLogins } from '../detected-logins';
 import { resolveBinding, serviceProtocols } from '../resolve';
 import { fillTemplate, templatePlaceholders } from '../template';
@@ -228,10 +223,6 @@ describe('resolveBinding: variant chosen per agent', () => {
       tier: 'native',
       protocol: 'openai-responses',
       baseUrl: 'https://gateway.linkcode.ai/v1',
-    });
-    expect(modelListSourceForProtocol('linkcode-gateway', 'anthropic')).toEqual({
-      url: 'https://gateway.linkcode.ai/v1/models?protocol=anthropic',
-      wire: 'anthropic',
     });
   });
 

--- a/packages/foundation/providers/src/__tests__/resolve.test.ts
+++ b/packages/foundation/providers/src/__tests__/resolve.test.ts
@@ -1,7 +1,12 @@
 import type { Account, AgentKind, AgentRuntimes } from '@linkcode/schema';
 import { nullthrow } from 'foxts/guard';
 import { describe, expect, it } from 'vitest';
-import { endpointServiceById, modelListSource, serviceById } from '../catalog';
+import {
+  endpointServiceById,
+  modelListSource,
+  modelListSourceForProtocol,
+  serviceById,
+} from '../catalog';
 import { detectedLogins } from '../detected-logins';
 import { resolveBinding, serviceProtocols } from '../resolve';
 import { fillTemplate, templatePlaceholders } from '../template';
@@ -197,29 +202,36 @@ describe('resolveBinding: variant chosen per agent', () => {
     ).toEqual({ tier: 'unavailable', reason: 'protocol-unsupported' });
   });
 
-  it('serves LinkCode Gateway over both OpenAI wires', () => {
+  it('serves LinkCode Gateway natively over Anthropic Messages and OpenAI Responses', () => {
     const gateway = account({
       service: 'linkcode-gateway',
       credential: { type: 'auth-token', token: 'lc-gateway-key' },
     });
     expect(resolveBinding(gateway, 'claude-code')).toEqual({
-      tier: 'translate',
-      protocol: 'openai-chat',
-      baseUrl: 'https://gateway.linkcode.ai/v1',
+      tier: 'native',
+      protocol: 'anthropic',
+      baseUrl: 'https://gateway.linkcode.ai',
     });
+    // Neither wire carries a knownProvider for these two (LinkCode Gateway names no vendor
+    // either agent's own catalog knows), so they fall through to protocol order like StepFun's
+    // Pi binding does — now landing on the same native anthropic wire as claude-code.
     const providerRoutedKinds = ['opencode', 'pi'] as const;
     for (let i = 0, len = providerRoutedKinds.length; i < len; i++) {
       const kind = providerRoutedKinds[i];
       expect(resolveBinding(gateway, kind)).toEqual({
         tier: 'native',
-        protocol: 'openai-chat',
-        baseUrl: 'https://gateway.linkcode.ai/v1',
+        protocol: 'anthropic',
+        baseUrl: 'https://gateway.linkcode.ai',
       });
     }
     expect(resolveBinding(gateway, 'codex')).toEqual({
       tier: 'native',
       protocol: 'openai-responses',
       baseUrl: 'https://gateway.linkcode.ai/v1',
+    });
+    expect(modelListSourceForProtocol('linkcode-gateway', 'anthropic')).toEqual({
+      url: 'https://gateway.linkcode.ai/v1/models?protocol=anthropic',
+      wire: 'anthropic',
     });
   });
 

--- a/packages/foundation/providers/src/catalog.ts
+++ b/packages/foundation/providers/src/catalog.ts
@@ -180,6 +180,15 @@ export const SERVICE_CATALOG: ServiceDescriptor[] = [
           wire: 'openai',
         },
       },
+      // Bare origin, not `/v1` — claude-code's own SDK appends `/v1/messages`, matching every
+      // other `anthropic` variant in this file. Lists only the Claude models served natively.
+      anthropic: {
+        baseUrl: 'https://gateway.linkcode.ai',
+        models: {
+          url: 'https://gateway.linkcode.ai/v1/models?protocol=anthropic',
+          wire: 'anthropic',
+        },
+      },
     },
     models: { url: 'https://gateway.linkcode.ai/v1/models', wire: 'openai' },
   },

--- a/packages/host/engine/src/__tests__/engine-model-probe.test.ts
+++ b/packages/host/engine/src/__tests__/engine-model-probe.test.ts
@@ -206,6 +206,12 @@ describe('config.probe-models', () => {
       if (url === '/v1/models?protocol=openai-responses') {
         return { status: 200, body: JSON.stringify({ data: [{ id: 'openai/gpt-5.6' }] }) };
       }
+      if (url === '/v1/models?protocol=anthropic') {
+        return {
+          status: 200,
+          body: JSON.stringify({ data: [{ id: 'anthropic/claude-sonnet-5' }] }),
+        };
+      }
       if (url === '/v1/models') {
         return {
           status: 200,
@@ -235,11 +241,20 @@ describe('config.probe-models', () => {
           // Returned by both lists: tagged with every protocol whose list named it.
           protocols: ['openai-chat', 'openai-responses'],
         },
-        { id: 'anthropic/claude-sonnet-5', protocols: ['openai-chat'] },
+        {
+          id: 'anthropic/claude-sonnet-5',
+          // Protocol order follows PROTOCOL_ORDER's processing order, not the mock's response
+          // order: the anthropic-only list merges in before the shared openai-chat one.
+          protocols: ['anthropic', 'openai-chat'],
+        },
       ]),
     );
     expect(reply.models).toHaveLength(2);
-    expect(seen.sort()).toEqual(['/v1/models', '/v1/models?protocol=openai-responses']);
+    expect(seen.sort()).toEqual([
+      '/v1/models',
+      '/v1/models?protocol=anthropic',
+      '/v1/models?protocol=openai-responses',
+    ]);
   });
 
   it('refuses to send an account secret to a service it does not belong to', async () => {


### PR DESCRIPTION
## Summary
- Add an `anthropic` service variant to the `linkcode-gateway` catalog entry, so `resolveBinding(account, "claude-code")` resolves it as `{tier: "native", protocol: "anthropic"}` instead of `{tier: "translate", protocol: "openai-chat"}`.
- No changes needed to `resolve.ts`, `translator.ts`, or `credential.ts` — the architecture was already generically correct: `translationUpstream()` only spawns the local `aigateway` sidecar when the resolved protocol is `openai-chat`, so adding the native `anthropic` variant makes the sidecar path unreachable for this account by construction, with zero branching added.

Linear: CODE-646

Filed as a follow-up, not part of this diff: CODE-651 — a pre-existing display bug in the shared `claude-code.ts` adapter (model name flip-flops between the client's provider-prefixed catalog id and the vendor's raw echoed id), newly exposed by this native routing but not caused by it.