### PR TITLE
fix(workbench): stop an uninstalled harness from looping catalog errors in the composer

### DIFF
--- a/packages/client/workbench/src/surface/__tests__/use-agent-catalogs.test.ts
+++ b/packages/client/workbench/src/surface/__tests__/use-agent-catalogs.test.ts
@@ -23,34 +23,28 @@ afterEach(() => {
   runtimeMock.runtimes = undefined;
 });
 
+const ALL_AVAILABLE: AgentRuntimes = {
+  'claude-code': { status: 'available', source: 'detected' },
+  codex: { status: 'available', source: 'detected' },
+  opencode: { status: 'available', source: 'detected' },
+  pi: { status: 'available', source: 'managed' },
+  'grok-build': { status: 'available', source: 'detected' },
+};
+
 describe('useAgentStartCatalogs', () => {
-  it('pauses only the Pi catalog while runtime availability is loading', () => {
+  it('pauses every catalog while runtime availability is loading', () => {
+    renderHook(() => useAgentStartCatalogs('/repo/app'));
+
+    expect(tayoriMock.params).toEqual([null, null, null, null, null]);
+  });
+
+  it('requests every catalog once the runtimes are available', () => {
+    runtimeMock.runtimes = ALL_AVAILABLE;
+
     renderHook(() => useAgentStartCatalogs('/repo/app'));
 
     // The cwd is what lets an adapter resolve the tier a session would really start under —
     // claude-code reads `permissions.defaultMode` from the workspace's own settings.
-    expect(tayoriMock.params).toEqual([
-      { agentKind: 'claude-code', cwd: '/repo/app' },
-      { agentKind: 'codex', cwd: '/repo/app' },
-      { agentKind: 'opencode', cwd: '/repo/app' },
-      null,
-      { agentKind: 'grok-build', cwd: '/repo/app' },
-    ]);
-  });
-
-  it('keeps the Pi catalog paused while its managed runtime is missing', () => {
-    runtimeMock.runtimes = { pi: { status: 'missing' } };
-
-    renderHook(() => useAgentStartCatalogs('/repo/app'));
-
-    expect(tayoriMock.params[3]).toBeNull();
-  });
-
-  it('requests the Pi catalog once its runtime is available', () => {
-    runtimeMock.runtimes = { pi: { status: 'available', source: 'managed' } };
-
-    renderHook(() => useAgentStartCatalogs('/repo/app'));
-
     expect(tayoriMock.params).toEqual([
       { agentKind: 'claude-code', cwd: '/repo/app' },
       { agentKind: 'codex', cwd: '/repo/app' },
@@ -60,8 +54,27 @@ describe('useAgentStartCatalogs', () => {
     ]);
   });
 
+  it('skips a missing runtime but keeps out-of-range and unevaluated kinds', () => {
+    // The dev mock host's onboarding fixture: one kind per runtime state.
+    runtimeMock.runtimes = {
+      'claude-code': { status: 'missing' },
+      codex: { status: 'out-of-range', source: 'detected', version: '0.99.0' },
+      pi: { status: 'available', source: 'builtin' },
+    };
+
+    renderHook(() => useAgentStartCatalogs('/repo/app'));
+
+    expect(tayoriMock.params).toEqual([
+      null,
+      { agentKind: 'codex', cwd: '/repo/app' },
+      { agentKind: 'opencode', cwd: '/repo/app' },
+      { agentKind: 'pi', cwd: '/repo/app' },
+      { agentKind: 'grok-build', cwd: '/repo/app' },
+    ]);
+  });
+
   it('follows a workspace switch rather than capturing the first cwd', () => {
-    runtimeMock.runtimes = { pi: { status: 'available', source: 'managed' } };
+    runtimeMock.runtimes = ALL_AVAILABLE;
     const { rerender } = renderHook(({ cwd }: { cwd: string }) => useAgentStartCatalogs(cwd), {
       initialProps: { cwd: '/repo/app' },
     });

--- a/packages/client/workbench/src/surface/use-agent-catalogs.ts
+++ b/packages/client/workbench/src/surface/use-agent-catalogs.ts
@@ -19,15 +19,17 @@ const SCOPED = { keepPreviousData: false } as const;
 
 export function useAgentStartCatalogs(cwd?: string): Partial<Record<AgentKind, AgentStartCatalog>> {
   const { data: runtimes } = useAgentRuntimes();
-  const claude = useData(getAgentCatalog, { agentKind: 'claude-code', cwd }, SCOPED);
-  const codex = useData(getAgentCatalog, { agentKind: 'codex', cwd }, SCOPED);
-  const opencode = useData(getAgentCatalog, { agentKind: 'opencode', cwd }, SCOPED);
-  const pi = useData(
-    getAgentCatalog,
-    runtimes?.pi?.status === 'available' ? { agentKind: 'pi', cwd } : null,
-    SCOPED,
-  );
-  const grok = useData(getAgentCatalog, { agentKind: 'grok-build', cwd }, SCOPED);
+  // A runtime the host cannot spawn has no catalog to serve — the adapter throws and SWR retries
+  // the failure indefinitely — so a `missing` kind is not requested (the harness picker already
+  // badges it "Not installed"). Loading pauses every request; a kind the host never evaluated is
+  // absent from the snapshot and stays fail-open, like `deriveAgentRuntimeCues`.
+  const request = (agentKind: AgentKind) =>
+    runtimes !== undefined && runtimes[agentKind]?.status !== 'missing' ? { agentKind, cwd } : null;
+  const claude = useData(getAgentCatalog, request('claude-code'), SCOPED);
+  const codex = useData(getAgentCatalog, request('codex'), SCOPED);
+  const opencode = useData(getAgentCatalog, request('opencode'), SCOPED);
+  const pi = useData(getAgentCatalog, request('pi'), SCOPED);
+  const grok = useData(getAgentCatalog, request('grok-build'), SCOPED);
   return {
     ...(claude.data && { 'claude-code': claude.data }),
     ...(codex.data && { codex: codex.data }),


### PR DESCRIPTION
## Summary

The empty "What should we build?" composer logged `[LinkCode data error] Error: Failed to load agent catalog` about 9–10 times per page load whenever a selectable harness has no runtime installed on the host — here `opencode`, whose binary is absent on this machine (tracked separately).

`useAgentStartCatalogs` requested a catalog for every harness unconditionally, gating only Pi on the `agent-runtime.list` probe (added for CODE-579). For a `missing` runtime, the engine's `agent.catalog` handler wraps the adapter's `startCatalog()` throw in an `OperationError` with `publicMessage: 'Failed to load agent catalog'` — and one such failure amplifies into ~10 reports through `handleFetchError`:

- SWR 2.4.2 defaults retry every error with exponential backoff (`errorRetryInterval` 5s, no `errorRetryCount` cap) and revalidate on focus and reconnect.
- Each connection generation remounts the tayori hooks, and `ReadyRevalidator` forces `mutate(trueFn)` across all keys once the transport is ready.
- Catalog keys are cwd-scoped, so each workspace resolution is a new key with its own failing fetch and retry chain.

The fix consults the agent-runtime probe for all five harnesses instead of gating Pi alone — the same source the onboarding Download card already reads:

- runtimes still loading → every request paused, so the picker never flashes a state that isn't true yet;
- `status: 'missing'` → never requested; the harness submenu already badges it "Not installed" through the existing runtime cues, so no UI change was needed;
- `out-of-range` and unevaluated (absent) kinds stay requested, matching `deriveAgentRuntimeCues`' fail-open reading.

No wire-protocol or engine change. The dev mock host needs none either: it never answers `agent.catalog` at all, and its runtime fixture already covers every status the gate reads.

Linear: [CODE-655](https://linear.app/arcbox/issue/CODE-655/fixworkbench-stop-an-uninstalled-harness-from-looping-catalog-errors)

## Verification

Ran the webview against the development daemon on 127.0.0.1:19533, where `opencode` is the uninstalled harness:

- The empty composer logged **zero** `[LinkCode data error]` lines. The same page served from a pre-fix checkout still logs `Failed to load agent catalog`, so the difference is the change and not the environment.
- OpenCode still appears in the Harness submenu, badged "Not installed".

Gates, both run under `devenv shell`:

- `pnpm check:ci` — format clean, lint 0 errors, typecheck clean.
- `pnpm test` — 353 files / 3039 tests passed (3 files / 5 tests skipped).

`use-agent-catalogs.test.ts` now covers runtimes-loading, all-available, the mixed fixture (missing / out-of-range / available / absent), and a workspace switch.

## Checklist

- [x] `pnpm check:ci` and `pnpm test` both pass (no Rust changes, so no `cargo` gates)
- [x] I ran the affected surface and observed the change working
- [x] If a wire message changed: `WIRE_PROTOCOL_VERSION` is bumped — n/a, no wire change
- [x] New code and assets are my own work, or their origin and license compatibility are noted above
- [x] Docs and comments are updated where behavior changed
